### PR TITLE
🎨 Palette: Improve copy button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Transient State Feedback and focus-visible]
+**Learning:** Updating the `aria-label` dynamically for transient states (like "Copied!") often fails to be announced reliably by screen readers since the state changes quickly. A static `aria-label` paired with an adjacent, permanently mounted visually hidden `<div aria-live="polite">` is much more reliable. Additionally, components that appear on hover (`group-hover:opacity-100`) must explicitly use `focus-visible:opacity-100` instead of just `focus` so they don't break expected keyboard interaction while avoiding lingering visual state.
+**Action:** Use permanently mounted `aria-live` regions for transient feedback rather than dynamic `aria-label`s. Ensure hover-revealed elements explicitly declare `focus-visible` accessibility utilities alongside base focus styles.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What**:
- Changed the dynamic `aria-label` on the copy button in `MessageBubble` to be static ("Copiar mensagem").
- Added an adjacent, permanently mounted visually hidden `<div aria-live="polite">` to announce the "Copiado!" state.
- Replaced the simple `focus:opacity-100` utility with a complete set of explicit `focus-visible` ring and opacity utilities (`focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none`).

🎯 **Why**:
- Screen readers often fail to announce transient state changes if only the `aria-label` of a focused button is changed rapidly, leaving visually impaired users without feedback that their copy action succeeded. A dedicated `aria-live` region solves this reliably.
- Components that are visible only on hover (`md:opacity-0 md:group-hover:opacity-100`) need robust `focus-visible` handling so that keyboard-only users can actually see the button when they tab to it, without it being permanently visible to mouse users.

📸 **Before/After**:
*Before:* Keyboard focus on the copy button was difficult to see against the dark background, and screen readers might inconsistently announce the "Copiado!" text since it relied on swapping the `aria-label`.
*After:* The copy button now features a clear, offset gray ring when focused via keyboard, and explicitly announces "Copiado!" to screen readers via a dedicated live region.

♿ **Accessibility**:
- Improved reliable screen reader feedback for a transient state action (copying to clipboard).
- Improved visual focus indicators for keyboard navigation in high-contrast dark mode contexts.

---
*PR created automatically by Jules for task [10912782213055964230](https://jules.google.com/task/10912782213055964230) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do botão de copiar mensagem do chat e documentar as diretrizes de design relacionadas.

Melhorias:
- Atualizar o botão de copiar mensagem para usar um `aria-label` estático com uma região `aria-live` adjacente, garantindo um feedback confiável do leitor de tela sobre o sucesso da cópia.
- Reforçar a visibilidade do foco via teclado para o botão de copiar exibido ao passar o mouse, usando utilitários explícitos de anel de `focus-visible` e de opacidade.
- Documentar aprendizados e diretrizes de acessibilidade sobre feedback de estado transitório e comportamento de `focus-visible` na documentação do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button and document related design guidelines.

Enhancements:
- Update the message copy button to use a static aria-label with an adjacent aria-live region for reliable screen reader feedback on copy success.
- Strengthen keyboard focus visibility for the hover-revealed copy button using explicit focus-visible ring and opacity utilities.
- Document accessibility learnings and guidelines around transient state feedback and focus-visible behavior in the Palette docs.

</details>