### PR TITLE
🎨 Palette: fix copy button a11y & transient state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Transient State Accessibility]
+**Learning:** Dynamically updating `aria-label` for transient states (like "Copied!") is unreliable because screen readers may not detect the change if the element is not currently the focus target or if the update is too brief.
+**Action:** Use a permanently mounted, visually hidden `aria-live="polite"` region to announce state changes, and keep the `aria-label` on the trigger element static to ensure reliable communication with assistive technologies.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? 'Copiado' : ''}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 What: Improved the accessibility of the copy message button by stabilizing its `aria-label`, adding an `aria-live` region for transient state feedback, and adding explicit focus ring styles.
🎯 Why: Screen readers often miss dynamic updates to `aria-label`s on buttons if the change is too fast or if focus moves. Using a permanently mounted `aria-live` region ensures the "Copiado!" state is reliably announced. The new focus ring makes keyboard navigation clearer and safer.
📸 Before/After: Added clear `focus-visible` ring states on the button, demonstrating explicit interactive states.
♿ Accessibility: Ensures reliable transient state announcements and robust keyboard navigation on dark backgrounds.

---
*PR created automatically by Jules for task [10422572828456836390](https://jules.google.com/task/10422572828456836390) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e o gerenciamento de foco do botão de copiar mensagem do chat e documentar o padrão de acessibilidade nas notas do Palette.

Novos recursos:
- Anunciar o sucesso da cópia por meio de uma região aria-live dedicada e visualmente oculta para a ação de copiar mensagem.

Melhorias:
- Estabilizar o aria-label do botão de copiar e adicionar estilos explícitos de foco visível (focus-visible ring) para melhor acessibilidade via teclado.

Documentação:
- Adicionar orientações no Palette sobre como lidar com acessibilidade de estados transitórios usando aria-labels estáticos e regiões aria-live.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus handling for the chat message copy button and document the accessibility pattern in the Palette notes.

New Features:
- Announce copy success via a dedicated, visually hidden aria-live region for the message copy action.

Enhancements:
- Stabilize the copy button’s aria-label and add explicit focus-visible ring styles for better keyboard accessibility.

Documentation:
- Add Palette guidance on handling transient state accessibility using static aria-labels and aria-live regions.

</details>