### PR TITLE
🎨 Palette: Fix focus management and code duplicates in ChatHeader

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,7 @@
 ## 2024-05-27 - [Focus Restoration Precision]
 **Learning:** While `autoFocus` handles initial focus well, using it for *restoration* (e.g. going back to a trigger button) can cause "sticky" focus on re-renders if state isn't managed perfectly. A `useRef` + `useEffect` pattern offers more precise control for restoring focus without side effects.
 **Action:** Prefer `useRef` and `useEffect` over state-controlled `autoFocus` when precise focus restoration is needed after closing a modal/dialog.
+
+## 2024-05-28 - [Single Source of Truth for Focus]
+**Learning:** Mixing declarative focus (`autoFocus`) with imperative focus logic (`useEffect`, state-based flags) leads to duplicate attributes and unpredictable behavior. Code becomes fragile and harder to maintain when multiple mechanisms try to control the same focus event.
+**Action:** Enforce a single strategy for each focus transition: use `autoFocus` for entry into new contexts (like modals), and `useEffect/useRef` for restoring focus to previous contexts.

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -27,22 +27,10 @@ const ChatHeader = ({ clearHistory }) => {
         }
         return () => document.removeEventListener('keydown', handleKeyDown);
     }, [showConfirm]);
-    const [shouldFocusTrash, setShouldFocusTrash] = useState(false);
 
     const handleClear = () => {
         clearHistory();
         setShowConfirm(false);
-    };
-
-    const handleTrashClick = () => {
-        setShouldFocusTrash(true);
-        setShowConfirm(true);
-    };
-
-    const handleKeyDown = (e) => {
-        if (e.key === 'Escape') {
-            setShowConfirm(false);
-        }
     };
 
     return (
@@ -52,10 +40,7 @@ const ChatHeader = ({ clearHistory }) => {
             </div>
 
             {showConfirm ? (
-                <div
-                    className="flex items-center gap-2"
-                    onKeyDown={handleKeyDown}
-                >
+                <div className="flex items-center gap-2">
                     <span className="text-sm text-gray-400">Confirmar?</span>
                     <button
                         onClick={handleClear}
@@ -68,26 +53,17 @@ const ChatHeader = ({ clearHistory }) => {
                     <button
                         autoFocus
                         onClick={() => setShowConfirm(false)}
-                        autoFocus
                         className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800"
                         title="Cancelar"
                         aria-label="Cancelar"
-                        autoFocus
                     >
                         <X size={20} />
                     </button>
                 </div>
             ) : (
                 <button
-                    autoFocus={shouldFocusTrash}
-                    onClick={handleTrashClick}
-                    ref={trashRef}
                     onClick={() => setShowConfirm(true)}
-                    onClick={() => {
-                        setShouldFocusTrash(true);
-                        setShowConfirm(true);
-                    }}
-                    autoFocus={shouldFocusTrash}
+                    ref={trashRef}
                     className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800"
                     title="Limpar conversa"
                     aria-label="Limpar conversa"


### PR DESCRIPTION
This PR refactors `ChatHeader.jsx` to resolve code quality issues and improve accessibility. It removes duplicate event handlers and attributes, and establishes a clean pattern for focus management (using `autoFocus` for entry and `useEffect` for restoration). This ensures the "Trash" and "Cancel" buttons behave predictably for keyboard users.


---
*PR created automatically by Jules for task [12136736082912383703](https://jules.google.com/task/12136736082912383703) started by @RenyEnnos*

## Summary by Sourcery

Refinar o comportamento de foco no cabeçalho do chat e limpar o tratamento duplicado de eventos, documentando ao mesmo tempo as diretrizes atualizadas de gerenciamento de foco nas notas do Palette.

Melhorias:
- Simplificar a interface de confirmação do ChatHeader removendo manipuladores de clique duplicados e lógica redundante de `keydown` que controla o estado de confirmação.
- Tornar o tratamento de foco nos botões de cancelar e lixeira mais enxuto, passando a depender de uma única estratégia previsível de gerenciamento de foco.

Documentação:
- Ampliar as notas de gerenciamento de foco do Palette com orientações sobre o uso de uma única estratégia por transição de foco e sobre a separação entre foco de entrada e foco de restauração.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine chat header focus behavior and clean up duplicate event handling, while documenting updated focus management guidelines in the Palette notes.

Enhancements:
- Simplify ChatHeader confirmation UI by removing duplicate click handlers and redundant keydown logic controlling the confirm state.
- Streamline focus handling on the cancel and trash buttons to rely on a single, predictable focus management strategy.

Documentation:
- Extend the Palette focus management notes with guidance on using a single strategy per focus transition and separating entry focus from restoration focus.

</details>