### PR TITLE
🎨 Palette: Improve copy button screen reader accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2026-04-15 - [Transient State Feedback Accessibility]
+**Learning:** Mutating the `aria-label` of a button (like 'Copy' to 'Copied!') dynamically is often missed or poorly handled by screen readers, confusing the user about the button's primary function. Adding an adjacent, permanently mounted `aria-live="polite"` region provides a reliable way to announce transient states without losing the primary button description.
+**Action:** Use a permanently mounted, visually hidden `aria-live` region to communicate transient success/error states to screen readers, while keeping the main `aria-label` static and only updating visual/mouse attributes like `title`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
                             className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
🎨 Palette here! 

I noticed a small accessibility improvement we can make to the `MessageBubble`'s Copy button.

Currently, when the button is clicked, we change its `aria-label` from "Copiar mensagem" to "Copiado". While this seems logical, mutating the primary `aria-label` dynamically is often missed or poorly handled by screen readers, and it can cause confusion if the user re-focuses the button later while the state is still briefly active.

**The Fix:**
- I kept the `aria-label` static ("Copiar mensagem") so screen readers always know what the button does.
- I added an adjacent, visually hidden (`sr-only`) `span` with `aria-live="polite"` that dynamically receives the "Copiado" text when activated. This ensures screen readers announce the success state reliably without altering the button's core identity.
- The `title` attribute remains dynamic so sighted users hovering with a mouse still see the tooltip change.

I've tested this change locally, confirmed the visual layout is completely unaffected, and logged this pattern in my journal! 📓🖌️

---
*PR created automatically by Jules for task [7853555121941999132](https://jules.google.com/task/7853555121941999132) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade de leitores de tela para o botão de copiar mensagem e documentar o padrão de acessibilidade no diário do Palette.

Novos recursos:
- Anunciar o estado de sucesso da cópia por meio de uma região `aria-live` dedicada e visualmente oculta, em vez de alterar o rótulo do botão.

Aperfeiçoamentos:
- Manter o atributo `aria-label` do botão de copiar estático, preservando ao mesmo tempo o texto dinâmico do tooltip e o estado do ícone.
- Documentar o padrão de acessibilidade para feedback de estado transitório no diário Palette (.Jules).

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve screen reader accessibility for the message copy button and document the accessibility pattern in the Palette journal.

New Features:
- Announce copy success state via a dedicated, visually hidden aria-live region instead of altering the button label.

Enhancements:
- Keep the copy button aria-label static while preserving dynamic tooltip text and icon state.
- Document the transient state feedback accessibility pattern in the Palette (.Jules) journal.

</details>