### PR TITLE
🎨 Palette: Improve accessibility and focus state of MessageBubble copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-23 - [Robust Copy Action Semantics]
+**Learning:** Using an `aria-live` region is superior to dynamically switching a button's `aria-label` (e.g., from "Copiar" to "Copiado") for announcing transient success states like clipboard actions. However, the `aria-live` container must be permanently mounted with its text content toggled, instead of conditionally rendering the container itself, to ensure screen readers capture the initial announcement reliably. Furthermore, elements hidden visually with `opacity-0` on desktop need explicit `focus-visible` styling (with appropriate offsets on dark backgrounds) to become discoverable for keyboard navigators.
+**Action:** Default to static `aria-label`s on buttons and a companion `sr-only aria-live` span for transient state announcements, and always verify hover-revealed elements include strong `focus-visible` styling.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -44,10 +44,13 @@ const MessageBubble = ({ message, isUser }) => {
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
                     <div className="flex flex-col justify-center">
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Mensagem copiada' : ''}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus:outline-none focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}


### PR DESCRIPTION
As "Palette", this PR introduces a micro-UX improvement to the `MessageBubble` component focused on accessibility and keyboard navigation.

**What:**
1. A visually hidden `aria-live="polite"` span was added to the copy button container. It now reliably announces "Mensagem copiada" when triggered.
2. The button's `aria-label` was made static to "Copiar mensagem".
3. Explicit `focus-visible` ring styling (with a dark background offset) was added to the button.

**Why:**
- Dynamically toggling a button's `aria-label` from "Copiar" to "Copiado" is notoriously unreliable for screen readers. A dedicated, permanently mounted `aria-live` region is the best practice for transient success states.
- The copy button was previously hidden on desktop using `opacity-0` but lacked focus styling. When a keyboard user navigated to it, the browser's default focus ring was insufficient against the dark background, making it hard to discover.

**Accessibility:**
- Improved screen reader announcements for clipboard actions.
- Clear visual focus indicator for keyboard users.

---
*PR created automatically by Jules for task [8035959458670918075](https://jules.google.com/task/8035959458670918075) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a capacidade de descoberta do botão de copiar do MessageBubble para usuários de leitores de tela e de teclado.

Melhorias:
- Anunciar o sucesso da cópia por meio de uma região `aria-live` persistente, visualmente oculta, em vez de alternar o rótulo do botão.
- Padronizar o `aria-label` do botão de copiar e adicionar uma estilização forte do anel de `focus-visible` adequada para fundos escuros.

Documentação:
- Documentar as melhores práticas para a semântica da ação de copiar, uso de `aria-live` e estilização de `focus-visible` nas diretrizes do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the accessibility and discoverability of the MessageBubble copy button for screen reader and keyboard users.

Enhancements:
- Announce copy success via a persistent visually hidden aria-live region instead of toggling the button label.
- Standardize the copy button aria-label and add strong focus-visible ring styling suitable for dark backgrounds.

Documentation:
- Document best practices for copy action semantics, aria-live usage, and focus-visible styling in the Palette guidelines.

</details>