### PR TITLE
🎨 Palette: Improve accessibility of copy button in MessageBubble

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible State Updates on Transient Actions]
+**Learning:** For transient feedback (like a "Copied!" checkmark) on buttons, dynamically changing the `aria-label` can cause screen readers to miss the update depending on their mode, and changing it back causes further noise. The most robust pattern is keeping the `aria-label` static ("Copy message") and using an adjacent, permanently mounted `aria-live="polite"` region that starts empty and populates with the confirmation text ("Message copied") on success.
+**Action:** Use permanently mounted `aria-live` containers for transient state announcements, keeping button labels consistent.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -44,10 +44,13 @@ const MessageBubble = ({ message, isUser }) => {
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
                     <div className="flex flex-col justify-center">
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}


### PR DESCRIPTION
🎨 Palette: Improved accessibility and focus states for the message copy button.

💡 **What:** 
- Changed the dynamic `aria-label` on the copy button to a static one.
- Added a dedicated, visually hidden `aria-live` region for announcing the "Copied!" state.
- Enhanced keyboard navigation by adding explicit `focus-visible` styling (blue ring with offset) to the copy button.

🎯 **Why:** 
- Dynamically changing an `aria-label` when a button is clicked can confuse screen readers. A dedicated `aria-live` region guarantees the success state is announced correctly while keeping the button's purpose clear.
- The copy button previously only used an opacity change on focus, which didn't provide a strong enough visual indicator for users relying on keyboard navigation.

♿ **Accessibility:**
- Improved screen reader reliability for transient actions.
- Clearer focus indication for keyboard users.

---
*PR created automatically by Jules for task [16404593793820113569](https://jules.google.com/task/16404593793820113569) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e o gerenciamento de foco do botão de copiar mensagem do chat e documenta o padrão de acessibilidade.

Novas funcionalidades:
- Anunciar o sucesso da cópia para o botão de copiar mensagem por meio de uma região dedicada `aria-live`.

Aprimoramentos:
- Reforçar a indicação de foco via teclado no botão de copiar mensagem com uma borda de foco-visível (`focus-visible`) explícita.
- Documentar as melhores práticas para anúncios acessíveis de estados transitórios na orientação do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus handling for the chat message copy button and document the accessibility pattern.

New Features:
- Announce copy success for the message copy button via a dedicated aria-live region.

Enhancements:
- Strengthen keyboard focus indication on the message copy button with explicit focus-visible ring styling.
- Document best practices for accessible transient state announcements in the Palette guidance.

</details>