### PR TITLE
🎨 Palette: Improve accessibility of MessageBubble copy button

### DIFF
--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,12 +46,15 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
-                            title={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
+                            title="Copiar mensagem"
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <span className="sr-only" aria-live="polite">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
🎨 Palette: Improve accessibility of MessageBubble copy button

💡 What:
- Converted dynamic `aria-label`/`title` to static values ("Copiar mensagem") to prevent screen reader confusion.
- Added a visually hidden `aria-live="polite"` region to reliably announce the "Mensagem copiada" state change to screen readers, keeping it separate from the button's primary label to prevent screen reader overlap.
- Added `aria-hidden="true"` to the decorative `Copy` and `Check` icons inside the button.
- Added explicit `focus-visible:ring-2` styling so keyboard navigators have a clear visual focus indicator, since the button normally relies on hover interactions to become fully visible.

🎯 Why:
To ensure the copy button is fully usable by keyboard navigators (clear focus state) and screen reader users (reliable announcement of actions without confusing label changes or redundant icon readouts).

♿ Accessibility:
- Keyboard navigation (focus ring)
- Screen reader announcements (aria-live)
- Removed redundant semantics (aria-hidden on icons)
- Stable accessible name

---
*PR created automatically by Jules for task [11388215301811453657](https://jules.google.com/task/11388215301811453657) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e a visibilidade do foco do botão de copiar mensagem de chat em `MessageBubble`.

Novas funcionalidades:
- Anunciar o resultado da ação de copiar por meio de uma região `aria-live` visualmente oculta para leitores de tela.

Aprimoramentos:
- Usar um nome acessível e tooltip estáticos e estáveis para o botão de copiar em vez de rótulos que mudam dinamicamente.
- Ocultar ícones decorativos de copiar e de confirmação das tecnologias assistivas para evitar anúncios redundantes.
- Adicionar estilização explícita de anel de `focus-visible` para que o botão de copiar tenha um indicador claro de foco via teclado.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the accessibility and focus visibility of the chat message copy button in MessageBubble.

New Features:
- Announce the copy action result via a visually hidden aria-live region for screen readers.

Enhancements:
- Use a stable, static accessible name and tooltip for the copy button instead of dynamically changing labels.
- Hide decorative copy and check icons from assistive technologies to avoid redundant announcements.
- Add explicit focus-visible ring styling so the copy button has a clear keyboard focus indicator.

</details>