### PR TITLE
🎨 Palette: Improve Copy Button Accessibility & Focus

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient States (Copy Button)]
+**Learning:** When a button triggers a transient state (like "Copied!") and the visual UI handles this via an icon change, updating the `aria-label` dynamically is insufficient for screen reader users because the label might be missed while the button is focused.
+**Action:** Use a permanently mounted, visually hidden `aria-live="polite"` region adjacent to the button to announce transient states, while keeping a static, descriptive `aria-label` on the button itself.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,10 +46,13 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
+                            <span aria-live="polite" className="sr-only">
+                                {isCopied ? 'Copiado!' : ''}
+                            </span>
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
                     </div>


### PR DESCRIPTION
🎨 Palette: Improve Copy Button Accessibility & Focus

💡 **What**:
- Replaced the dynamic `aria-label` with a static one on the "Copy" button in `MessageBubble`.
- Added a permanently mounted, visually hidden `aria-live="polite"` region to correctly announce the transient "Copiado!" state to screen readers.
- Upgraded the keyboard focus ring using `focus-visible` with explicit offsets to ensure high visibility against dark backgrounds.

🎯 **Why**:
- Updating an `aria-label` dynamically upon click is an anti-pattern as screen readers may miss the announcement since focus is already on the element. A dedicated `aria-live` region solves this reliably.
- The previous focus classes were subtle and lacked offset, making keyboard navigation difficult to track for sighted users with keyboard-only access.
- Kept the dynamic `title` attribute so sighted users still see the visual tooltip.

♿ **Accessibility**:
- Better screen reader announcement for transient states.
- Enhanced WCAG compliance for focus indicators.

---
*PR created automatically by Jules for task [14047759958698068521](https://jules.google.com/task/14047759958698068521) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e o comportamento de foco via teclado para o botão de copiar mensagens do chat e documentar o padrão nas diretrizes do Palette.

Melhorias:
- Refinar o botão de copiar mensagens do chat com um `aria-label` estático, uma região `aria-live` para o feedback transitório de cópia e um anel de foco mais visível para usuários de teclado.
- Ampliar a documentação do Palette com orientações sobre como lidar com estados transitórios acessíveis para botões de cópia usando regiões `aria-live`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and keyboard focus behavior for the chat message copy button and document the pattern in the Palette guidelines.

Enhancements:
- Refine the chat message copy button with a static aria-label, an aria-live region for transient copied feedback, and a more visible focus ring for keyboard users.
- Extend the Palette documentation with guidance on handling accessible transient states for copy buttons using aria-live regions.

</details>