### PR TITLE
🎨 Palette: Improve copy button transient state accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Transient State Accessibility]
+**Learning:** Updating the `aria-label` of a button dynamically to provide transient feedback (like "Copied!") often goes unnoticed by screen readers if the element retains focus, or it overrides the persistent action description.
+**Action:** Use a permanently mounted, visually hidden `aria-live="polite"` region to announce transient states (toggling its text content), while keeping the button's primary `aria-label` static and the `title` dynamic for sighted users.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -44,10 +44,13 @@ const MessageBubble = ({ message, isUser }) => {
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
                     <div className="flex flex-col justify-center">
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}


### PR DESCRIPTION
🎨 Palette: Improve copy button transient state accessibility

💡 What: Changed the copy button's transient "Copied!" state to use an `aria-live` region rather than updating its `aria-label`, and improved the button's focus state with offset styles.
🎯 Why: Screen readers often miss dynamic `aria-label` updates on elements that already have focus, or they override the main action description. A permanently mounted, visually hidden `aria-live="polite"` element provides reliable auditory feedback without compromising the primary label. Added focus ring offsets ensure keyboard users can clearly see the active state against the dark background.
♿ Accessibility: Ensures reliable transient state announcements and clear keyboard focus visibility.

---
*PR created automatically by Jules for task [9672365703910710088](https://jules.google.com/task/9672365703910710088) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do estado transitório do botão de copiar mensagem do chat e o tratamento de foco.

Melhorias:
- Anunciar o estado transitório de "copiado" do botão de copiar por meio de uma região aria-live visualmente oculta, mantendo seu aria-label principal estático.
- Melhorar a visibilidade do foco de teclado para o botão de copiar com estilos explícitos de focus-visible (anel de foco e espaçamento) em contraste com o fundo escuro.

Documentação:
- Documentar diretrizes para lidar com estados transitórios de acessibilidade usando regiões aria-live em vez de atualizações dinâmicas de aria-label no playbook do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button’s transient state and focus treatment.

Enhancements:
- Announce the copy button’s transient "copied" state via a visually hidden aria-live region while keeping its primary aria-label static.
- Enhance keyboard focus visibility for the copy button with explicit focus-visible ring and offset styles against the dark background.

Documentation:
- Document guidelines for handling transient accessibility states using aria-live regions instead of dynamic aria-label updates in the Palette playbook.

</details>