### PR TITLE
🎨 Palette: Improve ChatHeader focus management and keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2024-05-25 - [Responsive Visibility Overlap]
 **Learning:** Using only `opacity` for responsive visibility (e.g., `md:opacity-0`) can lead to duplicate interactive elements if hover states (`group-hover:opacity-100`) override the opacity on larger screens. Elements intended to be hidden on desktop may reappear on hover alongside their desktop counterparts.
 **Action:** Pair `hidden` / `block` utilities with opacity transitions when elements should be completely removed from the layout/accessibility tree on specific breakpoints, or ensure hover states are scoped to the correct breakpoint (e.g., `md:group-hover:opacity-100` vs `group-hover:opacity-100`).
+
+## 2024-05-26 - [Focus Management in Conditional UI]
+**Learning:** When conditional rendering swaps interactive elements (like a delete button becoming a confirmation dialog), focus management is crucial. Without `autoFocus` on the new element and a strategy to restore focus to the trigger (or its replacement) upon cancellation, keyboard users get lost.
+**Action:** Pair conditional UI swaps with `autoFocus` on the entering element and a state/ref mechanism to restore focus to the returning trigger.

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -3,10 +3,17 @@ import { Trash2, Check, X } from 'lucide-react';
 
 const ChatHeader = ({ clearHistory }) => {
     const [showConfirm, setShowConfirm] = useState(false);
+    const [shouldFocusTrash, setShouldFocusTrash] = useState(false);
 
     const handleClear = () => {
         clearHistory();
         setShowConfirm(false);
+        setShouldFocusTrash(true);
+    };
+
+    const handleCancel = () => {
+        setShowConfirm(false);
+        setShouldFocusTrash(true);
     };
 
     return (
@@ -16,7 +23,12 @@ const ChatHeader = ({ clearHistory }) => {
             </div>
 
             {showConfirm ? (
-                <div className="flex items-center gap-2">
+                <div
+                    className="flex items-center gap-2"
+                    onKeyDown={(e) => {
+                        if (e.key === 'Escape') handleCancel();
+                    }}
+                >
                     <span className="text-sm text-gray-400">Confirmar?</span>
                     <button
                         onClick={handleClear}
@@ -27,20 +39,25 @@ const ChatHeader = ({ clearHistory }) => {
                         <Check size={20} />
                     </button>
                     <button
-                        onClick={() => setShowConfirm(false)}
+                        onClick={handleCancel}
                         className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800"
                         title="Cancelar"
                         aria-label="Cancelar"
+                        autoFocus
                     >
                         <X size={20} />
                     </button>
                 </div>
             ) : (
                 <button
-                    onClick={() => setShowConfirm(true)}
+                    onClick={() => {
+                        setShowConfirm(true);
+                        setShouldFocusTrash(true);
+                    }}
                     className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800"
                     title="Limpar conversa"
                     aria-label="Limpar conversa"
+                    autoFocus={shouldFocusTrash}
                 >
                     <Trash2 size={20} />
                 </button>


### PR DESCRIPTION
💡 **What:**
- Added `autoFocus` to the "Cancel" button in the confirmation dialog.
- Added `autoFocus` to the "Trash" button (conditionally) to restore focus after cancellation.
- Added `Escape` key support to dismiss the confirmation dialog.

🎯 **Why:**
- Previously, clicking "Trash" caused focus to be lost when the button was replaced by the confirmation dialog.
- Keyboard users had to manually tab back to the controls.
- There was no keyboard shortcut to cancel the destructive action.

📸 **Before/After:**
- **Before:** Focus lost on click. No visual indicator of where focus went.
- **After:** Focus lands immediately on "Cancel" (safe default). Focus returns to "Trash" after cancelling. Escape key works.

♿ **Accessibility:**
- Improved focus management for screen readers and keyboard users.
- Added keyboard shortcuts (`Esc`).

---
*PR created automatically by Jules for task [13953765075049981978](https://jules.google.com/task/13953765075049981978) started by @RenyEnnos*

## Summary by Sourcery

Melhora o gerenciamento de foco e a acessibilidade via teclado no fluxo de confirmação de limpar histórico no cabeçalho do chat.

Novos recursos:
- Permitir dispensar o diálogo de confirmação de limpar histórico com a tecla Escape.

Melhorias:
- Garantir que o diálogo de confirmação dê foco automaticamente ao botão Cancelar quando for aberto.
- Restaurar o foco para o botão Trash após confirmar ou cancelar a ação de limpar histórico por meio de uma flag de foco.
- Documentar as melhores práticas de gerenciamento de foco para trocas condicionais de UI nas notas do Palette.

Documentação:
- Adicionar uma entrada no Palette descrevendo estratégias de gerenciamento de foco para elementos de UI renderizados condicionalmente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve focus management and keyboard accessibility in the chat header's clear-history confirmation flow.

New Features:
- Allow dismissing the clear-history confirmation dialog with the Escape key.

Enhancements:
- Ensure the confirmation dialog auto-focuses the Cancel button when opened.
- Restore focus to the Trash button after confirming or cancelling the clear-history action via a focus flag.
- Document focus management best practices for conditional UI swaps in the Palette notes.

Documentation:
- Add a Palette entry describing focus management strategies for conditionally rendered UI elements.

</details>