### PR TITLE
🎨 Palette: Improve Copy button accessibility with aria-live and focus styles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient State Feedback]
+**Learning:** Updating the `aria-label` dynamically to give transient feedback (like changing "Copy" to "Copied!") is generally unreliable, as screen readers may not announce the change if the element is already focused, and users might be confused about the button's primary action when revisiting it. A permanently mounted `<span aria-live="polite" className="sr-only">` element ensures consistent and accessible feedback.
+**Action:** Use a permanently mounted `aria-live` region adjacent to the element to convey transient states, while keeping the primary `aria-label` static and descriptive.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
🎨 **Palette: UX Enhancement - Accessible Transient States**

💡 **What:** 
- Modified the `MessageBubble.jsx` copy button to use a static `aria-label="Copiar mensagem"` instead of dynamically swapping it to "Copiado".
- Added a permanently mounted `<span aria-live="polite" className="sr-only">` adjacent to the button to announce the "Copiado" state to screen readers.
- Enhanced keyboard focus styles by replacing `focus:opacity-100` with robust `focus-visible` utilities (`focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900`) for better contrast against the dark background.
- Logged a new critical learning in `.Jules/palette.md` regarding `aria-live` patterns.

🎯 **Why:** 
Dynamically changing an `aria-label` on an element that is already focused can often be ignored by screen readers, leading to confusing feedback. By decoupling the interactive label from the state announcement (using `aria-live`), we ensure the primary action is always clear and transient feedback is reliably read aloud.

♿ **Accessibility:**
- Better screen reader reliability for the "Copied!" confirmation.
- Clearer, high-contrast keyboard focus outlines for users navigating via Tab.

---
*PR created automatically by Jules for task [3857567106619349001](https://jules.google.com/task/3857567106619349001) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco para o botão de copiar mensagens do chat e documentar o padrão de aria-live nas diretrizes do Palette.

Novos recursos:
- Anunciar a confirmação de cópia para mensagens do chat por meio de uma região dedicada de aria-live em vez de alterar o rótulo do botão.

Aprimoramentos:
- Reforçar os estilos de foco visível via teclado para o botão de copiar mensagens do chat, a fim de melhorar o contraste em fundos escuros.
- Documentar as melhores práticas para feedback acessível de estados transitórios usando regiões aria-live nas notas de aprendizado do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility for the chat message copy button and document the aria-live pattern in the Palette guidelines.

New Features:
- Announce copy confirmation for chat messages via a dedicated aria-live region instead of changing the button label.

Enhancements:
- Strengthen keyboard focus-visible styles for the chat message copy button to improve contrast on dark backgrounds.
- Document best practices for accessible transient state feedback using aria-live regions in the Palette learning notes.

</details>