### PR TITLE
🎨 Palette: Fix ChatHeader duplicate props & improve a11y

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,7 @@
 ## 2024-05-27 - [Focus Restoration Precision]
 **Learning:** While `autoFocus` handles initial focus well, using it for *restoration* (e.g. going back to a trigger button) can cause "sticky" focus on re-renders if state isn't managed perfectly. A `useRef` + `useEffect` pattern offers more precise control for restoring focus without side effects.
 **Action:** Prefer `useRef` and `useEffect` over state-controlled `autoFocus` when precise focus restoration is needed after closing a modal/dialog.
+
+## 2024-05-28 - [Inline Confirmation Semantics]
+**Learning:** When replacing a trigger button with inline confirmation controls, simply swapping elements can confuse screen readers. Wrapping the confirmation controls in a container with `role="group"` and `aria-label` provides necessary context that a modal would otherwise provide, without the overhead of a full dialog trap.
+**Action:** Wrap inline confirmation actions in a semantic group with a clear label to maintain context for assistive technology.

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -5,6 +5,7 @@ const ChatHeader = ({ clearHistory }) => {
     const [showConfirm, setShowConfirm] = useState(false);
     const trashRef = useRef(null);
     const prevShowConfirm = useRef(showConfirm);
+    const [shouldFocusTrash, setShouldFocusTrash] = useState(false);
 
     useEffect(() => {
         // Focus restoration when confirmation closes
@@ -27,7 +28,6 @@ const ChatHeader = ({ clearHistory }) => {
         }
         return () => document.removeEventListener('keydown', handleKeyDown);
     }, [showConfirm]);
-    const [shouldFocusTrash, setShouldFocusTrash] = useState(false);
 
     const handleClear = () => {
         clearHistory();
@@ -39,12 +39,6 @@ const ChatHeader = ({ clearHistory }) => {
         setShowConfirm(true);
     };
 
-    const handleKeyDown = (e) => {
-        if (e.key === 'Escape') {
-            setShowConfirm(false);
-        }
-    };
-
     return (
         <header className="flex-shrink-0 h-16 border-b border-gray-800 flex items-center justify-between px-4 md:px-8 bg-gray-900 z-10">
             <div className="font-semibold text-lg tracking-tight text-white">
@@ -54,41 +48,40 @@ const ChatHeader = ({ clearHistory }) => {
             {showConfirm ? (
                 <div
                     className="flex items-center gap-2"
-                    onKeyDown={handleKeyDown}
+                    role="group"
+                    aria-label="Confirmar limpeza do histórico"
                 >
-                    <span className="text-sm text-gray-400">Confirmar?</span>
+                    <span
+                        className="text-sm text-gray-400 animate-in fade-in duration-200"
+                        id="confirm-text"
+                    >
+                        Limpar histórico?
+                    </span>
                     <button
                         onClick={handleClear}
-                        className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-md hover:bg-gray-800"
+                        className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-red-400 focus:outline-none"
                         title="Confirmar limpeza"
                         aria-label="Confirmar limpeza"
+                        aria-describedby="confirm-text"
                     >
                         <Check size={20} />
                     </button>
                     <button
-                        autoFocus
                         onClick={() => setShowConfirm(false)}
                         autoFocus
-                        className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800"
+                        className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-gray-400 focus:outline-none"
                         title="Cancelar"
                         aria-label="Cancelar"
-                        autoFocus
                     >
                         <X size={20} />
                     </button>
                 </div>
             ) : (
                 <button
-                    autoFocus={shouldFocusTrash}
                     onClick={handleTrashClick}
                     ref={trashRef}
-                    onClick={() => setShowConfirm(true)}
-                    onClick={() => {
-                        setShouldFocusTrash(true);
-                        setShowConfirm(true);
-                    }}
                     autoFocus={shouldFocusTrash}
-                    className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800"
+                    className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-red-400 focus:outline-none"
                     title="Limpar conversa"
                     aria-label="Limpar conversa"
                 >


### PR DESCRIPTION
* 💡 What: Removed duplicate `onClick` and `autoFocus` props from the "Clear Chat" button and refactored the confirmation dialog.
* 🎯 Why: To fix potential runtime bugs and improve accessibility for screen reader and keyboard users.
* ♿ Accessibility: Added `role="group"`, `aria-label`, `aria-describedby` for confirmation state; ensured `autoFocus` on Cancel; improved focus visibility rings.
* References: Fixed `ChatHeader.jsx` duplicate props issue.

---
*PR created automatically by Jules for task [9654822169804411036](https://jules.google.com/task/9654822169804411036) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a experiência de uso (UX) e a acessibilidade da confirmação inline de limpar histórico no cabeçalho do chat, ao mesmo tempo em que se remove props duplicadas.

Correções de bugs:
- Remover handlers duplicados de clique e `autoFocus` do botão de disparo de limpar histórico para evitar comportamentos conflitantes.

Melhorias:
- Refinar a interface de confirmação inline de limpar histórico com um melhor tratamento de foco e anéis de foco visíveis para os botões de ação.
- Adicionar semântica ARIA apropriada (papel de grupo, rótulos e descrições) aos controles de confirmação para melhorar o contexto para leitores de tela.

Documentação:
- Documentar padrões de acessibilidade para confirmações inline e diretrizes nas notas do Palette, incluindo o uso de semântica de grupo em vez de diálogos completos.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the chat header’s inline clear-history confirmation UX and accessibility while cleaning up duplicated props.

Bug Fixes:
- Remove duplicated click and autoFocus handlers from the clear-history trigger button to prevent conflicting behavior.

Enhancements:
- Refine the inline clear-history confirmation UI with better focus handling and visible focus rings for action buttons.
- Add appropriate ARIA semantics (group role, labels, and descriptions) to the confirmation controls to improve screen reader context.

Documentation:
- Document inline confirmation accessibility patterns and guidance in the Palette notes, including using grouped semantics instead of full dialogs.

</details>