### PR TITLE
🎨 Palette: Manage focus in chat history clear confirmation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2024-05-25 - [Responsive Visibility Overlap]
 **Learning:** Using only `opacity` for responsive visibility (e.g., `md:opacity-0`) can lead to duplicate interactive elements if hover states (`group-hover:opacity-100`) override the opacity on larger screens. Elements intended to be hidden on desktop may reappear on hover alongside their desktop counterparts.
 **Action:** Pair `hidden` / `block` utilities with opacity transitions when elements should be completely removed from the layout/accessibility tree on specific breakpoints, or ensure hover states are scoped to the correct breakpoint (e.g., `md:group-hover:opacity-100` vs `group-hover:opacity-100`).
+
+## 2024-05-25 - [Focus Management in Conditional UI]
+**Learning:** When replacing interactive elements (like a delete button) with a confirmation dialog in the same container, focus is often lost to the `body` if the original element is removed from the DOM. This disorients keyboard users.
+**Action:** Use `useEffect` with `useRef` to programmatically move focus to the new primary action (e.g., "Cancel" or "Confirm") when the state changes, and restore it to the trigger element when the dialog closes.

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -1,13 +1,29 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Trash2, Check, X } from 'lucide-react';
 
 const ChatHeader = ({ clearHistory }) => {
     const [showConfirm, setShowConfirm] = useState(false);
+    const deleteBtnRef = useRef(null);
+    const cancelBtnRef = useRef(null);
+    const isFirstRender = useRef(true);
 
     const handleClear = () => {
         clearHistory();
         setShowConfirm(false);
     };
+
+    useEffect(() => {
+        if (isFirstRender.current) {
+            isFirstRender.current = false;
+            return;
+        }
+
+        if (showConfirm) {
+            cancelBtnRef.current?.focus();
+        } else {
+            deleteBtnRef.current?.focus();
+        }
+    }, [showConfirm]);
 
     return (
         <header className="flex-shrink-0 h-16 border-b border-gray-800 flex items-center justify-between px-4 md:px-8 bg-gray-900 z-10">
@@ -27,6 +43,7 @@ const ChatHeader = ({ clearHistory }) => {
                         <Check size={20} />
                     </button>
                     <button
+                        ref={cancelBtnRef}
                         onClick={() => setShowConfirm(false)}
                         className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800"
                         title="Cancelar"
@@ -37,6 +54,7 @@ const ChatHeader = ({ clearHistory }) => {
                 </div>
             ) : (
                 <button
+                    ref={deleteBtnRef}
                     onClick={() => setShowConfirm(true)}
                     className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800"
                     title="Limpar conversa"


### PR DESCRIPTION
*   💡 What: Added focus management to `ChatHeader` component.
*   🎯 Why: When users click the delete button, it is replaced by confirmation buttons, causing focus loss to `body`. This change ensures focus moves to the "Cancel" button, and returns to the "Delete" button if cancelled.
*   ♿ Accessibility: Fixes a significant keyboard navigation trap/disorientation issue.


---
*PR created automatically by Jules for task [9315470689737731365](https://jules.google.com/task/9315470689737731365) started by @RenyEnnos*

## Summary by Sourcery

Melhorar o gerenciamento do foco do teclado ao alternar a interface de confirmação de exclusão do histórico de chat.

Melhorias:
- Garantir que o foco vá para o botão de cancelar quando a confirmação de exclusão aparecer e retorne para o botão de excluir quando a confirmação for fechada.
- Documentar as orientações de gerenciamento de foco para padrões de UI condicionais nas notas da paleta.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve keyboard focus management when toggling the chat history delete confirmation UI.

Enhancements:
- Ensure focus moves to the cancel button when the delete confirmation appears and returns to the delete button when the confirmation is dismissed.
- Document focus management guidance for conditional UI patterns in the palette notes.

</details>