### PR TITLE
🎨 Palette: Improve accessibility of MessageBubble copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2024-03-20 - Transient Button State Accessibility
+**Learning:** For transient button states like "Copied!", dynamically updating the `aria-label` is unreliable as screen readers might miss the change or it disrupts the user's context. Additionally, when hiding buttons behind hover states (e.g. `opacity-0 md:group-hover:opacity-100`), they become invisible to keyboard users unless explicitly handled.
+**Action:** Always maintain a static `aria-label` on the interactive element. Use a permanently mounted, visually hidden (`sr-only`) `aria-live="polite"` adjacent element to announce state changes. Always pair hover-based visibility classes with `focus-visible:opacity-100` and robust `focus-visible:ring-*` classes so the element appears and is clearly highlighted when navigating via keyboard.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Mensagem copiada' : ''}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
🎨 Palette: Improve accessibility of MessageBubble copy button

💡 What:
- Converted dynamic `aria-label` to a static label ("Copiar mensagem") on the copy button.
- Added a visually hidden (`sr-only`), permanently mounted `aria-live="polite"` element to robustly announce the "Copied" transient state to screen readers without losing context.
- Added explicit `focus-visible` styles with offset rings so the button is clearly visible to keyboard users even when the default hover state (`opacity-0`) hides it visually.
- Appended a new critical learning log to `.Jules/palette.md` documenting this pattern.

🎯 Why:
Screen readers often miss dynamic `aria-label` updates on active buttons, or they disrupt the user's orientation. A static label with an adjacent live region provides a much more robust experience. Furthermore, hover-only visible elements (`opacity-0 group-hover:opacity-100`) become invisible traps for keyboard navigators unless paired with strong `focus-visible` styles.

♿ Accessibility:
- Keyboard users can now clearly see when they focus on the "Copy" button inside a message bubble.
- Screen reader users receive a robust "Mensagem copiada" announcement without their current button context abruptly changing.

---
*PR created automatically by Jules for task [2700950683579986114](https://jules.google.com/task/2700950683579986114) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e a visibilidade do foco do botão de copiar mensagem em bolhas de chat e documenta o padrão no diário de aprendizado do Palette.

Novos recursos:
- Anunciar o estado da ação de cópia por meio de uma região aria-live visualmente oculta adjacente ao botão de copiar mensagem.

Aprimoramentos:
- Garantir que o botão de copiar mensagem permaneça estaticamente rotulado para leitores de tela, ao mesmo tempo em que reflete o estado de copiado por meio do ícone visual e da tooltip.
- Adicionar estilos explícitos de opacidade e anel para `focus-visible`, de modo que o botão de copiar fique claramente visível quando estiver em foco via navegação por teclado.
- Documentar o padrão de acessibilidade de estado transitório de botão e o tratamento de foco para controles ocultos em hover no diário de aprendizado do Palette.

Documentação:
- Estender o diário de aprendizado de acessibilidade do Palette com orientações sobre como lidar com estados transitórios de botões e controles ocultos em hover.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the accessibility and focus visibility of the message copy button in chat bubbles and document the pattern in the Palette learning log.

New Features:
- Announce the copy action state via a visually hidden aria-live region adjacent to the message copy button.

Enhancements:
- Ensure the message copy button remains statically labelled for screen readers while still reflecting copied state via the visual icon and tooltip.
- Add explicit focus-visible opacity and ring styles so the copy button is clearly visible when focused via keyboard navigation.
- Document the transient button state accessibility pattern and hover-hidden control focus treatment in the Palette learning log.

Documentation:
- Extend the Palette accessibility learning log with guidance on handling transient button states and hover-hidden controls.

</details>