### PR TITLE
🎨 Palette: Fix Copy Button Accessibility and Focus State

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2026-05-08 - [Transient State Announcements & Focus Visibility]
+**Learning:** Changing the `aria-label` of a button dynamically to announce states (like "Copied!") is often missed by screen readers or causes confusing navigation state changes. Using a dedicated, permanently mounted `aria-live="polite"` region alongside the button provides a much more robust pattern. Additionally, combining group hover utilities with general `focus:` pseudo-classes can lead to inaccessible or missing focus rings if specific `focus-visible:` utilities are omitted.
+**Action:** Use a statically labelled button accompanied by a visually hidden `aria-live` region for conveying short-lived states, and consistently use complete `focus-visible` combinations (e.g., `focus-visible:opacity-100 focus-visible:ring-2`) over broad `focus:` styles to guarantee accessibility alongside hover states.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What**: Refactored the `MessageBubble` copy button to use a static `aria-label` paired with a visually hidden `aria-live="polite"` region for announcing transient states ("Copiado!"). Improved keyboard focus visibility by switching `focus:opacity-100` to explicit `focus-visible` utilities combined with ring styles (`focus-visible:ring-2`, etc.).

🎯 **Why**: Dynamically changing `aria-label` for short-lived state confirmations is unreliable and often missed by screen readers. Providing a stable label and a dedicated polite live region guarantees the state change is announced smoothly. Furthermore, combining group hover visibility with broad `focus` classes can sometimes lead to missing visual focus rings for keyboard users, which the explicit `focus-visible` combinations fix.

♿ **Accessibility**: 
- Screen readers now consistently announce "Copiado" via the live region without losing context of the "Copiar mensagem" button itself.
- Clearer focus outline on the copy button when navigated via keyboard.

---
*PR created automatically by Jules for task [15830642113111496530](https://jules.google.com/task/15830642113111496530) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco do botão de copiar mensagens do chat e documentar os padrões escolhidos nas diretrizes do Palette.

Correções de bugs:
- Garantir que o botão de copiar mensagem use um `aria-label` estável com uma região viva (`live region`) dedicada e polida, de modo que confirmações de cópia transitórias sejam anunciadas de forma confiável por leitores de tela.

Melhorias:
- Refinar a aparência do foco de teclado do botão de copiar usando estilos explícitos de anel de `focus-visible` para fornecer um contorno de foco mais nítido em diferentes dispositivos.
- Atualizar as diretrizes de acessibilidade do Palette com padrões para anúncios de estados transitórios e estilização robusta de `focus-visible` em interfaces dirigidas por hover.

Documentação:
- Estender a documentação do Palette com orientações sobre o uso de regiões `aria-live` para estados transitórios e sobre a preferência por utilitários de `focus-visible` para uma estilização de foco acessível.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility of the chat message copy button and document the chosen patterns in the Palette guidelines.

Bug Fixes:
- Ensure the message copy button uses a stable aria-label with a dedicated polite live region so transient copy confirmations are reliably announced by screen readers.

Enhancements:
- Refine the copy button’s keyboard focus appearance using explicit focus-visible ring styles to provide a clearer focus outline across devices.
- Update Palette accessibility guidelines with patterns for transient state announcements and robust focus-visible styling in hover-driven UIs.

Documentation:
- Extend Palette documentation with guidance on using aria-live regions for transient states and on preferring focus-visible utilities for accessible focus styling.

</details>