### PR TITLE
🎨 Palette: Ensure reliable screen reader feedback for copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [Reliable State Confirmation with aria-live]
+**Learning:** Dynamically updating an element's `aria-label` (e.g., from "Copiar" to "Copiado") is often unreliable for screen reader announcements because the element itself hasn't necessarily received focus again or triggered a new reading context. A more robust pattern for state confirmations (like "Copied!") is to keep the button's `aria-label` static and toggle text content inside a permanently mounted `div` with `aria-live="polite"` and `className="sr-only"`.
+**Action:** Use visually hidden `aria-live` regions instead of dynamic `aria-label` changes for announcing temporary state confirmations like success messages after button clicks.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
                             className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
-                            title={isCopied ? "Copiado" : "Copiar mensagem"}
+                            aria-label="Copiar mensagem"
+                            title="Copiar mensagem"
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <div role="status" aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What:** Added a permanently mounted, visually hidden `aria-live="polite"` region to the copy button in `MessageBubble.jsx` that toggles text to "Mensagem copiada" when activated. Added `aria-hidden="true"` to the Check and Copy icons. Kept the button's `aria-label` and `title` static.
🎯 **Why:** Dynamically changing the `aria-label` of a button after it is clicked is an unreliable pattern for screen reader state announcements because the reading context does not always update unless focus shifts. Using `aria-live` provides robust, guaranteed feedback to non-sighted users that their action succeeded.
📸 **Before/After:** Visually identical, but significantly improved auditory experience for screen readers.
♿ **Accessibility:**
  - Robust state confirmation via `aria-live`.
  - Prevented redundant SVG icon reading by adding `aria-hidden="true"`.
  - Maintains static accessible name (`aria-label`) on the trigger button.

---
*PR created automatically by Jules for task [5031546497069501418](https://jules.google.com/task/5031546497069501418) started by @RenyEnnos*

## Summary by Sourcery

Melhora o feedback de acessibilidade para o botão de copiar mensagem do chat usando uma região `aria-live`.

Melhorias:
- Manter o nome acessível do botão de copiar estático enquanto anuncia o sucesso da cópia por meio de uma mensagem de status `aria-live` com `polite` visualmente oculta e ocultando ícones SVG das tecnologias assistivas.

Documentação:
- Documentar o padrão `aria-live` para confirmação confiável de estado por leitores de tela nas diretrizes de acessibilidade do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility feedback for the chat message copy button using an aria-live region.

Enhancements:
- Keep the copy button’s accessible name static while announcing copy success via a visually hidden aria-live polite status message and hiding SVG icons from assistive technologies.

Documentation:
- Document the aria-live pattern for reliable screen reader state confirmation in the Palette accessibility guidelines.

</details>