### PR TITLE
🎨 Palette: Improve copy button accessibility with static aria-label and aria-live region

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2026-04-03 - [Accessible Transient States]
+**Learning:** Dynamically updating an interactive element's `aria-label` (e.g., changing "Copy" to "Copied!") is often missed by screen readers because the element is already focused. To provide reliable accessibility feedback for transient states, use a static `aria-label` on the button and an adjacent, permanently mounted visually hidden element with `aria-live="polite"` to announce the state change.
+**Action:** Use `aria-live` regions for transient state announcements instead of mutating `aria-label` attributes on focused elements.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,12 +46,15 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
🎨 Palette: Improve copy button accessibility with static aria-label and aria-live region

💡 What:
- Added a static `aria-label="Copiar mensagem"` to the copy button in `MessageBubble.jsx`.
- Introduced an adjacent, visually hidden `aria-live="polite"` region to announce the "Copiado" state.
- Added explicit `focus-visible` ring styles and opacity to the button.
- Logged the learning in `.Jules/palette.md`.

🎯 Why:
- Dynamically updating `aria-label`s on elements that currently have focus often fails to be announced by screen readers. A dedicated `aria-live` region ensures the transient "Copied!" state is reliably read out without losing context.
- The button lacked visible focus states on keyboard navigation, making it difficult for keyboard users to know when it was targeted.

♿ Accessibility:
- Ensures screen readers reliably announce the successful copy action.
- Improves keyboard navigation by making the button visually distinct when focused.

---
*PR created automatically by Jules for task [13654223670944354014](https://jules.google.com/task/13654223670944354014) started by @RenyEnnos*

## Summary by Sourcery

Melhorar o feedback de acessibilidade e a visibilidade do foco para o botão de copiar mensagem do chat.

Melhorias:
- Fazer com que o botão de copiar mensagem do chat use um `aria-label` estático e uma região `aria-live` visualmente oculta para anunciar o sucesso da cópia sem alterar o rótulo do controle.
- Aprimorar a acessibilidade via teclado do botão de copiar com um anel de foco (`focus-visible`) explícito e estilos de opacidade.
- Documentar o padrão de acessibilidade para estados transitórios e o uso de `aria-live` nas diretrizes do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility feedback and focus visibility for the chat message copy button.

Enhancements:
- Make the chat message copy button use a static aria-label and a visually hidden aria-live region to announce copy success without changing the control label.
- Enhance keyboard accessibility of the copy button with explicit focus-visible ring and opacity styles.
- Document the accessibility pattern for transient states and aria-live usage in the Palette guidelines.

</details>