### PR TITLE
🎨 Palette: Improve Copy Button Accessibility & Feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [Aria-Live vs Dynamic Aria-Label for Action Feedback]
+**Learning:** Dynamically updating an `aria-label` (e.g. from "Copy" to "Copied") for temporary action feedback is unreliable because screen readers often don't announce label changes on focused elements automatically. Using a static `aria-label` combined with a permanently mounted `<div aria-live="polite" className="sr-only">` that toggles its text content ensures the feedback is reliably announced.
+**Action:** Use `aria-live` regions for temporary state announcements instead of mutating `aria-label` attributes on buttons.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
-                            title={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
+                            title="Copiar mensagem"
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? 'Mensagem copiada para a área de transferência' : ''}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
**💡 What:** 
Improved the accessibility of the "Copiar mensagem" button on the assistant's `MessageBubble`. 
- Added robust keyboard focus rings using `focus-visible:ring-2 focus-visible:ring-offset-2`.
- Swapped a dynamic `aria-label` (which is often missed by screen readers if the element is already focused) for a permanent, static `aria-label` and a dedicated `aria-live="polite"` `sr-only` text container.

**🎯 Why:**
Users relying on screen readers need to know when an action like "Copying" text has been successful. Updating the `aria-label` while the button is focused is unreliable across different screen readers. An `aria-live` region guarantees the success feedback ("Mensagem copiada para a área de transferência") is properly announced. Keyboard users also need a high-contrast focus indicator to know which element is currently targeted.

**📸 Before/After:**
Screenshots were captured during local UI testing, confirming the focus ring appears correctly and the component visually updates its state.

**♿ Accessibility:**
- Added `focus-visible` offset patterns for better contrast in dark mode.
- Improved screen reader action feedback using `aria-live`.
- Documented this learning pattern in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [746556057505400900](https://jules.google.com/task/746556057505400900) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e o feedback do botão de copiar mensagem do assistente e documentar o padrão nas notas da paleta de design.

Melhorias:
- Adicionar estilos mais fortes de anel de foco visível via teclado (`focus-visible`) ao botão de copiar mensagem do assistente para melhor visibilidade, especialmente no modo escuro.
- Substituir as mudanças dinâmicas de `aria-label` no botão de copiar por um rótulo estático e uma região `aria-live` para fornecer feedback confiável de sucesso da cópia para leitores de tela.
- Documentar o padrão de `aria-live` para feedback de ações e os aprendizados sobre comportamento de foco no arquivo de orientações da paleta.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and feedback of the assistant message copy button and document the pattern in the design palette notes.

Enhancements:
- Add stronger keyboard focus-visible ring styles to the assistant message copy button for better visibility, especially in dark mode.
- Replace dynamic aria-label changes on the copy button with a static label and an aria-live region to provide reliable screen reader feedback on copy success.
- Document the aria-live pattern for action feedback and focus behavior learnings in the palette guidance file.

</details>