### PR TITLE
🎨 Palette: Improve copy button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient State Feedback]
+**Learning:** For transient state feedback (like "Copied!"), dynamically updating the `aria-label` of the triggered button is unreliable for screen readers. A better pattern is to use an adjacent, permanently mounted visually hidden element with `aria-live="polite"` and dynamically update its text content.
+**Action:** Use permanently mounted `aria-live` regions for transient state announcements, keeping the primary button `aria-label` static.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -44,10 +44,13 @@ const MessageBubble = ({ message, isUser }) => {
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
                     <div className="flex flex-col justify-center">
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}


### PR DESCRIPTION
🎨 **Palette: Improve copy button accessibility**

💡 **What:**
- Added a permanently mounted, visually hidden `span` with `aria-live="polite"` to handle the "Copiado" state announcement.
- Made the `aria-label` of the copy button static ("Copiar mensagem") while keeping the `title` attribute dynamic.
- Replaced basic `focus:opacity-100` with robust `focus-visible` styles (including `ring-2`, `ring-offset-2`, etc.) to make keyboard focus clearly visible on dark backgrounds.

🎯 **Why:**
- Dynamically changing the `aria-label` of a button right after it is clicked can be unreliable across different screen readers; using an `aria-live` region is the standard pattern for transient state announcements.
- Keyboard users need clear visual feedback when tabbing through the interface, especially for icon-only buttons that are usually hidden behind a hover state.

♿ **Accessibility:**
- Reliable screen reader announcements for successful copy actions.
- Clear focus indicators for keyboard navigation.

---
*PR created automatically by Jules for task [8580041456806776076](https://jules.google.com/task/8580041456806776076) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e o tratamento de foco para o botão de copiar mensagem do chat e documentar o padrão preferencial para anúncios de estados transitórios nas diretrizes do Palette.

Novos recursos:
- Anunciar ações bem-sucedidas de cópia de mensagens por meio de uma região aria-live dedicada e visualmente oculta, posicionada ao lado do botão de copiar.

Aperfeiçoamentos:
- Tornar o nome acessível do botão de copiar estático, mantendo o texto do tooltip dinâmico para fornecer feedback de estado copiado.
- Reforçar a visibilidade do foco de teclado no botão de copiar com estilos explícitos de anel e deslocamento para `focus-visible`, adequados para fundos escuros.

Documentação:
- Documentar o padrão de acessibilidade recomendado para feedback de estados transitórios usando regiões aria-live montadas permanentemente nas diretrizes do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus handling for the chat message copy button and document the preferred pattern for transient state announcements in the Palette guidelines.

New Features:
- Announce successful message copy actions via a dedicated, visually hidden aria-live region adjacent to the copy button.

Enhancements:
- Make the copy button’s accessible name static while keeping the tooltip text dynamic for copied state feedback.
- Strengthen keyboard focus visibility on the copy button with explicit focus-visible ring and offset styles suitable for dark backgrounds.

Documentation:
- Document the recommended accessibility pattern for transient state feedback using permanently mounted aria-live regions in the Palette guidelines.

</details>