### PR TITLE
🎨 Palette: Improve copy button accessibility and focus states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [Aria-Live vs Dynamic Aria-Label]
+**Learning:** For state confirmations (like a "Copied!" message), dynamically changing `aria-label` or `title` attributes on a triggered button can fail to be announced reliably by some screen readers. Using a visually hidden (`sr-only`), permanently mounted container with `aria-live="polite"` that toggles text content is a much more robust pattern for ensuring screen readers announce the state change.
+**Action:** Use permanently mounted `aria-live` regions instead of dynamic `aria-label` updates for temporary state confirmations triggered by user interaction.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,12 +46,15 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
-                            title={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none"
+                            aria-label="Copiar mensagem"
+                            title="Copiar mensagem"
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada!" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 What: Replaced the dynamic `aria-label` on the copy button with a permanent `aria-live` region for state confirmations ("Copied!"), and added dark-theme specific `focus-visible` keyboard focus rings.
🎯 Why: Dynamic `aria-label` updates on triggered buttons can fail to be announced reliably by screen readers. A dedicated `aria-live` region is the robust standard. Additionally, icon-only buttons need strong visual focus indicators for keyboard users.
♿ Accessibility:
- Added `aria-live="polite"` for reliable screen reader state confirmation.
- Changed to a static `aria-label="Copiar mensagem"` so the button's identity doesn't confusingly change while focused.
- Added `focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900` for clear keyboard navigation focus states against the dark background.

---
*PR created automatically by Jules for task [1776496302105080829](https://jules.google.com/task/1776496302105080829) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e o tratamento do foco via teclado para o botão de copiar mensagem do chat e documenta o padrão de aria-live no guia do Palette.

Novos recursos:
- Anunciar a confirmação de cópia por meio de uma região aria-live dedicada e visualmente oculta para a ação de copiar mensagem.

Aperfeiçoamentos:
- Definir um nome acessível estático e um título para o botão de copiar, preservando ao mesmo tempo o feedback visual do estado de “copiado”.
- Adicionar um estilo de anel de foco-visible mais forte para o botão de copiar, garantindo uma indicação clara de foco pelo teclado em fundos escuros.

Documentação:
- Documentar o uso recomendado de regiões aria-live montadas permanentemente em vez de atualizações dinâmicas de aria-label para confirmações de estado no guia do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and keyboard focus handling for the chat message copy button and document the aria-live pattern in the Palette guide.

New Features:
- Announce copy confirmation via a dedicated, visually hidden aria-live region for the message copy action.

Enhancements:
- Set a static accessible name and title for the copy button while preserving visual copied state feedback.
- Add stronger focus-visible ring styling for the copy button to ensure clear keyboard focus indication on dark backgrounds.

Documentation:
- Document the recommended use of permanently mounted aria-live regions over dynamic aria-label updates for state confirmations in the Palette guide.

</details>