### PR TITLE
🎨 Palette: Add copy-to-clipboard for assistant messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-05-22 - [Avatar Accessibility]
 **Learning:** Purely visual components like Avatars often get overlooked for accessibility. While "decorative", they provide context (who is speaking). Adding `role="img"` and `aria-label` to the container and hiding the internal icon (`aria-hidden="true"`) is a robust pattern to ensure screen readers announce "User" or "Bot" instead of ignoring it or reading the icon filename/SVG title.
 **Action:** Always check "decorative" icons that convey meaning (like speaker identity) and add appropriate ARIA labels.
+
+## 2024-05-24 - [Auxiliary Message Actions]
+**Learning:** Placing auxiliary actions (like copy) inside the message bubble can clutter the text. Placing them outside in a vertical flex container (`flex-col`) handles variable content widths gracefully and prevents overlap, while `group-hover` + `focus:opacity-100` keeps the UI clean but accessible.
+**Action:** Use vertical stacking for auxiliary actions attached to variable-width content blocks.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -1,28 +1,55 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { Copy, Check } from 'lucide-react';
 import Avatar from '../../../shared/components/ui/Avatar';
 
 const MessageBubble = ({ message, isUser }) => {
+    const [isCopied, setIsCopied] = useState(false);
+
+    const handleCopy = async () => {
+        try {
+            await navigator.clipboard.writeText(message);
+            setIsCopied(true);
+            setTimeout(() => setIsCopied(false), 2000);
+        } catch (err) {
+            console.error('Failed to copy text: ', err);
+        }
+    };
+
     return (
-        <div className={`flex w-full ${isUser ? 'justify-end' : 'justify-start'} mb-6`}>
+        <div className={`flex w-full ${isUser ? 'justify-end' : 'justify-start'} mb-6 group`}>
             <div className={`flex max-w-[80%] md:max-w-[70%] ${isUser ? 'flex-row-reverse' : 'flex-row'} gap-4`}>
                 {/* Avatar */}
                 <Avatar isUser={isUser} name={isUser ? "Você" : "Katherine"} />
 
-                {/* Message Content */}
-                <div className={`px-4 py-3 rounded-2xl shadow-sm text-sm md:text-base leading-relaxed ${isUser
-                    ? 'bg-blue-600 text-white rounded-tr-none'
-                    : 'bg-gray-800 text-gray-100 rounded-tl-none border border-gray-700'
-                    }`}>
-                    <div className="markdown-content">
-                        <ReactMarkdown
-                            components={{
-                                em: ({ node, ...props }) => <span className="text-gray-400 italic" {...props} />
-                            }}
-                        >
-                            {message}
-                        </ReactMarkdown>
+                {/* Message Content & Actions */}
+                <div className={`flex flex-col ${isUser ? 'items-end' : 'items-start'} max-w-full overflow-hidden`}>
+                    <div className={`px-4 py-3 rounded-2xl shadow-sm text-sm md:text-base leading-relaxed ${isUser
+                        ? 'bg-blue-600 text-white rounded-tr-none'
+                        : 'bg-gray-800 text-gray-100 rounded-tl-none border border-gray-700'
+                        }`}>
+                        <div className="markdown-content">
+                            <ReactMarkdown
+                                components={{
+                                    em: ({ node, ...props }) => <span className="text-gray-400 italic" {...props} />
+                                }}
+                            >
+                                {message}
+                            </ReactMarkdown>
+                        </div>
                     </div>
+
+                    {/* Copy Button (only for Assistant) */}
+                    {!isUser && (
+                        <button
+                            onClick={handleCopy}
+                            aria-label={isCopied ? "Copiado" : "Copiar resposta"}
+                            className="mt-1 p-1.5 text-gray-500 hover:text-gray-300 transition-all opacity-0 group-hover:opacity-100 focus:opacity-100 rounded-md hover:bg-gray-800"
+                            title="Copiar resposta"
+                        >
+                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                        </button>
+                    )}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
🎨 **Palette Enhancement: Copy to Clipboard**

💡 **What:** Added a "Copy" button to Katherine's messages in the chat interface.

🎯 **Why:** Users often want to use the AI's response elsewhere. Selecting text manually can be tedious, especially on mobile or for long responses. This micro-interaction makes it effortless.

📸 **Before/After:**
- **Before:** Text only.
- **After:** A subtle copy icon appears below the message (visible on hover/focus). Clicking it shows a "Check" icon and "Copiado!" state for 2 seconds.

♿ **Accessibility:**
- Added `aria-label` that updates from "Copiar resposta" to "Copiado".
- Button is keyboard accessible (`focus:opacity-100`).
- Icons hidden from screen readers where redundant.

📝 **Verification:**
- Verified using a temporary Playwright script that simulated the click and checked the clipboard content.
- Verified build passes with `pnpm build`.


---
*PR created automatically by Jules for task [7937261420718486712](https://jules.google.com/task/7937261420718486712) started by @RenyEnnos*