### PR TITLE
🎨 Palette: [UX improvement] Add clear disabled state to chat input and focus ring to send button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -24,3 +24,7 @@
 ## 2024-05-28 - [Inline Confirmation Semantics]
 **Learning:** When replacing a trigger button with inline confirmation controls, simply swapping elements can confuse screen readers. Wrapping the confirmation controls in a container with `role="group"` and `aria-label` provides necessary context that a modal would otherwise provide, without the overhead of a full dialog trap.
 **Action:** Wrap inline confirmation actions in a semantic group with a clear label to maintain context for assistive technology.
+
+## 2024-05-29 - [Explicit Feedback for Disabled Inputs]
+**Learning:** Adding the `disabled` attribute to inputs prevents interaction, but without visual cues (like opacity reduction or cursor changes), users may think the interface is broken or unresponsive during async operations like waiting for a chat response.
+**Action:** Always pair `disabled` attributes on inputs (especially textareas) with visual indicators like `disabled:opacity-50` and `disabled:cursor-not-allowed` to provide explicit feedback.

--- a/frontend/src/features/chat/components/ChatInput.jsx
+++ b/frontend/src/features/chat/components/ChatInput.jsx
@@ -19,7 +19,7 @@ const ChatInput = ({ input, setInput, handleSend, isLoading, inputRef }) => {
                     onKeyDown={handleKeyDown}
                     placeholder="Escreva aqui sua mensagem..."
                     aria-label="Sua mensagem"
-                    className="w-full bg-transparent text-white placeholder-gray-400 text-base p-2 max-h-32 min-h-[44px] resize-none focus:outline-none scrollbar-hide"
+                    className="w-full bg-transparent text-white placeholder-gray-400 text-base p-2 max-h-32 min-h-[44px] resize-none focus:outline-none scrollbar-hide disabled:opacity-50 disabled:cursor-not-allowed"
                     rows={1}
                     disabled={isLoading}
                     style={{ height: 'auto', minHeight: '44px' }}
@@ -33,7 +33,7 @@ const ChatInput = ({ input, setInput, handleSend, isLoading, inputRef }) => {
                     disabled={!input.trim() || isLoading}
                     aria-label="Enviar mensagem (Enter)"
                     title="Enviar mensagem (Enter)"
-                    className={`p-2 rounded-lg mb-1 transition-all ${input.trim() && !isLoading
+                    className={`p-2 rounded-lg mb-1 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${input.trim() && !isLoading
                         ? 'bg-blue-600 text-white hover:bg-blue-500 shadow-md'
                         : 'bg-gray-700 text-gray-500 cursor-not-allowed'
                         }`}


### PR DESCRIPTION
💡 **What**: Added explicit visual feedback for the `disabled` state of the chat input textarea (opacity and cursor change) and added a focus ring to the send button.
🎯 **Why**: When waiting for a chat response, the input is disabled, but without visual cues, it might look like the interface is broken or unresponsive. The focus ring improves keyboard navigation visibility.
📸 **Before/After**: The textarea now correctly looks dimmed when disabled, and the send button gets a blue focus ring when tabbed onto. 
♿ **Accessibility**: Enhanced keyboard navigation experience (focus states) and clear indication of non-interactive state (disabled input) during async operations.

---
*PR created automatically by Jules for task [2958488696473140271](https://jules.google.com/task/2958488696473140271) started by @RenyEnnos*

## Summary by Sourcery

Melhora o feedback visual e de acessibilidade para os estados do campo de entrada do chat e do botão de envio.

Melhorias:
- Adicionar estilo visual para o estado desabilitado da área de texto de entrada do chat, deixando mais claro quando ela não pode ser usada.
- Adicionar um anel de foco visível ao botão de envio para melhorar a visibilidade na navegação por teclado.

Documentação:
- Documentar o padrão de feedback visual para entradas desabilitadas e o estilo recomendado nas diretrizes de paleta.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve visual and accessibility feedback for the chat input and send button states.

Enhancements:
- Add visual disabled-state styling to the chat input textarea to clarify when it cannot be used.
- Add a visible focus ring to the send button to improve keyboard navigation visibility.

Documentation:
- Document the disabled input visual feedback pattern and recommended styling in the palette guidelines.

</details>