### PR TITLE
🎨 Palette: Enhance Markdown Styling in Chat Bubbles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -24,3 +24,7 @@
 ## 2024-05-28 - [Inline Confirmation Semantics]
 **Learning:** When replacing a trigger button with inline confirmation controls, simply swapping elements can confuse screen readers. Wrapping the confirmation controls in a container with `role="group"` and `aria-label` provides necessary context that a modal would otherwise provide, without the overhead of a full dialog trap.
 **Action:** Wrap inline confirmation actions in a semantic group with a clear label to maintain context for assistive technology.
+
+## 2024-05-29 - [Styling React Markdown v9]
+**Learning:** `react-markdown` v9 removed the `inline` prop from the `code` component, making it difficult to distinguish between inline code and code blocks for styling. However, code blocks are always wrapped in a `pre` element.
+**Action:** Style the `code` component with inline styles by default, and use a parent combinator in the `pre` component (e.g., `[&_code]:bg-transparent`) to override these styles for code blocks.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -31,7 +31,64 @@ const MessageBubble = ({ message, isUser }) => {
                         <div className="markdown-content">
                             <ReactMarkdown
                                 components={{
-                                    em: ({ node, ...props }) => <span className="text-gray-400 italic" {...props} />
+                                    // Headers
+                                    h1: ({ node, ...props }) => <h1 className="text-xl font-bold mt-4 mb-2" {...props} />,
+                                    h2: ({ node, ...props }) => <h2 className="text-lg font-bold mt-3 mb-2" {...props} />,
+                                    h3: ({ node, ...props }) => <h3 className="text-base font-bold mt-2 mb-1" {...props} />,
+
+                                    // Links
+                                    a: ({ node, ...props }) => (
+                                        <a
+                                            className={`hover:underline break-all ${isUser ? 'text-white underline' : 'text-blue-400'}`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            {...props}
+                                        />
+                                    ),
+
+                                    // Lists
+                                    ul: ({ node, ...props }) => <ul className="list-disc pl-5 space-y-1 my-2" {...props} />,
+                                    ol: ({ node, ...props }) => <ol className="list-decimal pl-5 space-y-1 my-2" {...props} />,
+                                    li: ({ node, ...props }) => <li className="pl-1" {...props} />,
+
+                                    // Code
+                                    code: ({ node, inline, className, children, ...props }) => {
+                                        return (
+                                            <code
+                                                className={`px-1.5 py-0.5 rounded text-sm font-mono ${isUser
+                                                    ? 'bg-blue-700 text-blue-100'
+                                                    : 'bg-gray-700 text-gray-200 border border-gray-600'}`}
+                                                {...props}
+                                            >
+                                                {children}
+                                            </code>
+                                        );
+                                    },
+                                    pre: ({ node, ...props }) => (
+                                        <div className={`rounded-lg overflow-hidden my-3 border ${isUser
+                                            ? 'bg-blue-800 border-blue-700'
+                                            : 'bg-gray-950 border-gray-700'}`}>
+                                            <pre
+                                                className={`p-3 overflow-x-auto font-mono text-sm [&_code]:bg-transparent [&_code]:border-none [&_code]:p-0`}
+                                                {...props}
+                                            />
+                                        </div>
+                                    ),
+
+                                    // Blockquotes
+                                    blockquote: ({ node, ...props }) => (
+                                        <blockquote
+                                            className={`border-l-4 pl-4 italic my-2 ${isUser
+                                                ? 'border-blue-400 text-blue-100'
+                                                : 'border-gray-600 text-gray-400'}`}
+                                            {...props}
+                                        />
+                                    ),
+
+                                    // Emphasis
+                                    em: ({ node, ...props }) => (
+                                        <span className={`italic ${isUser ? 'text-blue-100' : 'text-gray-400'}`} {...props} />
+                                    )
                                 }}
                             >
                                 {message}


### PR DESCRIPTION
Enhanced the Markdown rendering in chat bubbles to provide a richer and more readable experience.

**Improvements:**
- **Code Blocks:** Now have a distinct dark background, padding, and horizontal scroll support. Inline code styles are correctly applied only to inline code segments.
- **Links:** Rendered in blue with underline on hover, and include `rel="noopener noreferrer"` for security.
- **Lists:** Unordered and ordered lists are now properly styled with bullets/numbers and indentation.
- **Headers:** H1-H3 are now larger and bold.
- **Blockquotes:** Styled with a left border and italic text.

**Technical Details:**
- Addressed `react-markdown` v9 limitation where `inline` prop is missing for `code` component by applying base styles to `code` and overriding them in the `pre` component using Tailwind's `[&_code]` selector.
- Verified using a Playwright script to inspect DOM classes and visual inspection via screenshot.

---
*PR created automatically by Jules for task [11715515603428205352](https://jules.google.com/task/11715515603428205352) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a renderização de markdown e a legibilidade dentro dos balões de mensagens do chat e documentar a abordagem de estilização escolhida para o react-markdown v9.

Novos recursos:
- Adicionar estilização markdown rica para cabeçalhos, links, listas, código e citações em bloco dentro dos balões de mensagens do chat.

Aprimoramentos:
- Diferenciar a estilização para conteúdo markdown do usuário vs. assistente, incluindo links, ênfase e blocos de código, para melhor clareza visual.

Documentação:
- Documentar a estratégia de estilização para elementos `code` vs. `pre` do react-markdown v9 na documentação da paleta.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance markdown rendering and readability within chat message bubbles and document the chosen styling approach for react-markdown v9.

New Features:
- Add rich markdown styling for headers, links, lists, code, and blockquotes within chat message bubbles.

Enhancements:
- Differentiate styling for user vs. assistant markdown content, including links, emphasis, and code blocks for better visual clarity.

Documentation:
- Document the styling strategy for react-markdown v9 code vs. pre elements in the palette documentation.

</details>