### PR TITLE
🎨 Palette: Improve Copy button accessibility and focus visibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2024-05-29 - [Transient State Accessibility and Focus Styling]
+**Learning:** For accessibility, state confirmations like 'Copied!' should not rely on dynamically updating the `aria-label` of the triggered button, as screen readers might miss the initial announcement. A visually hidden `aria-live` region should be permanently mounted alongside, toggling its text content instead. Additionally, elements that use hover-based visibility (e.g., `opacity-0 group-hover:opacity-100`) must explicitly pair `focus-visible:opacity-100` with `focus-visible:ring-*` and `focus-visible:ring-offset-*` classes (especially on dark backgrounds) to maintain robust and visible keyboard accessibility.
+**Action:** Use a static `aria-label` for buttons that trigger transient states, accompanied by a dynamic `aria-live="polite"` region for announcements. Ensure hover-revealed interactive elements explicitly define `focus-visible:opacity-100` with strong focus ring contrast.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Mensagem copiada' : ''}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What:**
The UX enhancement improves the accessibility of the "Copiar mensagem" button in the `MessageBubble` component. It implements a static `aria-label` and introduces a visually hidden `aria-live` region for announcing the "Copied" transient state to screen readers. It also adds robust `focus-visible` styling to ensure the button is clearly visible when navigated via keyboard.

🎯 **Why:**
Previously, the copy button dynamically updated its `aria-label` when clicked, which can cause screen readers to miss the announcement of the transient state change. Furthermore, because the button uses `opacity-0 md:group-hover:opacity-100`, it lacked explicit focus ring styling, making it difficult for keyboard users to identify when the button received focus, especially against dark backgrounds. This enhancement solves both issues, ensuring a more inclusive and accessible experience.

📸 **Before/After:**
*(Visual changes are limited to the focus ring appearing when navigating via keyboard, and the addition of hidden elements for screen readers.)*

♿ **Accessibility:**
- Added a permanently mounted `aria-live="polite"` region for robust transient state announcements.
- Ensured a static `aria-label` is maintained on the trigger button.
- Added explicit, high-contrast `focus-visible` styling (`focus-visible:ring-2`, `focus-visible:ring-offset-2`) for keyboard navigation visibility.

---
*PR created automatically by Jules for task [6668011716127340541](https://jules.google.com/task/6668011716127340541) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco de teclado para o botão de copiar mensagem nos balões de mensagens do chat.

Novos recursos:
- Anunciar o estado de confirmação de cópia por meio de uma região dedicada, visualmente oculta, com `aria-live` para leitores de tela.

Aperfeiçoamentos:
- Usar um `aria-label` estático no botão de copiar enquanto mantém o estado visual de “copiado” por meio de alterações no ícone e no título.
- Adicionar opacidade explícita para `focus-visible` e estilização do anel de foco ao botão de copiar revelado no hover, para melhor visibilidade na navegação via teclado.
- Documentar aprendizados e diretrizes de acessibilidade para anúncios de estados transitórios e estilização de foco nas notas do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and keyboard focus visibility for the message copy button in chat message bubbles.

New Features:
- Announce the copy confirmation state via a dedicated visually hidden aria-live region for screen readers.

Enhancements:
- Use a static aria-label on the copy button while keeping visual copied state via icon and title changes.
- Add explicit focus-visible opacity and focus ring styling to the hover-revealed copy button for better keyboard navigation visibility.
- Document accessibility learnings and guidelines for transient state announcements and focus styling in the Palette notes.

</details>