### PR TITLE
🎨 Palette: Improve accessibility of MessageBubble copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2026-04-24 - [Transient State Announcements]
+**Learning:** For transient feedback (like a "Copied!" state that reverts after a few seconds), dynamically updating a button's `aria-label` is unreliable, as screen readers might not announce the change or might misidentify the button later. Using a permanently mounted, visually hidden (`sr-only`) region with `aria-live="polite"` that toggles its text content is a robust pattern to ensure reliable announcements without altering the button's core identity.
+**Action:** Use a statically mounted `aria-live` region adjacent to the trigger element to announce transient success/feedback states instead of modifying `aria-label`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,12 +46,15 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
### 💡 What: 
- Made the copy button's `aria-label` statically "Copiar mensagem".
- Added a visually hidden `span` with `aria-live="polite"` to reliably announce the "Mensagem copiada" success state to screen readers.
- Added explicit `focus-visible` utility classes (with offset for dark mode) to the copy button.

### 🎯 Why: 
- Dynamically changing a button's `aria-label` is unreliable for transient states; screen readers may miss the change while the button is focused. A permanently mounted `aria-live` region toggling its text is the robust solution for conveying success. 
- Without explicit focus styling, keyboard users had difficulty knowing the copy button was active since the default `group-hover` visibility relies strictly on mouse interaction.

### ♿ Accessibility:
- Keyboard focus is now clear.
- Screen readers receive reliable feedback without losing the button's core label identity.

---
*PR created automatically by Jules for task [386521201035294552](https://jules.google.com/task/386521201035294552) started by @RenyEnnos*

## Summary by Sourcery

Melhorar o feedback de acessibilidade e a indicação de foco para a ação de copiar mensagem do chat.

Novos recursos:
- Anunciar o estado de cópia bem-sucedida por meio de uma região aria-live montada estaticamente, visualmente oculta, posicionada ao lado do botão de copiar mensagem.

Aperfeiçoamentos:
- Fazer com que o botão de copiar mensagem use um `aria-label` estático, mantendo o texto transitório de sucesso separado do rótulo do controle.
- Adicionar estilização explícita do anel de `focus-visible` com deslocamento apropriado para modo escuro ao botão de copiar mensagem, para indicar de forma mais clara o foco via teclado.
- Documentar o padrão de aria-live para anúncios de estados transitórios nas diretrizes do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility feedback and focus indication for the chat message copy action.

New Features:
- Announce the copy success state via a statically mounted, visually hidden aria-live region next to the message copy button.

Enhancements:
- Make the message copy button use a static aria-label while keeping the transient success text separate from the control label.
- Add explicit focus-visible ring styling with dark-mode-appropriate offset to the message copy button for clearer keyboard focus indication.
- Document the aria-live pattern for transient state announcements in the Palette guidelines.

</details>