### PR TITLE
🎨 Palette: Improve accessibility of MessageBubble copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [State Confirmations via aria-live]
+**Learning:** For accessibility, state confirmations (like 'Copied!') should use a visually hidden 'aria-live' region rather than dynamically updating the 'aria-label' of the triggered button. Dynamically updating 'aria-label' can lead to inconsistent or missed announcements by screen readers, whereas 'aria-live' ensures reliable feedback when the state changes. 'aria-live' containers must be permanently mounted (toggling their text content) rather than conditionally rendered, to ensure screen readers reliably catch the initial announcement.
+**Action:** Use permanently mounted `aria-live` regions for short, temporary status announcements instead of changing button labels dynamically.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
-                            title={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
+                            title="Copiar mensagem"
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Mensagem copiada' : ''}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
🎨 Palette: Improve accessibility of MessageBubble copy button

💡 What: Replaced dynamic `aria-label` with a permanently mounted `aria-live` region for the copy button, added robust `focus-visible` styles, and marked internal icons as `aria-hidden`. Also logged the pattern to the learning journal.
🎯 Why: Screen readers often struggle with dynamically changing `aria-labels` on buttons, failing to announce state confirmations. Using an `aria-live` region is the robust standard for such status updates. The explicit focus styles ensure keyboard users can find the copy button, which is usually only revealed on hover.
♿ Accessibility:
- Switched status confirmation from dynamic `aria-label` to static `aria-label` + hidden `aria-live` element.
- Added explicit `focus-visible` states for keyboard navigability in dark mode.
- Hid decorative icons from screen readers.

---
*PR created automatically by Jules for task [18384308636291894326](https://jules.google.com/task/18384308636291894326) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e o gerenciamento de foco do botão de copiar mensagens do chat e documenta o padrão de aria-live no diário de aprendizagem do Palette.

Correções de bugs:
- Garantir que leitores de tela anunciem de forma confiável as confirmações de cópia usando uma região aria-live montada permanentemente em vez de um aria-label dinâmico.

Melhorias:
- Refinar os estilos de foco visível (`focus-visible`) do botão de copiar em `MessageBubble` para melhor acessibilidade via teclado no modo escuro e ocultar ícones decorativos das tecnologias assistivas.

Documentação:
- Documentar o padrão de aria-live para confirmações de estado no diário de aprendizagem do Palette para trabalhos futuros de acessibilidade.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the accessibility and focus handling of the chat message copy button and document the aria-live pattern in the Palette learning journal.

Bug Fixes:
- Ensure screen readers reliably announce copy confirmations using a permanently mounted aria-live region instead of a dynamic aria-label.

Enhancements:
- Refine MessageBubble copy button focus-visible styles for better keyboard accessibility in dark mode and hide decorative icons from assistive technologies.

Documentation:
- Document the aria-live pattern for state confirmations in the Palette learning journal for future accessibility work.

</details>