### PR TITLE
🎨 Palette: Improve Chat Header Focus Management

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2024-05-25 - [Responsive Visibility Overlap]
 **Learning:** Using only `opacity` for responsive visibility (e.g., `md:opacity-0`) can lead to duplicate interactive elements if hover states (`group-hover:opacity-100`) override the opacity on larger screens. Elements intended to be hidden on desktop may reappear on hover alongside their desktop counterparts.
 **Action:** Pair `hidden` / `block` utilities with opacity transitions when elements should be completely removed from the layout/accessibility tree on specific breakpoints, or ensure hover states are scoped to the correct breakpoint (e.g., `md:group-hover:opacity-100` vs `group-hover:opacity-100`).
+
+## 2024-05-27 - [Focus Management in Conditional Rendering]
+**Learning:** When replacing an interactive element (like a button) with new content (like a confirmation dialog) via conditional rendering, keyboard focus is lost to the document body, confusing screen reader users and breaking tab navigation flow.
+**Action:** Use `autoFocus` on the primary action of the new content to guide focus immediately, and ensure focus is restored to the trigger element (or a logical equivalent) when the new content is dismissed, using state-controlled `autoFocus` or `useEffect`.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,6 +13,10 @@
 **Learning:** Using only `opacity` for responsive visibility (e.g., `md:opacity-0`) can lead to duplicate interactive elements if hover states (`group-hover:opacity-100`) override the opacity on larger screens. Elements intended to be hidden on desktop may reappear on hover alongside their desktop counterparts.
 **Action:** Pair `hidden` / `block` utilities with opacity transitions when elements should be completely removed from the layout/accessibility tree on specific breakpoints, or ensure hover states are scoped to the correct breakpoint (e.g., `md:group-hover:opacity-100` vs `group-hover:opacity-100`).
 
