### PR TITLE
🎨 Palette: Improve copy button accessibility and focus styling

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,10 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+## 2026-05-26 - [MessageBubble Copy Button a11y]
+**Learning:** In headless Playwright tests, clipboard API (`navigator.clipboard.readText()`) may fail with a 'Document is not focused' error. A reliable alternative for testing copy functionality is verifying transient UI state changes.
+**Action:** Use UI visual verification (like checking the appearance of a 'Copied!' checkmark icon or an attached aria-live span) for clipboard interactions in Playwright.
+
+## 2026-05-26 - [MessageBubble Accessibility Patterns]
+**Learning:** For accessible transient state feedback (e.g., 'Copied!') on buttons without losing visual tooltips, keep the 'title' attribute dynamic for sighted users while using an adjacent, permanently mounted 'aria-live' region for screen readers, keeping the primary 'aria-label' static.
+**Action:** Use this `aria-live` pattern alongside `aria-hidden=true` on decorative icons to ensure reliable and non-redundant screen reader announcements.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
🎨 Palette: Message Copy Button Accessibility & UX Enhancements

💡 What:
Refactored the copy button in the `MessageBubble` component to use a more robust, accessible pattern for conveying its state (copied vs. ready to copy), and improved its keyboard navigation styling.

🎯 Why:
Dynamically changing an `aria-label` is not always reliably announced by screen readers. Furthermore, a user relying solely on a keyboard found it difficult to locate the copy button on dark backgrounds since the previous focus ring was non-existent (only utilizing an opacity change).

📸 Before/After:
Before: The copy button visually appeared on focus but lacked a clear indicator, and changed its `aria-label` when clicked. Screen readers redundantly read out the inner icons.
After: The button now explicitly highlights with a `ring-2` outline on focus. A dedicated, permanently mounted `aria-live` region announces the "Mensagem copiada" state, while decorative SVG icons are hidden from screen readers.

♿ Accessibility:
- Changed dynamic `aria-label` to static `aria-label="Copiar mensagem"`
- Appended a permanently mounted `<span aria-live="polite" className="sr-only">`
- Set `aria-hidden="true"` on the `Copy` and `Check` lucide icons
- Replaced `focus:opacity-100` with standard focus visible rings: `focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none`.

---
*PR created automatically by Jules for task [8068743552274479346](https://jules.google.com/task/8068743552274479346) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco para o botão de copiar mensagem em bolhas de mensagens de chat e documentar padrões relacionados no guia do Palette.

Novos recursos:
- Anunciar mudanças de estado de cópia por meio de uma região `aria-live` dedicada para o botão de copiar mensagem.

Correções de bugs:
- Garantir que o botão de copiar mensagem seja claramente visível quando estiver em foco, especialmente para usuários de teclado em fundos escuros.

Aprimoramentos:
- Simplificar e estabilizar os atributos de acessibilidade do botão de copiar, usando um `aria-label` estático e ocultando ícones decorativos de leitores de tela.
- Documentar estratégias de teste de área de transferência e padrões acessíveis de botões de cópia na base de conhecimento do Palette.

Documentação:
- Estender a documentação do Palette com orientações sobre teste de interações com a área de transferência e implementação de padrões acessíveis de botões de cópia.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility for the message copy button in chat message bubbles and document related patterns in the Palette guide.

New Features:
- Announce copy state changes via a dedicated aria-live region for the message copy button.

Bug Fixes:
- Ensure the message copy button is clearly visible when focused, especially for keyboard users on dark backgrounds.

Enhancements:
- Simplify and stabilize the copy button's accessibility attributes by using a static aria-label and hiding decorative icons from screen readers.
- Document clipboard testing strategies and accessible copy-button patterns in the Palette knowledge base.

Documentation:
- Extend the Palette documentation with guidance on testing clipboard interactions and implementing accessible copy-button patterns.

</details>