### PR TITLE
🎨 Palette: Improve focus management in ChatHeader

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2024-05-25 - [Responsive Visibility Overlap]
 **Learning:** Using only `opacity` for responsive visibility (e.g., `md:opacity-0`) can lead to duplicate interactive elements if hover states (`group-hover:opacity-100`) override the opacity on larger screens. Elements intended to be hidden on desktop may reappear on hover alongside their desktop counterparts.
 **Action:** Pair `hidden` / `block` utilities with opacity transitions when elements should be completely removed from the layout/accessibility tree on specific breakpoints, or ensure hover states are scoped to the correct breakpoint (e.g., `md:group-hover:opacity-100` vs `group-hover:opacity-100`).
+
+## 2024-05-26 - [Focus Management in Dynamic UI]
+**Learning:** When replacing interactive elements (like a delete button) with a confirmation dialog in-place, keyboard focus is lost if not manually managed. This disorients screen reader users. Using `useRef` to shift focus to the "Cancel" action (safe default) on open, and back to the trigger on close, preserves context.
+**Action:** Always implement `useEffect` with focus refs when toggling visibility of interactive components that replace the trigger.

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -1,8 +1,22 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Trash2, Check, X } from 'lucide-react';
 
 const ChatHeader = ({ clearHistory }) => {
     const [showConfirm, setShowConfirm] = useState(false);
+    const trashRef = useRef(null);
+    const cancelRef = useRef(null);
+    const prevShowConfirm = useRef(showConfirm);
+
+    useEffect(() => {
+        if (!prevShowConfirm.current && showConfirm) {
+            // Focus on cancel button when confirmation shows for safety
+            cancelRef.current?.focus();
+        } else if (prevShowConfirm.current && !showConfirm) {
+            // Return focus to trash button when confirmation closes
+            trashRef.current?.focus();
+        }
+        prevShowConfirm.current = showConfirm;
+    }, [showConfirm]);
 
     const handleClear = () => {
         clearHistory();
@@ -20,15 +34,16 @@ const ChatHeader = ({ clearHistory }) => {
                     <span className="text-sm text-gray-400">Confirmar?</span>
                     <button
                         onClick={handleClear}
-                        className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-md hover:bg-gray-800"
+                        className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-red-400 focus:outline-none"
                         title="Confirmar limpeza"
                         aria-label="Confirmar limpeza"
                     >
                         <Check size={20} />
                     </button>
                     <button
+                        ref={cancelRef}
                         onClick={() => setShowConfirm(false)}
-                        className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800"
+                        className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-gray-400 focus:outline-none"
                         title="Cancelar"
                         aria-label="Cancelar"
                     >
@@ -37,8 +52,9 @@ const ChatHeader = ({ clearHistory }) => {
                 </div>
             ) : (
                 <button
+                    ref={trashRef}
                     onClick={() => setShowConfirm(true)}
-                    className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800"
+                    className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-gray-400 focus:outline-none"
                     title="Limpar conversa"
                     aria-label="Limpar conversa"
                 >


### PR DESCRIPTION
Implemented focus management in `ChatHeader.jsx` to ensure accessibility during the clear history confirmation flow. When the user clicks the delete button, focus is now moved to the "Cancel" button, preventing accidental deletion and maintaining context. When the action is cancelled, focus is restored to the delete button. Visual focus indicators (`focus-visible`) were also enhanced. Validated with Playwright script.

---
*PR created automatically by Jules for task [12123690152461508379](https://jules.google.com/task/12123690152461508379) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e o gerenciamento de foco para o fluxo de confirmação de limpeza do histórico de chat em `ChatHeader`.

Novas funcionalidades:
- Adicionar gerenciamento de foco via teclado ao alternar a confirmação de limpeza do histórico no cabeçalho do chat.

Aprimoramentos:
- Aprimorar o estilo de `focus-visible` para os botões de excluir, confirmar e cancelar no cabeçalho do chat.
- Documentar as melhores práticas de gerenciamento de foco para interações dinâmicas de UI nas notas do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus management for the chat history clear confirmation flow in ChatHeader.

New Features:
- Add keyboard focus management when toggling the clear history confirmation in the chat header.

Enhancements:
- Enhance focus-visible styling for delete, confirm, and cancel buttons in the chat header.
- Document focus management best practices for dynamic UI interactions in the Palette notes.

</details>