### PR TITLE
🎨 Palette: Fix duplicate copy button and enhance accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-05-24 - [Auxiliary Message Actions]
 **Learning:** Placing auxiliary actions (like copy) inside the message bubble can clutter the text. Placing them outside in a vertical flex container (`flex-col`) handles variable content widths gracefully and prevents overlap, while `group-hover` + `focus:opacity-100` keeps the UI clean but accessible.
 **Action:** Use vertical stacking for auxiliary actions attached to variable-width content blocks.
+
+## 2024-05-25 - [Responsive Visibility Overlap]
+**Learning:** Using only `opacity` for responsive visibility (e.g., `md:opacity-0`) can lead to duplicate interactive elements if hover states (`group-hover:opacity-100`) override the opacity on larger screens. Elements intended to be hidden on desktop may reappear on hover alongside their desktop counterparts.
+**Action:** Pair `hidden` / `block` utilities with opacity transitions when elements should be completely removed from the layout/accessibility tree on specific breakpoints, or ensure hover states are scoped to the correct breakpoint (e.g., `md:group-hover:opacity-100` vs `group-hover:opacity-100`).

--- a/frontend/src/features/chat/components/ChatInput.jsx
+++ b/frontend/src/features/chat/components/ChatInput.jsx
@@ -31,8 +31,8 @@ const ChatInput = ({ input, setInput, handleSend, isLoading, inputRef }) => {
                 <button
                     onClick={handleSend}
                     disabled={!input.trim() || isLoading}
-                    aria-label="Enviar mensagem"
-                    title="Enviar mensagem"
+                    aria-label="Enviar mensagem (Enter)"
+                    title="Enviar mensagem (Enter)"
                     className={`p-2 rounded-lg mb-1 transition-all ${input.trim() && !isLoading
                         ? 'bg-blue-600 text-white hover:bg-blue-500 shadow-md'
                         : 'bg-gray-700 text-gray-500 cursor-not-allowed'

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -39,17 +39,6 @@ const MessageBubble = ({ message, isUser }) => {
                         </div>
                     </div>
 
-                    {/* Copy Button (only for Assistant) */}
-                    {!isUser && (
-                        <button
-                            onClick={handleCopy}
-                            aria-label={isCopied ? "Copiado" : "Copiar resposta"}
-                            className="mt-1 p-1.5 text-gray-500 hover:text-gray-300 transition-all opacity-0 group-hover:opacity-100 focus:opacity-100 rounded-md hover:bg-gray-800"
-                            title="Copiar resposta"
-                        >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
-                        </button>
-                    )}
                 </div>
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
@@ -58,10 +47,10 @@ const MessageBubble = ({ message, isUser }) => {
                         <button
                             onClick={handleCopy}
                             className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label="Copiar mensagem"
-                            title="Copiar mensagem"
+                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
                     </div>
                 )}


### PR DESCRIPTION
- 💡 **What**: Removed redundant copy button in `MessageBubble.jsx` that appeared on desktop hover, and consolidated logic into the remaining button. Added "(Enter)" hint to the Send button in `ChatInput.jsx`.
- 🎯 **Why**: Users on desktop saw two copy buttons when hovering over assistant messages due to overlapping responsive visibility classes. Keyboard users also lacked a clear indication that "Enter" sends the message.
- 📸 **Verification**: Validated with Playwright script that only one copy button appears on hover and that accessibility labels are correct.
- ♿ **Accessibility**: 
  - Dynamic `aria-label` for copy button ("Copiar mensagem" / "Copiado").
  - "Enter" shortcut hint added to Send button `aria-label` and `title`.

---
*PR created automatically by Jules for task [9959308212195972217](https://jules.google.com/task/9959308212195972217) started by @RenyEnnos*