### PR TITLE
🎨 Palette: Improve keyboard navigation and disabled states

### DIFF
--- a/frontend/src/features/chat/components/ChatInput.jsx
+++ b/frontend/src/features/chat/components/ChatInput.jsx
@@ -19,7 +19,7 @@ const ChatInput = ({ input, setInput, handleSend, isLoading, inputRef }) => {
                     onKeyDown={handleKeyDown}
                     placeholder="Escreva aqui sua mensagem..."
                     aria-label="Sua mensagem"
-                    className="w-full bg-transparent text-white placeholder-gray-400 text-base p-2 max-h-32 min-h-[44px] resize-none focus:outline-none scrollbar-hide"
+                    className="w-full bg-transparent text-white placeholder-gray-400 text-base p-2 max-h-32 min-h-[44px] resize-none focus:outline-none scrollbar-hide disabled:opacity-50 disabled:cursor-not-allowed"
                     rows={1}
                     disabled={isLoading}
                     style={{ height: 'auto', minHeight: '44px' }}
@@ -33,7 +33,7 @@ const ChatInput = ({ input, setInput, handleSend, isLoading, inputRef }) => {
                     disabled={!input.trim() || isLoading}
                     aria-label="Enviar mensagem (Enter)"
                     title="Enviar mensagem (Enter)"
-                    className={`p-2 rounded-lg mb-1 transition-all ${input.trim() && !isLoading
+                    className={`p-2 rounded-lg mb-1 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${input.trim() && !isLoading
                         ? 'bg-blue-600 text-white hover:bg-blue-500 shadow-md'
                         : 'bg-gray-700 text-gray-500 cursor-not-allowed'
                         }`}

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,7 +46,7 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
                             aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >


### PR DESCRIPTION
🎨 Palette: Improve keyboard navigation and disabled states

💡 What:
- Added `disabled:opacity-50` and `disabled:cursor-not-allowed` to the chat input textarea to visually indicate when the user cannot type.
- Added explicit `focus-visible:ring-2` styles to the Send button in the chat input.
- Added explicit `focus-visible:ring-2` styles to the Copy button in the message bubble.

🎯 Why:
- Without clear disabled styles on the textarea, users might try to type or become confused when the input is inactive (e.g., waiting for the AI response).
- Standard focus states on buttons improve keyboard navigation accessibility.

♿ Accessibility:
- Improves visual feedback for screen reader and keyboard-only users navigating the interface.

---
*PR created automatically by Jules for task [7965151099859661308](https://jules.google.com/task/7965151099859661308) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e o feedback visual para o campo de entrada do chat e os controles de mensagens.

Melhorias:
- Adicionar estados visuais de desabilitado à área de texto de entrada do chat quando a entrada estiver bloqueada.
- Adicionar estilos explícitos de anel de `focus-visible` ao botão de envio do chat para melhorar a navegação por teclado.
- Adicionar estilos explícitos de anel de `focus-visible` ao botão de copiar mensagem para aprimorar a acessibilidade via teclado.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and visual feedback for chat input and message controls.

Enhancements:
- Add disabled visual states to the chat input textarea when input is blocked.
- Add explicit focus-visible ring styles to the chat send button for better keyboard navigation.
- Add explicit focus-visible ring styles to the message copy button to enhance keyboard accessibility.

</details>