### PR TITLE
🎨 Palette: Improve accessibility of MessageBubble copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-05-13 - [Accessible Transient State Feedback]
+**Learning:** Updating the `aria-label` dynamically to indicate transient states (like "Copied!") is unreliable for screen readers, which might not announce the change on an already-focused element. Additionally, elements using hover-based visibility must have robust `focus-visible` styling (`focus-visible:ring-*` and `focus-visible:opacity-100`) to be usable via keyboard navigation.
+**Action:** Use a static `aria-label` for the action, paired with an adjacent, permanently mounted visually hidden container (`sr-only`) with `aria-live="polite"` to announce state changes reliably. Always pair hover visibility with `focus-visible` utilities.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada!" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What**: The UX enhancement added:
- Replaced dynamic `aria-label` with a static one ("Copiar mensagem") on the copy button in `MessageBubble.jsx`.
- Added an adjacent `aria-live="polite"` visually hidden `span` to announce the "Mensagem copiada!" state to screen readers reliably.
- Added comprehensive `focus-visible` ring styles (`focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900`) and ensured `focus-visible:opacity-100` so the button is visible when navigated to via keyboard.

🎯 **Why**: The user problem it solves:
- Screen readers often miss dynamic updates to `aria-label` on currently focused elements, meaning users wouldn't know if the copy action succeeded.
- Elements hidden behind `group-hover:opacity-100` must have explicit `focus-visible` styles to be usable by keyboard navigators.

♿ **Accessibility**: 
- Transient state feedback is now robust using `aria-live`.
- Keyboard interaction is fully supported with visible focus indicators.

---
*PR created automatically by Jules for task [4572380885645274944](https://jules.google.com/task/4572380885645274944) started by @RenyEnnos*

## Resumo por Sourcery

Melhora a acessibilidade e a usabilidade via teclado do botão de copiar mensagem do chat e documenta o padrão de acessibilidade relacionado nas diretrizes do Palette.

Novos recursos:
- Anuncia ações bem-sucedidas de cópia de mensagem para leitores de tela usando uma região aria-live visualmente oculta.

Aperfeiçoamentos:
- Garante que o botão de copiar mensagem permaneça visível e claramente focalizado para usuários de teclado, com estilos explícitos de anel de focus-visible e opacidade.
- Usa um aria-label estático no botão de copiar mensagem, confiando em uma região ao vivo (live region) para o feedback de estado transitório.
- Documenta as melhores práticas para feedback acessível de estados transitórios e para estilização de focus-visible nas diretrizes de acessibilidade do Palette.

Documentação:
- Adiciona uma nova entrada de acessibilidade do Palette descrevendo padrões para anunciar estados transitórios e combinar visibilidade em hover com utilitários de focus-visible.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and keyboard usability of the chat message copy button and document the related accessibility pattern in the Palette guidelines.

New Features:
- Announces successful message copy actions to screen readers using a visually hidden aria-live region.

Enhancements:
- Ensure the message copy button remains visible and clearly focused for keyboard users with explicit focus-visible ring and opacity styles.
- Use a static aria-label on the message copy button while relying on a live region for transient state feedback.
- Document best practices for accessible transient state feedback and focus-visible styling in the Palette accessibility guidelines.

Documentation:
- Add a new Palette accessibility entry describing patterns for announcing transient states and pairing hover visibility with focus-visible utilities.

</details>