### PR TITLE
🎨 Palette: Explicit visual feedback for disabled ChatInput

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -24,3 +24,7 @@
 ## 2024-05-28 - [Inline Confirmation Semantics]
 **Learning:** When replacing a trigger button with inline confirmation controls, simply swapping elements can confuse screen readers. Wrapping the confirmation controls in a container with `role="group"` and `aria-label` provides necessary context that a modal would otherwise provide, without the overhead of a full dialog trap.
 **Action:** Wrap inline confirmation actions in a semantic group with a clear label to maintain context for assistive technology.
+
+## 2024-05-29 - [Explicit Disabled States on Text Inputs]
+**Learning:** During async operations (like waiting for an AI response), text inputs that are disabled but visually identical to their active state can cause the app to feel frozen or unresponsive if users attempt to type. Disabled elements should have explicit visual cues.
+**Action:** Always add explicit visual feedback (like `opacity-50` and `cursor-not-allowed`) to disabled textareas and inputs to immediately communicate their non-interactive state.

--- a/frontend/src/features/chat/components/ChatInput.jsx
+++ b/frontend/src/features/chat/components/ChatInput.jsx
@@ -19,7 +19,7 @@ const ChatInput = ({ input, setInput, handleSend, isLoading, inputRef }) => {
                     onKeyDown={handleKeyDown}
                     placeholder="Escreva aqui sua mensagem..."
                     aria-label="Sua mensagem"
-                    className="w-full bg-transparent text-white placeholder-gray-400 text-base p-2 max-h-32 min-h-[44px] resize-none focus:outline-none scrollbar-hide"
+                    className="w-full bg-transparent text-white placeholder-gray-400 text-base p-2 max-h-32 min-h-[44px] resize-none focus:outline-none scrollbar-hide disabled:opacity-50 disabled:cursor-not-allowed"
                     rows={1}
                     disabled={isLoading}
                     style={{ height: 'auto', minHeight: '44px' }}


### PR DESCRIPTION
💡 **What:** Added `disabled:opacity-50` and `disabled:cursor-not-allowed` utility classes to the ChatInput textarea.
🎯 **Why:** To provide immediate visual feedback when the textarea is disabled (e.g., waiting for the AI response), preventing the app from feeling frozen or unresponsive.
♿ **Accessibility:** Visually distinguishing disabled states prevents user confusion and conforms to standard UX expectations.
📸 **Before/After:** The input is now visibly dimmed with a 'not allowed' cursor when `isLoading` is true.

---
*PR created automatically by Jules for task [1634085269467319403](https://jules.google.com/task/1634085269467319403) started by @RenyEnnos*

## Summary by Sourcery

Documentar e implementar visuais mais claros para o estado desabilitado da área de texto de entrada do chat durante operações assíncronas.

Melhorias:
- Adicionar estilização explícita para o estado desabilitado da área de texto (`textarea`) em `ChatInput` para comunicar visualmente o estado não interativo durante o carregamento.
- Registrar o aprendizado de UX sobre campos de texto desabilitados e o feedback visual necessário na documentação da paleta compartilhada.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document and implement clearer disabled-state visuals for the chat input textarea during async operations.

Enhancements:
- Add explicit disabled-state styling to the ChatInput textarea to visually communicate non-interactive state during loading.
- Capture the UX learning about disabled text inputs and required visual feedback in the shared palette documentation.

</details>