### PR TITLE
🎨 Palette: Improve accessibility of the Copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Transient State Accessibility on Controls]
+**Learning:** Changing `aria-label` dynamically to indicate transient states (like changing "Copiar mensagem" to "Copiado" on a copy button) can result in screen readers missing the update or announcing confusing context if the user moves away or refocuses quickly.
+**Action:** Keep primary control labels (`aria-label`) static. Use an adjacent, permanently mounted visually hidden container with `aria-live="polite"` to announce transient state changes like "Copiado" or "Sucesso" to screen readers robustly.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,11 +43,14 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Mensagem copiada' : ''}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}


### PR DESCRIPTION
🎨 Palette: Transient State Accessibility for Copy Button

**💡 What:** 
Improved the accessibility of the "Copiar" button in the `MessageBubble` component. Replaced the dynamic `aria-label` with a permanently mounted visually hidden container using `aria-live="polite"` for state announcements. Added explicit `focus-visible` styling for robust keyboard accessibility against the dark UI.

**🎯 Why:**
Changing an `aria-label` on an element dynamically to reflect a transient state ("Copiar mensagem" -> "Copiado") often causes screen readers to miss the update or announce confusing context if the user moves focus. By separating the primary control label from the transient state announcement (via `aria-live`), we ensure reliable feedback for screen reader users. The explicit `focus-visible` ring also ensures keyboard-only users can clearly see when the copy action is targeted.

**♿ Accessibility:**
- Maintained static `aria-label="Copiar mensagem"` on the button.
- Added `aria-live="polite"` span for announcing "Mensagem copiada" when triggered.
- Added `focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900` for strong visual keyboard focus indicators.

---
*PR created automatically by Jules for task [6893821000619755010](https://jules.google.com/task/6893821000619755010) started by @RenyEnnos*

## Summary by Sourcery

Melhorar o feedback de acessibilidade e o foco de teclado para o botão de copiar mensagem do chat e documentar o padrão de acessibilidade nas diretrizes da paleta.

Novos recursos:
- Anunciar o sucesso da cópia para o botão de copiar mensagem por meio de uma região aria-live visualmente oculta, em vez de alterar o rótulo do controle.

Aprimoramentos:
- Adicionar um forte estilo de anel de focus-visible ao botão de copiar para melhor visibilidade via teclado na interface escura.
- Documentar as melhores práticas para lidar com anúncios transitórios de estado de acessibilidade usando aria-labels estáticos nas diretrizes da paleta.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility feedback and keyboard focus for the chat message copy button and document the accessibility pattern in the palette guidelines.

New Features:
- Announce copy success for the message copy button via a visually hidden aria-live region instead of changing the control label.

Enhancements:
- Add strong focus-visible ring styling to the copy button for better keyboard visibility in the dark UI.
- Document best practices for handling transient accessibility state announcements with static aria-labels in the palette guidelines.

</details>