### PR TITLE
🎨 Palette: Improve screen reader accessibility for copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Aria-live vs Dynamic Aria-label]
+**Learning:** Screen readers often miss dynamic changes to an `aria-label` attribute on a button when it's activated (like changing "Copy" to "Copied"). A more robust pattern for transient state feedback is keeping the button's `aria-label` static and using a permanently mounted, visually hidden `span` with `aria-live="polite"` that conditionally contains the success message.
+**Action:** Use an adjacent `aria-live` region rather than updating `aria-label` for transient button feedback, while continuing to update the `title` attribute dynamically for sighted users.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -44,10 +44,13 @@ const MessageBubble = ({ message, isUser }) => {
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
                     <div className="flex flex-col justify-center">
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}


### PR DESCRIPTION
💡 What: Replaced dynamic aria-label on copy button with an aria-live region and static aria-label, and improved focus styles.
🎯 Why: Screen readers often miss dynamic aria-label changes on click. An aria-live region reliably announces transient states like "Copied!".
📸 Before/After: Visual focus ring added for keyboard users.
♿ Accessibility: Fixes unreliable screen reader announcements on copy action and improves keyboard visibility.

---
*PR created automatically by Jules for task [5017199762944561086](https://jules.google.com/task/5017199762944561086) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do botão de copiar mensagem do chat para usuários de leitores de tela e teclado.

Melhorias:
- Anunciar o sucesso da cópia por meio de uma região dedicada `aria-live`, mantendo o `aria-label` do botão estático.
- Melhorar a visibilidade do foco de teclado para o botão de copiar com uma estilização mais forte do anel de `focus-visible`.

Documentação:
- Documentar, nas diretrizes do Palette, o padrão preferencial de uso de regiões `aria-live` em vez de `aria-labels` dinâmicos para feedback transitório de botões.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button for screen reader and keyboard users.

Enhancements:
- Announce copy success via a dedicated aria-live region while keeping the button's aria-label static.
- Enhance keyboard focus visibility for the copy button with stronger focus-visible ring styling.

Documentation:
- Document the preferred pattern of using aria-live regions instead of dynamic aria-labels for transient button feedback in the Palette guidance.

</details>