### PR TITLE
🎨 Palette: Improve ChatInput UX and Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -24,3 +24,7 @@
 ## 2024-05-28 - [Inline Confirmation Semantics]
 **Learning:** When replacing a trigger button with inline confirmation controls, simply swapping elements can confuse screen readers. Wrapping the confirmation controls in a container with `role="group"` and `aria-label` provides necessary context that a modal would otherwise provide, without the overhead of a full dialog trap.
 **Action:** Wrap inline confirmation actions in a semantic group with a clear label to maintain context for assistive technology.
+
+## 2024-05-29 - [Visual Disabled States & Keyboard Focus]
+**Learning:** It's easy to forget visual cues for `disabled` states on inputs like textareas when relying on default browser behavior. Explicitly adding `disabled:opacity-50` and `disabled:cursor-not-allowed` makes the non-interactive state immediately apparent to users. Additionally, action buttons need distinct `focus-visible` styles (e.g., `ring`, `ring-offset`) for keyboard accessibility, especially when they have complex dynamic styling based on state. Redundant screen reader announcements on icon-only buttons can be avoided by adding `aria-hidden="true"` to the icon element itself when the parent button already has a clear `aria-label`.
+**Action:** Always include explicit `disabled:` utility classes for form inputs, ensure buttons have `focus-visible:` styles, and hide decorative/redundant icons from screen readers using `aria-hidden="true"`.

--- a/frontend/src/features/chat/components/ChatInput.jsx
+++ b/frontend/src/features/chat/components/ChatInput.jsx
@@ -19,7 +19,7 @@ const ChatInput = ({ input, setInput, handleSend, isLoading, inputRef }) => {
                     onKeyDown={handleKeyDown}
                     placeholder="Escreva aqui sua mensagem..."
                     aria-label="Sua mensagem"
-                    className="w-full bg-transparent text-white placeholder-gray-400 text-base p-2 max-h-32 min-h-[44px] resize-none focus:outline-none scrollbar-hide"
+                    className="w-full bg-transparent text-white placeholder-gray-400 text-base p-2 max-h-32 min-h-[44px] resize-none focus:outline-none scrollbar-hide disabled:opacity-50 disabled:cursor-not-allowed"
                     rows={1}
                     disabled={isLoading}
                     style={{ height: 'auto', minHeight: '44px' }}
@@ -33,12 +33,12 @@ const ChatInput = ({ input, setInput, handleSend, isLoading, inputRef }) => {
                     disabled={!input.trim() || isLoading}
                     aria-label="Enviar mensagem (Enter)"
                     title="Enviar mensagem (Enter)"
-                    className={`p-2 rounded-lg mb-1 transition-all ${input.trim() && !isLoading
+                    className={`p-2 rounded-lg mb-1 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800 ${input.trim() && !isLoading
                         ? 'bg-blue-600 text-white hover:bg-blue-500 shadow-md'
                         : 'bg-gray-700 text-gray-500 cursor-not-allowed'
                         }`}
                 >
-                    {isLoading ? <Loader2 size={20} className="animate-spin" /> : <Send size={20} />}
+                    {isLoading ? <Loader2 size={20} className="animate-spin" aria-hidden="true" /> : <Send size={20} aria-hidden="true" />}
                 </button>
             </div>
             <div className="text-center text-xs text-gray-500 mt-2">


### PR DESCRIPTION
💡 **What:** Added visual disabled states (`disabled:opacity-50`, `disabled:cursor-not-allowed`) to the `textarea` in `ChatInput.jsx`. Added keyboard focus indicators (`focus-visible:ring-2`, etc.) to the Send button. Added `aria-hidden="true"` to the decorative icons inside the Send button.

🎯 **Why:** To improve accessibility and user experience. Users need visual feedback when an input is non-interactive. Keyboard users need clear focus states on interactive elements like buttons. Screen reader users shouldn't hear redundant announcements for decorative icons when the parent button already has a clear `aria-label`.

📸 **Before/After:** See attached screenshots in the verification output.

♿ **Accessibility:**
- Clear visual disabled states for form inputs.
- Distinct focus states for keyboard navigation.
- Reduced noise for screen reader users by hiding decorative icons.

---
*PR created automatically by Jules for task [11854566185572307952](https://jules.google.com/task/11854566185572307952) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a experiência do usuário (UX) do componente de entrada do chat e documentar os aprendizados de design relacionados.

Melhorias:
- Adicionar estados visuais desabilitados explícitos à textarea do chat para indicar claramente quando ela está não interativa.
- Adicionar estilos de anel de foco visível ao botão de enviar do chat para melhorar a clareza da navegação por teclado.
- Ocultar ícones decorativos de carregamento e de envio dos leitores de tela via `aria-hidden` para reduzir anúncios redundantes.
- Documentar diretrizes de acessibilidade e UX para estados desabilitados, foco de teclado e ícones decorativos nas notas do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and UX of the chat input component and document related design learnings.

Enhancements:
- Add explicit disabled visual states to the chat textarea to clearly indicate when it is non-interactive.
- Add keyboard focus-visible ring styles to the chat send button to improve keyboard navigation clarity.
- Hide decorative loader and send icons from screen readers via aria-hidden to reduce redundant announcements.
- Document accessibility and UX guidelines for disabled states, keyboard focus, and decorative icons in the Palette notes.

</details>