### PR TITLE
🎨 Palette: Improved accessibility for Message copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2026-04-12 - [Accessible State Confirmations]
+**Learning:** For transient button states (like a 'Copied!' confirmation), dynamically changing the `aria-label` is unreliable for screen readers, which may not announce the update in time. Keeping the `aria-label` static (e.g., "Copiar mensagem") and using an adjacent, permanently mounted element with `aria-live="polite"` (which toggles its text content) ensures the state change is reliably announced without losing the original button's context.
+**Action:** Use visually hidden `aria-live` regions for transient feedback rather than updating `aria-label`s on buttons.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Copiado!' : ''}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What:** Added accessible screen reader confirmation for the 'Copied' state on the message copy button and enhanced keyboard focus visibility.
🎯 **Why:** To ensure screen reader users receive reliable audio feedback when an action is performed, rather than relying on unreliable dynamic `aria-label` changes. It also helps keyboard navigators by making the focus state explicitly visible.
♿ **Accessibility:**
- Added a permanently mounted `aria-live="polite"` region that announces 'Copiado!' reliably.
- Kept the button's `aria-label` static ("Copiar mensagem").
- Added distinct `focus-visible` styles with offset rings for better visibility against dark backgrounds.

---
*PR created automatically by Jules for task [14789065611295651048](https://jules.google.com/task/14789065611295651048) started by @RenyEnnos*

## Summary by Sourcery

Melhorar o feedback de acessibilidade e a visibilidade do foco para o botão de copiar mensagem do chat e documentar o padrão nas diretrizes do Palette.

Novos recursos:
- Anunciar a confirmação de cópia da mensagem por meio de uma região `aria-live` dedicada, com prioridade `polite`, para leitores de tela.

Aperfeiçoamentos:
- Manter o `aria-label` do botão de cópia estático enquanto atualiza o título do tooltip para refletir o estado de “copiado”.
- Adicionar estilos mais fortes de anel e deslocamento de `focus-visible` ao botão de cópia para melhor visibilidade em planos de fundo escuros.

Documentação:
- Documentar um padrão de acessibilidade para confirmações transitórias de estado de botões usando `aria-label`s estáticos e regiões `aria-live` nas diretrizes do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility feedback and focus visibility for the chat message copy button and document the pattern in the Palette guidelines.

New Features:
- Announce the message copy confirmation via a dedicated aria-live polite region for screen readers.

Enhancements:
- Keep the copy button aria-label static while updating the tooltip title to reflect the copied state.
- Add stronger focus-visible ring and offset styles to the copy button for better visibility on dark backgrounds.

Documentation:
- Document an accessibility pattern for transient button state confirmations using static aria-labels and aria-live regions in the Palette guidelines.

</details>