### PR TITLE
🎨 Palette: Improve focus management in ChatHeader

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2024-05-25 - [Responsive Visibility Overlap]
 **Learning:** Using only `opacity` for responsive visibility (e.g., `md:opacity-0`) can lead to duplicate interactive elements if hover states (`group-hover:opacity-100`) override the opacity on larger screens. Elements intended to be hidden on desktop may reappear on hover alongside their desktop counterparts.
 **Action:** Pair `hidden` / `block` utilities with opacity transitions when elements should be completely removed from the layout/accessibility tree on specific breakpoints, or ensure hover states are scoped to the correct breakpoint (e.g., `md:group-hover:opacity-100` vs `group-hover:opacity-100`).
+
+## 2026-02-09 - [Focus Management on Toggle]
+**Learning:** When replacing an interactive element with another (e.g., Delete button -> Confirm/Cancel buttons), focus is lost to the body if not manually managed, disorienting keyboard users.
+**Action:** Use `useRef` to track state transitions and `useEffect` to programmatically focus the new element on entry and restore focus to the trigger on exit.

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -1,8 +1,20 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Trash2, Check, X } from 'lucide-react';
 
 const ChatHeader = ({ clearHistory }) => {
     const [showConfirm, setShowConfirm] = useState(false);
+    const confirmBtnRef = useRef(null);
+    const trashBtnRef = useRef(null);
+    const prevShowConfirm = useRef(showConfirm);
+
+    useEffect(() => {
+        if (showConfirm && !prevShowConfirm.current) {
+            confirmBtnRef.current?.focus();
+        } else if (!showConfirm && prevShowConfirm.current) {
+            trashBtnRef.current?.focus();
+        }
+        prevShowConfirm.current = showConfirm;
+    }, [showConfirm]);
 
     const handleClear = () => {
         clearHistory();
@@ -19,8 +31,9 @@ const ChatHeader = ({ clearHistory }) => {
                 <div className="flex items-center gap-2">
                     <span className="text-sm text-gray-400">Confirmar?</span>
                     <button
+                        ref={confirmBtnRef}
                         onClick={handleClear}
-                        className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-md hover:bg-gray-800"
+                        className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
                         title="Confirmar limpeza"
                         aria-label="Confirmar limpeza"
                     >
@@ -28,7 +41,7 @@ const ChatHeader = ({ clearHistory }) => {
                     </button>
                     <button
                         onClick={() => setShowConfirm(false)}
-                        className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800"
+                        className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-500"
                         title="Cancelar"
                         aria-label="Cancelar"
                     >
@@ -37,8 +50,9 @@ const ChatHeader = ({ clearHistory }) => {
                 </div>
             ) : (
                 <button
+                    ref={trashBtnRef}
                     onClick={() => setShowConfirm(true)}
-                    className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800"
+                    className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-500"
                     title="Limpar conversa"
                     aria-label="Limpar conversa"
                 >


### PR DESCRIPTION
💡 What: Implemented manual focus management in the "Clear History" confirmation flow in ChatHeader.jsx.
🎯 Why: When the delete button was replaced by the confirm/cancel buttons, keyboard focus was lost to the document body, forcing users to tab through the interface again.
♿ Accessibility: Focus now moves to the "Confirm" button when the dialog appears, and returns to the "Delete" button when cancelled. Added visible focus rings.
📸 Screenshot verified.

---
*PR created automatically by Jules for task [11808073733851447981](https://jules.google.com/task/11808073733851447981) started by @RenyEnnos*

## Summary by Sourcery

Melhorar o gerenciamento de foco e a acessibilidade via teclado para o fluxo de confirmação de limpar histórico no ChatHeader.

Melhorias:
- Adicionar gerenciamento manual de foco, de modo que o foco vá para o botão de confirmação quando o estado de confirmação for aberto e retorne para o botão de excluir quando ele for fechado.
- Adicionar estilos visíveis de anel de foco aos botões de excluir, confirmar e cancelar na interface de limpar histórico do ChatHeader.
- Documentar o padrão de gerenciamento de foco nas notas do Palette para trabalhos futuros relacionados à acessibilidade da interface.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve focus management and keyboard accessibility for the ChatHeader clear-history confirmation flow.

Enhancements:
- Add manual focus management so focus moves to the confirm button when the confirmation state opens and returns to the delete button when it closes.
- Add visible focus ring styles to delete, confirm, and cancel buttons in the ChatHeader clear-history UI.
- Document the focus management pattern in the Palette notes for future accessibility-related UI work.

</details>