### PR TITLE
🎨 Palette: Make copy confirmation accessible in MessageBubble

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [Accessible Transient States]
+**Learning:** For accessibility, changing the `aria-label` of a button dynamically to announce transient states (like "Copied!") is unreliable because screen readers may not read the updated label unless focus changes. Keeping the `aria-label` static (e.g. "Copy message") and pairing it with a permanently mounted, visually hidden `aria-live="polite"` container that conditionally renders its text content correctly notifies users.
+**Action:** Use a static `aria-label` and an adjacent `aria-live` region for short-lived state confirmations instead of dynamically updating the button's label.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,12 +43,15 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado!" : ""}
+                        </span>
                         <button
                             onClick={handleCopy}
                             className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
-                            title={isCopied ? "Copiado" : "Copiar mensagem"}
+                            aria-label="Copiar mensagem"
+                            title={isCopied ? "Copiado!" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>


### PR DESCRIPTION
🎨 Palette: Make copy confirmation accessible in MessageBubble

💡 What: Changed the copy button to have a static `aria-label` ("Copiar mensagem") and added an adjacent `aria-live="polite"` visually-hidden container to announce the transient "Copiado!" state.
🎯 Why: Dynamically changing an `aria-label` on a focused button is unreliable for screen readers. A static label combined with a permanently mounted live region ensures users get robust confirmation that the message was copied.
♿ Accessibility: Ensures robust screen reader announcements for the copy action without degrading the visual tooltip for sighted users.

---
*PR created automatically by Jules for task [3082730869279973631](https://jules.google.com/task/3082730869279973631) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade da ação de copiar mensagens do chat e documentar o padrão nas diretrizes do Palette.

Correções de bug:
- Garantir que a confirmação de mensagem copiada seja anunciada de forma confiável para usuários de leitor de tela via uma região `aria-live` em vez de um `aria-label` dinâmico.

Aprimoramentos:
- Atualizar o botão de copiar do `MessageBubble` para usar um rótulo acessível estático, preservando o feedback visual por meio do tooltip de `title`.

Documentação:
- Adicionar orientação no Palette sobre o uso de `aria-label`s estáticos com regiões `aria-live` adjacentes para estados de confirmação transitórios.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy action and document the pattern in the Palette guidelines.

Bug Fixes:
- Ensure copied-message confirmation is reliably announced to screen reader users via an aria-live region instead of a dynamic aria-label.

Enhancements:
- Update the MessageBubble copy button to use a static accessible label while preserving visual feedback via the title tooltip.

Documentation:
- Add Palette guidance on using static aria-labels with adjacent aria-live regions for transient confirmation states.

</details>