### PR TITLE
🎨 Palette: Improve accessibility of MessageBubble copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient State Feedback]
+**Learning:** For transient button states (like a temporary "Copied!" confirmation), changing the `aria-label` dynamically can be unreliable for screen reader announcements and causes loss of context for the button's primary action. A more robust pattern is to keep the `aria-label` static while rendering an adjacent, visually hidden `aria-live="polite"` region that mounts empty and populates with the feedback text.
+**Action:** Use an adjacent `aria-live` container to announce temporary state changes instead of mutating the primary interactive element's `aria-label`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,11 +43,14 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado!" : ""}
+                        </div>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}


### PR DESCRIPTION
🎨 Palette: Improve accessibility of MessageBubble copy button

💡 What:
- Replaced the dynamic `aria-label` mutation on the copy button with a static `aria-label`.
- Added a visually hidden `aria-live="polite"` region adjacent to the copy button to reliably announce the "Copiado!" state to screen readers.
- Upgraded the hover-only visibility pattern by adding robust `focus-visible` ring styling with appropriate dark theme offset for keyboard users.

🎯 Why:
- Screen readers often drop context or fail to announce dynamic label changes on interactive elements. Using an `aria-live` region is the best practice for transient state feedback without losing the primary semantic action ("Copy message").
- The copy button was previously inaccessible visually to keyboard users because it only appeared on `focus` with `opacity-100` but lacked any focus ring outline, making it impossible to see when navigating via Tab key.

♿ Accessibility:
- Improves SR context and announcements via `aria-live`.
- Fixes keyboard focus visibility.

---
*PR created automatically by Jules for task [8691574986367135517](https://jules.google.com/task/8691574986367135517) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do botão de copiar mensagem do chat e documentar o padrão escolhido para feedback de estado transitório.

Novas funcionalidades:
- Anunciar a confirmação de cópia por meio de uma região aria-live adjacente, visualmente oculta, em vez de depender de alterações dinâmicas em aria-label.

Aperfeiçoamentos:
- Adicionar um estilo focus-visible mais forte e um ring offset ao botão de copiar mensagem para melhorar a visibilidade do foco via teclado.
- Documentar um padrão de acessibilidade para feedback de estado transitório usando aria-labels estáticos e regiões aria-live nas diretrizes da paleta.

Documentação:
- Estender a documentação da paleta com orientações sobre o uso de regiões aria-live para anúncios de estado transitório de botões.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button and document the chosen pattern for transient state feedback.

New Features:
- Announce copy confirmation via an adjacent visually hidden aria-live region instead of relying on dynamic aria-label changes.

Enhancements:
- Add stronger focus-visible styling and ring offset to the message copy button for better keyboard focus visibility.
- Document an accessibility pattern for transient state feedback using static aria-labels and aria-live regions in the palette guidelines.

Documentation:
- Extend palette documentation with guidance on using aria-live regions for transient button state announcements.

</details>