### PR TITLE
🎨 Palette: Improve copy button accessibility with aria-live and focus-visible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Aria-live State Announcements]
+**Learning:** Dynamically modifying `aria-label` for transient states (like "Copiado!" after a button click) is often unreliable for screen readers as they may not re-announce the changed label. Mounting a permanent, visually hidden `<div aria-live="polite">` and updating its content is a far more robust pattern for accessible state confirmations without compromising visual tooltips.
+**Action:** Use permanently mounted `aria-live` regions instead of dynamic `aria-label` changes for transient success/error messages triggered by user actions.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,12 +46,15 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
🎨 **What:**
Improved the accessibility of the copy button inside the `MessageBubble` component. 

🎯 **Why:**
Screen readers often struggle with dynamically changing `aria-label`s on elements that currently have focus. When clicking the "Copiar mensagem" button, modifying its label to "Copiado" is unreliable. The fix keeps the `aria-label` static while utilizing a permanently mounted `aria-live="polite"` region to accurately announce the state change. Additionally, clear `focus-visible` ring offsets were added to vastly improve visual feedback for keyboard navigation on the dark-themed background.

♿ **Accessibility:**
- Better, more reliable screen reader announcements using `aria-live`.
- Enhanced keyboard visibility with explicit `focus-visible:ring-offset-gray-900`.

---
*PR created automatically by Jules for task [6868410232603403516](https://jules.google.com/task/6868410232603403516) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do botão de copiar mensagem do chat e documentar o padrão de aria-live nas diretrizes do Palette.

Melhorias:
- Refinar o botão de copiar em `MessageBubble` para usar um `aria-label` estático, uma região `aria-live` com nível *polite* e um estilo de anel de foco visível mais claro, proporcionando melhor acessibilidade e navegação por teclado.
- Ampliar as diretrizes de acessibilidade do Palette com recomendações sobre o uso de regiões permanentes `aria-live` em vez de alterações dinâmicas de `aria-label` para anúncios de estados transitórios.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button and document the aria-live pattern in the Palette guidelines.

Enhancements:
- Refine the copy button in MessageBubble to use a static aria-label, an aria-live polite region, and clearer focus-visible ring styling for better accessibility and keyboard navigation.
- Extend the Palette accessibility guidelines with recommendations on using permanent aria-live regions instead of dynamic aria-label changes for transient state announcements.

</details>