### PR TITLE
🎨 Palette: Improve copy button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Aria-live State Confirmations]
+**Learning:** Dynamically changing the `aria-label` of a button for temporary state feedback (like "Copied!") is unreliable for screen readers. A better pattern is to keep the `aria-label` static and use an adjacent, permanently mounted `span` with `aria-live="polite"` and `className="sr-only"` to announce the state change.
+**Action:** Use a static `aria-label` combined with an `aria-live` region for temporary state confirmations instead of toggling the `aria-label`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado!" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What**: Improved the accessibility of the copy button in `MessageBubble` by using a static `aria-label` and an adjacent `aria-live` region for state feedback ("Copiado!"). Enhanced its focus styles for better keyboard navigation visibility.
🎯 **Why**: Dynamically toggling `aria-label`s for temporary state feedback is unreliable for screen readers. Using an `aria-live` region provides robust, semantic feedback. The added focus styles ensure keyboard users can clearly see when the button has focus, especially against the dark background.
♿ **Accessibility**: Better screen reader announcements for temporary states and improved focus visibility.

---
*PR created automatically by Jules for task [18297367870187143773](https://jules.google.com/task/18297367870187143773) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do botão de copiar mensagem do chat e documentar o padrão de aria-live para confirmações temporárias de estado.

Melhorias:
- Reforçar o estilo de `focus-visible` e a visibilidade do botão de copiar mensagem para ajudar usuários de teclado.
- Usar um `aria-label` estático com uma região `aria-live` adjacente para fornecer retorno do leitor de tela quando uma mensagem é copiada.

Documentação:
- Documentar o padrão de `aria-live` para confirmações temporárias de estado nas diretrizes de acessibilidade do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button and document the aria-live pattern for temporary state confirmations.

Enhancements:
- Strengthen focus-visible styling and visibility for the message copy button to aid keyboard users.
- Use a static aria-label with an adjacent aria-live region to provide screen reader feedback when a message is copied.

Documentation:
- Document the aria-live pattern for temporary state confirmations in the Palette accessibility guidelines.

</details>

Melhorias:
- Refinar o botão de copiar mensagens com um aria-label estático, uma região aria-live para confirmação de cópia e estilos de focus-visible mais fortes para usuários de teclado.

Documentação:
- Documentar o padrão de aria-live para confirmações de estado temporário nas diretrizes de acessibilidade do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Melhorar a acessibilidade do botão de copiar mensagem do chat e documentar o padrão de aria-live para confirmações temporárias de estado.

Melhorias:
- Reforçar o estilo de `focus-visible` e a visibilidade do botão de copiar mensagem para ajudar usuários de teclado.
- Usar um `aria-label` estático com uma região `aria-live` adjacente para fornecer retorno do leitor de tela quando uma mensagem é copiada.

Documentação:
- Documentar o padrão de `aria-live` para confirmações temporárias de estado nas diretrizes de acessibilidade do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button and document the aria-live pattern for temporary state confirmations.

Enhancements:
- Strengthen focus-visible styling and visibility for the message copy button to aid keyboard users.
- Use a static aria-label with an adjacent aria-live region to provide screen reader feedback when a message is copied.

Documentation:
- Document the aria-live pattern for temporary state confirmations in the Palette accessibility guidelines.

</details>

</details>