### PR TITLE
🎨 Palette: Improve accessibility of copy button in MessageBubble

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [Reliable Transient State Feedback]
+**Learning:** Dynamically updating a button's `aria-label` to announce transient states (like "Copied!") can be unreliable for screen readers and often conflicts with visual tooltips. A more robust pattern is to keep the button's `aria-label` static and add an adjacent, permanently mounted visually hidden container with `aria-live="polite"`. The text content inside this live region can then be conditionally rendered, ensuring the update is reliably announced.
+**Action:** Use permanently mounted `aria-live` regions for transient state confirmations instead of dynamically updating primary `aria-label`s.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
🎨 Palette: Improve accessibility of copy button in MessageBubble

💡 What: Changed the copy button to use a static `aria-label` while keeping the dynamic visual tooltip. Added a permanently mounted visually hidden `aria-live` region for screen reader announcements. Also added explicit `focus-visible` styling with offsets for dark theme visibility.
🎯 Why: Dynamically updating `aria-label` for transient states ("Copied!") can cause screen readers to miss the announcement or confuse the primary action. Additionally, the button lacked visible focus states for keyboard navigation on larger screens where opacity was zero.
♿ Accessibility: Ensures reliable screen reader feedback via `aria-live` and explicit `focus-visible` rings for keyboard users.

