### PR TITLE
🎨 Palette: Improve accessibility of the Copy button in MessageBubble

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-04-23 - [Accessible Transient State Feedback]
+**Learning:** Updating the primary `aria-label` or `title` on an icon button to indicate a transient state like "Copied!" can be flaky for screen readers and disrupt visual tooltips. Using a dedicated, permanently mounted `aria-live="polite"` region (toggling its text content, not its visibility in the DOM) provides reliable, non-disruptive feedback.
+**Action:** Use permanently mounted `aria-live` containers adjacent to interactive elements for transient state announcements, keeping the primary interactive label static.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
### 💡 What
The accessibility of the "Copiar mensagem" (Copy message) button in `MessageBubble.jsx` has been improved.

### 🎯 Why
- Screen readers sometimes struggle to announce dynamic updates to `aria-label` attributes on focused elements reliably.
- Visually, focus indicators are sometimes difficult to see against dark backgrounds without specific offsets.
- By providing a permanent `aria-live` region, transient states like "Mensagem copiada" are read out smoothly without confusing users navigating with keyboards.

### ♿ Accessibility
- Added a static `aria-label="Copiar mensagem"` while keeping dynamic visual `title`.
- Added a hidden, permanently mounted `aria-live="polite"` span to handle the "Mensagem copiada" announcement reliably.
- Added specific `focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900` styles to ensure the focus ring pops out against the dark UI context.

---
*PR created automatically by Jules for task [14457783528133851192](https://jules.google.com/task/14457783528133851192) started by @RenyEnnos*

## Summary by Sourcery

Melhorar o feedback de acessibilidade e os estilos de foco para o botão de copiar mensagem do chat e documentar o padrão nas diretrizes do Palette.

Novos recursos:
- Adicionar um anúncio em região ao vivo (live region) para o feedback de mensagem copiada na bolha de mensagem do chat.

Aprimoramentos:
- Reforçar os estilos do anel de `focus-visible` para o botão de copiar mensagem, a fim de melhorar a visibilidade em fundos escuros.
- Fazer com que o botão de copiar use um rótulo acessível estático, mantendo o título visual dinâmico.
- Documentar o padrão de feedback de estado transitório acessível nas diretrizes do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility feedback and focus styles for the chat message copy button and document the pattern in the Palette guidelines.

New Features:
- Add a live region announcement for copied message feedback in the chat message bubble.

Enhancements:
- Strengthen focus-visible ring styles for the message copy button to improve visibility on dark backgrounds.
- Make the copy button use a static accessible label while keeping the visual title dynamic.
- Document the accessible transient state feedback pattern in the Palette guidelines.

</details>