### PR TITLE
🎨 Palette: Enhance keyboard focus and screen reader context for chat controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [Explicit Screen Reader Feedback]
+**Learning:** Dynamic `aria-label` changes on buttons (e.g., changing from "Copy" to "Copied!") are not reliably announced by screen readers since the announcement typically happens when focus shifts, not when attributes mutate. Adding a visually hidden (`sr-only`) element with `role="status"` and `aria-live="polite"` ensures explicit state feedback. Additionally, `aria-hidden="true"` is essential on decorative icons inside labeled buttons to prevent confusing or redundant announcements.
+**Action:** Use `aria-live` regions for dynamic state changes like "Copied!" instead of relying on `aria-label` swaps, and always hide icons inside `aria-label`'d interactive elements.

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -59,21 +59,21 @@ const ChatHeader = ({ clearHistory }) => {
                     </span>
                     <button
                         onClick={handleClear}
-                        className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-red-400 focus:outline-none"
+                        className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800 focus:outline-none"
                         title="Confirmar limpeza"
                         aria-label="Confirmar limpeza"
                         aria-describedby="confirm-text"
                     >
-                        <Check size={20} />
+                        <Check size={20} aria-hidden="true" />
                     </button>
                     <button
                         onClick={() => setShowConfirm(false)}
                         autoFocus
-                        className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-gray-400 focus:outline-none"
+                        className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800 focus:outline-none"
                         title="Cancelar"
                         aria-label="Cancelar"
                     >
-                        <X size={20} />
+                        <X size={20} aria-hidden="true" />
                     </button>
                 </div>
             ) : (
@@ -81,11 +81,11 @@ const ChatHeader = ({ clearHistory }) => {
                     onClick={handleTrashClick}
                     ref={trashRef}
                     autoFocus={shouldFocusTrash}
-                    className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-red-400 focus:outline-none"
+                    className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800 focus:outline-none"
                     title="Limpar conversa"
                     aria-label="Limpar conversa"
                 >
-                    <Trash2 size={20} />
+                    <Trash2 size={20} aria-hidden="true" />
                 </button>
             )}
         </header>

--- a/frontend/src/features/chat/components/ChatInput.jsx
+++ b/frontend/src/features/chat/components/ChatInput.jsx
@@ -38,7 +38,7 @@ const ChatInput = ({ input, setInput, handleSend, isLoading, inputRef }) => {
                         : 'bg-gray-700 text-gray-500 cursor-not-allowed'
                         }`}
                 >
-                    {isLoading ? <Loader2 size={20} className="animate-spin" /> : <Send size={20} />}
+                    {isLoading ? <Loader2 size={20} className="animate-spin" aria-hidden="true" /> : <Send size={20} aria-hidden="true" />}
                 </button>
             </div>
             <div className="text-center text-xs text-gray-500 mt-2">

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,11 +46,14 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800"
                             aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
+                            <span className="sr-only" role="status" aria-live="polite">
+                                {isCopied ? "Mensagem copiada" : ""}
+                            </span>
                         </button>
                     </div>
                 )}


### PR DESCRIPTION
💡 **What**: 
1. Added explicit dark mode focus rings (`focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800`) to interactive buttons in `ChatHeader` and `MessageBubble`.
2. Added a visually hidden `aria-live="polite"` span to the `MessageBubble` copy button to announce "Mensagem copiada" explicitly when copied.
3. Added `aria-hidden="true"` to all Lucide icons inside buttons that already use `aria-label` (across `ChatHeader`, `MessageBubble`, and `ChatInput`).
4. Added an entry to `.Jules/palette.md` explaining why dynamic `aria-label` changes are insufficient for screen reader feedback and why `aria-live` is preferred.

🎯 **Why**: 
1. Keyboard users could not clearly see the focus indicator on the copy button or header buttons against the dark background. The standard `ring-2` is often too subtle without an offset.
2. Screen readers typically don't announce a change in an `aria-label` attribute if the focus hasn't moved. When a user clicks "Copy", changing the label to "Copied" is visual, but an `aria-live` region ensures the screen reader explicitly announces the success state.
3. Decorative icons inside labeled buttons can cause screen readers to announce redundant or confusing information (e.g., reading "trash button, image" instead of just "Limpar conversa"). Hiding the SVG prevents this.

♿ **Accessibility**: 
- Improved keyboard navigation visibility (`focus-visible`).
- Improved screen reader clarity by hiding decorative SVGs (`aria-hidden="true"`).
- Added explicit state feedback for screen readers via `aria-live="polite"`.

---
*PR created automatically by Jules for task [4550970646346862803](https://jules.google.com/task/4550970646346862803) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade dos controles de chat no cabeçalho, bolhas de mensagem e ações de entrada.

Melhorias:
- Reforçar a visibilidade do foco de teclado nos botões de confirmação e de lixeira do cabeçalho do chat e nos botões de copiar mensagem, com anéis de foco explícitos e offsets adaptados para temas escuros.
- Garantir que ícones decorativos em botões de chat com rótulo sejam ocultados de tecnologias assistivas, marcando os ícones SVG do Lucide como `aria-hidden` no cabeçalho, nas bolhas de mensagem e nas ações de entrada.
- Fornecer orientações mais claras para futuros trabalhos de UI, documentando boas práticas de uso de `aria-live` e ocultação de ícones nas diretrizes da paleta.

Documentação:
- Estender a documentação da paleta com orientações sobre o uso de regiões `aria-live` e ícones `aria-hidden` para fornecer feedback confiável e não visual para estados dinâmicos de botões.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of chat controls across header, message bubbles, and input actions.

Enhancements:
- Strengthen keyboard focus visibility on chat header confirmation and trash buttons and on message copy buttons with explicit focus ring offsets tailored for dark themes.
- Ensure decorative icons within labeled chat buttons are hidden from assistive technologies by marking Lucide SVG icons as aria-hidden in header, message bubble, and input actions.
- Provide clearer guidance for future UI work by documenting best practices for aria-live usage and icon hiding in the palette guidelines.

Documentation:
- Extend the palette documentation with guidance on using aria-live regions and aria-hidden icons to provide reliable, non-visual feedback for dynamic button states.

</details>