### PR TITLE
🎨 Palette: Improve copy button accessibility and focus state

### DIFF
--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -44,10 +44,13 @@ const MessageBubble = ({ message, isUser }) => {
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
                     <div className="flex flex-col justify-center">
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}


### PR DESCRIPTION
**💡 What:** Improved the accessibility of the copy message button in the `MessageBubble` component.
**🎯 Why:**
1. Dynamic `aria-label`s on buttons that do not change function can confuse screen readers. A static label combined with an `aria-live` region is the best practice for transient state feedback (like "Copied!").
2. The previous focus state (`focus:opacity-100`) was insufficient for keyboard users on dark backgrounds, making it hard to see which element was focused. The new `focus-visible` styles with offsets provide clear visual feedback.
**♿ Accessibility:** Added robust `aria-live` support for copy confirmation and distinct `focus-visible` ring styling for keyboard navigation.

---
*PR created automatically by Jules for task [18442701587485064700](https://jules.google.com/task/18442701587485064700) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e a visibilidade do foco para o botão de copiar nas bolhas de mensagens do chat.

Novos recursos:
- Anunciar a confirmação de cópia por meio de uma região `aria-live` para usuários de leitores de tela.

Aperfeiçoamentos:
- Usar um `aria-label` estático e estilos aprimorados de contorno para `:focus-visible` para fornecer uma indicação mais clara de foco via teclado em fundos escuros.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility for the copy button in chat message bubbles.

New Features:
- Announce copy confirmation via an aria-live region for screen reader users.

Enhancements:
- Use a static aria-label and enhanced focus-visible ring styles to provide clearer keyboard focus indication on dark backgrounds.

</details>