### PR TITLE
🎨 Palette: Improve copy button accessibility and focus states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [Aria-live vs Aria-label Updates]
+**Learning:** Dynamically updating a button's `aria-label` (e.g., changing "Copy" to "Copied") is not reliably announced by screen readers at the moment of interaction. A more robust pattern is to keep the `aria-label` static and add a permanently mounted, visually hidden `span` with `aria-live="polite"` that conditionally toggles the success text.
+**Action:** Use visually hidden `aria-live` regions for state confirmations instead of mutating the trigger button's `aria-label`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,12 +46,15 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus:outline-none focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What:** 
- Changed the dynamic `aria-label` on the copy button to be static.
- Added a visually hidden `span` with `aria-live="polite"` to reliably announce the "Copied" success state to screen readers.
- Added explicit `focus-visible` styling with ring offsets for dark mode so the button has a clear keyboard focus indicator (it previously only relied on `focus:opacity-100`).
- Added `aria-hidden="true"` to the internal `Copy` and `Check` icons so they aren't redundantly announced.
- Documented the learning regarding `aria-live` vs `aria-label` updates in the Palette journal.

🎯 **Why:** 
Screen readers often fail to announce dynamic text changes made directly to an `aria-label` attribute upon clicking. Using a dedicated, permanently mounted `aria-live` region is the recommended pattern for announcing transient success states like "Copied!". Furthermore, interactive elements need explicit focus indicators for users relying on keyboard navigation.

♿ **Accessibility:** 
- Improved screen reader reliability for the "Copied!" action feedback.
- Ensured purely decorative icons within labeled buttons are hidden from the accessibility tree.
- Improved visibility of the element when navigated via keyboard.

---
*PR created automatically by Jules for task [12739276433906416019](https://jules.google.com/task/12739276433906416019) started by @RenyEnnos*

## Summary by Sourcery

Melhorar o feedback de acessibilidade e a visibilidade do foco do botão de copiar mensagens do chat, e registrar os aprendizados relacionados à acessibilidade no diário do Palette.

Correções de bug:
- Garantir que o botão de copiar forneça um anúncio confiável de status "Copied" para leitores de tela por meio de uma região dedicada com `aria-live`.

Aprimoramentos:
- Tornar o estado de foco de teclado do botão de copiar claramente visível com um anel de `focus-visible` explícito, incluindo no modo escuro.
- Ocultar ícones decorativos de copiar e de confirmação das tecnologias assistivas para evitar anúncios redundantes.
- Documentar no diário do Palette os aprendizados de acessibilidade sobre o uso de regiões `aria-live` em vez de atualizações dinâmicas de `aria-label`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the chat message copy button’s accessibility feedback and focus visibility, and record the related accessibility learnings in the Palette journal.

Bug Fixes:
- Ensure the copy button provides a reliable "Copied" status announcement to screen readers via a dedicated aria-live region.

Enhancements:
- Make the copy button’s keyboard focus state clearly visible with explicit focus-visible ring styling, including in dark mode.
- Hide decorative copy and confirmation icons from assistive technologies to avoid redundant announcements.
- Document accessibility learnings about using aria-live regions instead of dynamic aria-label updates in the Palette journal.

</details>

Correções de bug:
- Garantir que o botão de copiar forneça um aviso confiável de status "Copiado" para leitores de tela usando uma região `aria-live`.

Aprimoramentos:
- Tornar o estado de foco do botão de copiar claramente visível com uma borda de foco explícita (`focus-visible`), especialmente no modo escuro.
- Ocultar ícones decorativos de copiar/confirmação das tecnologias assistivas para evitar anúncios redundantes.
- Documentar os aprendizados de acessibilidade sobre `aria-live` versus atualizações de `aria-label` no diário do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Melhorar o feedback de acessibilidade e a visibilidade do foco do botão de copiar mensagens do chat, e registrar os aprendizados relacionados à acessibilidade no diário do Palette.

Correções de bug:
- Garantir que o botão de copiar forneça um anúncio confiável de status "Copied" para leitores de tela por meio de uma região dedicada com `aria-live`.

Aprimoramentos:
- Tornar o estado de foco de teclado do botão de copiar claramente visível com um anel de `focus-visible` explícito, incluindo no modo escuro.
- Ocultar ícones decorativos de copiar e de confirmação das tecnologias assistivas para evitar anúncios redundantes.
- Documentar no diário do Palette os aprendizados de acessibilidade sobre o uso de regiões `aria-live` em vez de atualizações dinâmicas de `aria-label`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the chat message copy button’s accessibility feedback and focus visibility, and record the related accessibility learnings in the Palette journal.

Bug Fixes:
- Ensure the copy button provides a reliable "Copied" status announcement to screen readers via a dedicated aria-live region.

Enhancements:
- Make the copy button’s keyboard focus state clearly visible with explicit focus-visible ring styling, including in dark mode.
- Hide decorative copy and confirmation icons from assistive technologies to avoid redundant announcements.
- Document accessibility learnings about using aria-live regions instead of dynamic aria-label updates in the Palette journal.

</details>

</details>