### PR TITLE
🎨 Palette: Enhance Copy Button Accessibility and Focus State

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [Transient State Accessibility for Buttons]
+**Learning:** Dynamically updating a button's `aria-label` to provide transient state feedback (e.g. "Copied!") is unreliable for screen reader announcements when the element retains focus. Instead, a static primary label with a permanently mounted, adjacent `aria-live="polite"` region ensures the feedback is consistently announced.
+**Action:** Use an adjacent `aria-live` span for transient success/state messages alongside static button `aria-label`s instead of dynamically replacing the `aria-label` itself. Maintain dynamic `title` attributes if visual tooltips are desired for sighted users.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -44,10 +44,13 @@ const MessageBubble = ({ message, isUser }) => {
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
                     <div className="flex flex-col justify-center">
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}


### PR DESCRIPTION
💡 What: Enhanced the accessibility and keyboard usability of the "Copy" button in the `MessageBubble` component.
🎯 Why: Screen readers often fail to announce dynamic changes to an element's `aria-label` when it retains focus. By using a static label combined with an adjacent `aria-live` region, the transient "Copied!" message is now reliably read out. Additionally, the button lacked a visible focus indicator for keyboard users navigating the dark theme.
♿ Accessibility: 
  - Added robust screen reader announcements for the success state using `aria-live="polite"`.
  - Added `focus-visible:ring-2` and `focus-visible:ring-offset-2` to ensure the button has a clear focus ring for keyboard navigation.
  - Kept the visual tooltip (`title`) dynamic for sighted mouse users.

---
*PR created automatically by Jules for task [7570266157612508041](https://jules.google.com/task/7570266157612508041) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e a visibilidade do foco para o botão de copiar mensagem na interface de chat e documenta as orientações de design associadas nas notas da paleta.

Correções de bugs:
- Garante que o estado de sucesso do botão de copiar seja anunciado de forma confiável para usuários de leitores de tela por meio de uma região `aria-live` adjacente.

Melhorias:
- Adiciona um anel de foco visível para navegação por teclado ao botão de copiar que funciona bem em contextos de tema escuro.
- Documenta as práticas recomendadas para anúncios de estados transitórios de botões e uso estático de `aria-label` nas diretrizes da paleta.

Documentação:
- Estende a documentação da paleta com orientações sobre o uso de regiões `aria-live` para estados transitórios de botões e a manutenção de `aria-labels` estáticas.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility for the message copy button in the chat UI and document the associated design guidance in the palette notes.

Bug Fixes:
- Ensure the copy button’s success state is announced reliably to screen reader users via an adjacent aria-live region.

Enhancements:
- Add a visible keyboard focus ring to the copy button that works well in dark theme contexts.
- Document best practices for transient button state announcements and static aria-label usage in the palette guidelines.

Documentation:
- Extend palette documentation with guidance on using aria-live regions for transient button states and maintaining static aria-labels.

</details>