### PR TITLE
🎨 Palette: [UX improvement] Improve MessageBubble copy button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2026-04-25 - [Transient State Accessibility]
+**Learning:** For accessibility, changing the `aria-label` dynamically to indicate transient states (like 'Copiado!') is unreliable because screen readers may not re-announce the label change if focus remains on the element. Providing an adjacent permanently mounted `aria-live="polite"` visually hidden element (`sr-only`) is a more robust way to announce these state changes. Also, replacing `focus` with `focus-visible` coupled with strong ring offsets improves the keyboard experience in dark themes without affecting pointer users.
+**Action:** Use an `aria-live` region for transient confirmation messages rather than altering static `aria-label`s, and ensure interactive elements use explicit `focus-visible` styling.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus:outline-none focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <div className="sr-only" aria-live="polite">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
🎨 Palette: [UX improvement] Improve MessageBubble copy button accessibility

💡 What: Replaced the dynamic `aria-label` with an `aria-live` visually hidden region for the copy button confirmation state, and added explicit `focus-visible` styling with ring offsets for dark mode.
🎯 Why: Screen readers often do not re-announce an `aria-label` change if focus remains on the element, making transient states like "Copiado!" inaccessible. Also, the button lacked clear keyboard focus indicators on dark backgrounds.
📸 Before/After: Verified visually with Playwright.
♿ Accessibility: Improved screen reader reliability for transient states and improved keyboard navigation focus visibility.

---
*PR created automatically by Jules for task [898868304467009447](https://jules.google.com/task/898868304467009447) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e a visibilidade do foco do botão de copiar mensagem do chat e documenta as diretrizes de design relacionadas nas notas do Palette.

Novos recursos:
- Anunciar a confirmação de cópia por meio de uma região `aria-live` adjacente visualmente oculta, em vez de alterar o rótulo do botão.

Aprimoramentos:
- Adicionar estilização explícita de anel (`focus-visible ring`) e espaçamento de foco para o botão de copiar, a fim de melhorar a visibilidade do foco via teclado no modo escuro.
- Documentar aprendizados de acessibilidade e boas práticas para anúncios de estados transitórios e estilização de `focus-visible` no guia do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility of the chat message copy button and document the related design guidance in the Palette notes.

New Features:
- Announce copy confirmation via an adjacent visually hidden aria-live region instead of changing the button label.

Enhancements:
- Add explicit focus-visible ring and offset styling for the copy button to improve keyboard focus visibility in dark mode.
- Document accessibility learnings and best practices for transient state announcements and focus-visible styling in the Palette guide.

</details>