### PR TITLE
🎨 Palette: Improve focus management for clear history action

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2024-05-25 - [Responsive Visibility Overlap]
 **Learning:** Using only `opacity` for responsive visibility (e.g., `md:opacity-0`) can lead to duplicate interactive elements if hover states (`group-hover:opacity-100`) override the opacity on larger screens. Elements intended to be hidden on desktop may reappear on hover alongside their desktop counterparts.
 **Action:** Pair `hidden` / `block` utilities with opacity transitions when elements should be completely removed from the layout/accessibility tree on specific breakpoints, or ensure hover states are scoped to the correct breakpoint (e.g., `md:group-hover:opacity-100` vs `group-hover:opacity-100`).
+
+## 2024-05-26 - [Focus Management in Conditional UI]
+**Learning:** For simple UI toggles (e.g., replacing a button with a confirmation dialog), conditionally rendering elements with `autoFocus` is a robust and minimal pattern for managing focus. It avoids complex `useEffect` + `useRef` logic while ensuring keyboard users are not lost when the DOM structure changes.
+**Action:** Use conditional rendering + `autoFocus` for inline confirmation states to preserve keyboard context.

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -3,10 +3,17 @@ import { Trash2, Check, X } from 'lucide-react';
 
 const ChatHeader = ({ clearHistory }) => {
     const [showConfirm, setShowConfirm] = useState(false);
+    const [shouldFocusTrash, setShouldFocusTrash] = useState(false);
 
     const handleClear = () => {
         clearHistory();
         setShowConfirm(false);
+    };
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            setShowConfirm(false);
+        }
     };
 
     return (
@@ -16,7 +23,10 @@ const ChatHeader = ({ clearHistory }) => {
             </div>
 
             {showConfirm ? (
-                <div className="flex items-center gap-2">
+                <div
+                    className="flex items-center gap-2"
+                    onKeyDown={handleKeyDown}
+                >
                     <span className="text-sm text-gray-400">Confirmar?</span>
                     <button
                         onClick={handleClear}
@@ -28,6 +38,7 @@ const ChatHeader = ({ clearHistory }) => {
                     </button>
                     <button
                         onClick={() => setShowConfirm(false)}
+                        autoFocus
                         className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800"
                         title="Cancelar"
                         aria-label="Cancelar"
@@ -37,7 +48,11 @@ const ChatHeader = ({ clearHistory }) => {
                 </div>
             ) : (
                 <button
-                    onClick={() => setShowConfirm(true)}
+                    onClick={() => {
+                        setShouldFocusTrash(true);
+                        setShowConfirm(true);
+                    }}
+                    autoFocus={shouldFocusTrash}
                     className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800"
                     title="Limpar conversa"
                     aria-label="Limpar conversa"


### PR DESCRIPTION
Improved the accessibility of the "Clear History" action in the chat header.

**Changes:**
- **Focus Management:** When the confirmation dialog opens, focus is now automatically moved to the "Cancel" button. When the dialog is closed (either by confirming or cancelling), focus is restored to the "Trash" button. This prevents focus loss for keyboard users.
- **Keyboard Shortcut:** Added support for the `Escape` key to dismiss the confirmation dialog.

**Verification:**
- Verified manually using a Playwright script that focus moves correctly between the Trash button and the Cancel button.
- Ran `pnpm lint` and `pnpm build` successfully.

---
*PR created automatically by Jules for task [5353489803706290061](https://jules.google.com/task/5353489803706290061) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e o gerenciamento de foco no fluxo de confirmação de limpeza de histórico no cabeçalho do chat.

Novos recursos:
- Permitir dispensar o diálogo de confirmação de limpeza de histórico com a tecla Escape.

Aprimoramentos:
- Mover automaticamente o foco para o botão de cancelar quando o diálogo de confirmação de limpeza de histórico aparecer e restaurar o foco para o botão de lixeira quando ele for fechado, usando renderização condicional com `autoFocus`.
- Documentar aprendizados e diretrizes de gerenciamento de foco nas notas da paleta.

Documentação:
- Adicionar uma entrada na paleta descrevendo as melhores práticas para gerenciamento de foco em UI condicional.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus management for the chat header clear history confirmation flow.

New Features:
- Allow dismissing the clear history confirmation dialog with the Escape key.

Enhancements:
- Automatically move focus to the cancel button when the clear history confirmation dialog appears and restore focus to the trash button when it closes using conditional rendering with autoFocus.
- Document focus management learnings and guidelines in the palette notes.

Documentation:
- Add a palette entry describing best practices for focus management in conditional UI.

</details>