### PR TITLE
🎨 Palette: Improve accessibility of transient state on copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2026-05-14 - [Transient State Accessibility]
+**Learning:** For transient feedback states like "Copied!", dynamically toggling a button's `aria-label` often fails to be reliably announced by screen readers. A dedicated, permanently mounted visually hidden element with `aria-live="polite"` that toggles its text content (e.g., `{isCopied ? "Copiado" : ""}`) is far more robust. Additionally, adding `aria-hidden="true"` to inner SVGs prevents redundant readings.
+**Action:** Always use an adjacent `aria-live` container for brief confirmation states, keep the primary `aria-label` static, and hide decorative inner SVGs from assistive technologies.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
-                            title={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
+                            title="Copiar mensagem"
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Enhanced the accessibility and keyboard navigation for the Copy button on the `MessageBubble` component. Replaced dynamic `aria-label` toggling with a dedicated `aria-live="polite"` container, hid decorative SVGs from screen readers, and refined `focus-visible` styling.

### 🎯 Why: The user problem it solves
Screen readers often fail to reliably announce brief, transient changes to an element's `aria-label` (like changing "Copy" to "Copied" for 2 seconds). Using an `aria-live` region is the robust standard for these confirmations. Additionally, the previous focus styling (`focus:opacity-100`) lacked a visible focus ring, making it difficult for keyboard users to see their active state against the dark theme.

### 📸 Before/After
*(Visuals verified via internal Playwright testing - focus ring now distinctly visible)*

### ♿ Accessibility
- Implemented `aria-live="polite"` for robust state announcements.
- Maintained static `aria-label` for consistent naming.
- Added `aria-hidden="true"` to SVGs.
- Added explicit `focus-visible:ring-2 focus-visible:ring-offset-2` for keyboard users.

---
*PR created automatically by Jules for task [7062585567375078851](https://jules.google.com/task/7062585567375078851) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do botão de copiar mensagens do chat e documentar as melhores práticas de acessibilidade para estados de UI transitórios.

Novos recursos:
- Anunciar a confirmação de cópia por meio de uma região adjacente com `aria-live="polite"` em vez de alterar o rótulo do botão.

Aperfeiçoamentos:
- Refinar o estilo de `focus-visible` do botão de copiar e sua visibilidade para usuários de teclado no tema escuro.
- Ocultar ícones SVG decorativos de copiar/confirmação dos leitores de tela para evitar anúncios redundantes.
- Documentar diretrizes para lidar com estados de acessibilidade transitórios e semântica de SVG nas notas da palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button and document accessibility best practices for transient UI states.

New Features:
- Announce copy confirmation via an adjacent aria-live="polite" region instead of changing the button label.

Enhancements:
- Refine copy button focus-visible styling and visibility for keyboard users in dark theme.
- Hide decorative copy/check SVG icons from screen readers to avoid redundant announcements.
- Document guidelines for handling transient accessibility states and SVG semantics in the palette notes.

</details>