### PR TITLE
🎨 Palette: Improve copy button accessibility and keyboard navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-04-01 - [Transient States and Screen Readers]
+**Learning:** Changing the `aria-label` of a button dynamically (e.g., from "Copiar" to "Copiado") is often missed by screen readers because the focus is already on the button. A much more reliable pattern for announcing transient state changes (like success messages) is to keep the button's `aria-label` static and use an adjacent, permanently mounted `aria-live` region to announce the change. Also, elements relying on hover visibility patterns (e.g., `opacity-0 group-hover:opacity-100`) must explicitly use `focus-visible:opacity-100` alongside `focus-visible:ring-*` classes to ensure they appear and are clearly indicated when focused via keyboard navigation.
+**Action:** Use permanently mounted `aria-live` regions for transient state announcements instead of dynamic `aria-label`s on the triggering element, and always pair hover visibility with explicit `focus-visible` styling.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,12 +46,15 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Copiado' : ''}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 What: Improved accessibility of the copy button in `MessageBubble.jsx` by using an `aria-live` region for the "Copied" transient state, standardizing the `aria-label`, and adding robust `focus-visible` styling. Also documented this learning in `.Jules/palette.md`.
🎯 Why: Screen readers often miss dynamic changes to the `aria-label` of a currently focused element. Using an adjacent `aria-live` region ensures the "Copied!" feedback is always announced. Furthermore, adding explicit `focus-visible` styles ensures keyboard users can actually see and interact with elements that rely on `group-hover` for visibility on larger screens.
📸 Before/After: Screenshots were taken in the testing stage confirming the new visual focus ring correctly applies without breaking the UI flow.
♿ Accessibility: Ensures reliable screen reader feedback for copy actions and guarantees keyboard visibility against dark backgrounds.

---
*PR created automatically by Jules for task [7453596592130945218](https://jules.google.com/task/7453596592130945218) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a usabilidade via teclado do botão de copiar mensagem do chat e documentar o padrão nas diretrizes do Palette.

Novos recursos:
- Adicionar uma região `aria-live` para anunciar o estado transitório "Copiado" para a ação de copiar mensagem.

Aprimoramentos:
- Padronizar o texto de `aria-label` do botão de copiar e melhorar seu anel de `focus-visible` e visibilidade para usuários de teclado, especialmente quando normalmente oculto atrás de estilos acionados apenas por hover.

Documentação:
- Documentar boas práticas para lidar com estados transitórios com leitores de tela e combinar visibilidade apenas em hover com estilização explícita de `focus-visible` nas notas do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and keyboard usability of the chat message copy button and document the pattern in the Palette guidelines.

New Features:
- Add an aria-live region to announce the transient "Copiado" state for the message copy action.

Enhancements:
- Standardize the copy button aria-label text and improve its focus-visible ring and visibility for keyboard users, especially when normally hidden behind hover-only styles.

Documentation:
- Document best practices for handling transient states with screen readers and pairing hover-only visibility with explicit focus-visible styling in the Palette notes.

</details>