### PR TITLE
🎨 Palette: Improve copy button accessibility and focus styling

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2026-04-19 - [Transient State Announcements & Focus Styling]
+**Learning:** Dynamically updating a button's `aria-label` to announce transient states (like 'Copiado') is unreliable for screen readers. Instead, an adjacent `aria-live` region should be used while keeping the primary `aria-label` static. Additionally, when using hover-based visibility (e.g., `opacity-0` to `opacity-100`), it must be paired with explicit `focus-visible:opacity-100` and offset ring classes (`focus-visible:ring-offset-gray-900`) to ensure keyboard users can find and focus the element.
+**Action:** Use permanently mounted `aria-live` regions for transient state feedback, and always pair hover-visibility with robust `focus-visible` styles.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,11 +43,14 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}


### PR DESCRIPTION
💡 What: Replaced the dynamic `aria-label` on the copy button with a static label and a visually-hidden `aria-live` region for announcing the "Copied" transient state. Added `focus-visible` ring and opacity utilities so the button appears clearly when focused via keyboard.
🎯 Why: Screen readers often struggle to announce changes to `aria-label` after an interaction, so transient states are best announced via a dedicated live region. Additionally, since the button is normally invisible (opacity-0) until hovered, keyboard users need explicit focus styles to know where they are.
♿ Accessibility: Ensures correct semantic announcements of the transient state, and clear visual focus indicator for keyboard users navigating dark-themed UI components.

---
*PR created automatically by Jules for task [6439696894415663642](https://jules.google.com/task/6439696894415663642) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade de foco do botão de copiar mensagem do chat e documentar o padrão nas diretrizes do Palette.

Novos recursos:
- Anunciar o sucesso da cópia por meio de uma região `aria-live` dedicada e visualmente oculta, em vez de alterar dinamicamente o rótulo do botão de copiar.

Aprimoramentos:
- Tornar o botão de copiar mensagem do chat visível via teclado, adicionando opacidade para `:focus-visible` e estilização de contorno (ring), mantendo um `aria-label` estático.
- Documentar as melhores práticas para anúncios de estado transitório e visibilidade baseada em hover com estilização de foco nas notas do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility for the chat message copy button and document the pattern in the Palette guidelines.

New Features:
- Announce copy success via a dedicated visually-hidden aria-live region instead of dynamically changing the copy button label.

Enhancements:
- Make the chat message copy button keyboard-visible by adding focus-visible opacity and ring styling while keeping a static aria-label.
- Document best practices for transient state announcements and hover-based visibility with focus styling in the Palette notes.

</details>