### PR TITLE
🎨 Palette: Improve copy button accessibility and focus state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2024-05-22 - [Transient State Accessibility]
+**Learning:** For transient button states (like "Copied!"), dynamically updating the `aria-label` can cause screen readers to miss the initial announcement. A better pattern is to keep the `aria-label` static and add an adjacent, permanently mounted visually hidden (`sr-only`) `<span aria-live="polite">` element that toggles text content.
+**Action:** Use permanently mounted `aria-live` regions for short-lived state confirmations rather than mutating `aria-label` attributes on active buttons.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -44,10 +44,13 @@ const MessageBubble = ({ message, isUser }) => {
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
                     <div className="flex flex-col justify-center">
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado!" : ""}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}


### PR DESCRIPTION
### 💡 What
Improved the accessibility and keyboard focus state of the auxiliary "Copy" button in `MessageBubble.jsx`. 
- Added an `aria-live` visually hidden region for the transient "Copiado!" confirmation state, keeping the button's core `aria-label` static to ensure screen readers reliably announce the confirmation.
- Improved the keyboard focus styling to use `focus-visible:ring-2` with dark offset colors instead of just basic `focus:opacity-100`.

### 🎯 Why
- The previous implementation updated the `aria-label` on the button itself dynamically. This can often cause screen readers to miss the update since the element is already focused. A permanently mounted `aria-live` region avoids this issue.
- The button lacked proper visual feedback when accessed via keyboard navigation (tabbing), making it difficult for power users or those relying on keyboards to see which element was currently active.

### ♿ Accessibility
- Ensured consistent and reliable screen reader feedback on successful clipboard copies.
- Greatly improved keyboard accessibility with high-contrast focus rings.

---
*PR created automatically by Jules for task [14493554670914788912](https://jules.google.com/task/14493554670914788912) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e o comportamento de foco do botão de copiar mensagem do chat e documentar o padrão de acessibilidade escolhido nas diretrizes do Palette.

Novos recursos:
- Fornecer anúncios de leitor de tela para o estado de confirmação de cópia por meio de uma região `aria-live` dedicada, adjacente ao botão de copiar.

Aperfeiçoamentos:
- Refinar o estilo de foco de teclado para o botão de copiar com anéis de `focus-visible` explícitos e offsets no modo escuro.
- Documentar um padrão de acessibilidade reutilizável para estados de confirmação transitórios de botões usando `aria-labels` estáticos e regiões `aria-live` nas notas do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus behavior for the chat message copy button and document the chosen accessibility pattern in the Palette guidelines.

New Features:
- Provide screen reader announcements for the copy confirmation state via a dedicated aria-live region adjacent to the copy button.

Enhancements:
- Refine keyboard focus styling for the copy button with explicit focus-visible rings and offsets in dark mode.
- Document a reusable accessibility pattern for transient button confirmation states using static aria-labels and aria-live regions in the Palette notes.

</details>