---
*PR created automatically by Jules for task [16173005222403255494](https://jules.google.com/task/16173005222403255494) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco do botão de copiar mensagem do assistente e documentar o padrão recomendado de aria-live nas diretrizes do Palette.

Bug Fixes:
- Garantir que o botão de copiar mensagem do assistente exponha um aria-label estático consistente, ao mesmo tempo em que anuncia confirmações de cópia por meio de uma região aria-live.

Enhancements:
- Adicionar um estilo explícito de anel de focus-visible com offsets para tema escuro ao botão de copiar mensagem do assistente, para melhor visibilidade do foco ao usar o teclado.
- Introduzir uma região aria-live permanentemente montada e visualmente oculta para fornecer anúncios confiáveis de estados de cópia transitórios para leitores de tela.

Documentation:
- Ampliar a documentação do Palette com orientações sobre o uso de aria-labels estáticos e regiões aria-live separadas e permanentemente montadas para feedback de estados transitórios.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility of the assistant message copy button and document the recommended aria-live pattern in Palette guidelines.

Bug Fixes:
- Ensure the assistant message copy button exposes a consistent static aria-label while still announcing copy confirmations via an aria-live region.

Enhancements:
- Add explicit focus-visible ring styling with dark-theme offsets to the assistant message copy button for better keyboard focus visibility.
- Introduce a permanently mounted visually hidden aria-live region to provide reliable transient copy state announcements for screen readers.

Documentation:
- Extend Palette documentation with guidance on using static aria-labels and separate, permanently mounted aria-live regions for transient state feedback.

</details>

Correções de bugs:
- Garante que o botão de copiar mensagens do assistente exponha um aria-label consistente e anuncie confirmações de cópia por meio de uma região dedicada de aria-live.

Melhorias:
- Adiciona estilização explícita do anel de foco (focus-visible) e ajustes para o tema escuro ao botão de copiar mensagens do assistente, para melhorar a visibilidade do foco ao usar o teclado.
- Documenta o padrão recomendado para anúncios de estados transitórios usando regiões aria-live permanentemente montadas nas diretrizes do Palette.

Documentação:
- Estende a documentação do Palette com orientações sobre o uso de aria-labels estáticos e regiões separadas de aria-live para feedback de estados transitórios.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco do botão de copiar mensagem do assistente e documentar o padrão recomendado de aria-live nas diretrizes do Palette.

Bug Fixes:
- Garantir que o botão de copiar mensagem do assistente exponha um aria-label estático consistente, ao mesmo tempo em que anuncia confirmações de cópia por meio de uma região aria-live.

Enhancements:
- Adicionar um estilo explícito de anel de focus-visible com offsets para tema escuro ao botão de copiar mensagem do assistente, para melhor visibilidade do foco ao usar o teclado.
- Introduzir uma região aria-live permanentemente montada e visualmente oculta para fornecer anúncios confiáveis de estados de cópia transitórios para leitores de tela.

Documentation:
- Ampliar a documentação do Palette com orientações sobre o uso de aria-labels estáticos e regiões aria-live separadas e permanentemente montadas para feedback de estados transitórios.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility of the assistant message copy button and document the recommended aria-live pattern in Palette guidelines.

Bug Fixes:
- Ensure the assistant message copy button exposes a consistent static aria-label while still announcing copy confirmations via an aria-live region.

Enhancements:
- Add explicit focus-visible ring styling with dark-theme offsets to the assistant message copy button for better keyboard focus visibility.
- Introduce a permanently mounted visually hidden aria-live region to provide reliable transient copy state announcements for screen readers.

Documentation:
- Extend Palette documentation with guidance on using static aria-labels and separate, permanently mounted aria-live regions for transient state feedback.

</details>

</details>

Melhorias:
- Adicionar estilização explícita do anel de `focus-visible` e ajustes para o tema escuro no botão de copiar da mensagem do assistente, garantindo a visibilidade do foco ao usar o teclado.
- Substituir o `aria-label` dinâmico no botão de copiar por um rótulo estático e uma região `aria-live` separada, a fim de fornecer feedback confiável do leitor de tela para confirmações de cópia.
- Documentar o padrão recomendado para anúncios de estado transitório usando regiões `aria-live` permanentemente montadas nas diretrizes do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco do botão de copiar mensagem do assistente e documentar o padrão recomendado de aria-live nas diretrizes do Palette.

Bug Fixes:
- Garantir que o botão de copiar mensagem do assistente exponha um aria-label estático consistente, ao mesmo tempo em que anuncia confirmações de cópia por meio de uma região aria-live.

Enhancements:
- Adicionar um estilo explícito de anel de focus-visible com offsets para tema escuro ao botão de copiar mensagem do assistente, para melhor visibilidade do foco ao usar o teclado.
- Introduzir uma região aria-live permanentemente montada e visualmente oculta para fornecer anúncios confiáveis de estados de cópia transitórios para leitores de tela.

Documentation:
- Ampliar a documentação do Palette com orientações sobre o uso de aria-labels estáticos e regiões aria-live separadas e permanentemente montadas para feedback de estados transitórios.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility of the assistant message copy button and document the recommended aria-live pattern in Palette guidelines.

Bug Fixes:
- Ensure the assistant message copy button exposes a consistent static aria-label while still announcing copy confirmations via an aria-live region.

Enhancements:
- Add explicit focus-visible ring styling with dark-theme offsets to the assistant message copy button for better keyboard focus visibility.
- Introduce a permanently mounted visually hidden aria-live region to provide reliable transient copy state announcements for screen readers.

Documentation:
- Extend Palette documentation with guidance on using static aria-labels and separate, permanently mounted aria-live regions for transient state feedback.

</details>

Correções de bugs:
- Garante que o botão de copiar mensagens do assistente exponha um aria-label consistente e anuncie confirmações de cópia por meio de uma região dedicada de aria-live.

Melhorias:
- Adiciona estilização explícita do anel de foco (focus-visible) e ajustes para o tema escuro ao botão de copiar mensagens do assistente, para melhorar a visibilidade do foco ao usar o teclado.
- Documenta o padrão recomendado para anúncios de estados transitórios usando regiões aria-live permanentemente montadas nas diretrizes do Palette.

Documentação:
- Estende a documentação do Palette com orientações sobre o uso de aria-labels estáticos e regiões separadas de aria-live para feedback de estados transitórios.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco do botão de copiar mensagem do assistente e documentar o padrão recomendado de aria-live nas diretrizes do Palette.

Bug Fixes:
- Garantir que o botão de copiar mensagem do assistente exponha um aria-label estático consistente, ao mesmo tempo em que anuncia confirmações de cópia por meio de uma região aria-live.

Enhancements:
- Adicionar um estilo explícito de anel de focus-visible com offsets para tema escuro ao botão de copiar mensagem do assistente, para melhor visibilidade do foco ao usar o teclado.
- Introduzir uma região aria-live permanentemente montada e visualmente oculta para fornecer anúncios confiáveis de estados de cópia transitórios para leitores de tela.

Documentation:
- Ampliar a documentação do Palette com orientações sobre o uso de aria-labels estáticos e regiões aria-live separadas e permanentemente montadas para feedback de estados transitórios.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility of the assistant message copy button and document the recommended aria-live pattern in Palette guidelines.

Bug Fixes:
- Ensure the assistant message copy button exposes a consistent static aria-label while still announcing copy confirmations via an aria-live region.

Enhancements:
- Add explicit focus-visible ring styling with dark-theme offsets to the assistant message copy button for better keyboard focus visibility.
- Introduce a permanently mounted visually hidden aria-live region to provide reliable transient copy state announcements for screen readers.

Documentation:
- Extend Palette documentation with guidance on using static aria-labels and separate, permanently mounted aria-live regions for transient state feedback.

</details>

</details>

</details>