### PR TITLE
🎨 Palette: Add copy button to assistant messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-05-22 - [Avatar Accessibility]
 **Learning:** Purely visual components like Avatars often get overlooked for accessibility. While "decorative", they provide context (who is speaking). Adding `role="img"` and `aria-label` to the container and hiding the internal icon (`aria-hidden="true"`) is a robust pattern to ensure screen readers announce "User" or "Bot" instead of ignoring it or reading the icon filename/SVG title.
 **Action:** Always check "decorative" icons that convey meaning (like speaker identity) and add appropriate ARIA labels.
+
+## 2024-05-24 - [Mobile-First Action Visibility]
+**Learning:** Auxiliary actions (like copy buttons) that rely on hover for visibility are inaccessible on touch devices. A robust pattern is `opacity-100 md:opacity-0 md:group-hover:opacity-100`, which makes actions always visible on mobile but keeps the desktop UI clean until interaction.
+**Action:** Use this utility class combination for any secondary actions inside lists or cards.

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,25 @@
+{
+    "env": {
+        "browser": true,
+        "es2020": true,
+        "node": true
+    },
+    "extends": [
+        "eslint:recommended",
+        "plugin:react/recommended",
+        "plugin:react-hooks/recommended"
+    ],
+    "parserOptions": {
+        "ecmaVersion": "latest",
+        "sourceType": "module"
+    },
+    "settings": {
+        "react": {
+            "version": "detect"
+        }
+    },
+    "rules": {
+        "react/react-in-jsx-scope": "off",
+        "react/prop-types": "off"
+    }
+}

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -1,28 +1,56 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { Copy, Check } from 'lucide-react';
 import Avatar from '../../../shared/components/ui/Avatar';
 
 const MessageBubble = ({ message, isUser }) => {
+    const [copied, setCopied] = useState(false);
+
+    const handleCopy = async () => {
+        try {
+            await navigator.clipboard.writeText(message);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch (err) {
+            console.error('Failed to copy text: ', err);
+        }
+    };
+
     return (
-        <div className={`flex w-full ${isUser ? 'justify-end' : 'justify-start'} mb-6`}>
+        <div className={`flex w-full ${isUser ? 'justify-end' : 'justify-start'} mb-6 group`}>
             <div className={`flex max-w-[80%] md:max-w-[70%] ${isUser ? 'flex-row-reverse' : 'flex-row'} gap-4`}>
                 {/* Avatar */}
                 <Avatar isUser={isUser} name={isUser ? "Você" : "Katherine"} />
 
-                {/* Message Content */}
-                <div className={`px-4 py-3 rounded-2xl shadow-sm text-sm md:text-base leading-relaxed ${isUser
-                    ? 'bg-blue-600 text-white rounded-tr-none'
-                    : 'bg-gray-800 text-gray-100 rounded-tl-none border border-gray-700'
-                    }`}>
-                    <div className="markdown-content">
-                        <ReactMarkdown
-                            components={{
-                                em: ({ node, ...props }) => <span className="text-gray-400 italic" {...props} />
-                            }}
-                        >
-                            {message}
-                        </ReactMarkdown>
+                <div className={`flex flex-col ${isUser ? 'items-end' : 'items-start'} max-w-full min-w-0`}>
+                    {/* Message Content */}
+                    <div className={`px-4 py-3 rounded-2xl shadow-sm text-sm md:text-base leading-relaxed ${isUser
+                        ? 'bg-blue-600 text-white rounded-tr-none'
+                        : 'bg-gray-800 text-gray-100 rounded-tl-none border border-gray-700'
+                        }`}>
+                        <div className="markdown-content">
+                            <ReactMarkdown
+                                components={{
+                                    em: ({ node, ...props }) => <span className="text-gray-400 italic" {...props} />
+                                }}
+                            >
+                                {message}
+                            </ReactMarkdown>
+                        </div>
                     </div>
+
+                    {/* Copy Button (Assistant Only) */}
+                    {!isUser && (
+                        <button
+                            onClick={handleCopy}
+                            className="flex items-center gap-1 mt-1 text-xs text-gray-500 hover:text-gray-300 transition-colors opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 p-1 rounded"
+                            aria-label={copied ? "Copiado!" : "Copiar mensagem"}
+                            title="Copiar mensagem"
+                        >
+                            {copied ? <Check size={14} className="text-green-500" /> : <Copy size={14} />}
+                            <span>{copied ? 'Copiado' : 'Copiar'}</span>
+                        </button>
+                    )}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
💡 **What:** Added a "Copy" button to assistant messages in the chat interface.
🎯 **Why:** Allows users to easily copy code snippets or responses generated by the assistant, improving usability for coding or text generation tasks.
♿ **Accessibility:**
- Added `aria-label` that updates state.
- Button is accessible via keyboard (`focus:opacity-100`).
- Mobile-friendly: Always visible on touch devices, hover-only on desktop to reduce clutter.
🛠️ **Fixes:**
- Added `frontend/.eslintrc.json` to fix broken linting command.

---
*PR created automatically by Jules for task [2173798412587180531](https://jules.google.com/task/2173798412587180531) started by @RenyEnnos*