### PR TITLE
🎨 Palette: Improve accessibility of Copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient State Feedback]
+**Learning:** Toggling `aria-label` to announce transient states (like changing "Copy" to "Copied") is often missed by screen readers because the focus might shift or the change isn't broadcast as a live update. Additionally, replacing the `aria-label` temporarily removes the primary description of the button.
+**Action:** Keep the `aria-label` static (e.g. "Copiar mensagem") and use an adjacent, permanently mounted visually hidden (`sr-only`) `aria-live="polite"` region that only populates text (e.g., "Copiado") when the transient state occurs. This guarantees a reliable announcement without breaking the button's static label.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -44,10 +44,13 @@ const MessageBubble = ({ message, isUser }) => {
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
                     <div className="flex flex-col justify-center">
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </div>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}


### PR DESCRIPTION
🎨 Palette: Improve accessibility of Copy button in MessageBubble

💡 What:
- Kept `aria-label` static as "Copiar mensagem".
- Added a visually hidden `aria-live="polite"` region to announce the "Copiado" state.
- Added explicit `focus-visible` ring styles with dark mode offsets for the copy button.

🎯 Why:
- Toggling `aria-label` dynamically for transient states (like "Copied") is unreliable for screen readers.
- Adding a dedicated `aria-live` region guarantees that the state change is announced while preserving the original button label.
- Explicit focus styling ensures keyboard users can clearly see when they have navigated to the copy button in dark mode.

♿ Accessibility:
- Improves screen reader reliability for transient actions.
- Enhances visual focus indicators for keyboard navigation.

---
*PR created automatically by Jules for task [12551276872646553046](https://jules.google.com/task/12551276872646553046) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e o comportamento de foco do botão de copiar mensagem em bolhas de chat e documentar o padrão nas diretrizes do Palette.

Melhorias:
- Adicionar um `aria-label` estático e uma região `aria-live` para fornecer feedback confiável de leitor de tela sobre o estado do botão de copiar.
- Aprimorar a visibilidade do foco de teclado para o botão de copiar com um anel de foco explícito (`focus-visible`) e estilos de deslocamento (offset) para o modo escuro.
- Documentar as práticas recomendadas para feedback acessível de estados transitórios nas diretrizes do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the accessibility and focus behavior of the message copy button in chat bubbles and document the pattern in the Palette guidelines.

Enhancements:
- Add a static aria-label and an aria-live region to provide reliable screen reader feedback for the copy button state.
- Enhance keyboard focus visibility for the copy button with explicit focus-visible ring and dark-mode offset styles.
- Document best practices for accessible transient state feedback in the Palette guidelines.

</details>