### PR TITLE
🎨 Palette: Improve copy button accessibility in MessageBubble

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2024-05-18 - [Transient State Accessibility Pattern]
+**Learning:** For transient feedback (e.g., "Copied!" button states) where a `title` provides visual feedback for sighted users, dynamically altering the primary `aria-label` can cause screen readers to miss the state change if focus moves or the interval is brief.
+**Action:** Use an adjacent, permanently mounted `sr-only` element with `aria-live="polite"` to reliably announce the transient state (e.g., "Copied"), while keeping the button's `aria-label` static (e.g., "Copy message") for consistent identification.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <div className="sr-only" aria-live="polite">
+                            {isCopied ? "Copiado" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What:** Added a visually hidden `aria-live` region for the "Copied!" state, made the `aria-label` static, and enhanced keyboard focus visibility on the `MessageBubble` copy button.
🎯 **Why:** Dynamically changing the `aria-label` on a button to provide feedback (like "Copied!") often causes screen readers to miss the announcement, especially if focus shifts or the change is brief. Using a dedicated `aria-live` region ensures reliable feedback for visually impaired users. Furthermore, relying on default focus rings in a dark-themed UI often results in poor contrast for keyboard users.
📸 **Before/After:** Keyboard focus now has a clear white ring offset against the dark background. Screen readers will now reliably announce "Copiado" without losing the "Copiar mensagem" button identity.
♿ **Accessibility:**
- Improved screen reader reliability for transient states (`aria-live="polite"`).
- Maintained consistent interactive element identity (static `aria-label`).
- Enhanced visual feedback for keyboard navigation (`focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900`).

---
*PR created automatically by Jules for task [10466382680877748045](https://jules.google.com/task/10466382680877748045) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e a visibilidade do foco para o botão de cópia do MessageBubble.

Aprimoramentos:
- Adicionar um `aria-label` estático e uma região `aria-live` para fornecer feedback confiável de leitor de tela para o estado de copiado do botão de cópia do MessageBubble.
- Aprimorar o estilo de foco de teclado para o botão de cópia do MessageBubble, garantindo clara visibilidade contra o fundo do tema escuro.
- Documentar um padrão de acessibilidade reutilizável para anúncios de estados transitórios nas diretrizes da paleta.

Documentação:
- Estender a documentação da paleta com orientações sobre como lidar com feedback de acessibilidade transitório usando regiões `aria-live` apenas para leitores de tela (`sr-only`).

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility for the MessageBubble copy button.

Enhancements:
- Add a static aria-label and an aria-live region to provide reliable screen reader feedback for the MessageBubble copy button's copied state.
- Enhance keyboard focus styling for the MessageBubble copy button to ensure clear visibility against the dark theme background.
- Document a reusable accessibility pattern for transient state announcements in the palette guidelines.

Documentation:
- Extend the palette documentation with guidance on handling transient accessibility feedback using sr-only aria-live regions.

</details>