### PR TITLE
🎨 Palette: Improve copy button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-05-06 - [Transient State Announcements]
+**Learning:** For transient feedback (e.g., "Copied!") on action buttons, dynamically replacing the main `aria-label` is unreliable for screen readers as it may miss the announcement or confuse the primary action. Using a permanently mounted, visually hidden (`sr-only`) `aria-live="polite"` region adjacent to the button is a much more robust pattern.
+**Action:** When providing temporary status feedback without a toast notification, keep the static `aria-label` for the button and announce the state change via a dedicated `aria-live` region.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
🎨 Palette: Improve copy button accessibility with aria-live and focus visible

💡 What:
- Updated the copy button in `MessageBubble.jsx` to use a static `aria-label` and introduced an adjacent, visually hidden `aria-live` region for announcing the "Copied!" state.
- Added explicit `focus-visible` utility classes to the button.

🎯 Why:
- Dynamically changing an `aria-label` (from "Copy message" to "Copied") is an unreliable pattern for screen readers, which might not announce the change or might lose the original context of the button. A dedicated `aria-live` region ensures the feedback is reliably announced.
- Explicit focus styling (`focus-visible:ring-*`) improves keyboard navigability, especially against the dark background.

♿ Accessibility:
- Replaced dynamic `aria-label` with a static one.
- Added `aria-live="polite"` region.
- Added `focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900`.

---
*PR created automatically by Jules for task [12087414611442856788](https://jules.google.com/task/12087414611442856788) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do botão de copiar mensagem do chat e documentar o padrão escolhido nas diretrizes do Palette.

Correções de bugs:
- Usar um `aria-label` estático com uma região `aria-live` dedicada para fornecer anúncios confiáveis do estado de “copiado” para tecnologias assistivas.

Melhorias:
- Adicionar estilos explícitos de anel `focus-visible` e de deslocamento ao botão de copiar para melhorar a visibilidade do foco de teclado em fundos escuros.
- Envolver o contêiner do botão de copiar em uma coluna flex relativa para oferecer suporte ao novo layout da região `aria-live`.

Documentação:
- Ampliar as diretrizes de acessibilidade do Palette com recomendações para anunciar estados transitórios da interface do usuário por meio de uma região `aria-live` visualmente escondida, em vez de alterar `aria-labels`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button and document the chosen pattern in the Palette guidelines.

Bug Fixes:
- Use a static aria-label with a dedicated aria-live region to provide reliable copied-state announcements for assistive technologies.

Enhancements:
- Add explicit focus-visible ring and offset styles to the copy button to improve keyboard focus visibility on dark backgrounds.
- Wrap the copy button container in a relative flex column to support the new aria-live region layout.

Documentation:
- Extend the Palette accessibility guidelines with recommendations for announcing transient UI states via a visually hidden aria-live region instead of changing aria-labels.

</details>