### PR TITLE
🎨 Palette: Improve Copy Button Accessibility & Keyboard Focus

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-03-13 - [Aria-live vs Dynamic Aria-label for Button States]
+**Learning:** Changing the `aria-label` of a focused button dynamically (e.g., from "Copy" to "Copied") is often not announced reliably by screen readers because the focus event has already passed. Using a separate, visually hidden `aria-live="polite"` region to announce the status change while keeping the button's `aria-label` static provides a much more robust experience.
+**Action:** Use `aria-live` containers for transient status updates (like "Copied!") instead of mutating `aria-label` on the trigger element itself.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,12 +46,15 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 What: Added a dedicated `aria-live` region to announce the "Copied" state, made the `aria-label` static, hid redundant SVG icons from screen readers, and added clear `focus-visible` styling for keyboard navigation.
🎯 Why: Screen readers often fail to announce dynamic changes to an element's `aria-label` when it already has focus. Using `aria-live` fixes this. Adding a focus ring ensures the button is usable via keyboard.
📸 Before/After: Visual change introduces an offset focus ring when navigating via keyboard.
♿ Accessibility:
- Replaced dynamic `aria-label` with static `aria-label` and `aria-live="polite"` region.
- Added `aria-hidden="true"` to `Check` and `Copy` SVG icons.
- Added `focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900` to the button for keyboard navigation.

Additionally, recorded the learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [12621045394977901563](https://jules.google.com/task/12621045394977901563) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e o comportamento de foco via teclado para o botão de copiar mensagem do chat e documenta aprendizados relacionados à acessibilidade.

Novos recursos:
- Anunciar atualizações de status de cópia por meio de uma região aria-live dedicada e visualmente oculta, em vez de alterar o rótulo do botão.

Aperfeiçoamentos:
- Adicionar um anel de foco bem visível (`focus-visible`) ao botão de copiar para melhorar a visibilidade na navegação por teclado.
- Ocultar ícones decorativos de estado de cópia dos leitores de tela para evitar anúncios redundantes.
- Documentar boas práticas para o uso de regiões aria-live em vez de alterações dinâmicas em aria-label para estados transitórios de botões no playbook do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and keyboard focus behavior for the chat message copy button and document related accessibility learnings.

New Features:
- Announce copy status updates via a dedicated visually hidden aria-live region instead of changing the button label.

Enhancements:
- Add clear focus-visible ring styling to the copy button for better keyboard navigation visibility.
- Hide decorative copy state icons from screen readers to avoid redundant announcements.
- Document best practices for using aria-live regions versus dynamic aria-label changes for transient button states in the Palette playbook.

</details>