### PR TITLE
🎨 Palette: Use aria-live for copy confirmation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [Reliable State Confirmations with aria-live]
+**Learning:** Dynamically updating a button's `aria-label` (e.g., from "Copy" to "Copied") is often unreliable for screen reader announcements because focus remains on the button and the change may not be polled immediately.
+**Action:** Use a dedicated, visually hidden `aria-live="polite"` region alongside the button to announce ephemeral state changes (like "Copied!"), keeping the button's `aria-label` consistent and avoiding redundant icon announcements with `aria-hidden="true"`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -44,13 +44,16 @@ const MessageBubble = ({ message, isUser }) => {
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
                     <div className="flex flex-col justify-center">
+                        <span className="sr-only" aria-live="polite">
+                            {isCopied ? "Copiado" : ""}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
                     </div>
                 )}


### PR DESCRIPTION
💡 **What:** 
Replaced dynamic `aria-label` swapping with a visually hidden `aria-live="polite"` region on the `MessageBubble` copy button. Added explicit focus-ring styles to the button. Added `aria-hidden="true"` to purely decorative icons within the button.

🎯 **Why:** 
Dynamically updating an `aria-label` while an element has focus often fails to trigger a screen reader announcement. An `aria-live` region provides a reliable, robust way to announce transient confirmation states without breaking the component's semantic name. The custom focus styling fixes an issue where standard focus rings lack sufficient contrast against dark background themes.

♿ **Accessibility:** 
- Added `aria-live="polite"` for reliable state announcements.
- Maintained a stable `aria-label="Copiar mensagem"` for consistent element naming.
- Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900` to guarantee high visibility for keyboard navigation.
- Hide decorative inner icons to prevent redundant or confusing screen reader reading.

---
*PR created automatically by Jules for task [9784921056472118519](https://jules.google.com/task/9784921056472118519) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e o comportamento de feedback do botão de copiar mensagem do chat.

Melhorias:
- Usar um aria-label estável e uma região aria-live visualmente oculta para anunciar a confirmação de cópia para o botão de copiar mensagem.
- Adicionar estilos de anel de foco visível com alto contraste ao botão de copiar para melhor acessibilidade via teclado.
- Ocultar ícones decorativos de copiar/confirmação das tecnologias assistivas usando aria-hidden para evitar anúncios redundantes.

Documentação:
- Estender as notas do Palette com orientações sobre o uso de regiões aria-live para confirmações de estado confiáveis e sobre manter os rótulos de botões estáveis.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and feedback behavior of the chat message copy button.

Enhancements:
- Use a stable aria-label and a visually hidden aria-live region to announce copy confirmation for the message copy button.
- Add high-contrast focus-visible ring styles to the copy button for better keyboard accessibility.
- Hide decorative copy/check icons from assistive technologies using aria-hidden to avoid redundant announcements.

Documentation:
- Extend the Palette notes with guidance on using aria-live regions for reliable state confirmations and keeping button labels stable.

</details>