### PR TITLE
🎨 Palette: Copy Button Accessibility Enhancement

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [Reliable State Confirmations with aria-live]
+**Learning:** Dynamically updating a button's `aria-label` to provide transient feedback (like "Copied!") is not reliably announced by all screen readers, as the focus remains on the element but its label abruptly changes.
+**Action:** For reliable screen reader announcements of transient states, use a permanently mounted, visually hidden `aria-live="polite"` region that conditionally renders its text content, rather than changing the `aria-label` of the trigger button.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:opacity-100"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What**: Added a visually hidden `aria-live` region to announce the "Copied!" state, kept the button's `aria-label` static, kept the `title` dynamic for tooltips, and improved the button's focus ring styling.

🎯 **Why**: When a button's `aria-label` changes while it has focus, screen readers often do not reliably announce the change. Using an `aria-live` region is the recommended pattern for transient feedback (like a "Copied" toast). Additionally, the copy button lacked a clear focus ring, making keyboard navigation difficult.

♿ **Accessibility**: 
- Screen readers will now reliably say "Mensagem copiada" when the user clicks the copy button.
- Keyboard navigators can now easily see when the copy button has focus, thanks to the new `focus-visible` ring styles.

---
*PR created automatically by Jules for task [8322463363147096674](https://jules.google.com/task/8322463363147096674) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco do botão de copiar mensagens do chat.

Novos recursos:
- Anunciar a cópia bem-sucedida da mensagem por meio de uma região aria-live visualmente oculta para leitores de tela.

Aprimoramentos:
- Manter o aria-label do botão de copiar estático enquanto se usa um título dinâmico para o feedback do tooltip.
- Reforçar o estilo do anel de focus-visible do botão de copiar para melhor visibilidade na navegação por teclado.
- Documentar o padrão de aria-live para feedback transitório nas diretrizes de acessibilidade da paleta.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the chat message copy button’s accessibility and focus visibility.

New Features:
- Announce successful message copying via a visually hidden aria-live region for screen readers.

Enhancements:
- Keep the copy button’s aria-label static while using a dynamic title for tooltip feedback.
- Strengthen the copy button’s focus-visible ring styling for better keyboard navigation visibility.
- Document the aria-live pattern for transient feedback in the palette accessibility guidelines.

</details>