### PR TITLE
🎨 Palette: Improve MessageBubble copy button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient State Feedback]
+**Learning:** For transient feedback states like "Copied!", dynamically updating the trigger button's `aria-label` can confuse screen readers and remove the underlying action's context. Instead, keeping the `aria-label` static and using a permanently mounted `span` with `aria-live="polite"` (which toggles its text content) is a much more robust a11y pattern.
+**Action:** When implementing copy-to-clipboard or similar transient successes, use a visually hidden `aria-live` region rather than updating the `aria-label` of the triggered button.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 What:
- Kept the copy button's `aria-label` static as "Copiar mensagem".
- Added a visually hidden `span` with `aria-live="polite"` to reliably announce the "Mensagem copiada" state to screen readers.
- Replaced `focus:opacity-100` with explicit `focus-visible` outline and ring classes matching the dark theme to make the button keyboard-accessible.

🎯 Why:
- Dynamically updating `aria-label` for transient states can disorient screen reader users, whereas `aria-live` is designed exactly for this.
- The copy button was visible on hover but lacked explicit focus indicators for keyboard users, making it difficult to find and activate without a mouse.

♿ Accessibility:
- Screen readers will now reliably announce "Mensagem copiada" when the action succeeds without losing context of the button itself.
- Keyboard users can now clearly see when they have tabbed to the copy button.

---
*PR created automatically by Jules for task [2174226316822818569](https://jules.google.com/task/2174226316822818569) started by @RenyEnnos*

## Resumo por Sourcery

Melhora a acessibilidade e o tratamento de foco para o botão de copiar mensagem do chat e documenta o padrão preferencial para feedback de estado transitório.

Novos recursos:
- Anunciar ações bem-sucedidas de cópia de mensagem por meio de uma região aria-live visualmente oculta para leitores de tela.

Aperfeiçoamentos:
- Tornar o botão de copiar mensagem do chat acessível via teclado, com estilização explícita de anel de focus-visible no tema escuro.
- Manter o aria-label do botão de copiar estático, usando o texto do tooltip para fornecer feedback transitório de estado “copiado”.

Documentação:
- Adicionar orientação ao palette sobre usar regiões aria-live em vez de alterar aria-labels para estados transitórios de sucesso, como copiar para a área de transferência.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus handling for the chat message copy button and document the preferred pattern for transient state feedback.

New Features:
- Announce successful message copy actions via a visually hidden aria-live region for screen readers.

Enhancements:
- Make the chat message copy button keyboard-accessible with explicit focus-visible ring styling in the dark theme.
- Keep the copy button aria-label static while using the tooltip text for transient copied state feedback.

Documentation:
- Add palette guidance on using aria-live regions instead of changing aria-labels for transient success states like copy-to-clipboard.

</details>