### PR TITLE
🎨 Palette: Improve Copy Button Accessibility & Focus

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [State Announcements & Dynamic Labels]
+**Learning:** Changing the `aria-label` dynamically (e.g., from "Copy" to "Copied") on a button is often unreliable because screen readers might not announce the change after the click if focus remains on the element. Using a static `aria-label` for the action, combined with a permanently mounted, visually hidden `aria-live` region that updates its text content for the state change, guarantees reliable announcement.
+**Action:** Always prefer an adjacent `aria-live` container for transient state feedback (like "Copied!") over dynamic attribute changes on the focused element itself.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Mensagem copiada' : ''}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
### 💡 What
- Replaced the dynamic `aria-label` on the copy button in `MessageBubble` with a static "Copiar mensagem".
- Added an adjacent, permanently mounted `span` with `aria-live="polite"` and `className="sr-only"` to announce the "Mensagem copiada" state to screen readers.
- Upgraded the CSS classes on the button from standard hover opacity to include explicit keyboard focus visibility: `focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900`.
- Documented a critical learning in the Palette journal regarding state announcements and dynamic labels.

### 🎯 Why
Dynamically changing an `aria-label` while an element is focused is notoriously unreliable across different screen readers; they often simply repeat the old label or say nothing. Using a static label for the action and an adjacent `aria-live` region for the *result* of the action ensures every user receives the transient state feedback reliably. Additionally, relying solely on opacity for hover states can make keyboard navigation difficult on dark backgrounds without explicit, offset focus rings.

### ♿ Accessibility
- **Screen Readers:** Reliable announcement of the "Copied" state without confusing the button's core identity.
- **Keyboard Navigation:** The copy button is now clearly visible when tabbed to, even against the dark message background, thanks to explicit offset focus rings.

---
*PR created automatically by Jules for task [11039557056489479340](https://jules.google.com/task/11039557056489479340) started by @RenyEnnos*

## Summary by Sourcery

Melhorar o feedback de acessibilidade e a visibilidade do foco para o botão de copiar mensagem do chat e documentar o padrão de acessibilidade relacionado no diário do Palette.

Aperfeiçoamentos:
- Fazer com que o botão de copiar mensagem do chat use um `aria-label` estático com uma região `aria-live` adjacente para anunciar o estado de “copiado” aos leitores de tela.
- Aperfeiçoar a visibilidade do foco de teclado para o botão de copiar com um anel de `focus-visible` explícito e estilização de deslocamento em fundos escuros.
- Documentar os aprendizados de acessibilidade sobre anúncios de estado e rótulos dinâmicos no diário do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility feedback and focus visibility for the chat message copy button and document the related accessibility pattern in the Palette journal.

Enhancements:
- Make the chat message copy button use a static aria-label with an adjacent aria-live region to announce the copied state to screen readers.
- Enhance keyboard focus visibility for the copy button with explicit focus-visible ring and offset styling on dark backgrounds.
- Document accessibility learnings about state announcements and dynamic labels in the Palette journal.

</details>