### PR TITLE
🎨 Palette: Improve accessibility of copy message button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [A11y: aria-hidden on icons inside labeled buttons]
+**Learning:** When using an icon-only button, if you provide an `aria-label` on the button itself, the inner SVG icon can sometimes still be redundantly read by some screen readers if it lacks `aria-hidden="true"`.
+**Action:** Always add `aria-hidden="true"` to decorative or redundantly labeled icons (like `lucide-react` components) inside buttons that already have `aria-label` or `aria-labelledby`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 What: Added robust accessibility for the copy message action. The button now uses a static `aria-label` with a separate `aria-live` sr-only region for state announcements. Added `aria-hidden` to the internal icons and explicit `focus-visible` offset ring styles.
🎯 Why: Toggling `aria-label` on buttons dynamically to announce states (like "Copied!") is often unreliable for screen readers. Using an `aria-live` region is the standard approach. Also added visual focus indicators so keyboard users can clearly see when the copy button is focused against the dark background.
♿ Accessibility: Better screen reader announcements and improved keyboard navigation focus visibility.

---
*PR created automatically by Jules for task [7611314551603177883](https://jules.google.com/task/7611314551603177883) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco para o botão de copiar mensagens do chat e atualizar a documentação interna de diretrizes de acessibilidade.

Melhorias:
- Refinar o botão de copiar mensagens do chat para usar um `aria-label` estático, ocultar ícones decorativos de leitores de tela e fornecer um estilo de anel de foco (`focus-visible`) mais claro para usuários de teclado.

Documentação:
- Ampliar as diretrizes de acessibilidade do Palette com recomendações para o uso de `aria-hidden` em ícones dentro de botões somente com ícone que já possuem rótulo.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility for the chat message copy button and update internal accessibility guidelines documentation.

Enhancements:
- Refine the chat message copy button to use a static aria-label, hide decorative icons from screen readers, and provide clearer focus-visible ring styling for keyboard users.

Documentation:
- Extend the Palette accessibility guidelines with recommendations for using aria-hidden on icons inside labeled icon-only buttons.

</details>