### PR TITLE
🎨 Palette: Improve accessibility of transient state on Copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient State Feedback]
+**Learning:** Dynamically changing the `aria-label` of a button for transient states (like changing "Copy" to "Copied!") is often unreliable because screen readers might not announce the change if focus remains on the element. A more robust approach is to keep the `aria-label` static (describing the action) and use an adjacent, permanently mounted `aria-live="polite"` region (e.g., `<span aria-live="polite" className="sr-only">`) to announce the transient state text to screen readers. Sighted users still receive visual feedback via changes to the icon or the `title` attribute tooltips.
+**Action:** Use permanently mounted `aria-live` containers for transient feedback announcements like "Copied", keeping the button's primary `aria-label` static.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,19 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        {/* Accessible status announcement */}
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What:** 
- The `aria-label` of the Copy button in `MessageBubble` has been made static ("Copiar mensagem").
- A visually hidden, permanently mounted `<span aria-live="polite">` has been added adjacent to the button to handle the transient "Copiado" state announcement.
- The button now has explicit `focus-visible` outline styles (a ring with an offset matching the dark background).
- The internal `Copy` and `Check` SVG icons now have `aria-hidden="true"`.

🎯 **Why:** 
Dynamically changing an `aria-label` while an element is focused is often unreliable for screen readers (they may not read the updated label). Using a static label for the action and an adjacent `aria-live` region for transient state changes ensures both the action and the state change are communicated reliably. Furthermore, keyboard-only users need clear visual focus indicators, and default focus rings often disappear against dark backgrounds without explicit offsets.

♿ **Accessibility:**
- Better, more reliable screen reader announcements for the copy action.
- Stronger visual focus indicators for keyboard navigation.
- No redundant icon descriptions.

---
*PR created automatically by Jules for task [2289459140021977788](https://jules.google.com/task/2289459140021977788) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a estilização de foco do botão de copiar mensagem e documentar o padrão escolhido para anúncios de estado transitório.

Melhorias:
- Fazer com que o botão de copiar mensagem use um `aria-label` estático com uma região `aria-live` adjacente para anunciar o estado transitório de “copiado” para leitores de tela.
- Adicionar estilos explícitos de anel de `focus-visible` ao botão de copiar para garantir uma indicação de foco clara em fundos escuros.
- Marcar ícones SVG relacionados à cópia como `aria-hidden` para evitar anúncios redundantes pelos leitores de tela.

Documentação:
- Documentar o padrão de acessibilidade para feedback de estado transitório e o uso de regiões `aria-live` nas diretrizes do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus styling of the message copy button and document the chosen pattern for transient state announcements.

Enhancements:
- Make the message copy button use a static aria-label with an adjacent aria-live region for announcing the transient copied state to screen readers.
- Add explicit focus-visible ring styles to the copy button to ensure clear focus indication on dark backgrounds.
- Mark copy-related SVG icons as aria-hidden to avoid redundant screen reader announcements.

Documentation:
- Document the accessibility pattern for transient state feedback and the use of aria-live regions in the Palette guidelines.

</details>