### PR TITLE
🎨 Palette: Improve accessibility and focus state of Copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2026-03-10 - [Dynamic Aria-Label vs sr-only Announcement]
+**Learning:** Dynamically updating the `aria-label` of a focused button (like changing from "Copy" to "Copied") is often not announced reliably by screen readers since focus remains on the element. A more robust pattern is keeping the `aria-label` static and using a visually hidden (`sr-only`) element with `role="status"` and `aria-live="polite"` nearby to conditionally inject the success message text.
+**Action:** Prefer using `aria-live` status elements over dynamic `aria-label` updates on focused interactive elements for asynchronous success feedback.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,12 +46,15 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span className="sr-only" role="status" aria-live="polite">
+                            {isCopied ? 'Copiado' : ''}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What:**
- Added explicit `focus-visible` utility classes to the copy button in the `MessageBubble` component so that it has a clear, accessible focus ring when navigated via keyboard.
- Refactored the copy success feedback for screen readers: changed the dynamic `aria-label` on the button to a static one ("Copiar mensagem") and added a visually hidden (`sr-only`) element with `role="status"` and `aria-live="polite"` that outputs "Copiado" when the state changes.

🎯 **Why:**
- Interactive elements must have clear visual focus indicators to support keyboard users.
- Dynamically changing the `aria-label` of a focused button is an anti-pattern as screen readers often fail to announce the change. Using a dedicated `aria-live` status element ensures the "Copiado" confirmation is reliably announced without confusing the button's identity.

📸 **Before/After:**
- Visually, the button now displays a distinct focus ring (gray with an offset) when tabbed to, improving visibility against dark backgrounds. Previously, it relied only on `focus:opacity-100`.

♿ **Accessibility:**
- Resolved an issue with missing focus rings for keyboard users.
- Greatly improved the reliability of screen reader announcements for the copy action success state.

---
*PR created automatically by Jules for task [4323680545352131870](https://jules.google.com/task/4323680545352131870) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e o comportamento de feedback do botão de copiar mensagem do chat.

Novas funcionalidades:
- Adicionar um estilo de anel de foco visível acessível (`focus-visible`) ao botão de copiar mensagem para tornar o foco do teclado claramente visível.
- Fornecer um anúncio de sucesso de cópia compatível com leitores de tela usando um elemento de status ao vivo `sr-only` em vez de alterar o rótulo do botão.

Aprimoramentos:
- Documentar, nas diretrizes da paleta, o padrão de acessibilidade de usar elementos de status `aria-live` em vez de atualizações dinâmicas de `aria-label`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and feedback behavior of the chat message copy button.

New Features:
- Add an accessible focus-visible ring style to the message copy button to make keyboard focus clearly visible.
- Provide a screen-reader-friendly copy success announcement using an sr-only live status element instead of changing the button label.

Enhancements:
- Document the accessibility pattern of using aria-live status elements instead of dynamic aria-label updates in the palette guidelines.

</details>