### PR TITLE
🎨 Palette: Improve accessibility of copy message button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient State Feedback]
+**Learning:** For transient feedback states (like "Copied!" after clicking a button), dynamically updating the `aria-label` of the triggered button can be unreliable for screen readers. A more robust pattern is to keep the primary button `aria-label` static (e.g., "Copiar mensagem"), update the `title` for visual tooltips, and use an adjacent, permanently mounted container with `aria-live="polite"` and `.sr-only` that updates its text content. The `aria-live` container must be permanently mounted rather than conditionally rendered to ensure the initial announcement is caught reliably.
+**Action:** Use permanently mounted `aria-live` containers alongside static `aria-label` buttons for accessible transient state feedback.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada!" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
This PR implements an accessibility improvement for the copy button on assistant messages.

**💡 What:** 
- Changed the copy button's `aria-label` to be static ("Copiar mensagem").
- Added a visually hidden `span` with `aria-live="polite"` to reliably announce the "Copiado" state to screen readers.
- Fixed keyboard focus styling (`focus-visible`) to ensure the button is clearly visible when focused via keyboard navigation, especially given its conditional hover visibility.

**🎯 Why:**
Dynamically changing `aria-label` values (e.g., from "Copiar mensagem" to "Copiado") is often unreliable for screen readers, missing the announcement entirely. A dedicated, permanently mounted `aria-live` region is a much more robust pattern for transient feedback. Additionally, the focus rings needed to be explicitly styled with offsets to stand out against the dark gray background of the chat bubbles.

**♿ Accessibility:**
- Improved screen reader reliability for copy action feedback.
- Improved keyboard navigation visibility.

---
*PR created automatically by Jules for task [12863340251542590469](https://jules.google.com/task/12863340251542590469) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco via teclado do botão de copiar mensagens do assistente e documentar o padrão nas diretrizes da paleta.

Novos recursos:
- Anunciar o resultado da ação de copiar por meio de uma região aria-live dedicada e visualmente oculta, associada ao botão de copiar mensagens do assistente.

Melhorias:
- Simplificar a acessibilidade do botão de copiar usando um `aria-label` estático, mantendo o texto do tooltip dinâmico para feedback do estado “copiado”.
- Aumentar a visibilidade do foco via teclado do botão de copiar mensagens do assistente com um anel `focus-visible` explícito e estilização de deslocamento (offset).

Documentação:
- Documentar um padrão acessível para feedback de estado transitório usando `aria-labels` estáticos e regiões `aria-live` montadas permanentemente nas diretrizes da paleta.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and keyboard focus visibility of the assistant message copy button and document the pattern in the palette guidelines.

New Features:
- Announce the copy action result via a dedicated, visually hidden aria-live region associated with the assistant message copy button.

Enhancements:
- Simplify the copy button accessibility by using a static aria-label while keeping tooltip text dynamic for copied state feedback.
- Enhance keyboard focus visibility of the assistant message copy button with explicit focus-visible ring and offset styling.

Documentation:
- Document an accessible pattern for transient state feedback using static aria-labels and permanently mounted aria-live regions in the palette guidelines.

</details>