### PR TITLE
🎨 Palette: Add copy button to assistant messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-05-22 - [Avatar Accessibility]
 **Learning:** Purely visual components like Avatars often get overlooked for accessibility. While "decorative", they provide context (who is speaking). Adding `role="img"` and `aria-label` to the container and hiding the internal icon (`aria-hidden="true"`) is a robust pattern to ensure screen readers announce "User" or "Bot" instead of ignoring it or reading the icon filename/SVG title.
 **Action:** Always check "decorative" icons that convey meaning (like speaker identity) and add appropriate ARIA labels.
+
+## 2024-05-24 - [Message Actions Layout]
+**Learning:** To support auxiliary actions (like Copy) on chat bubbles without breaking the avatar-message horizontal alignment, wrapping the message content in a `flex-col` container (sibling to the Avatar) provides a stable area for actions below the bubble. This scales better than absolute positioning which can overlap content.
+**Action:** Use vertical flex wrappers for message content when adding message-level actions.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,6 +5,6 @@
 **Learning:** Purely visual components like Avatars often get overlooked for accessibility. While "decorative", they provide context (who is speaking). Adding `role="img"` and `aria-label` to the container and hiding the internal icon (`aria-hidden="true"`) is a robust pattern to ensure screen readers announce "User" or "Bot" instead of ignoring it or reading the icon filename/SVG title.
 **Action:** Always check "decorative" icons that convey meaning (like speaker identity) and add appropriate ARIA labels.
 
