### PR TITLE
🎨 Palette: Improve accessibility of MessageBubble copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient States]
+**Learning:** For transient feedback (like a "Copied!" state on a button), dynamically changing the `aria-label` can be unreliable for screen readers, as the focus may move or the timing may be missed. Additionally, screen readers announce the state change better when handled by a dedicated live region.
+**Action:** Use an `aria-live="polite"` region (e.g., `<span aria-live="polite" className="sr-only">`) alongside a statically labelled button for reliable transient state announcements, keeping the `title` dynamic for visual tooltip users.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -44,10 +44,13 @@ const MessageBubble = ({ message, isUser }) => {
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
                     <div className="flex flex-col justify-center">
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus:outline-none"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}


### PR DESCRIPTION
This PR introduces accessibility and micro-UX improvements to the `MessageBubble`'s copy button. 

**Changes:**
- Removed dynamic state from `aria-label` on the copy button, keeping it static to "Copiar mensagem".
- Added an adjacent `<span aria-live="polite" className="sr-only">` element to handle the "Copiado" screen reader announcements reliably.
- Kept the visual `title` tooltip dynamic for mouse users.
- Replaced `focus:opacity-100` with `focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus:outline-none` so keyboard users get a clear visual indicator when focusing the conditionally hidden button.

All changes were verified visually and with lint/build checks.

---
*PR created automatically by Jules for task [13557599414790566893](https://jules.google.com/task/13557599414790566893) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco do botão de cópia do MessageBubble e documentar o padrão de acessibilidade relacionado no guia do Palette.

Aprimoramentos:
- Ajustar o botão de cópia do MessageBubble para usar um `aria-label` estático com uma região `aria-live` separada para anúncios de estado copiado.
- Atualizar os estilos de foco do botão de cópia do MessageBubble para fornecer um anel de foco visível mais claro para usuários de teclado.
- Documentar as boas práticas para anúncios acessíveis de estados transitórios no guia de acessibilidade do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility of the MessageBubble copy button and document the related accessibility pattern in the Palette guide.

Enhancements:
- Adjust MessageBubble copy button to use a static aria-label with a separate aria-live region for copied state announcements.
- Update MessageBubble copy button focus styles to provide a clearer focus-visible ring for keyboard users.
- Document best practices for accessible transient state announcements in the Palette accessibility guide.

</details>