-## 2024-05-27 - [Focus Management in Conditional Rendering]
-**Learning:** When replacing an interactive element (like a button) with new content (like a confirmation dialog) via conditional rendering, keyboard focus is lost to the document body, confusing screen reader users and breaking tab navigation flow.
-**Action:** Use `autoFocus` on the primary action of the new content to guide focus immediately, and ensure focus is restored to the trigger element (or a logical equivalent) when the new content is dismissed, using state-controlled `autoFocus` or `useEffect`.
+## 2024-05-26 - [Focus Management in Conditional UI]
+**Learning:** For simple UI toggles (e.g., replacing a button with a confirmation dialog), conditionally rendering elements with `autoFocus` is a robust and minimal pattern for managing focus. It avoids complex `useEffect` + `useRef` logic while ensuring keyboard users are not lost when the DOM structure changes.
+**Action:** Use conditional rendering + `autoFocus` for inline confirmation states to preserve keyboard context.
+
+## 2024-05-27 - [Focus Restoration Precision]
+**Learning:** While `autoFocus` handles initial focus well, using it for *restoration* (e.g. going back to a trigger button) can cause "sticky" focus on re-renders if state isn't managed perfectly. A `useRef` + `useEffect` pattern offers more precise control for restoring focus without side effects.
+**Action:** Prefer `useRef` and `useEffect` over state-controlled `autoFocus` when precise focus restoration is needed after closing a modal/dialog.

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -3,10 +3,21 @@ import { Trash2, Check, X } from 'lucide-react';
 
 const ChatHeader = ({ clearHistory }) => {
     const [showConfirm, setShowConfirm] = useState(false);
+    const [shouldFocusTrash, setShouldFocusTrash] = useState(false);
 
     const handleClear = () => {
         clearHistory();
         setShowConfirm(false);
+        setShouldFocusTrash(true);
+    };
+
+    const handleCancel = () => {
+        setShowConfirm(false);
+        setShouldFocusTrash(true);
+    };
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Escape') handleCancel();
     };
 
     return (
@@ -16,7 +27,10 @@ const ChatHeader = ({ clearHistory }) => {
             </div>
 
             {showConfirm ? (
-                <div className="flex items-center gap-2">
+                <div
+                    className="flex items-center gap-2"
+                    onKeyDown={handleKeyDown}
+                >
                     <span className="text-sm text-gray-400">Confirmar?</span>
                     <button
                         onClick={handleClear}
@@ -27,20 +41,22 @@ const ChatHeader = ({ clearHistory }) => {
                         <Check size={20} />
                     </button>
                     <button
-                        onClick={() => setShowConfirm(false)}
+                        onClick={handleCancel}
                         className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800"
                         title="Cancelar"
                         aria-label="Cancelar"
+                        autoFocus
                     >
                         <X size={20} />
                     </button>
                 </div>
             ) : (
                 <button
-                    onClick={() => setShowConfirm(true)}
+                    onClick={() => { setShowConfirm(true); setShouldFocusTrash(false); }}
                     className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800"
                     title="Limpar conversa"
                     aria-label="Limpar conversa"
+                    autoFocus={shouldFocusTrash}
                 >
                     <Trash2 size={20} />
                 </button>

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -1,9 +1,17 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Trash2, Check, X } from 'lucide-react';
 
 const ChatHeader = ({ clearHistory }) => {
     const [showConfirm, setShowConfirm] = useState(false);
     const [shouldFocusTrash, setShouldFocusTrash] = useState(false);
+    const trashRef = useRef(null);
+
+    useEffect(() => {
+        if (!showConfirm && shouldFocusTrash && trashRef.current) {
+            trashRef.current.focus();
+            setShouldFocusTrash(false);
+        }
+    }, [showConfirm, shouldFocusTrash]);
 
     const handleClear = () => {
         clearHistory();
@@ -52,11 +60,11 @@ const ChatHeader = ({ clearHistory }) => {
                 </div>
             ) : (
                 <button
-                    onClick={() => { setShowConfirm(true); setShouldFocusTrash(false); }}
+                    ref={trashRef}
+                    onClick={() => setShowConfirm(true)}
                     className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800"
                     title="Limpar conversa"
                     aria-label="Limpar conversa"
-                    autoFocus={shouldFocusTrash}
                 >
                     <Trash2 size={20} />
                 </button>

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -3,29 +3,34 @@ import { Trash2, Check, X } from 'lucide-react';
 
 const ChatHeader = ({ clearHistory }) => {
     const [showConfirm, setShowConfirm] = useState(false);
-    const [shouldFocusTrash, setShouldFocusTrash] = useState(false);
     const trashRef = useRef(null);
+    const prevShowConfirm = useRef(showConfirm);
 
     useEffect(() => {
-        if (!showConfirm && shouldFocusTrash && trashRef.current) {
+        // Focus restoration when confirmation closes
+        if (prevShowConfirm.current && !showConfirm && trashRef.current) {
             trashRef.current.focus();
-            setShouldFocusTrash(false);
         }
-    }, [showConfirm, shouldFocusTrash]);
+        prevShowConfirm.current = showConfirm;
+    }, [showConfirm]);
+
+    useEffect(() => {
+        // Handle Escape key globally when confirmation is open
+        const handleKeyDown = (e) => {
+            if (e.key === 'Escape') {
+                setShowConfirm(false);
+            }
+        };
+
+        if (showConfirm) {
+            document.addEventListener('keydown', handleKeyDown);
+        }
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [showConfirm]);
 
     const handleClear = () => {
         clearHistory();
         setShowConfirm(false);
-        setShouldFocusTrash(true);
-    };
-
-    const handleCancel = () => {
-        setShowConfirm(false);
-        setShouldFocusTrash(true);
-    };
-
-    const handleKeyDown = (e) => {
-        if (e.key === 'Escape') handleCancel();
     };
 
     return (
@@ -35,10 +40,7 @@ const ChatHeader = ({ clearHistory }) => {
             </div>
 
             {showConfirm ? (
-                <div
-                    className="flex items-center gap-2"
-                    onKeyDown={handleKeyDown}
-                >
+                <div className="flex items-center gap-2">
                     <span className="text-sm text-gray-400">Confirmar?</span>
                     <button
                         onClick={handleClear}
@@ -49,7 +51,7 @@ const ChatHeader = ({ clearHistory }) => {
                         <Check size={20} />
                     </button>
                     <button
-                        onClick={handleCancel}
+                        onClick={() => setShowConfirm(false)}
                         className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800"
                         title="Cancelar"
                         aria-label="Cancelar"


### PR DESCRIPTION
This PR improves the accessibility of the "Clear History" confirmation in the ChatHeader component.

**Changes:**
- Implemented focus management: Focus now moves to the "Cancel" button when the confirmation dialog opens, and returns to the "Trash" button when it closes.
- Added `Escape` key support: Users can now dismiss the confirmation dialog by pressing the Escape key.
- Updated `ChatHeader.jsx` to use `autoFocus` and state-controlled focus restoration.

**Why:**
Previously, when the "Trash" button was replaced by the confirmation buttons, focus was lost to the document body, forcing keyboard users to tab through the interface again to find the controls. This change ensures a seamless keyboard navigation experience.

**Verification:**
- Verified using a custom Playwright script that tested:
    - Focus moving to "Cancel" on open.
    - Focus returning to "Trash" on Escape.
    - Focus returning to "Trash" on Cancel click.
- Ran `pnpm lint` and `pnpm build` successfully.

---
*PR created automatically by Jules for task [7316594142307566910](https://jules.google.com/task/7316594142307566910) started by @RenyEnnos*

## Summary by Sourcery

Melhora o gerenciamento de foco do teclado e a acessibilidade da caixa de diálogo de confirmação de limpeza de histórico no cabeçalho do chat.

Novos recursos:
- Adicionar gerenciamento de foco do teclado para que o botão de cancelamento da confirmação receba foco quando exibido e o foco retorne ao botão de lixeira quando a caixa de diálogo for fechada.
- Permitir dispensar a caixa de diálogo de confirmação de limpeza de histórico com a tecla Escape.

Aprimoramentos:
- Refinar o estado de `ChatHeader` para controlar quando o botão de lixeira recupera o foco após ações de confirmação.
- Documentar padrões de gerenciamento de foco para elementos interativos renderizados condicionalmente nas notas do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve keyboard focus management and accessibility for the chat header's clear-history confirmation dialog.

New Features:
- Add keyboard focus management so the confirmation cancel button is focused when shown and focus returns to the trash button when dismissed.
- Allow dismissing the clear-history confirmation dialog with the Escape key.

Enhancements:
- Refine ChatHeader state to control when the trash button regains focus after confirmation actions.
- Document focus management patterns for conditionally rendered interactive elements in the Palette notes.

</details>