### PR TITLE
feat: add copy button to assistant messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,6 +5,6 @@
 **Learning:** Purely visual components like Avatars often get overlooked for accessibility. While "decorative", they provide context (who is speaking). Adding `role="img"` and `aria-label` to the container and hiding the internal icon (`aria-hidden="true"`) is a robust pattern to ensure screen readers announce "User" or "Bot" instead of ignoring it or reading the icon filename/SVG title.
 **Action:** Always check "decorative" icons that convey meaning (like speaker identity) and add appropriate ARIA labels.
 
-## 2024-05-24 - [Chat Actions Accessibility]
+## 2026-02-03 - [Chat Actions Accessibility]
 **Learning:** When adding auxiliary actions (like "Copy") to message bubbles, grouping them in a vertical flex container below the bubble ensures they are associated with the message without breaking the visual flow or overlapping content on small screens.
 **Action:** Use `flex-col` for message/action grouping and ensure actions are keyboard accessible with `aria-label`.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,6 +5,6 @@
 **Learning:** Purely visual components like Avatars often get overlooked for accessibility. While "decorative", they provide context (who is speaking). Adding `role="img"` and `aria-label` to the container and hiding the internal icon (`aria-hidden="true"`) is a robust pattern to ensure screen readers announce "User" or "Bot" instead of ignoring it or reading the icon filename/SVG title.
 **Action:** Always check "decorative" icons that convey meaning (like speaker identity) and add appropriate ARIA labels.
 
-## 2026-02-03 - [Chat Actions Accessibility]
+## 2024-05-24 - [Chat Actions Accessibility]
 **Learning:** When adding auxiliary actions (like "Copy") to message bubbles, grouping them in a vertical flex container below the bubble ensures they are associated with the message without breaking the visual flow or overlapping content on small screens.
 **Action:** Use `flex-col` for message/action grouping and ensure actions are keyboard accessible with `aria-label`.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-05-22 - [Avatar Accessibility]
 **Learning:** Purely visual components like Avatars often get overlooked for accessibility. While "decorative", they provide context (who is speaking). Adding `role="img"` and `aria-label` to the container and hiding the internal icon (`aria-hidden="true"`) is a robust pattern to ensure screen readers announce "User" or "Bot" instead of ignoring it or reading the icon filename/SVG title.
 **Action:** Always check "decorative" icons that convey meaning (like speaker identity) and add appropriate ARIA labels.
+
+## 2026-02-03 - [Chat Actions Accessibility]
+**Learning:** When adding auxiliary actions (like "Copy") to message bubbles, grouping them in a vertical flex container below the bubble ensures they are associated with the message without breaking the visual flow or overlapping content on small screens.
+**Action:** Use `flex-col` for message/action grouping and ensure actions are keyboard accessible with `aria-label`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -1,28 +1,54 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { Copy, Check } from 'lucide-react';
 import Avatar from '../../../shared/components/ui/Avatar';
 
 const MessageBubble = ({ message, isUser }) => {
+    const [isCopied, setIsCopied] = useState(false);
+
+    const handleCopy = async () => {
+        try {
+            await navigator.clipboard.writeText(message);
+            setIsCopied(true);
+            setTimeout(() => setIsCopied(false), 2000);
+        } catch (err) {
+            console.error('Failed to copy:', err);
+        }
+    };
+
     return (
         <div className={`flex w-full ${isUser ? 'justify-end' : 'justify-start'} mb-6`}>
             <div className={`flex max-w-[80%] md:max-w-[70%] ${isUser ? 'flex-row-reverse' : 'flex-row'} gap-4`}>
                 {/* Avatar */}
                 <Avatar isUser={isUser} name={isUser ? "Você" : "Katherine"} />
 
-                {/* Message Content */}
-                <div className={`px-4 py-3 rounded-2xl shadow-sm text-sm md:text-base leading-relaxed ${isUser
-                    ? 'bg-blue-600 text-white rounded-tr-none'
-                    : 'bg-gray-800 text-gray-100 rounded-tl-none border border-gray-700'
-                    }`}>
-                    <div className="markdown-content">
-                        <ReactMarkdown
-                            components={{
-                                em: ({ node, ...props }) => <span className="text-gray-400 italic" {...props} />
-                            }}
-                        >
-                            {message}
-                        </ReactMarkdown>
+                {/* Message Content & Actions */}
+                <div className={`flex flex-col gap-1 max-w-full ${isUser ? 'items-end' : 'items-start'}`}>
+                    <div className={`px-4 py-3 rounded-2xl shadow-sm text-sm md:text-base leading-relaxed ${isUser
+                        ? 'bg-blue-600 text-white rounded-tr-none'
+                        : 'bg-gray-800 text-gray-100 rounded-tl-none border border-gray-700'
+                        }`}>
+                        <div className="markdown-content">
+                            <ReactMarkdown
+                                components={{
+                                    em: ({ node, ...props }) => <span className="text-gray-400 italic" {...props} />
+                                }}
+                            >
+                                {message}
+                            </ReactMarkdown>
+                        </div>
                     </div>
+
+                    {!isUser && (
+                        <button
+                            onClick={handleCopy}
+                            aria-label="Copiar resposta"
+                            className="flex items-center gap-1.5 text-xs text-gray-400 hover:text-gray-300 focus-visible:text-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-600 rounded transition-colors ml-1 p-1"
+                        >
+                            {isCopied ? <Check size={14} className="text-green-500" /> : <Copy size={14} />}
+                            {isCopied ? 'Copiado!' : 'Copiar'}
+                        </button>
+                    )}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
🎨 Palette: Added Copy Button to Message Bubbles

💡 **What:** Added a small "Copy" button below Katherine's (assistant) messages.
🎯 **Why:** Users often need to copy AI responses. A dedicated button is faster and cleaner than manual selection.
📸 **Before/After:**
- **Before:** No way to copy message easily.
- **After:** A small button appears below the message. Clicking it copies text and shows "Copiado!" with a check icon.

♿ **Accessibility:**
- Button has `aria-label="Copiar resposta"`.
- Keyboard accessible (tabbable, focus styles).
- Visual feedback is color-coded but also text-based ("Copiado!").


---
*PR created automatically by Jules for task [15136218781078490986](https://jules.google.com/task/15136218781078490986) started by @RenyEnnos*

## Summary by Sourcery

Adiciona uma ação de copiar às bolhas de mensagens do assistente na interface de chat.

Novos recursos:
- Introduz um botão de copiar para mensagens do assistente que copia todo o texto da resposta para a área de transferência, com feedback visual.

Documentação:
- Documenta a ação de mensagens de chat e os padrões de acessibilidade nas diretrizes da paleta.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a copy action to assistant message bubbles in the chat interface.

New Features:
- Introduce a copy button for assistant messages that copies the full response text to the clipboard with visual feedback.

Documentation:
- Document chat message action and accessibility patterns in the palette guidelines.

</details>