### PR TITLE
🎨 Palette: Accessible Copy Button State & Focus Ring

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [Aria-live vs Dynamic Aria-label for State Changes]
+**Learning:** For accessibility, changing the `aria-label` of a button on click to denote a state change (like "Copied!") is unreliable because screen readers often don't re-announce the label if focus stays on the element. A more robust pattern is keeping the `aria-label` static and using a permanently mounted, visually hidden `aria-live` region nearby to announce the transient state change.
+**Action:** Use an adjacent, permanent `aria-live` region rather than toggling `aria-label` on buttons to announce transient confirmation states.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -44,10 +44,13 @@ const MessageBubble = ({ message, isUser }) => {
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
                     <div className="flex flex-col justify-center">
+                        <span className="sr-only" aria-live="polite">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}


### PR DESCRIPTION
**💡 What:** Improved the accessibility of the message copy button by adding a visually hidden `aria-live="polite"` region and an explicit `focus-visible` ring.
**🎯 Why:** Screen readers often fail to re-announce dynamic changes to `aria-label` when focus remains on the element, making it hard for users to know if the copy action succeeded. A permanently mounted `aria-live` region solves this. Additionally, the previous `focus:opacity-100` lacked clear visual bounds for keyboard navigation users, which is fixed by adding a high-contrast focus ring with offsets.
**📸 Before/After:** See the attached Playwright verification screenshot for the new focus ring visibility.
**♿ Accessibility:** Enhanced screen reader state confirmation and keyboard navigation visibility.

---
*PR created automatically by Jules for task [11236108234353581382](https://jules.google.com/task/11236108234353581382) started by @RenyEnnos*

## Summary by Sourcery

Melhorar o feedback de acessibilidade e a visibilidade do foco para o botão de copiar mensagem do chat e documentar o padrão `aria-live` escolhido nas notas do Palette.

Novas funcionalidades:
- Anunciar o sucesso da cópia de mensagens do chat por meio de uma região `aria-live` discreta (visualmente oculta) e com prioridade “polite”, em vez de depender de alterações dinâmicas em `aria-label`.

Aperfeiçoamentos:
- Refinar o comportamento de foco do botão de copiar mensagem do chat com um anel de foco visível de alto contraste e uma estilização de foco por teclado mais clara.
- Documentar as melhores práticas para usar regiões `aria-live` permanentes em vez de mudanças dinâmicas em `aria-label` para anúncios de estados transitórios no guia do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility feedback and focus visibility for the chat message copy button and document the chosen aria-live pattern in the Palette notes.

New Features:
- Announce copy success for chat messages via a visually hidden, polite aria-live region instead of relying on dynamic aria-label changes.

Enhancements:
- Refine the chat message copy button focus behavior with a high-contrast focus-visible ring and clearer keyboard focus styling.
- Document best practices for using permanent aria-live regions versus dynamic aria-label changes for transient state announcements in the Palette guide.

</details>