### PR TITLE
🎨 Palette: Accessible Copy Feedback via aria-live

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [Aria-live vs Dynamic Aria-label for Momentary States]
+**Learning:** Dynamically mutating an `aria-label` (e.g. from "Copy" to "Copied!") for momentary states is unreliable for screen readers, as the focus state or timing might prevent the change from being announced. A permanently mounted, visually hidden `aria-live="polite"` region that toggles its text content is a much more robust and accessible pattern for announcing state changes without interrupting the user.
+**Action:** Use a dedicated `aria-live` region for momentary state announcements (like "Copied") instead of updating the trigger button's `aria-label`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,14 +43,22 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
+                        {/* Visually hidden aria-live region for screen reader announcements */}
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Mensagem copiada!' : ''}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? (
+                                <Check size={16} className="text-green-500" aria-hidden="true" />
+                            ) : (
+                                <Copy size={16} aria-hidden="true" />
+                            )}
                         </button>
                     </div>
                 )}


### PR DESCRIPTION
I have added an accessibility and micro-UX enhancement to the `MessageBubble` component!

I noticed that the copy button was dynamically updating its `aria-label` to "Copiado" when clicked. This pattern is often unreliable for screen reader users, as the momentary state change might not be announced correctly depending on timing and focus state. 

I've refactored this interaction to use a much more robust pattern: a permanently mounted, visually hidden `aria-live="polite"` region that toggles its text content. This ensures screen readers reliably announce the confirmation without interrupting the user's flow.

At the same time, I added `aria-hidden="true"` to the inner Lucide icons to prevent any redundant readouts, and I greatly improved the keyboard focus indicator (`focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900`) so keyboard users can clearly see the button when they tab to it, even on the dark background.

I've verified the changes using Playwright, checked the build/linting locally, and updated my Palette Journal with these a11y learnings.

---
*PR created automatically by Jules for task [5100018692557127821](https://jules.google.com/task/5100018692557127821) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e a experiência do usuário (UX) do botão de copiar mensagens do chat e documenta o padrão de aria-live no diário do Palette.

Novos recursos:
- Anunciar a confirmação de cópia para mensagens que não são do usuário por meio de uma região aria-live dedicada e visualmente oculta.

Aprimoramentos:
- Refinar o estilo de foco via teclado do botão de copiar para fornecer um anel de foco claro e deslocado em fundos escuros.
- Ocultar ícones decorativos de copiar/checagem das tecnologias assistivas usando aria-hidden para evitar anúncios redundantes.

Documentação:
- Documentar, no diário do Palette, a abordagem preferencial com aria-live em vez de atualizações dinâmicas de aria-label para anúncios de estado transitório.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and UX of the chat message copy button and document the aria-live pattern in the Palette journal.

New Features:
- Announce copy confirmation for non-user messages via a dedicated visually hidden aria-live region.

Enhancements:
- Refine the copy button’s keyboard focus styling to provide a clear, offset focus ring on dark backgrounds.
- Hide decorative copy/check icons from assistive technologies using aria-hidden to avoid redundant announcements.

Documentation:
- Document the preferred aria-live approach over dynamic aria-label updates for transient state announcements in the Palette journal.

</details>