-## 2024-05-24 - [Message Actions Layout]
-**Learning:** To support auxiliary actions (like Copy) on chat bubbles without breaking the avatar-message horizontal alignment, wrapping the message content in a `flex-col` container (sibling to the Avatar) provides a stable area for actions below the bubble. This scales better than absolute positioning which can overlap content.
-**Action:** Use vertical flex wrappers for message content when adding message-level actions.
+## 2024-05-24 - [Auxiliary Message Actions]
+**Learning:** Placing auxiliary actions (like copy) inside the message bubble can clutter the text. Placing them outside in a vertical flex container (`flex-col`) handles variable content widths gracefully and prevents overlap, while `group-hover` + `focus:opacity-100` keeps the UI clean but accessible.
+**Action:** Use vertical stacking for auxiliary actions attached to variable-width content blocks.

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,0 +1,21 @@
+module.exports = {
+  root: true,
+  env: { browser: true, es2020: true },
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:react/jsx-runtime',
+    'plugin:react-hooks/recommended',
+  ],
+  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+  settings: { react: { version: '18.2' } },
+  plugins: ['react-refresh'],
+  rules: {
+    'react-refresh/only-export-components': [
+      'warn',
+      { allowConstantExport: true },
+    ],
+    'react/prop-types': 'off', // Common in Vite+React projects to disable if not using PropTypes strictly
+  },
+}

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -17,13 +17,13 @@ const MessageBubble = ({ message, isUser }) => {
     };
 
     return (
-        <div className={`flex w-full ${isUser ? 'justify-end' : 'justify-start'} mb-6`}>
-            <div className={`flex max-w-[80%] md:max-w-[70%] ${isUser ? 'flex-row-reverse' : 'flex-row'} gap-4 group`}>
+        <div className={`flex w-full ${isUser ? 'justify-end' : 'justify-start'} mb-6 group`}>
+            <div className={`flex max-w-[80%] md:max-w-[70%] ${isUser ? 'flex-row-reverse' : 'flex-row'} gap-4`}>
                 {/* Avatar */}
                 <Avatar isUser={isUser} name={isUser ? "Você" : "Katherine"} />
 
                 {/* Content Wrapper */}
-                <div className={`flex flex-col ${isUser ? 'items-end' : 'items-start'} min-w-0`}>
+                <div className={`flex flex-col ${isUser ? 'items-end' : 'items-start'} max-w-full overflow-hidden`}>
                     {/* Message Content */}
                     <div className={`px-4 py-3 rounded-2xl shadow-sm text-sm md:text-base leading-relaxed ${isUser
                         ? 'bg-blue-600 text-white rounded-tr-none'

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -1,28 +1,65 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { Copy, Check } from 'lucide-react';
 import Avatar from '../../../shared/components/ui/Avatar';
 
 const MessageBubble = ({ message, isUser }) => {
+    const [isCopied, setIsCopied] = useState(false);
+
+    const handleCopy = async () => {
+        try {
+            await navigator.clipboard.writeText(message);
+            setIsCopied(true);
+            setTimeout(() => setIsCopied(false), 2000);
+        } catch (err) {
+            console.error('Failed to copy text: ', err);
+        }
+    };
+
     return (
         <div className={`flex w-full ${isUser ? 'justify-end' : 'justify-start'} mb-6`}>
-            <div className={`flex max-w-[80%] md:max-w-[70%] ${isUser ? 'flex-row-reverse' : 'flex-row'} gap-4`}>
+            <div className={`flex max-w-[80%] md:max-w-[70%] ${isUser ? 'flex-row-reverse' : 'flex-row'} gap-4 group`}>
                 {/* Avatar */}
                 <Avatar isUser={isUser} name={isUser ? "Você" : "Katherine"} />
 
-                {/* Message Content */}
-                <div className={`px-4 py-3 rounded-2xl shadow-sm text-sm md:text-base leading-relaxed ${isUser
-                    ? 'bg-blue-600 text-white rounded-tr-none'
-                    : 'bg-gray-800 text-gray-100 rounded-tl-none border border-gray-700'
-                    }`}>
-                    <div className="markdown-content">
-                        <ReactMarkdown
-                            components={{
-                                em: ({ node, ...props }) => <span className="text-gray-400 italic" {...props} />
-                            }}
-                        >
-                            {message}
-                        </ReactMarkdown>
+                {/* Content Wrapper */}
+                <div className={`flex flex-col ${isUser ? 'items-end' : 'items-start'} min-w-0`}>
+                    {/* Message Content */}
+                    <div className={`px-4 py-3 rounded-2xl shadow-sm text-sm md:text-base leading-relaxed ${isUser
+                        ? 'bg-blue-600 text-white rounded-tr-none'
+                        : 'bg-gray-800 text-gray-100 rounded-tl-none border border-gray-700'
+                        }`}>
+                        <div className="markdown-content">
+                            <ReactMarkdown
+                                components={{
+                                    em: ({ node, ...props }) => <span className="text-gray-400 italic" {...props} />
+                                }}
+                            >
+                                {message}
+                            </ReactMarkdown>
+                        </div>
                     </div>
+
+                    {/* Copy Button */}
+                    {!isUser && (
+                        <button
+                            onClick={handleCopy}
+                            aria-label={isCopied ? "Copiado com sucesso" : "Copiar resposta"}
+                            className="mt-1 flex items-center gap-1.5 p-1 text-xs text-gray-500 hover:text-gray-300 transition-all opacity-0 group-hover:opacity-100 focus:opacity-100"
+                        >
+                            {isCopied ? (
+                                <>
+                                    <Check size={14} className="text-green-500" />
+                                    <span className="text-green-500 font-medium">Copiado!</span>
+                                </>
+                            ) : (
+                                <>
+                                    <Copy size={14} />
+                                    <span>Copiar</span>
+                                </>
+                            )}
+                        </button>
+                    )}
                 </div>
             </div>
         </div>

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -22,9 +22,8 @@ const MessageBubble = ({ message, isUser }) => {
                 {/* Avatar */}
                 <Avatar isUser={isUser} name={isUser ? "Você" : "Katherine"} />
 
-                {/* Content Wrapper */}
+                {/* Message Content & Actions */}
                 <div className={`flex flex-col ${isUser ? 'items-end' : 'items-start'} max-w-full overflow-hidden`}>
-                    {/* Message Content */}
                     <div className={`px-4 py-3 rounded-2xl shadow-sm text-sm md:text-base leading-relaxed ${isUser
                         ? 'bg-blue-600 text-white rounded-tr-none'
                         : 'bg-gray-800 text-gray-100 rounded-tl-none border border-gray-700'
@@ -40,24 +39,15 @@ const MessageBubble = ({ message, isUser }) => {
                         </div>
                     </div>
 
-                    {/* Copy Button */}
+                    {/* Copy Button (only for Assistant) */}
                     {!isUser && (
                         <button
                             onClick={handleCopy}
-                            aria-label={isCopied ? "Copiado com sucesso" : "Copiar resposta"}
-                            className="mt-1 flex items-center gap-1.5 p-1 text-xs text-gray-500 hover:text-gray-300 transition-all opacity-0 group-hover:opacity-100 focus:opacity-100"
+                            aria-label={isCopied ? "Copiado" : "Copiar resposta"}
+                            className="mt-1 p-1.5 text-gray-500 hover:text-gray-300 transition-all opacity-0 group-hover:opacity-100 focus:opacity-100 rounded-md hover:bg-gray-800"
+                            title="Copiar resposta"
                         >
-                            {isCopied ? (
-                                <>
-                                    <Check size={14} className="text-green-500" />
-                                    <span className="text-green-500 font-medium">Copiado!</span>
-                                </>
-                            ) : (
-                                <>
-                                    <Copy size={14} />
-                                    <span>Copiar</span>
-                                </>
-                            )}
+                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
                     )}
                 </div>


### PR DESCRIPTION
*   💡 What: Added a "Copy" button to Katherine's messages in the chat.
*   🎯 Why: To allow users to easily copy the assistant's response to their clipboard.
*   ♿ Accessibility: Added `aria-label` which updates to "Copiado!" on success. The button is keyboard accessible (focus visible) and hidden until hover/focus to reduce visual clutter.
*   Also added `.eslintrc.cjs` to enable `pnpm lint` verification.

---
*PR created automatically by Jules for task [1863030758560394263](https://jules.google.com/task/1863030758560394263) started by @RenyEnnos*

## Summary by Sourcery

Adiciona uma ação de copiar para a área de transferência às mensagens do assistente no chat e configura as definições de ESLint no frontend.

Novos recursos:
- Adicionar um botão de copiar às bolhas de mensagens do assistente (não do usuário) no chat para copiar o texto completo da mensagem para a área de transferência.

Aperfeiçoamentos:
- Melhorar o layout das mensagens do chat com um contêiner flex vertical para suportar ações no nível da mensagem sem afetar o alinhamento do avatar.
- Documentar os aprendizados de layout para ações de mensagem nas notas do Palette.

Build:
- Introduzir uma configuração de ESLint para o frontend (`.eslintrc.cjs`) com regras recomendadas para React e React Hooks.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a copy-to-clipboard action to assistant chat messages and configure frontend ESLint settings.

New Features:
- Add a copy button to assistant (non-user) chat message bubbles to copy the full message text to the clipboard.

Enhancements:
- Improve chat message layout with a vertical flex wrapper to support message-level actions without affecting avatar alignment.
- Document layout learnings for message actions in the Palette notes.

Build:
- Introduce a frontend ESLint configuration (.eslintrc.cjs) with recommended React and React Hooks rules.

</details>