### PR TITLE
🎨 Palette: Improve MessageBubble Copy accessibility and keyboard UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible State Confirmations & Focus Visibility]
+**Learning:** Dynamically updating a button's `aria-label` to announce state changes (like "Copied!") is unreliable because screen readers often only read the label when focus lands. A permanently mounted `<span aria-live="polite" className="sr-only">` that toggles text content ensures reliable announcements. Furthermore, elements hidden via `opacity-0` but interactable via keyboard must have `focus-visible:opacity-100` alongside their `focus-visible:ring-*` classes so they become visible when tabbed to.
+**Action:** Use `aria-live` regions for temporary state confirmations instead of dynamic labels, and pair `opacity-0` visibility patterns with `focus-visible:opacity-100`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,14 +43,19 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
+                        {/* Live region for screen reader announcements */}
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Mensagem copiada' : ''}
+                        </span>
+
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
-                            title={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus-visible:opacity-100"
+                            aria-label="Copiar mensagem"
+                            title="Copiar mensagem"
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
                     </div>
                 )}


### PR DESCRIPTION
💡 What: Improved the "Copy" button inside the `MessageBubble` component by replacing dynamic `aria-label` updates with a reliable `aria-live` screen reader region. Also added robust `focus-visible` styling and properly hid decorative icons from screen readers.
🎯 Why: Dynamic aria-labels are often unreliable for state announcements since screen readers typically only read them upon initial focus. The copy action needs to clearly announce its success state without moving focus. Furthermore, keyboard users tabbing through elements need clear visual focus on the copy button, which was previously invisible on desktop until hovered.
♿ Accessibility:
- Added permanently mounted `aria-live="polite"` region for reliable "Mensagem copiada" announcements.
- Made the button's `aria-label` static ("Copiar mensagem").
- Added explicit `focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:opacity-100` classes so the button becomes visible and highlighted when navigating via keyboard.
- Added `aria-hidden="true"` to the internal Check/Copy icons to prevent redundant announcements.

---
*PR created automatically by Jules for task [12547562157678418843](https://jules.google.com/task/12547562157678418843) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e o comportamento de foco via teclado para o botão de copiar do MessageBubble e documentar padrões de acessibilidade relacionados nas diretrizes do Palette.

Novos recursos:
- Anunciar o sucesso da cópia para o botão de copiar do MessageBubble por meio de uma região dedicada `aria-live` em vez de mudanças no rótulo.

Aprimoramentos:
- Reforçar a visibilidade do foco de teclado para o botão de copiar do MessageBubble, garantindo que ele esteja visível e destacado quando focalizado por navegação via teclado.
- Ocultar ícones decorativos de copiar/check em MessageBubble das tecnologias assistivas usando `aria-hidden` para evitar anúncios redundantes.
- Documentar as melhores práticas para uso de `aria-live` e comportamento de `focus-visible` nas diretrizes de acessibilidade do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and keyboard focus behavior for the MessageBubble copy button and document related accessibility patterns in the Palette guidelines.

New Features:
- Announce copy success for the MessageBubble copy button via a dedicated aria-live region instead of label changes.

Enhancements:
- Strengthen keyboard focus visibility for the MessageBubble copy button, ensuring it is visible and highlighted when focused via keyboard navigation.
- Hide decorative copy/check icons in MessageBubble from assistive technologies using aria-hidden to avoid redundant announcements.
- Document best practices for aria-live usage and focus-visible behavior in the Palette accessibility guidelines.

</details>