### PR TITLE
🎨 Palette: Improve copy button accessibility and focus styles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient State Feedback]
+**Learning:** Mutating `aria-label` for transient states (like changing "Copy" to "Copied!") is unreliable for screen readers, which often miss the update. Additionally, utility buttons appearing on hover need strong, persistent focus rings (`focus-visible`) since keyboard users can't trigger the hover state to reveal them intuitively.
+**Action:** Use a static `aria-label` and an adjacent, permanently mounted `aria-live` region to announce transient state changes without disrupting the primary button's label. Always provide explicit `focus-visible` styling for conditionally visible buttons.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,12 +46,15 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
🎨 Palette: Improve Copy Button Accessibility

💡 **What:** 
- Made the `aria-label` of the message copy button static ("Copiar mensagem") instead of toggling it dynamically.
- Added a permanently mounted, visually hidden `aria-live="polite"` region adjacent to the button to correctly announce the transient "Mensagem copiada" state to screen readers.
- Added explicit keyboard focus styling (`focus-visible:ring-2`, etc.) to the copy button.

🎯 **Why:** 
Screen readers often miss rapid changes to attributes like `aria-label`. For transient states (like changing "Copy" to "Copied!"), a dedicated `aria-live` region is much more reliable. Furthermore, because this button appears on hover for desktop users, keyboard users need a very clear, persistent focus ring to indicate they have tabbed onto it, as they cannot trigger the hover state naturally.

📸 **Before/After:** 
(Focus ring is now visible when tabbing to the copy button).

♿ **Accessibility:** 
- Improved screen reader reliability for the "Copied!" notification.
- Improved keyboard navigation visibility for the auxiliary action button.

---
*PR created automatically by Jules for task [5317836093807935334](https://jules.google.com/task/5317836093807935334) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e o comportamento de foco via teclado para o botão de copiar mensagem do chat.

Novas funcionalidades:
- Anunciar o resultado da ação de copiar por meio de uma região aria-live dedicada, visualmente oculta, ao lado do botão de copiar.

Aprimoramentos:
- Tornar estático o aria-label do botão de copiar, mantendo o texto do tooltip dinâmico com base no estado de cópia.
- Adicionar estilos explícitos de anel de focus-visible ao botão de copiar revelado no hover para melhor visibilidade via teclado.
- Documentar aprendizados e diretrizes de acessibilidade para feedback de estados transitórios e estilização de foco nas notas do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and keyboard focus behavior for the chat message copy button.

New Features:
- Announce the copy action result via a dedicated, visually hidden aria-live region next to the copy button.

Enhancements:
- Make the copy button's aria-label static while keeping the tooltip text dynamic based on copy state.
- Add explicit focus-visible ring styles to the hover-revealed copy button for better keyboard visibility.
- Document accessibility learnings and guidelines for transient state feedback and focus styling in the Palette notes.

</details>