### PR TITLE
🎨 Palette: [UX improvement] Accessible copy feedback & focus states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [Accessible Transient State Feedback]
+**Learning:** For accessibility, state confirmations (like 'Copied!') should use a visually hidden 'aria-live' region rather than dynamically updating the 'aria-label' of the triggered button. This ensures reliable screen reader announcements while keeping the primary 'aria-label' static. Furthermore, hover-based visibility patterns (`group-hover:opacity-100`) must be paired with explicit `focus-visible:opacity-100` alongside `focus-visible:ring-*` classes to maintain robust keyboard accessibility and visibility when targeted directly.
+**Action:** When providing transient state feedback on buttons, use an adjacent, permanently mounted 'aria-live' region (toggling its text content) and ensure strong keyboard focus visibility for dynamically revealed elements.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
-                            title={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
+                            title={isCopied ? "Copiado!" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What**: Refactored the `MessageBubble`'s copy button to utilize a static `aria-label` accompanied by an `aria-live="polite"` hidden region for state announcements. Added robust `focus-visible` styling (`focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900`) for keyboard users.
🎯 **Why**: Dynamically swapping an `aria-label` when a button is clicked often fails to be announced by screen readers, leaving visually impaired users unaware if the copy action succeeded. Furthermore, the button was missing a clear focus ring, making keyboard navigation difficult in the dark theme.
📸 **Before/After**: See attached Playwright verification screenshots showing the new visible focus ring.
♿ **Accessibility**: Significant improvement for screen reader users relying on transient state feedback and keyboard-only users needing visual focus indication.

---
*PR created automatically by Jules for task [571473255074780849](https://jules.google.com/task/571473255074780849) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e o tratamento do foco de teclado para o botão de copiar mensagem do chat e documenta as diretrizes de design associadas nas notas da paleta.

Correções de bugs:
- Garante que o feedback da ação de copiar seja anunciado de forma confiável aos leitores de tela por meio de uma região dedicada `aria-live` em vez de alterar o `aria-label` do botão.

Aprimoramentos:
- Refina o botão de copiar mensagem do chat com um estilo de `focus-visible` mais evidente e um texto de título mais claro para o estado copiado.

Documentação:
- Estende as diretrizes de acessibilidade da paleta com recomendações para feedback de estado transitório usando regiões `aria-live` e visibilidade robusta do foco de teclado.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and keyboard focus handling for the chat message copy button and document the associated design guidance in the palette notes.

Bug Fixes:
- Ensure copy action feedback is reliably announced to screen readers via a dedicated aria-live region instead of changing the button's aria-label.

Enhancements:
- Refine the chat message copy button with stronger focus-visible styling and clearer title text for copied state.

Documentation:
- Extend the palette accessibility guidelines with recommendations for transient state feedback using aria-live regions and robust keyboard focus visibility.

</details>