### PR TITLE
🎨 Palette: Enhance MessageBubble Copy Button Accessibility and Focus Styling

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [Aria-live vs Dynamic Aria-label for State Confirmation]
+**Learning:** For transient state confirmations (like "Copiado!" after clicking a copy button), dynamically updating the `aria-label` or `title` of the focused element is unreliable. Screen readers often miss the update because the element's name changed while it was already focused. A dedicated, visually hidden `aria-live="polite"` region that receives text content updates is much more robust for announcing these state changes.
+**Action:** Use a permanent, visually hidden `aria-live` region for announcing transient state changes instead of mutating the `aria-label` of the active element.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,12 +43,16 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
+                        {/* Visually hidden aria-live region for screen reader confirmation */}
+                        <div className="sr-only" aria-live="polite">
+                            {isCopied ? "Copiado" : ""}
+                        </div>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
-                            title={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
+                            title="Copiar mensagem"
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>


### PR DESCRIPTION
💡 **What:**
- Changed the `aria-label` and `title` of the `MessageBubble` copy button to be static ("Copiar mensagem").
- Added a permanently mounted, visually hidden `aria-live="polite"` div to announce the "Copiado" state.
- Enhanced keyboard accessibility by adding `focus-visible` styling (`ring-2`, `ring-offset-2`) so the button is clearly visible when focused, even if hidden on desktop normally.
- Logged the learning in `.Jules/palette.md`.

🎯 **Why:**
When a user clicks a button to copy text, dynamically changing its `aria-label` while it has focus is unreliable for screen readers. Using an `aria-live` region guarantees the state change is announced. Additionally, interactive elements must have clear focus rings for keyboard navigation, particularly when they rely on hover states (`group-hover`) to become visible on desktop.

♿ **Accessibility:**
- Reliable screen reader announcement of transient state ("Copiado").
- Strong visual focus indicator for keyboard users.

---
*PR created automatically by Jules for task [12841945431500374899](https://jules.google.com/task/12841945431500374899) started by @RenyEnnos*

## Resumo por Sourcery

Melhora a acessibilidade e a visibilidade de foco do botão de copiar do MessageBubble e documenta o aprendizado relacionado no guia do Palette.

Novos recursos:
- Anunciar a confirmação de cópia do texto da mensagem por meio de uma região aria-live visualmente oculta.

Aprimoramentos:
- Fazer com que o botão de copiar do MessageBubble tenha sempre um anel de foco visível claro e manter seu nome acessível estático para leitores de tela.
- Registrar, na documentação do Palette, as melhores práticas de acessibilidade para usar aria-live em vez de alterar aria-label.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility of the MessageBubble copy button and document the related learning in the Palette guide.

New Features:
- Announce copy confirmation for message text via a visually hidden aria-live region.

Enhancements:
- Make the MessageBubble copy button always have a clear focus-visible ring and keep its accessible name static for screen readers.
- Record accessibility best practices for using aria-live instead of mutating aria-label in the Palette documentation.

</details>