### PR TITLE
🎨 Palette: Improve copy button accessibility and focus visibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient States and Hover Elements]
+**Learning:** For actions like "Copy to Clipboard", dynamically updating `aria-label` can be unreliable for screen readers. A better pattern is to keep `aria-label` static (e.g., "Copiar mensagem") and use an adjacent, permanently mounted `aria-live="polite"` region (using `sr-only`) to announce the state change ("Mensagem copiada!"). Also, for elements that appear on hover (using `md:opacity-0 md:group-hover:opacity-100`), always include `focus-visible:opacity-100` alongside strong `focus-visible:ring-*` classes so keyboard users can discover and interact with them.
+**Action:** Use permanently mounted `aria-live` containers for transient accessibility feedback instead of dynamic labels, and guarantee keyboard discoverability for hover-revealed elements with `focus-visible:opacity-100`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada!" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What:**
Improved the accessibility and keyboard navigation of the "Copy to clipboard" button on message bubbles.

🎯 **Why:**
Previously, the button used a dynamically changing `aria-label` to announce its copied state, which can be unreliable across different screen readers. Furthermore, the button was only visible on hover (on desktop) and lacked explicit `focus-visible:opacity-100` styling, meaning keyboard users tabbing through the interface would not see the button or a focus ring when they landed on it. 

♿ **Accessibility:**
- Added a static `aria-label="Copiar mensagem"`.
- Added a dedicated, permanently mounted `<div aria-live="polite" className="sr-only">` to announce the "Mensagem copiada!" transient state.
- Added `aria-hidden="true"` to the inner SVG icons to avoid redundant noise.
- Added `focus-visible:opacity-100` and robust `focus-visible:ring-*` styles to ensure it becomes visible and clearly outlined when focused via keyboard navigation, even if not hovered.

---
*PR created automatically by Jules for task [4723583174541414698](https://jules.google.com/task/4723583174541414698) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco de teclado para o botão de copiar para a área de transferência na mensagem em forma de balão.

Novos recursos:
- Anunciar o estado de sucesso da cópia por meio de uma região aria-live dedicada, somente para leitores de tela, dentro do balão de mensagem do chat.

Aperfeiçoamentos:
- Usar um `aria-label` estático e ícones SVG com `aria-hidden` no botão de copiar para fornecer um comportamento mais claro para leitores de tela.
- Garantir que o botão de copiar continue descobrível e claramente contornado para usuários de teclado, com estilos de opacidade e contorno (ring) ativados por `focus-visible`.
- Documentar padrões de acessibilidade para estados transitórios e elementos revelados ao passar o mouse (hover) nas diretrizes do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and keyboard focus visibility for the message bubble copy-to-clipboard button.

New Features:
- Announce copy success state via a dedicated, screen-reader-only aria-live region in the chat message bubble.

Enhancements:
- Use a static aria-label and aria-hidden SVG icons on the copy button to provide clearer screen reader behavior.
- Ensure the copy button remains discoverable and clearly outlined for keyboard users with focus-visible opacity and ring styles.
- Document accessibility patterns for transient states and hover-revealed elements in the Palette guidelines.

</details>