### PR TITLE
🎨 Palette: Improve focus management in Chat Header

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2024-05-25 - [Responsive Visibility Overlap]
 **Learning:** Using only `opacity` for responsive visibility (e.g., `md:opacity-0`) can lead to duplicate interactive elements if hover states (`group-hover:opacity-100`) override the opacity on larger screens. Elements intended to be hidden on desktop may reappear on hover alongside their desktop counterparts.
 **Action:** Pair `hidden` / `block` utilities with opacity transitions when elements should be completely removed from the layout/accessibility tree on specific breakpoints, or ensure hover states are scoped to the correct breakpoint (e.g., `md:group-hover:opacity-100` vs `group-hover:opacity-100`).
+
+## 2024-05-24 - [Focus Management on Conditional Render]
+**Learning:** For simple visibility toggles (like confirmation dialogs replacing the trigger button), focus is lost to the document body when the focused element unmounts. Using `autoFocus` on the entering element and conditional `autoFocus` on the returning trigger is a simpler, more declarative pattern than using `useEffect` + refs for restoring focus in React.
+**Action:** Use `autoFocus` prop for inline confirmation patterns where elements are swapped in/out of the DOM.

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -3,10 +3,23 @@ import { Trash2, Check, X } from 'lucide-react';
 
 const ChatHeader = ({ clearHistory }) => {
     const [showConfirm, setShowConfirm] = useState(false);
+    const [shouldFocusTrash, setShouldFocusTrash] = useState(false);
 
     const handleClear = () => {
         clearHistory();
+        setShouldFocusTrash(true);
         setShowConfirm(false);
+    };
+
+    const handleCancel = () => {
+        setShouldFocusTrash(true);
+        setShowConfirm(false);
+    };
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+            handleCancel();
+        }
     };
 
     return (
@@ -16,7 +29,10 @@ const ChatHeader = ({ clearHistory }) => {
             </div>
 
             {showConfirm ? (
-                <div className="flex items-center gap-2">
+                <div
+                    className="flex items-center gap-2"
+                    onKeyDown={handleKeyDown}
+                >
                     <span className="text-sm text-gray-400">Confirmar?</span>
                     <button
                         onClick={handleClear}
@@ -27,10 +43,11 @@ const ChatHeader = ({ clearHistory }) => {
                         <Check size={20} />
                     </button>
                     <button
-                        onClick={() => setShowConfirm(false)}
+                        onClick={handleCancel}
                         className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800"
                         title="Cancelar"
                         aria-label="Cancelar"
+                        autoFocus
                     >
                         <X size={20} />
                     </button>
@@ -41,6 +58,7 @@ const ChatHeader = ({ clearHistory }) => {
                     className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800"
                     title="Limpar conversa"
                     aria-label="Limpar conversa"
+                    autoFocus={shouldFocusTrash}
                 >
                     <Trash2 size={20} />
                 </button>


### PR DESCRIPTION
Improved accessibility and keyboard navigation in the Chat Header by managing focus when the "Clear History" confirmation dialog is shown or hidden.

💡 **What:** Added focus management to the chat history clear confirmation.
🎯 **Why:** Previously, focus was lost to the document body when toggling the confirmation state, confusing screen reader users and breaking keyboard navigation flow.
📸 **Before/After:** No visual change, but interaction flow is improved.
♿ **Accessibility:**
- Focus moves to "Cancelar" button when confirmation appears.
- Focus returns to "Limpar conversa" button when cancelled.
- `Escape` key now dismisses the confirmation.

---
*PR created automatically by Jules for task [1050305913789976261](https://jules.google.com/task/1050305913789976261) started by @RenyEnnos*

## Summary by Sourcery

Melhora o gerenciamento de foco e a acessibilidade via teclado no fluxo de confirmação de limpar histórico no cabeçalho do chat.

Aperfeiçoamentos:
- Adicionar restauração de foco ao gatilho de limpar histórico após confirmar ou cancelar a ação de limpar o chat.
- Permitir o fechamento da confirmação de limpar histórico com a tecla Escape e garantir que o foco vá para o botão de cancelar quando ele aparecer.

Documentação:
- Documentar o padrão de gerenciamento de foco para cenários de renderização condicional no arquivo de aprendizados do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve focus management and keyboard accessibility in the chat header clear-history confirmation flow.

Enhancements:
- Add focus restoration to the clear-history trigger after confirming or cancelling the chat clear action.
- Enable dismissal of the clear-history confirmation with the Escape key and ensure focus moves to the cancel button when it appears.

Documentation:
- Document the focus management pattern for conditional render scenarios in the Palette learnings file.

</details>