### PR TITLE
🎨 Palette: Improve accessibility of MessageBubble copy button

### DIFF
--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Copiado' : ''}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
🎨 Palette: Improve accessibility of MessageBubble copy button

💡 What:
- Made the `aria-label` for the copy button static ("Copiar mensagem").
- Added a permanently mounted, visually hidden `span` with `aria-live="polite"` to announce the "Copiado" state to screen readers.
- Added explicit `focus-visible` styles to ensure the button has a clear focus ring, even against dark backgrounds (`focus-visible:ring-offset-gray-900`).

🎯 Why: 
Previously, the copy button updated its `aria-label` dynamically, which screen readers sometimes fail to announce reliably during transient state changes. By using an `aria-live` region, the "Copied!" feedback is robustly announced. Additionally, relying solely on default focus styles can lead to invisible focus rings in dark mode components; the added utilities ensure keyboard users always know when the button is focused.

📸 Before/After: Verified visually via Playwright headless screenshot on isolated component.
♿ Accessibility: Improved screen reader announcements and keyboard focus visibility.

---
*PR created automatically by Jules for task [163806455598251753](https://jules.google.com/task/163806455598251753) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco do botão de copiar mensagens do assistente nos balões de mensagens do chat.

Melhorias:
- Tornar o atributo aria-label do botão de copiar estático, usando uma região ao vivo (live region) para anunciar o estado de cópia às tecnologias assistivas.
- Garantir que o botão de copiar tenha um anel de foco-visível claro e personalizado, que permaneça visível em fundos escuros.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility of the assistant message copy button in chat message bubbles.

Enhancements:
- Make the copy button’s aria-label static while using a live region to announce the copied state to assistive technologies.
- Ensure the copy button has a clear, custom focus-visible ring that remains visible against dark backgrounds.

</details>