### PR TITLE
🎨 Palette: Improve focus management for clear history action

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2024-05-25 - [Responsive Visibility Overlap]
 **Learning:** Using only `opacity` for responsive visibility (e.g., `md:opacity-0`) can lead to duplicate interactive elements if hover states (`group-hover:opacity-100`) override the opacity on larger screens. Elements intended to be hidden on desktop may reappear on hover alongside their desktop counterparts.
 **Action:** Pair `hidden` / `block` utilities with opacity transitions when elements should be completely removed from the layout/accessibility tree on specific breakpoints, or ensure hover states are scoped to the correct breakpoint (e.g., `md:group-hover:opacity-100` vs `group-hover:opacity-100`).
+
+## 2026-02-13 - [Focus Management for Conditional UI]
+**Learning:** When interactive elements are conditionally replaced (e.g., swapping a "Delete" button for "Confirm/Cancel"), focus is often lost to the document body, disrupting keyboard navigation.
+**Action:** Use `useRef` and `useEffect` to manually shift focus to the new primary action (or the cancel button for safety) when the component state changes, and restore focus to the trigger element when the action is cancelled.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,6 +13,6 @@
 **Learning:** Using only `opacity` for responsive visibility (e.g., `md:opacity-0`) can lead to duplicate interactive elements if hover states (`group-hover:opacity-100`) override the opacity on larger screens. Elements intended to be hidden on desktop may reappear on hover alongside their desktop counterparts.
 **Action:** Pair `hidden` / `block` utilities with opacity transitions when elements should be completely removed from the layout/accessibility tree on specific breakpoints, or ensure hover states are scoped to the correct breakpoint (e.g., `md:group-hover:opacity-100` vs `group-hover:opacity-100`).
 
