### PR TITLE
🎨 Palette: Add copy-to-clipboard for assistant messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-05-22 - [Avatar Accessibility]
 **Learning:** Purely visual components like Avatars often get overlooked for accessibility. While "decorative", they provide context (who is speaking). Adding `role="img"` and `aria-label` to the container and hiding the internal icon (`aria-hidden="true"`) is a robust pattern to ensure screen readers announce "User" or "Bot" instead of ignoring it or reading the icon filename/SVG title.
 **Action:** Always check "decorative" icons that convey meaning (like speaker identity) and add appropriate ARIA labels.
+
+## 2024-05-24 - [Hover Visibility & Keyboard Access]
+**Learning:** When using `group-hover:opacity-100` to reveal actions (like copy buttons) on hover, keyboard users are often left behind because the element remains invisible when focused.
+**Action:** Always pair `group-hover:opacity-100` with `focus:opacity-100` (on the element itself) or `focus-within:opacity-100` (on the container) to ensure actions are discoverable via keyboard navigation.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -1,8 +1,21 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { Copy, Check } from 'lucide-react';
 import Avatar from '../../../shared/components/ui/Avatar';
 
 const MessageBubble = ({ message, isUser }) => {
+    const [isCopied, setIsCopied] = useState(false);
+
+    const handleCopy = async () => {
+        try {
+            await navigator.clipboard.writeText(message);
+            setIsCopied(true);
+            setTimeout(() => setIsCopied(false), 2000);
+        } catch (err) {
+            console.error('Failed to copy:', err);
+        }
+    };
+
     return (
         <div className={`flex w-full ${isUser ? 'justify-end' : 'justify-start'} mb-6`}>
             <div className={`flex max-w-[80%] md:max-w-[70%] ${isUser ? 'flex-row-reverse' : 'flex-row'} gap-4`}>
@@ -10,19 +23,31 @@ const MessageBubble = ({ message, isUser }) => {
                 <Avatar isUser={isUser} name={isUser ? "Você" : "Katherine"} />
 
                 {/* Message Content */}
-                <div className={`px-4 py-3 rounded-2xl shadow-sm text-sm md:text-base leading-relaxed ${isUser
-                    ? 'bg-blue-600 text-white rounded-tr-none'
-                    : 'bg-gray-800 text-gray-100 rounded-tl-none border border-gray-700'
-                    }`}>
-                    <div className="markdown-content">
-                        <ReactMarkdown
-                            components={{
-                                em: ({ node, ...props }) => <span className="text-gray-400 italic" {...props} />
-                            }}
-                        >
-                            {message}
-                        </ReactMarkdown>
+                <div className="group flex flex-col gap-1 items-start">
+                    <div className={`px-4 py-3 rounded-2xl shadow-sm text-sm md:text-base leading-relaxed ${isUser
+                        ? 'bg-blue-600 text-white rounded-tr-none'
+                        : 'bg-gray-800 text-gray-100 rounded-tl-none border border-gray-700'
+                        }`}>
+                        <div className="markdown-content">
+                            <ReactMarkdown
+                                components={{
+                                    em: ({ node, ...props }) => <span className="text-gray-400 italic" {...props} />
+                                }}
+                            >
+                                {message}
+                            </ReactMarkdown>
+                        </div>
                     </div>
+                    {!isUser && (
+                        <button
+                            onClick={handleCopy}
+                            className="p-1.5 text-gray-500 hover:text-gray-300 transition-opacity opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
+                            aria-label={isCopied ? "Copiado!" : "Copiar resposta"}
+                            title="Copiar resposta"
+                        >
+                            {isCopied ? <Check size={14} /> : <Copy size={14} />}
+                        </button>
+                    )}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
💡 What: Added a "Copy" button to the assistant's message bubbles.
🎯 Why: Users frequently need to copy AI responses. This improves the interaction flow.
♿ Accessibility:
- Button has `aria-label="Copiar resposta"` which updates to "Copiado!" on success.
- Uses `focus:opacity-100` to ensure keyboard accessibility, as the button is hidden by default (hover-only on desktop).
- Uses `p-1.5` padding for better touch target.
- Visual feedback (Check icon) lasts for 2 seconds.

---
*PR created automatically by Jules for task [4323694707021911560](https://jules.google.com/task/4323694707021911560) started by @RenyEnnos*

## Summary by Sourcery

Adicionar funcionalidade de copiar para a área de transferência para mensagens do assistente no chat e documentar considerações de acessibilidade para ações reveladas ao passar o mouse.

Novos recursos:
- Adicionar um botão de copiar para a área de transferência às bolhas de mensagens do assistente na interface de chat.

Aperfeiçoamentos:
- Fornecer feedback visual e baseado em ARIA quando uma mensagem é copiada com sucesso a partir da bolha do assistente.
- Garantir que os botões de ação revelados ao passar o mouse permaneçam descobríveis para usuários de teclado, emparelhando os estados de visibilidade de hover e foco.

Documentação:
- Documentar orientações de acessibilidade para padrões de visibilidade baseados em hover nas notas da paleta.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add copy-to-clipboard functionality for assistant chat messages and document accessibility considerations for hover-revealed actions.

New Features:
- Add a copy-to-clipboard button to assistant message bubbles in the chat interface.

Enhancements:
- Provide visual and ARIA-based feedback when a message is successfully copied from the assistant bubble.
- Ensure hover-revealed action buttons remain discoverable for keyboard users by pairing hover and focus visibility states.

Documentation:
- Document accessibility guidance for hover-based visibility patterns in the palette notes.

</details>