### PR TITLE
🎨 Palette: Improve accessibility of copy button in MessageBubble

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2024-05-29 - [Transient State Feedback on Icon Buttons]
+**Learning:** For transient button states like a "Copied!" checkmark on an icon-only copy button, changing the `aria-label` dynamically (e.g., from "Copy" to "Copied") is unreliable for screen readers since focus might not trigger the read.
+**Action:** Use a static `aria-label` on the button and add a separate, permanently mounted (visually hidden) `aria-live="polite"` region to announce state changes (like "Copiado!"). Ensure decorative icons inside have `aria-hidden="true"`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado!" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 What: Improved the accessibility of the Copy button inside the `MessageBubble` component.
🎯 Why: Dynamic `aria-label`s are often unreliable for announcing transient states like "Copiado!" because focus might not re-trigger the read. Using a static `aria-label` with a permanently mounted `aria-live="polite"` region ensures screen readers dependably announce the confirmation. Keyboard focus was also insufficiently visible, which has been corrected with robust `focus-visible` ring styling.
📸 Before/After: See generated Playwright screenshots demonstrating the new focus ring and interaction state.
♿ Accessibility: Ensures transient state feedback reaches screen readers reliably and provides clear keyboard navigation indicators.

---
*PR created automatically by Jules for task [12040553389118345647](https://jules.google.com/task/12040553389118345647) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e o gerenciamento de foco do botão de copiar na mensagem do chat e documenta o padrão de acessibilidade no guia do Palette.

Melhorias:
- Refina o botão de copiar do `MessageBubble` com um estilo de `focus-visible` mais forte e tratamento explícito do contorno de foco para melhor visibilidade na navegação por teclado.
- Ajusta a semântica do botão de copiar usando um `aria-label` estático, marcando ícones decorativos como `aria-hidden` e usando uma região ao vivo (`live region`) para anunciar o estado de cópia.

Documentação:
- Documenta um padrão de acessibilidade para feedback transitório em botões apenas com ícone no guia do Palette, recomendando `aria-label`s estáticos, uma região `aria-live` com prioridade “polite” e ícones com `aria-hidden`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus handling of the copy button in the chat message bubble and document the accessibility pattern in the Palette guide.

Enhancements:
- Refine the MessageBubble copy button with stronger focus-visible styling and explicit focus ring handling for better keyboard navigation visibility.
- Adjust the copy button’s semantics by using a static aria-label, marking decorative icons as aria-hidden, and relying on a live region for announcing copied state.

Documentation:
- Document an accessibility pattern for transient feedback on icon-only buttons in the Palette guide, recommending static aria-labels plus a polite aria-live region and aria-hidden icons.

</details>