### PR TITLE
🎨 Palette: Add focus management and visual indicators

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2024-05-25 - [Responsive Visibility Overlap]
 **Learning:** Using only `opacity` for responsive visibility (e.g., `md:opacity-0`) can lead to duplicate interactive elements if hover states (`group-hover:opacity-100`) override the opacity on larger screens. Elements intended to be hidden on desktop may reappear on hover alongside their desktop counterparts.
 **Action:** Pair `hidden` / `block` utilities with opacity transitions when elements should be completely removed from the layout/accessibility tree on specific breakpoints, or ensure hover states are scoped to the correct breakpoint (e.g., `md:group-hover:opacity-100` vs `group-hover:opacity-100`).
+
+## 2024-05-26 - [Focus Management for Conditional UI]
+**Learning:** When interactive elements (like a delete button) are replaced by a confirmation dialog, the browser often loses focus or resets it to the body, disorienting keyboard users. Manually managing focus via `useEffect` and `useRef` ensures the user's flow is uninterrupted.
+**Action:** Always capture focus when a modal/dialog opens, and restore it to the trigger element (or a logical alternative) when it closes.

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -1,8 +1,20 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Trash2, Check, X } from 'lucide-react';
 
 const ChatHeader = ({ clearHistory }) => {
     const [showConfirm, setShowConfirm] = useState(false);
+    const cancelButtonRef = useRef(null);
+    const trashButtonRef = useRef(null);
+    const prevShowConfirm = useRef(showConfirm);
+
+    useEffect(() => {
+        if (!prevShowConfirm.current && showConfirm) {
+            cancelButtonRef.current?.focus();
+        } else if (prevShowConfirm.current && !showConfirm) {
+            trashButtonRef.current?.focus();
+        }
+        prevShowConfirm.current = showConfirm;
+    }, [showConfirm]);
 
     const handleClear = () => {
         clearHistory();
@@ -20,15 +32,16 @@ const ChatHeader = ({ clearHistory }) => {
                     <span className="text-sm text-gray-400">Confirmar?</span>
                     <button
                         onClick={handleClear}
-                        className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-md hover:bg-gray-800"
+                        className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
                         title="Confirmar limpeza"
                         aria-label="Confirmar limpeza"
                     >
                         <Check size={20} />
                     </button>
                     <button
+                        ref={cancelButtonRef}
                         onClick={() => setShowConfirm(false)}
-                        className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800"
+                        className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
                         title="Cancelar"
                         aria-label="Cancelar"
                     >
@@ -37,8 +50,9 @@ const ChatHeader = ({ clearHistory }) => {
                 </div>
             ) : (
                 <button
+                    ref={trashButtonRef}
                     onClick={() => setShowConfirm(true)}
-                    className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800"
+                    className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
                     title="Limpar conversa"
                     aria-label="Limpar conversa"
                 >

--- a/frontend/src/features/chat/components/ChatInput.jsx
+++ b/frontend/src/features/chat/components/ChatInput.jsx
@@ -33,7 +33,7 @@ const ChatInput = ({ input, setInput, handleSend, isLoading, inputRef }) => {
                     disabled={!input.trim() || isLoading}
                     aria-label="Enviar mensagem (Enter)"
                     title="Enviar mensagem (Enter)"
-                    className={`p-2 rounded-lg mb-1 transition-all ${input.trim() && !isLoading
+                    className={`p-2 rounded-lg mb-1 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${input.trim() && !isLoading
                         ? 'bg-blue-600 text-white hover:bg-blue-500 shadow-md'
                         : 'bg-gray-700 text-gray-500 cursor-not-allowed'
                         }`}

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,7 +46,7 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                             aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >


### PR DESCRIPTION
Implemented focus management for the "Clear History" confirmation dialog to prevent focus loss for keyboard users. Added consistent `focus-visible` rings to interactive buttons (Trash, Confirm, Cancel, Copy, Send) to improve accessibility. Verified with Playwright script.

---
*PR created automatically by Jules for task [10126542960019290687](https://jules.google.com/task/10126542960019290687) started by @RenyEnnos*

## Summary by Sourcery

Melhora o tratamento do foco do teclado e os indicadores visuais de foco nos componentes da interface de chat.

Melhorias:
- Adicionar gerenciamento de foco entre o botão de lixeira e os botões da caixa de diálogo de confirmação para preservar o foco do teclado ao alternar o estado de confirmação de limpeza do histórico.
- Aplicar estilos consistentes de anel `focus-visible` aos botões interativos primários no cabeçalho do chat, na entrada e nas ações de mensagem para melhor acessibilidade.
- Documentar aprendizados e diretrizes de gerenciamento de foco para UI condicional nas notas do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve keyboard focus handling and visual focus indicators in chat UI components.

Enhancements:
- Add focus management between the trash button and confirmation dialog buttons to preserve keyboard focus when toggling the clear-history confirmation state.
- Apply consistent focus-visible ring styles to primary interactive buttons in the chat header, input, and message actions for better accessibility.
- Document focus management learnings and guidelines for conditional UI in the Palette notes.

</details>