### PR TITLE
🎨 Palette: Improve accessibility of MessageBubble copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+## 2025-02-19 - Improved MessageBubble Copy Button Accessibility
+**Learning:** Copy buttons using dynamic `aria-label` texts fail to reliably announce their updated state (e.g. from "Copiar mensagem" to "Copiado") to screen readers because the label changes instantly and the button loses context.
+**Action:** Used an `aria-live="polite"` region with `.sr-only` permanently mounted next to the button that holds the state announcement, and made the button's `aria-label` static. Also included explicit `focus-visible` classes to ensure visibility for keyboard navigators.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,12 +46,15 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus:outline-none"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
## 💡 What
Updated the Copy button in the `MessageBubble` component to improve its accessibility for screen readers and keyboard users.
- Replaced the dynamic `aria-label` with a static "Copiar mensagem".
- Added an `aria-live="polite"` region `.sr-only` to visually hide but properly announce the state change ("Mensagem copiada") when the button is clicked.
- Added explicit `focus-visible` classes to ensure the button is visually outlined and visible when focused via keyboard navigation.
- Maintained the dynamic `title` attribute for mouse hover tooltips.

## 🎯 Why
Dynamically changing `aria-label` texts on a button after click can be unreliable because the element might lose context or the screen reader might skip the updated text. Using an `aria-live` region is the best practice for robust announcements. Adding `focus-visible` classes improves keyboard navigation accessibility, making it clear when the button is focused.

## ♿ Accessibility
- Ensured state change is properly announced to screen readers (`aria-live`).
- Improved visibility for keyboard users (`focus-visible`).

---
*PR created automatically by Jules for task [150270218604553620](https://jules.google.com/task/150270218604553620) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do botão de copiar do MessageBubble e documentar os aprendizados relacionados à acessibilidade.

Melhorias:
- Tornar o botão de copiar do MessageBubble mais acessível usando um `aria-label` estático, uma região `aria-live` para anúncios de status de cópia e estilos explícitos de `focus-visible` para usuários de teclado.

Documentação:
- Documentar os aprendizados de acessibilidade e as ações tomadas para o botão de copiar do MessageBubble no palette journal.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the MessageBubble copy button and document the related accessibility learnings.

Enhancements:
- Make the MessageBubble copy button more accessible by using a static aria-label, an aria-live region for copy status announcements, and explicit focus-visible styles for keyboard users.

Documentation:
- Document the accessibility learnings and actions taken for the MessageBubble copy button in the palette journal.

</details>