### PR TITLE
🎨 Palette: Improve copy button accessibility and keyboard UX

### DIFF
--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,14 +43,17 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Mensagem copiada' : ''}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
-                            title={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
+                            title="Copiar mensagem"
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
                     </div>
                 )}


### PR DESCRIPTION
💡 What: 
- Added an `aria-live="polite"` region to announce the "Copiado" state for screen readers.
- Added explicit `focus-visible` classes to the copy button.
- Added `aria-hidden="true"` to the inner icons.

🎯 Why: 
- Dynamically changing the `aria-label` of a focused element is an unreliable way to announce a state change to screen readers. An `aria-live` region is the best practice for transient notifications like "Copied!".
- The copy button was visible on hover, but if focused via keyboard, it was hard to see. Explicit `focus-visible` outline classes ensure keyboard users can always see what they are focusing.
- The button already had an `aria-label`, so the internal SVG icons didn't need to be read by screen readers, preventing redundancy.

♿ Accessibility:
- Improved screen reader announcements for the copy action.
- Improved keyboard navigation visibility for the copy action.
- Reduced redundant screen reader output.

---
*PR created automatically by Jules for task [9605312689295166080](https://jules.google.com/task/9605312689295166080) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a usabilidade via teclado do botão de copiar mensagem do chat.

Melhorias:
- Anunciar o estado da ação de copiar por meio de uma região `aria-live` em vez de alterar o rótulo do botão.
- Tornar o botão de copiar claramente visível quando estiver em foco via teclado, usando estilização `focus-visible` e contornos.
- Ocultar ícones decorativos de copiar/verificação dos leitores de tela para evitar anúncios redundantes.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the chat message copy button’s accessibility and keyboard usability.

Enhancements:
- Announce the copy action state via an aria-live region instead of changing the button label.
- Make the copy button clearly visible when focused via keyboard using focus-visible styling and outlines.
- Hide decorative copy/check icons from screen readers to avoid redundant announcements.

</details>