### PR TITLE
🎨 Palette: Improve accessibility of MessageBubble copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Transient State Feedback & Accessible Focus Rings]
+**Learning:** Dynamically updating the `aria-label` of a button for transient states (like "Copiado!") can cause screen readers to miss the initial announcement or confuse users. Instead, a permanent `aria-live="polite"` region that conditionally updates text provides much more reliable feedback. Additionally, hover-revealed buttons need explicit `focus-visible:opacity-100` alongside their focus rings (`focus-visible:ring-2`, etc.) to ensure keyboard users can both see and target them properly.
+**Action:** Use visually hidden `aria-live` containers for transient confirmation states while keeping the button's primary `aria-label` static. Always pair hover visibility toggles with `focus-visible` to support keyboard navigation.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,11 +46,14 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus-visible:opacity-100"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            <span aria-live="polite" className="sr-only">
+                                {isCopied ? 'Mensagem copiada' : ''}
+                            </span>
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
                     </div>
                 )}


### PR DESCRIPTION
## 💡 What:
Improved the accessibility of the Copy button in the `MessageBubble` component. 

## 🎯 Why:
The Copy button had a few key accessibility and usability issues:
1. It used a dynamic `aria-label` to announce the "Copied" state. This pattern can be unreliable for screen readers, as the focus is on the button, and changing its label abruptly might cause the announcement to be missed or confusing.
2. Because the button was only visible on hover (`opacity-0 md:group-hover:opacity-100`), a keyboard user tabbing through the interface would not see the focus ring since the button remained completely transparent. 
3. The SVG icons inside the button did not have `aria-hidden="true"`, potentially leading to redundant or confusing announcements depending on the screen reader.

## ♿ Accessibility improvements:
- Kept the `aria-label` static ("Copiar mensagem") to provide consistent context.
- Introduced a visually hidden `span` with `aria-live="polite"` to reliably announce the transient state change ("Mensagem copiada").
- Added explicit focus ring and opacity utility classes (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus-visible:opacity-100`) so the button becomes visible and displays a clear focus ring when targeted via keyboard navigation.
- Hidden decorative SVG icons from the accessibility tree using `aria-hidden="true"`.

---
*PR created automatically by Jules for task [14596427415853166194](https://jules.google.com/task/14596427415853166194) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade de foco do botão de copiar do MessageBubble e documentar os aprendizados relacionados à acessibilidade.

Novos recursos:
- Adicionar uma região `aria-live` visualmente oculta para anunciar quando uma mensagem foi copiada a partir do botão de copiar do MessageBubble.

Melhorias:
- Tornar o `aria-label` do botão de copiar do MessageBubble estático, usando o atributo `title` para fornecer feedback de estado copiado.
- Garantir que o botão de copiar do MessageBubble fique totalmente visível com um anel de foco claro quando estiver focado via navegação por teclado.
- Ocultar ícones decorativos de copiar e de check no botão de copiar do MessageBubble das tecnologias assistivas usando `aria-hidden`.

Documentação:
- Documentar aprendizados de acessibilidade e boas práticas relacionadas a feedback transitório e anéis de foco no arquivo de orientação do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility of the MessageBubble copy button and document related accessibility learnings.

New Features:
- Add a visually hidden aria-live region to announce when a message has been copied from the MessageBubble copy button.

Enhancements:
- Make the MessageBubble copy button’s aria-label static while using the title attribute for copied state feedback.
- Ensure the MessageBubble copy button becomes fully visible with a clear focus ring when focused via keyboard navigation.
- Hide decorative copy and check icons in the MessageBubble copy button from assistive technologies using aria-hidden.

Documentation:
- Document accessibility learnings and best practices around transient feedback and focus rings in the Palette guidance file.

</details>