### PR TITLE
🎨 Palette: Improve accessibility of MessageBubble copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-03-01 - [Reliable State Confirmations with aria-live]
+**Learning:** For accessibility, changing a button's `aria-label` dynamically (e.g., from "Copy" to "Copied") is often not announced reliably by screen readers since focus is already on the element. Using a permanently mounted, visually hidden `aria-live="polite"` region that receives text when the action succeeds ensures a reliable announcement without breaking the button's initial semantics.
+**Action:** Use visually hidden `aria-live` containers for temporary success/state confirmations instead of conditionally updating `aria-label`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
-                            title={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
+                            title="Copiar mensagem"
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Mensagem copiada' : ''}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
🎨 **Palette: Reliable State Confirmations with aria-live**

**💡 What:** 
Improved the accessibility of the Copy button on assistant messages in `MessageBubble.jsx`. Replaced the dynamic `aria-label` swapping with a visually hidden, permanently mounted `<span aria-live="polite">` container to announce "Mensagem copiada", and added explicit `focus-visible` classes with proper offsets for dark mode. Also marked the internal SVG icons as `aria-hidden="true"`.

**🎯 Why:**
Dynamically changing an `aria-label` while an element has focus often fails to trigger a screen reader announcement. Using an `aria-live` region is the robust standard for announcing transient state changes (like "Copied!"). The addition of `focus-visible:ring-offset-2` ensures keyboard users can clearly see when they've navigated to the button, improving overall usability without cluttering the mouse/touch UI.

**♿ Accessibility:**
- Reliable screen reader announcements for the copy action.
- Prevented redundant "Copy" or "Check" announcements from the SVGs.
- Clear, high-contrast focus rings for keyboard navigation.

---
*PR created automatically by Jules for task [17071435252412553540](https://jules.google.com/task/17071435252412553540) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e o gerenciamento de foco para o botão de copiar mensagens do assistente e o uso de aria-live na documentação das diretrizes do Palette.

Melhorias:
- Aprimorar o botão de copiar mensagens do assistente com um estilo consistente para `focus-visible`, rotulagem estática e uma região `aria-live` para confirmações de cópia confiáveis.
- Ocultar ícones SVG decorativos dos leitores de tela para evitar anúncios redundantes.

Documentação:
- Adicionar orientação no Palette sobre usar regiões `aria-live` visualmente ocultas em vez de atualizações dinâmicas de `aria-label` para confirmações de estado transitório.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus handling for the assistant message copy button and document aria-live usage in the Palette guidelines.

Enhancements:
- Enhance the assistant message copy button with consistent focus-visible styling, static labeling, and an aria-live region for reliable copy confirmations.
- Hide decorative SVG icons from screen readers to avoid redundant announcements.

Documentation:
- Add Palette guidance on using visually hidden aria-live regions instead of dynamic aria-label updates for transient state confirmations.

</details>