### PR TITLE
🎨 Palette: Improve accessibility of copy button in MessageBubble

### DIFF
--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -44,10 +44,13 @@ const MessageBubble = ({ message, isUser }) => {
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
                     <div className="flex flex-col justify-center">
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Copiado' : ''}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}


### PR DESCRIPTION
💡 **What:** Added `focus-visible` styling to the Message Bubble copy button and improved how the "Copiado" state is announced to screen readers by using a dedicated `aria-live` region.
🎯 **Why:** The copy button was previously missing clear keyboard focus indicators, making it hard to use for keyboard navigators. Additionally, dynamically changing the `aria-label` when the button is clicked is an unreliable pattern for screen readers; a dedicated `aria-live` region ensures the "Copiado" feedback is reliably announced.
♿ **Accessibility:** Added `focus-visible:ring-2`, `focus-visible:ring-gray-400`, `focus-visible:ring-offset-2`, and `focus-visible:ring-offset-gray-900` to the button. Added a visually hidden `span` with `aria-live="polite"` inside the copy container.

---
*PR created automatically by Jules for task [15221435661618751163](https://jules.google.com/task/15221435661618751163) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade do botão de copiar mensagem do chat, adicionando indicadores claros de foco via teclado e um feedback confiável para leitores de tela quanto ao estado de conteúdo copiado.

Melhorias:
- Adicionar estilos de anel de `focus-visible` e redefinição de contorno ao botão de copiar mensagem para fornecer um indicador de foco via teclado claro.
- Anunciar o estado de conteúdo copiado por meio de uma região dedicada, visualmente oculta, com `aria-live`, em vez de alterar o `aria-label` do botão.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button by adding clear keyboard focus indicators and reliable screen reader feedback for the copied state.

Enhancements:
- Add focus-visible ring and outline reset styles to the message copy button to provide a clear keyboard focus indicator.
- Announce the copied state via a dedicated visually hidden aria-live region instead of changing the button aria-label.

</details>