### PR TITLE
🎨 Palette: Enhance MessageBubble copy button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2024-05-29 - [Transient State Feedback (aria-live vs aria-label)]
+**Learning:** For accessibility, state confirmations (like 'Copied!') should use a visually hidden 'aria-live' region rather than dynamically updating the 'aria-label' of the triggered button, to ensure reliable screen reader announcements.
+**Action:** To provide accessible transient state feedback (e.g., 'Copied!') on buttons without losing visual tooltips, keep the 'title' attribute dynamic for sighted users while using an adjacent, permanently mounted 'aria-live' region for screen readers, keeping the primary 'aria-label' static.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
-                            title={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
+                            title={isCopied ? "Copiado!" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada para a área de transferência" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
🎨 **Palette: Enhance MessageBubble Accessibility**

**💡 What:**
Improved the accessibility of the "Copy" button in the `MessageBubble` component.
- The `aria-label` was made static ("Copiar mensagem"), while the `title` remains dynamic ("Copiado!" vs "Copiar mensagem") for visual hover tooltips.
- Added a visually hidden `<span aria-live="polite">` element that toggles text to reliably announce the "Copied" transient state to screen readers.
- Added explicit `focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900` classes to ensure the button is clearly visible when navigated via keyboard.

**🎯 Why:**
- Dynamically changing the `aria-label` of a button immediately upon click often fails to be announced by screen readers, leaving users unaware if the action succeeded. An `aria-live` region is the standard pattern for transient state announcements.
- The previous implementation relied purely on `focus:opacity-100` which lacked an explicit visual focus ring, making keyboard navigation difficult to track, especially against the dark background.

**♿ Accessibility:**
- Improved screen reader reliability for the copy action feedback.
- Enhanced keyboard navigation visibility.

---
*PR created automatically by Jules for task [10352866604521209948](https://jules.google.com/task/10352866604521209948) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco do botão de copiar do MessageBubble e documentar o padrão escolhido no guia do Palette.

Melhorias:
- Refinar a semântica e os estilos de foco do botão de copiar do MessageBubble para fornecer uma indicação de foco de teclado mais clara e um comportamento mais confiável para tecnologias assistivas.
- Introduzir uma região `aria-live` junto ao botão de copiar para anunciar o estado de “copiado” sem alterar o rótulo principal do botão.

Documentação:
- Estender a documentação do Palette com orientações sobre o uso de regiões `aria-live` em vez de `aria-labels` dinâmicos para feedback de estado transitório, mantendo os tooltips visuais.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility of the MessageBubble copy button and document the chosen pattern in the Palette guide.

Enhancements:
- Refine the MessageBubble copy button semantics and focus styles to provide clearer keyboard focus indication and more reliable assistive technology behavior.
- Introduce an aria-live region alongside the copy button to announce the copied state without changing the button’s core label.

Documentation:
- Extend the Palette documentation with guidance on using aria-live regions instead of dynamic aria-labels for transient state feedback while keeping visual tooltips.

</details>