### PR TITLE
🎨 Palette: Improve ChatInput focus and disabled states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -24,3 +24,7 @@
 ## 2024-05-28 - [Inline Confirmation Semantics]
 **Learning:** When replacing a trigger button with inline confirmation controls, simply swapping elements can confuse screen readers. Wrapping the confirmation controls in a container with `role="group"` and `aria-label` provides necessary context that a modal would otherwise provide, without the overhead of a full dialog trap.
 **Action:** Wrap inline confirmation actions in a semantic group with a clear label to maintain context for assistive technology.
+
+## 2025-02-12 - [Explicit Focus & Disabled States]
+**Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
+**Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.

--- a/frontend/src/features/chat/components/ChatInput.jsx
+++ b/frontend/src/features/chat/components/ChatInput.jsx
@@ -19,7 +19,7 @@ const ChatInput = ({ input, setInput, handleSend, isLoading, inputRef }) => {
                     onKeyDown={handleKeyDown}
                     placeholder="Escreva aqui sua mensagem..."
                     aria-label="Sua mensagem"
-                    className="w-full bg-transparent text-white placeholder-gray-400 text-base p-2 max-h-32 min-h-[44px] resize-none focus:outline-none scrollbar-hide"
+                    className="w-full bg-transparent text-white placeholder-gray-400 text-base p-2 max-h-32 min-h-[44px] resize-none focus:outline-none scrollbar-hide disabled:opacity-50 disabled:cursor-not-allowed"
                     rows={1}
                     disabled={isLoading}
                     style={{ height: 'auto', minHeight: '44px' }}
@@ -33,7 +33,7 @@ const ChatInput = ({ input, setInput, handleSend, isLoading, inputRef }) => {
                     disabled={!input.trim() || isLoading}
                     aria-label="Enviar mensagem (Enter)"
                     title="Enviar mensagem (Enter)"
-                    className={`p-2 rounded-lg mb-1 transition-all ${input.trim() && !isLoading
+                    className={`p-2 rounded-lg mb-1 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800 ${input.trim() && !isLoading
                         ? 'bg-blue-600 text-white hover:bg-blue-500 shadow-md'
                         : 'bg-gray-700 text-gray-500 cursor-not-allowed'
                         }`}


### PR DESCRIPTION
💡 **What:** 
- Added `disabled:opacity-50 disabled:cursor-not-allowed` utilities to the ChatInput textarea element.
- Restored `focus-visible` offset ring classes on the ChatInput Send button to exist outside its conditional styling logic.

🎯 **Why:** 
When Katherine is typing (`isLoading` is true), the input becomes disabled to prevent rapid-fire sending, but there was zero visual feedback indicating this non-interactive state to the user.
Additionally, the Send button was missing keyboard focus indicators in its normal state due to complex dynamic class logic overriding it, making it difficult to interact with via keyboard in dark mode.

📸 **Before/After:** 
(See verification screenshot - opacity applied when disabled, explicit focus ring restored on the Send button).

♿ **Accessibility:** 
- Provides crucial visual feedback for a temporary disabled state.
- Restores visible keyboard focus tracking for the primary CTA button.

---
*PR created automatically by Jules for task [7034698233624383905](https://jules.google.com/task/7034698233624383905) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do ChatInput e os estados visuais, incorporando os aprendizados de design na orientação de paleta.

Aprimoramentos:
- Adicionar estilo visual para o estado desabilitado na área de texto do ChatInput e restaurar o estilo consistente de anel de foco visível no botão Send.

Documentação:
- Documentar os aprendizados e as melhores práticas sobre o anel de foco e o estado desabilitado no arquivo de orientação de paleta.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve ChatInput accessibility and visual states while capturing the design learnings in the palette guidance.

Enhancements:
- Add visual disabled-state styling to the ChatInput textarea and restore consistent focus-visible ring styling on the Send button.

Documentation:
- Document focus ring and disabled state learnings and best practices in the palette guidance file.

</details>