### PR TITLE
🎨 Palette: ChatInput Accessibility and State Improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -24,3 +24,11 @@
 ## 2024-05-28 - [Inline Confirmation Semantics]
 **Learning:** When replacing a trigger button with inline confirmation controls, simply swapping elements can confuse screen readers. Wrapping the confirmation controls in a container with `role="group"` and `aria-label` provides necessary context that a modal would otherwise provide, without the overhead of a full dialog trap.
 **Action:** Wrap inline confirmation actions in a semantic group with a clear label to maintain context for assistive technology.
+
+## 2024-05-29 - [Disabled Input Semantics]
+**Learning:** Textareas and inputs inside stylized container wrappers often rely on the parent wrapper to indicate focus (`focus-within`), but the disabled state of the input itself can be missed visually. Explicitly applying `disabled:opacity-50` and `disabled:cursor-not-allowed` ensures users clearly understand the form cannot be interacted with.
+**Action:** Always add explicit disabled styling directly to the `<textarea>` or `<input>`, even if the outer wrapper changes its border or background color.
+
+## 2024-05-29 - [Icon-Only Button Accessibility in Send Actions]
+**Learning:** The Send button inside a chat input uses an icon (`Send` or `Loader2`). If the button already has `aria-label` or `title`, adding `aria-hidden="true"` to the SVG icons prevents redundant readouts by screen readers, creating a cleaner a11y tree.
+**Action:** Always add `aria-hidden="true"` to SVG elements that are purely decorative or nested inside buttons with adequate `aria-label` attributes.

--- a/frontend/src/features/chat/components/ChatInput.jsx
+++ b/frontend/src/features/chat/components/ChatInput.jsx
@@ -19,7 +19,7 @@ const ChatInput = ({ input, setInput, handleSend, isLoading, inputRef }) => {
                     onKeyDown={handleKeyDown}
                     placeholder="Escreva aqui sua mensagem..."
                     aria-label="Sua mensagem"
-                    className="w-full bg-transparent text-white placeholder-gray-400 text-base p-2 max-h-32 min-h-[44px] resize-none focus:outline-none scrollbar-hide"
+                    className="w-full bg-transparent text-white placeholder-gray-400 text-base p-2 max-h-32 min-h-[44px] resize-none focus:outline-none scrollbar-hide disabled:opacity-50 disabled:cursor-not-allowed"
                     rows={1}
                     disabled={isLoading}
                     style={{ height: 'auto', minHeight: '44px' }}
@@ -33,12 +33,12 @@ const ChatInput = ({ input, setInput, handleSend, isLoading, inputRef }) => {
                     disabled={!input.trim() || isLoading}
                     aria-label="Enviar mensagem (Enter)"
                     title="Enviar mensagem (Enter)"
-                    className={`p-2 rounded-lg mb-1 transition-all ${input.trim() && !isLoading
+                    className={`p-2 rounded-lg mb-1 transition-all focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800 focus:outline-none ${input.trim() && !isLoading
                         ? 'bg-blue-600 text-white hover:bg-blue-500 shadow-md'
                         : 'bg-gray-700 text-gray-500 cursor-not-allowed'
                         }`}
                 >
-                    {isLoading ? <Loader2 size={20} className="animate-spin" /> : <Send size={20} />}
+                    {isLoading ? <Loader2 size={20} className="animate-spin" aria-hidden="true" /> : <Send size={20} aria-hidden="true" />}
                 </button>
             </div>
             <div className="text-center text-xs text-gray-500 mt-2">


### PR DESCRIPTION
🎨 Palette: ChatInput Accessibility and State Improvements

**💡 What:**
- Added explicit visual disabled states for the chat input textarea (`opacity-50` and `cursor-not-allowed`) during the loading state.
- Enhanced the Send button's keyboard accessibility by adding a visible focus ring (`focus-visible:ring-2` with offsets for dark mode).
- Cleaned up the accessibility tree by hiding purely decorative icons inside the Send button (`aria-hidden="true"`).

**🎯 Why:**
- Users relying on visual cues might not immediately realize the input is disabled while the bot is "typing" just from the button state. Making the textarea itself visibly disabled clarifies the UI state.
- Keyboard users require a clear, high-contrast visual indicator of which element currently has focus to navigate effectively.
- Screen reader users benefit from a cleaner experience when redundant icons inside correctly labeled buttons are hidden from the accessibility API.

**♿ Accessibility:**
- Improved keyboard navigation via explicit focus states.
- Reduced screen reader redundancy.
- Enhanced visual indicators for disabled form controls.

---
*PR created automatically by Jules for task [2946822922306515939](https://jules.google.com/task/2946822922306515939) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade da entrada de chat e a clareza do estado desativado na interface de chat.

Aperfeiçoamentos:
- Fazer com que a área de texto do chat indique visualmente seu estado desativado durante o carregamento.
- Adicionar um anel de foco de teclado visível ao botão de enviar do chat para melhor visibilidade do foco.
- Ocultar ícones decorativos de envio/carregamento no botão de enviar das tecnologias assistivas para reduzir o ruído para leitores de tela.

Documentação:
- Documentar aprendizados e diretrizes de acessibilidade sobre estilização de entradas desativadas e semântica de botões de envio compostos apenas por ícone nas notas da paleta.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve chat input accessibility and disabled-state clarity in the chat UI.

Enhancements:
- Make the chat textarea visually indicate its disabled state when loading.
- Add a visible keyboard focus ring to the chat send button for better focus visibility.
- Hide decorative send/loader icons in the send button from assistive technologies to reduce screen reader noise.

Documentation:
- Document accessibility learnings and guidelines around disabled input styling and icon-only send button semantics in the palette notes.

</details>