### PR TITLE
🎨 Palette: Improve accessibility of MessageBubble copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [Aria-live Regions for State Confirmation]
+**Learning:** For accessibility, changing the `aria-label` of a button dynamically (e.g., from "Copiar mensagem" to "Copiado" after clicking) is not reliably announced by all screen readers. Instead, the best practice is to keep the `aria-label` static and add a visually hidden `aria-live="polite"` region near the button to announce the state change confirmation text (like "Mensagem copiada").
+**Action:** Use an `aria-live` visually hidden region for brief state confirmations rather than mutating the active element's `aria-label`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
-                            title={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none"
+                            aria-label="Copiar mensagem"
+                            title="Copiar mensagem"
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
🎨 Palette: Improved accessibility and focus states for the message copy button

💡 What:
- Kept the `aria-label` on the copy button static (`"Copiar mensagem"`).
- Added a visually hidden `span` with `aria-live="polite"` to reliably announce `"Mensagem copiada"` when the text is copied.
- Added explicit `focus-visible` styles (`ring-2`, offsets) to the copy button for better keyboard navigation visibility.

🎯 Why:
- Dynamically changing `aria-label` on a button after it's clicked is notoriously unreliable for screen reader announcements across different browser/AT combinations. Using an `aria-live` region is the robust, standard pattern for state change confirmations.
- Adding explicit `focus-visible` offset rings ensures keyboard users can easily see which auxiliary action is focused against the dark background.

📸 Before/After:
Before: The button had no clear focus state, and screen readers might miss the "Copiado" announcement.
After: The button has a clear gray focus ring, and screen readers will politely announce the state change.

♿ Accessibility: 
- `aria-live` announcement for clipboard actions.
- Improved keyboard focus visibility.

---
*PR created automatically by Jules for task [10634408119267188809](https://jules.google.com/task/10634408119267188809) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco para o botão de cópia de mensagem do assistente e documentar o padrão `aria-live` escolhido no guia do Palette.

Novos recursos:
- Anunciar ações bem-sucedidas de cópia de mensagem por meio de uma região `aria-live` visualmente oculta, adjacente ao botão de cópia.

Aperfeiçoamentos:
- Adicionar estilos explícitos de anel de `focus-visible` e deslocamento ao botão de cópia de mensagem para melhor visibilidade na navegação por teclado.
- Manter o rótulo do botão de cópia estático, ao mesmo tempo em que reflete o estado de copiado por meio de alterações no ícone.

Documentação:
- Documentar práticas recomendadas para usar regiões `aria-live` em vez de alterações dinâmicas de `aria-label` no guia de acessibilidade do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility for the assistant message copy button and document the chosen aria-live pattern in the Palette guide.

New Features:
- Announce successful message copy actions via a visually hidden aria-live region adjacent to the copy button.

Enhancements:
- Add explicit focus-visible ring and offset styles to the message copy button for better keyboard navigation visibility.
- Keep the copy button label static while still reflecting copied state via icon changes.

Documentation:
- Document best practices for using aria-live regions instead of dynamic aria-label changes in the Palette accessibility guide.

</details>