-## 2026-02-13 - [Focus Management for Conditional UI]
-**Learning:** When interactive elements are conditionally replaced (e.g., swapping a "Delete" button for "Confirm/Cancel"), focus is often lost to the document body, disrupting keyboard navigation.
-**Action:** Use `useRef` and `useEffect` to manually shift focus to the new primary action (or the cancel button for safety) when the component state changes, and restore focus to the trigger element when the action is cancelled.
+## 2024-05-26 - [Focus Management in Conditional UI]
+**Learning:** For simple UI toggles (e.g., replacing a button with a confirmation dialog), conditionally rendering elements with `autoFocus` is a robust and minimal pattern for managing focus. It avoids complex `useEffect` + `useRef` logic while ensuring keyboard users are not lost when the DOM structure changes.
+**Action:** Use conditional rendering + `autoFocus` for inline confirmation states to preserve keyboard context.

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -1,27 +1,18 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Trash2, Check, X } from 'lucide-react';
 
 const ChatHeader = ({ clearHistory }) => {
     const [showConfirm, setShowConfirm] = useState(false);
-    const trashBtnRef = useRef(null);
-    const cancelBtnRef = useRef(null);
-    const isFirstRender = useRef(true);
-
-    useEffect(() => {
-        if (isFirstRender.current) {
-            isFirstRender.current = false;
-            return;
-        }
-        if (showConfirm) {
-            cancelBtnRef.current?.focus();
-        } else {
-            trashBtnRef.current?.focus();
-        }
-    }, [showConfirm]);
+    const [shouldFocusTrash, setShouldFocusTrash] = useState(false);
 
     const handleClear = () => {
         clearHistory();
         setShowConfirm(false);
+    };
+
+    const handleTrashClick = () => {
+        setShouldFocusTrash(true);
+        setShowConfirm(true);
     };
 
     return (
@@ -42,7 +33,7 @@ const ChatHeader = ({ clearHistory }) => {
                         <Check size={20} />
                     </button>
                     <button
-                        ref={cancelBtnRef}
+                        autoFocus
                         onClick={() => setShowConfirm(false)}
                         className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800"
                         title="Cancelar"
@@ -53,8 +44,8 @@ const ChatHeader = ({ clearHistory }) => {
                 </div>
             ) : (
                 <button
-                    ref={trashBtnRef}
-                    onClick={() => setShowConfirm(true)}
+                    autoFocus={shouldFocusTrash}
+                    onClick={handleTrashClick}
                     className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800"
                     title="Limpar conversa"
                     aria-label="Limpar conversa"

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -15,6 +15,12 @@ const ChatHeader = ({ clearHistory }) => {
         setShowConfirm(true);
     };
 
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            setShowConfirm(false);
+        }
+    };
+
     return (
         <header className="flex-shrink-0 h-16 border-b border-gray-800 flex items-center justify-between px-4 md:px-8 bg-gray-900 z-10">
             <div className="font-semibold text-lg tracking-tight text-white">
@@ -22,7 +28,7 @@ const ChatHeader = ({ clearHistory }) => {
             </div>
 
             {showConfirm ? (
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2" onKeyDown={handleKeyDown}>
                     <span className="text-sm text-gray-400">Confirmar?</span>
                     <button
                         onClick={handleClear}

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -1,8 +1,23 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Trash2, Check, X } from 'lucide-react';
 
 const ChatHeader = ({ clearHistory }) => {
     const [showConfirm, setShowConfirm] = useState(false);
+    const trashBtnRef = useRef(null);
+    const cancelBtnRef = useRef(null);
+    const isFirstRender = useRef(true);
+
+    useEffect(() => {
+        if (isFirstRender.current) {
+            isFirstRender.current = false;
+            return;
+        }
+        if (showConfirm) {
+            cancelBtnRef.current?.focus();
+        } else {
+            trashBtnRef.current?.focus();
+        }
+    }, [showConfirm]);
 
     const handleClear = () => {
         clearHistory();
@@ -27,6 +42,7 @@ const ChatHeader = ({ clearHistory }) => {
                         <Check size={20} />
                     </button>
                     <button
+                        ref={cancelBtnRef}
                         onClick={() => setShowConfirm(false)}
                         className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800"
                         title="Cancelar"
@@ -37,6 +53,7 @@ const ChatHeader = ({ clearHistory }) => {
                 </div>
             ) : (
                 <button
+                    ref={trashBtnRef}
                     onClick={() => setShowConfirm(true)}
                     className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800"
                     title="Limpar conversa"

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -28,7 +28,10 @@ const ChatHeader = ({ clearHistory }) => {
             </div>
 
             {showConfirm ? (
-                <div className="flex items-center gap-2" onKeyDown={handleKeyDown}>
+                <div
+                    className="flex items-center gap-2"
+                    onKeyDown={handleKeyDown}
+                >
                     <span className="text-sm text-gray-400">Confirmar?</span>
                     <button
                         onClick={handleClear}


### PR DESCRIPTION
# 🎨 Palette: Improve focus management for clear history action

## 💡 What
Added explicit focus management to the "Clear History" confirmation flow in `ChatHeader.jsx`.

## 🎯 Why
When a user clicks the "Trash" icon, it is replaced by "Confirm" and "Cancel" buttons. Previously, focus was lost to the document body, forcing keyboard users to tab through the interface again to find their place. This change ensures focus is moved to the "Cancel" button (as a safety precaution) and restored to the "Trash" button if the action is cancelled.

## ♿ Accessibility
- **Focus Management:** Focus is programmatically moved to the relevant interactive element when the UI state changes.
- **Safety:** Focus defaults to "Cancel" rather than "Confirm" to prevent accidental data loss via Space/Enter key presses.

## 📸 Verification
- Verified using a Playwright script that simulates keyboard navigation and asserts `document.activeElement` is correct at each step.
- Screenshots confirmed the focus ring appears on the correct elements.


---
*PR created automatically by Jules for task [18382635857532733912](https://jules.google.com/task/18382635857532733912) started by @RenyEnnos*

## Summary by Sourcery

Melhorar o gerenciamento de foco do teclado ao alternar a confirmação de limpar histórico no cabeçalho do chat e documentar o padrão nas notas da paleta.

Melhorias:
- Adicionar gerenciamento explícito de foco entre o botão de lixeira e o botão de cancelamento quando o estado de confirmação de limpar histórico é alternado no cabeçalho do chat.
- Documentar um padrão reutilizável para gerenciar foco em interfaces condicionais na base de conhecimento da paleta.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve keyboard focus management when toggling the clear-history confirmation in the chat header and document the pattern in the palette notes.

Enhancements:
- Add explicit focus management between the trash button and cancel button when the clear-history confirmation state toggles in the chat header.
- Document a reusable pattern for managing focus in conditional UIs in the palette knowledge base.

</details>