### PR TITLE
🎨 Palette: Improve accessible feedback for copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient States with aria-live]
+**Learning:** Dynamically updating the `aria-label` of a focused element (like changing "Copy" to "Copied!") is often missed by screen readers because the element's identity changes while it's focused. It's more reliable to keep the `aria-label` static and use an adjacent, permanently mounted `aria-live="polite"` region to announce state changes.
+**Action:** For transient confirmation states (like copy buttons), use a visually hidden `aria-live` region rather than updating the `aria-label`. Keep the `title` attribute dynamic for sighted users.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -44,10 +44,13 @@ const MessageBubble = ({ message, isUser }) => {
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
                     <div className="flex flex-col justify-center">
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado!" : ""}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}


### PR DESCRIPTION
**💡 What:** 
Improved the accessibility of the "Copiar mensagem" button inside `MessageBubble`. Instead of dynamically changing the `aria-label` when the button is clicked (which screen readers often miss since the element is focused), it now uses a permanently mounted, visually hidden `aria-live="polite"` region to announce "Copiado!". Explicit keyboard focus styles (`focus-visible:ring-2`) were also added to ensure it is clearly visible when navigated via keyboard.

**🎯 Why:**
Dynamically changing an `aria-label` on a focused element is an anti-pattern because the screen reader expects the identity of the focused element to remain stable. Using `aria-live` ensures the transient state feedback is reliably announced, while proper `focus-visible` rings ensure keyboard users can track their navigation path.

**♿ Accessibility:**
- Added `aria-live="polite"` for reliable state announcements.
- Made `aria-label` static ("Copiar mensagem").
- Added strong `focus-visible` outline specific to the dark theme.

---
*PR created automatically by Jules for task [18162454927972418085](https://jules.google.com/task/18162454927972418085) started by @RenyEnnos*

## Summary by Sourcery

Melhorar o feedback de acessibilidade e o estilo de foco via teclado para o botão de copiar mensagem do chat.

Melhorias:
- Anunciar a confirmação de cópia por meio de uma região persistente, visualmente oculta, com `aria-live="polite"` em vez de alterar dinamicamente o `aria-label` do botão.
- Refinar os estilos de `focus-visible` do botão de copiar para fornecer um contorno de foco claro em layouts com tema escuro.

Documentação:
- Documentar o padrão de uso de `aria-live` para estados transitórios e o uso estático de `aria-label` nas diretrizes do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility feedback and keyboard focus styling for the chat message copy button.

Enhancements:
- Announce copy confirmation via a persistent, visually hidden aria-live="polite" region instead of dynamically changing the button aria-label.
- Refine copy button focus-visible styles to provide a clear focus ring in dark theme layouts.

Documentation:
- Document the aria-live pattern for transient states and static aria-label usage in the Palette guidelines.

</details>