### PR TITLE
🎨 Palette: Improve markdown rendering in chat bubbles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -24,3 +24,7 @@
 ## 2024-05-28 - [Inline Confirmation Semantics]
 **Learning:** When replacing a trigger button with inline confirmation controls, simply swapping elements can confuse screen readers. Wrapping the confirmation controls in a container with `role="group"` and `aria-label` provides necessary context that a modal would otherwise provide, without the overhead of a full dialog trap.
 **Action:** Wrap inline confirmation actions in a semantic group with a clear label to maintain context for assistive technology.
+
+## 2024-05-22 - Improved Markdown Rendering in Chat
+**Learning:** `react-markdown` without `@tailwindcss/typography` or custom components renders unstyled HTML, which is a major UX gap for chat apps that output code or lists. Conditional styling based on message sender (user vs assistant) is crucial for readability on different background colors.
+**Action:** Always inspect `ReactMarkdown` implementation to ensure `components` are mapped to styled elements, especially for `code`, `pre`, `ul`, `ol`, and `a`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -31,7 +31,17 @@ const MessageBubble = ({ message, isUser }) => {
                         <div className="markdown-content">
                             <ReactMarkdown
                                 components={{
-                                    em: ({ node, ...props }) => <span className="text-gray-400 italic" {...props} />
+                                    em: ({ node, ...props }) => <span className="italic opacity-75" {...props} />,
+                                    ul: ({ node, ...props }) => <ul className="list-disc ml-4 space-y-1 my-2" {...props} />,
+                                    ol: ({ node, ...props }) => <ol className="list-decimal ml-4 space-y-1 my-2" {...props} />,
+                                    li: ({ node, ...props }) => <li className="pl-1" {...props} />,
+                                    a: ({ node, ...props }) => <a className={`underline hover:opacity-80 break-all ${isUser ? 'text-white' : 'text-blue-400'}`} target="_blank" rel="noopener noreferrer" {...props} />,
+                                    h1: ({ node, ...props }) => <h1 className="text-lg font-bold mt-2 mb-1" {...props} />,
+                                    h2: ({ node, ...props }) => <h2 className="text-base font-bold mt-2 mb-1" {...props} />,
+                                    h3: ({ node, ...props }) => <h3 className="text-sm font-bold mt-2 mb-1" {...props} />,
+                                    code: ({ node, ...props }) => <code className={`font-mono text-xs px-1 py-0.5 rounded ${isUser ? 'bg-blue-700' : 'bg-gray-700'}`} {...props} />,
+                                    pre: ({ node, ...props }) => <pre className={`font-mono text-xs p-3 rounded-lg overflow-x-auto my-2 [&_code]:bg-transparent [&_code]:p-0 ${isUser ? 'bg-blue-800' : 'bg-gray-900'}`} {...props} />,
+                                    blockquote: ({ node, ...props }) => <blockquote className="border-l-2 border-current pl-3 italic opacity-80 my-2" {...props} />
                                 }}
                             >
                                 {message}


### PR DESCRIPTION
Improved the rendering of Markdown content within chat bubbles. Previously, lists, code blocks, and links were unstyled or hard to read. I implemented custom component mappings for `ReactMarkdown` using Tailwind CSS to provide proper formatting (bullets, indentation, code block backgrounds) and ensured high contrast by conditionally styling elements based on whether the message is from the user or the assistant. Confirmed the visual improvements with verification screenshots.

---
*PR created automatically by Jules for task [17878773693518107769](https://jules.google.com/task/17878773693518107769) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a renderização e a estilização de Markdown nos balões de mensagens de chat para melhor legibilidade de conteúdo formatado.

Melhorias:
- Adicionar mapeamentos personalizados de componentes ReactMarkdown para estilizar ênfase, listas, títulos, links, código, citações em bloco e blocos pré-formatados nas mensagens de chat, com tematização sensível ao usuário/assistente.
- Documentar a abordagem de renderização de Markdown e os aprendizados no diário do Palette para futuras implementações de UI.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve markdown rendering and styling in chat message bubbles for better readability of formatted content.

Enhancements:
- Add custom ReactMarkdown component mappings to style emphasis, lists, headings, links, code, blockquotes, and preformatted blocks in chat messages with user/assistant-aware theming.
- Document the markdown rendering approach and learnings in the Palette journal for future UI implementations.

</details>