### PR TITLE
🎨 Palette: Improve copy button accessibility and focus states

### DIFF
--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800 focus-visible:ring-gray-400"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Mensagem copiada' : ''}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 What: The copy button in the MessageBubble component was updated to be more accessible to screen readers and keyboard navigators.
🎯 Why: Dynamic aria-labels on icon-only trigger buttons can be missed by screen readers when state changes. A static label combined with a dedicated aria-live region ensures reliable announcements. Additionally, keyboard users now receive a clear visual focus ring indicating they are focused on the button, which was previously lacking.
📸 Before/After: Added focus-visible classes that create a distinctive ring against the dark background.
♿ Accessibility: Improved keyboard navigation with robust focus styles and reliable state announcement for screen reader users via aria-live="polite".

---
*PR created automatically by Jules for task [3508414301168931809](https://jules.google.com/task/3508414301168931809) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e o comportamento de foco do botão de copiar mensagem em `MessageBubble`.

Novas funcionalidades:
- Anunciar mudanças de estado de cópia para o botão de copiar mensagem por meio de uma região `aria-live` para leitores de tela.

Aprimoramentos:
- Adicionar estilos de anel de foco visível ao botão de copiar mensagem para melhor feedback de navegação por teclado.
- Usar um `aria-label` estático no botão de copiar somente ícone, mantendo as mudanças de estado no tooltip e na região ao vivo (`live region`) para um comportamento mais confiável em leitores de tela.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus behavior of the chat message copy button in MessageBubble.

New Features:
- Announce copy state changes for the message copy button via an aria-live region for screen readers.

Enhancements:
- Add visible focus ring styles to the message copy button for better keyboard navigation feedback.
- Use a static aria-label on the icon-only copy button while keeping state changes in the tooltip and live region for more reliable screen reader behavior.

</details>