### PR TITLE
🎨 Palette: Improve accessibility of MessageBubble copy button

### DIFF
--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
-                            title={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
+                            title="Copiar mensagem"
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 What: Improved the copy button's accessibility by using an `aria-live` region for screen reader announcements, fixing focus visibility, and hiding decorative icons from screen readers.
🎯 Why: Relying on dynamic `aria-label` updates for state changes ("Copied") is unreliable for screen readers. Using a visually hidden `aria-live` region ensures the state is correctly announced. The focus ring was also added to ensure the button is navigable and visible for keyboard users.
♿ Accessibility: Added `aria-live="polite"`, `aria-hidden="true"` to SVG icons, static `aria-label`, and `focus-visible` styles with ring offset.

---
*PR created automatically by Jules for task [16201348284501384005](https://jules.google.com/task/16201348284501384005) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e o gerenciamento de foco do botão de copiar mensagens do chat.

Novos recursos:
- Anunciar o status da cópia por meio de uma região `aria-live` fora da tela em vez de alterações dinâmicas em `aria-label`.

Aprimoramentos:
- Tornar o estado de foco do botão de copiar claramente visível para usuários de teclado e ocultar ícones decorativos dos leitores de tela.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus handling for the chat message copy button.

New Features:
- Announce copy status via an offscreen aria-live region instead of dynamic aria-label changes.

Enhancements:
- Make the copy button’s focus state clearly visible for keyboard users and hide decorative icons from screen readers.

</details>