### PR TITLE
🎨 Palette: Improve markdown styling in chat bubbles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -24,3 +24,7 @@
 ## 2024-05-28 - [Inline Confirmation Semantics]
 **Learning:** When replacing a trigger button with inline confirmation controls, simply swapping elements can confuse screen readers. Wrapping the confirmation controls in a container with `role="group"` and `aria-label` provides necessary context that a modal would otherwise provide, without the overhead of a full dialog trap.
 **Action:** Wrap inline confirmation actions in a semantic group with a clear label to maintain context for assistive technology.
+
+## 2024-05-30 - [Markdown Accessibility]
+**Learning:** `react-markdown` v9 renders plain HTML elements that are unstyled by default in Tailwind, making lists and code blocks inaccessible and hard to scan. Custom component mapping is required to restore visual hierarchy and accessibility (e.g., proper list bullets, code block contrast).
+**Action:** Always provide custom components for `ul`, `ol`, `code`, `pre`, and `a` when using `react-markdown` in a Tailwind project to ensure readability and accessibility.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -31,7 +31,26 @@ const MessageBubble = ({ message, isUser }) => {
                         <div className="markdown-content">
                             <ReactMarkdown
                                 components={{
-                                    em: ({ node, ...props }) => <span className="text-gray-400 italic" {...props} />
+                                    em: ({ node, ...props }) => <span className="italic opacity-80" {...props} />,
+                                    strong: ({ node, ...props }) => <span className="font-semibold" {...props} />,
+                                    ul: ({ node, ...props }) => <ul className="list-disc pl-4 space-y-1 my-2" {...props} />,
+                                    ol: ({ node, ...props }) => <ol className="list-decimal pl-4 space-y-1 my-2" {...props} />,
+                                    li: ({ node, ...props }) => <li className="pl-1" {...props} />,
+                                    a: ({ node, ...props }) => (
+                                        <a target="_blank" rel="noopener noreferrer"
+                                           className={`underline ${isUser ? 'text-blue-100 hover:text-white' : 'text-blue-400 hover:text-blue-300'}`}
+                                           {...props}
+                                        />
+                                    ),
+                                    code: ({ node, ...props }) => (
+                                        <code className={`font-mono text-xs px-1 py-0.5 rounded ${isUser ? 'bg-blue-700 text-blue-50' : 'bg-gray-900 text-pink-200'}`} {...props} />
+                                    ),
+                                    pre: ({ node, ...props }) => (
+                                        <pre className={`p-3 rounded-lg overflow-x-auto my-2 border text-sm [&_code]:bg-transparent [&_code]:p-0 [&_code]:text-inherit ${isUser ? 'bg-blue-800 border-blue-700 text-blue-50' : 'bg-gray-950 border-gray-700 text-gray-300'}`} {...props} />
+                                    ),
+                                    blockquote: ({ node, ...props }) => (
+                                        <blockquote className={`border-l-4 pl-3 py-1 italic my-2 ${isUser ? 'border-blue-400 text-blue-100' : 'border-gray-600 text-gray-400'}`} {...props} />
+                                    )
                                 }}
                             >
                                 {message}


### PR DESCRIPTION
Improved the UX and accessibility of chat messages by adding custom styling for Markdown elements. Previously, lists, code blocks, and links were rendered as unstyled HTML, making them hard to distinguish and read. This change introduces tailored Tailwind classes for these elements, ensuring lists have bullets/numbers, code blocks are distinct and scrollable, and links are clearly visible. It also handles color contrast correctly depending on whether the message is from the user (blue background) or the assistant (dark gray background).

---
*PR created automatically by Jules for task [5603910041327035615](https://jules.google.com/task/5603910041327035615) started by @RenyEnnos*

## Summary by Sourcery

Melhora a renderização de Markdown e a acessibilidade nos balões de mensagens de chat e documenta o padrão na paleta.

Melhorias:
- Estilizar elementos Markdown nos balões de chat (ênfase, listas, links, código, texto pré-formatado, citações em bloco) com classes do Tailwind que respeitam os temas de balão do usuário vs assistente para melhor legibilidade e contraste.

Documentação:
- Adicionar uma entrada na paleta descrevendo considerações de acessibilidade e componentes personalizados necessários ao usar react-markdown com Tailwind.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Markdown rendering and accessibility in chat message bubbles and document the pattern in the palette.

Enhancements:
- Style Markdown elements in chat bubbles (emphasis, lists, links, code, preformatted text, blockquotes) with Tailwind classes that respect user vs assistant bubble themes for better readability and contrast.

Documentation:
- Add a palette entry describing accessibility considerations and required custom components when using react-markdown with Tailwind.

</details>