### PR TITLE
🎨 Palette: Improve Markdown rendering in chat bubbles

### DIFF
--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { Copy, Check } from 'lucide-react';
 import Avatar from '../../../shared/components/ui/Avatar';
@@ -16,32 +16,52 @@ const MessageBubble = ({ message, isUser }) => {
         }
     };
 
+    const components = useMemo(() => ({
+        em: ({ node, ...props }) => <span className="italic opacity-80" {...props} />,
+        strong: ({ node, ...props }) => <span className="font-bold" {...props} />,
+        h1: ({ node, ...props }) => <h1 className="text-xl font-bold mt-4 mb-2 first:mt-0" {...props} />,
+        h2: ({ node, ...props }) => <h2 className="text-lg font-bold mt-3 mb-2" {...props} />,
+        h3: ({ node, ...props }) => <h3 className="text-base font-bold mt-2 mb-1" {...props} />,
+        a: ({ node, ...props }) => (
+            <a
+                className={`underline underline-offset-2 transition-colors ${isUser ? 'text-white hover:text-blue-100' : 'text-blue-400 hover:text-blue-300'}`}
+                target="_blank" rel="noopener noreferrer" {...props}
+            />
+        ),
+        ul: ({ node, ...props }) => <ul className="list-disc pl-4 mb-2 space-y-1" {...props} />,
+        ol: ({ node, ...props }) => <ol className="list-decimal pl-4 mb-2 space-y-1" {...props} />,
+        li: ({ node, ...props }) => <li className="pl-1" {...props} />,
+        blockquote: ({ node, ...props }) => (
+            <blockquote
+                className={`border-l-4 pl-4 py-1 my-2 italic ${isUser ? 'border-white/30 text-white/90' : 'border-gray-600 text-gray-400'}`}
+                {...props}
+            />
+        ),
+        pre: ({ node, ...props }) => (
+            <pre className="bg-gray-950/50 p-3 rounded-lg overflow-x-auto my-2 border border-white/10 [&_code]:bg-transparent [&_code]:p-0" {...props} />
+        ),
+        code: ({ node, className, ...props }) => (
+            <code
+                className={`px-1.5 py-0.5 rounded text-sm font-mono ${isUser ? 'bg-blue-700 text-white' : 'bg-gray-700 text-gray-200'}`}
+                {...props}
+            />
+        ),
+    }), [isUser]);
+
     return (
         <div className={`flex w-full ${isUser ? 'justify-end' : 'justify-start'} mb-6 group`}>
             <div className={`flex max-w-[80%] md:max-w-[70%] ${isUser ? 'flex-row-reverse' : 'flex-row'} gap-4`}>
-                {/* Avatar */}
                 <Avatar isUser={isUser} name={isUser ? "Você" : "Katherine"} />
-
-                {/* Message Content & Actions */}
                 <div className={`flex flex-col ${isUser ? 'items-end' : 'items-start'} max-w-full overflow-hidden`}>
                     <div className={`px-4 py-3 rounded-2xl shadow-sm text-sm md:text-base leading-relaxed ${isUser
                         ? 'bg-blue-600 text-white rounded-tr-none'
                         : 'bg-gray-800 text-gray-100 rounded-tl-none border border-gray-700'
                         }`}>
                         <div className="markdown-content">
-                            <ReactMarkdown
-                                components={{
-                                    em: ({ node, ...props }) => <span className="text-gray-400 italic" {...props} />
-                                }}
-                            >
-                                {message}
-                            </ReactMarkdown>
+                            <ReactMarkdown components={components}>{message}</ReactMarkdown>
                         </div>
                     </div>
-
                 </div>
-
-                {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
                     <div className="flex flex-col justify-center">
                         <button


### PR DESCRIPTION
This PR enhances the Markdown rendering within the `MessageBubble` component. It introduces custom renderers for standard Markdown elements like headers, lists, links, blockquotes, and code blocks.

Key improvements:
- **Typography:** Headers and lists are now properly styled with Tailwind utility classes.
- **Links:** Links are visually distinct (underlined, color-coded) and open in new tabs securely.
- **Code Blocks:** Code blocks are wrapped in styled `pre` containers with overflow handling, while inline code uses `code` tags. The "double-boxing" issue was avoided by stripping default styles from nested `code` elements.
- **Performance:** The `components` object passed to `ReactMarkdown` is memoized with `useMemo` to prevent unnecessary re-renders.
- **Accessibility:** Color contrast is maintained for both user (blue background) and assistant (dark background) messages.

---
*PR created automatically by Jules for task [7226226725598549988](https://jules.google.com/task/7226226725598549988) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a renderização e a estilização de Markdown nas bolhas de mensagens de chat, tanto para mensagens do usuário quanto do assistente.

Melhorias:
- Personalizar os renderizadores do `ReactMarkdown` para estilizar ênfase, títulos, listas, links, citações em bloco e blocos de código com tipografia e cores consistentes baseadas em Tailwind.
- Diferenciar a estilização de links e código para mensagens do usuário e do assistente, a fim de manter contraste e clareza visual.
- Memorizar a configuração dos componentes de Markdown com base no tipo de autor para evitar renderizações desnecessárias.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Markdown rendering and styling in chat message bubbles for both user and assistant messages.

Enhancements:
- Customize ReactMarkdown renderers to style emphasis, headings, lists, links, blockquotes, and code blocks with consistent Tailwind-based typography and colors.
- Differentiate link and code styling for user vs assistant messages to maintain contrast and visual clarity.
- Memoize the Markdown components configuration based on author type to avoid unnecessary re-renders.

</details>