### PR TITLE
🎨 Palette: Enhanced Markdown Styling in Messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -24,3 +24,7 @@
 ## 2024-05-28 - [Inline Confirmation Semantics]
 **Learning:** When replacing a trigger button with inline confirmation controls, simply swapping elements can confuse screen readers. Wrapping the confirmation controls in a container with `role="group"` and `aria-label` provides necessary context that a modal would otherwise provide, without the overhead of a full dialog trap.
 **Action:** Wrap inline confirmation actions in a semantic group with a clear label to maintain context for assistive technology.
+
+## 2024-05-30 - [Markdown Component Styling]
+**Learning:** `react-markdown` v9 removes the `inline` prop for code components, making it tricky to distinguish inline `code` from block `pre`. However, using a CSS descendant selector pattern (e.g., `pre` styling `[&>code]:bg-transparent`) allows for clean separation of block vs. inline styles without complex logic or additional dependencies.
+**Action:** Use parent-based CSS selectors to style nested components when direct props are unavailable or unreliable.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -31,7 +31,36 @@ const MessageBubble = ({ message, isUser }) => {
                         <div className="markdown-content">
                             <ReactMarkdown
                                 components={{
-                                    em: ({ node, ...props }) => <span className="text-gray-400 italic" {...props} />
+                                    em: ({ node, ...props }) => <span className="text-gray-400 italic" {...props} />,
+                                    code: ({ node, className, children, ...props }) => {
+                                        const bgClass = isUser ? 'bg-blue-800 text-blue-100' : 'bg-gray-900 text-gray-200';
+                                        return (
+                                            <code className={`${bgClass} px-1.5 py-0.5 rounded text-sm font-mono break-words`} {...props}>
+                                                {children}
+                                            </code>
+                                        );
+                                    },
+                                    pre: ({ node, children, ...props }) => {
+                                        const containerClass = isUser ? 'bg-blue-900 border-blue-700' : 'bg-gray-950 border-gray-700';
+                                        return (
+                                            <pre className={`${containerClass} text-gray-200 p-4 rounded-lg overflow-x-auto text-sm my-3 border shadow-inner [&>code]:bg-transparent [&>code]:p-0 [&>code]:text-inherit`} {...props}>
+                                                {children}
+                                            </pre>
+                                        );
+                                    },
+                                    a: ({ node, ...props }) => {
+                                        const linkClass = isUser ? 'text-white underline hover:text-blue-100' : 'text-blue-400 hover:text-blue-300 underline';
+                                        return <a className={`${linkClass} transition-colors font-medium`} target="_blank" rel="noopener noreferrer" {...props} />;
+                                    },
+                                    h1: ({ node, ...props }) => <h1 className="text-xl font-bold mt-4 mb-2" {...props} />,
+                                    h2: ({ node, ...props }) => <h2 className="text-lg font-semibold mt-3 mb-2" {...props} />,
+                                    h3: ({ node, ...props }) => <h3 className="text-base font-medium mt-2 mb-1" {...props} />,
+                                    ul: ({ node, ...props }) => <ul className="list-disc list-outside ml-4 mb-2 space-y-1" {...props} />,
+                                    ol: ({ node, ...props }) => <ol className="list-decimal list-outside ml-4 mb-2 space-y-1" {...props} />,
+                                    blockquote: ({ node, ...props }) => {
+                                        const borderClass = isUser ? 'border-blue-400 bg-blue-700/30' : 'border-gray-600 bg-gray-700/30';
+                                        return <blockquote className={`border-l-4 ${borderClass} pl-3 py-1 my-2 italic rounded-r`} {...props} />;
+                                    },
                                 }}
                             >
                                 {message}
@@ -46,7 +75,7 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-500 outline-none"
                             aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >


### PR DESCRIPTION
*   💡 **What:** Added custom component styling for `react-markdown` in `MessageBubble.jsx`.
*   🎯 **Why:** Default markdown rendering (especially for code blocks, headers, and links) was unstyled and hard to read in the dark theme.
*   ♿ **Accessibility:** Improved code block readability with proper contrast and overflow handling; clear header hierarchy; discernible links.

---
*PR created automatically by Jules for task [13061492423579114440](https://jules.google.com/task/13061492423579114440) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a renderização de Markdown e a acessibilidade nos balões de mensagens do chat.

Aprimoramentos:
- Personalizar a renderização do `react-markdown` para código, cabeçalhos, listas, links e citações em bloco com estilos compatíveis com o tema em `MessageBubble`.
- Ajustar o estilo de blocos de código e texto pré-formatado para melhor legibilidade, contraste e tratamento de overflow no tema escuro.
- Melhorar a visibilidade do foco de teclado no botão de copiar mensagem para aumentar a acessibilidade.
- Documentar um padrão para estilização de componentes do `react-markdown` usando seletores CSS baseados no elemento pai nas notas da paleta.

Documentação:
- Adicionar entrada na paleta descrevendo a abordagem de estilização de componentes Markdown com `react-markdown` e seletores descendentes de CSS.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Markdown rendering and accessibility in chat message bubbles.

Enhancements:
- Customize react-markdown rendering for code, headings, lists, links, and blockquotes with theme-aware styles in MessageBubble.
- Adjust code and preformatted block styling for better readability, contrast, and overflow handling in dark theme.
- Enhance keyboard focus visibility on the message copy button for improved accessibility.
- Document a pattern for styling react-markdown components using parent-based CSS selectors in the palette notes.

Documentation:
- Add palette entry describing Markdown component styling approach with react-markdown and CSS descendant selectors.

</details>