### PR TITLE
🎨 Palette: Improve focus management in Chat Header

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2024-05-25 - [Responsive Visibility Overlap]
 **Learning:** Using only `opacity` for responsive visibility (e.g., `md:opacity-0`) can lead to duplicate interactive elements if hover states (`group-hover:opacity-100`) override the opacity on larger screens. Elements intended to be hidden on desktop may reappear on hover alongside their desktop counterparts.
 **Action:** Pair `hidden` / `block` utilities with opacity transitions when elements should be completely removed from the layout/accessibility tree on specific breakpoints, or ensure hover states are scoped to the correct breakpoint (e.g., `md:group-hover:opacity-100` vs `group-hover:opacity-100`).
+
+## 2024-05-26 - [Focus Management in Toggle UI]
+**Learning:** When a button toggles a UI state that removes the button itself (e.g., Delete -> Confirm/Cancel), keyboard focus is lost if not manually managed. This creates a disorientation for keyboard users.
+**Action:** Always use `useRef` to store references to the new focus target (e.g., Cancel button) and the original trigger (e.g., Delete button), and use `useEffect` to move focus when the state changes.

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -1,8 +1,27 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Trash2, Check, X } from 'lucide-react';
 
 const ChatHeader = ({ clearHistory }) => {
     const [showConfirm, setShowConfirm] = useState(false);
+    const trashRef = useRef(null);
+    const cancelRef = useRef(null);
+    const isFirstRender = useRef(true);
+
+    // Focus management
+    useEffect(() => {
+        if (isFirstRender.current) {
+            isFirstRender.current = false;
+            return;
+        }
+
+        if (showConfirm) {
+            // Focus on Cancel button for safety when confirmation appears
+            cancelRef.current?.focus();
+        } else {
+            // Return focus to Trash button when confirmation is closed/cancelled
+            trashRef.current?.focus();
+        }
+    }, [showConfirm]);
 
     const handleClear = () => {
         clearHistory();
@@ -20,15 +39,16 @@ const ChatHeader = ({ clearHistory }) => {
                     <span className="text-sm text-gray-400">Confirmar?</span>
                     <button
                         onClick={handleClear}
-                        className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-md hover:bg-gray-800"
+                        className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-red-500 focus:outline-none"
                         title="Confirmar limpeza"
                         aria-label="Confirmar limpeza"
                     >
                         <Check size={20} />
                     </button>
                     <button
+                        ref={cancelRef}
                         onClick={() => setShowConfirm(false)}
-                        className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800"
+                        className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-gray-600 focus:outline-none"
                         title="Cancelar"
                         aria-label="Cancelar"
                     >
@@ -37,8 +57,9 @@ const ChatHeader = ({ clearHistory }) => {
                 </div>
             ) : (
                 <button
+                    ref={trashRef}
                     onClick={() => setShowConfirm(true)}
-                    className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800"
+                    className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-gray-600 focus:outline-none"
                     title="Limpar conversa"
                     aria-label="Limpar conversa"
                 >


### PR DESCRIPTION
# UX Improvement: Focus Management in Chat Header

## 💡 What
Implemented focus management for the "Clear History" confirmation dialog in the `ChatHeader` component.

## 🎯 Why
When a user clicked the "Trash" icon to clear history, the button was removed from the DOM and replaced by "Confirmar?" buttons. This caused keyboard focus to be lost (reset to body), disorienting keyboard and screen reader users.

## 📸 Changes
- **Focus Transition:** Focus now moves automatically to the "Cancel" button when the confirmation appears.
- **Focus Restoration:** Focus returns to the "Trash" button when the confirmation is cancelled.
- **Visual Feedback:** Added `focus-visible:ring` styles to the buttons to clearly indicate focus state.

## ♿ Accessibility
- Prevents "focus loss" which is a WCAG failure (Focus Order).
- Improves navigation flow for keyboard users.
- Added visual indicators for focus state.

---
*PR created automatically by Jules for task [17747490012861337302](https://jules.google.com/task/17747490012861337302) started by @RenyEnnos*

## Summary by Sourcery

Melhora o tratamento do foco do teclado para a confirmação de limpeza do histórico de chat no componente ChatHeader.

Melhorias:
- Adicionar lógica de gerenciamento de foco para mover o foco para o botão de cancelar quando a confirmação de limpeza aparecer e de volta para o botão de lixeira quando ela for fechada.
- Aprimorar os botões de limpar/confirmar/cancelar com estilos de anel de foco visível para melhorar a acessibilidade e a indicação de foco.

Documentação:
- Documentar considerações de gerenciamento de foco para interfaces do tipo “toggle” nas notas internas da paleta.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve keyboard focus handling for the chat history clear confirmation in the ChatHeader component.

Enhancements:
- Add focus management logic to move focus to the cancel button when the clear confirmation appears and back to the trash button when it closes.
- Enhance clear/confirm/cancel buttons with visible focus ring styles to improve accessibility and focus indication.

Documentation:
- Document focus management considerations for toggle-style UIs in the internal palette notes.

</details>