### PR TITLE
🎨 Palette: Improve copy button accessibility with aria-live

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient States (Copy Button)]
+**Learning:** Dynamically updating the `aria-label` of a button to reflect a transient success state (like changing "Copy" to "Copied!") is often unreliable because screen readers may not re-announce the label if focus remains on the element, or they might read it out of context. The visual tooltip (`title`) is great for sighted users, but a permanently mounted, visually hidden `aria-live` region is required for robust screen reader announcements of state changes.
+**Action:** Use a static `aria-label` for the primary button action, and announce transient state changes via an adjacent `aria-live="polite"` region that receives text content dynamically.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 What: Improved the accessibility of the message copy button by replacing the dynamic `aria-label` with a static one, and utilizing a permanently mounted, visually hidden `aria-live="polite"` region for the transient "Copiado" state. Also added explicit focus ring styles.
🎯 Why: Screen readers often fail to announce dynamic changes to an `aria-label` if focus remains on the element, resulting in silent failure for blind users when they copy a message. `aria-live` ensures the state change is reliably announced. The focus ring ensures keyboard-only users can see when the button is focused.
♿ Accessibility: Ensures reliable screen reader announcement for transient button states and improves keyboard focus visibility on a dark background.

---
*PR created automatically by Jules for task [17716159180845941376](https://jules.google.com/task/17716159180845941376) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do botão de copiar mensagens do chat e documentar aprendizagens de acessibilidade.

Novos recursos:
- Anunciar o sucesso da cópia por meio de uma região aria-live visualmente oculta, adjacente ao botão de copiar.

Aprimoramentos:
- Usar um `aria-label` estático para o botão de copiar enquanto mantém o título visual do tooltip dinâmico.
- Adicionar estilos explícitos de anel de `focus-visible` ao botão de copiar para melhorar a visibilidade do foco de teclado em fundos escuros.
- Documentar as melhores práticas de acessibilidade para estados transitórios e o comportamento do botão de copiar no guia do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button and document accessibility learnings.

New Features:
- Announce copy success via a visually hidden aria-live region adjacent to the copy button.

Enhancements:
- Use a static aria-label for the copy button while keeping the visual title tooltip dynamic.
- Add explicit focus-visible ring styles to the copy button for better keyboard focus visibility on dark backgrounds.
- Document accessibility best practices for transient states and copy button behavior in the Palette guide.

</details>