### PR TITLE
🎨 Palette: Accessible copy confirmation feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient State Feedback]
+**Learning:** Updating the `aria-label` dynamically to announce state changes (like changing "Copy" to "Copied!") is often unreliable because screen readers might not announce the label change on the active button if focus hasn't moved, or they might re-read the entire button. It also hides the original purpose of the button while the state is active.
+**Action:** Keep the `aria-label` static (e.g., "Copiar mensagem") and use a permanently mounted `<div aria-live="polite" className="sr-only">` adjacent to the button to conditionally render the state text (e.g., "Copiado"). This ensures the screen reader catches the initial announcement of the text appearing without disrupting the button's static semantic label.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
                             className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
**💡 What:** Improved the accessibility of the copy button inside `MessageBubble.jsx`. I've transitioned away from updating the `aria-label` dynamically when the button is clicked. Instead, the `aria-label` remains statically "Copiar mensagem", and a new, visually hidden `<div aria-live="polite">` is rendered next to the button that conditionally contains the text "Copiado". Also documented this learning in `.Jules/palette.md`.

**🎯 Why:** Screen readers often fail to announce dynamic changes to an `aria-label` on an element that currently has focus, or they re-read the entire element, confusing the user about its primary purpose. By leaving the semantic label intact and using an `aria-live` region, we ensure assistive technologies predictably announce the transient state feedback (the "Copied!" confirmation) as it appears.

**♿ Accessibility:** This pattern ensures robust feedback for screen reader users and maintains a consistent static label, while sighted users continue to see the icon change and the updated native `title` tooltip.

---
*PR created automatically by Jules for task [3840667537315504016](https://jules.google.com/task/3840667537315504016) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do botão de copiar mensagens do chat utilizando uma região `aria-live` para confirmações de cópia transitórias e documentar o padrão.

Novas funcionalidades:
- Anunciar confirmações de cópia para mensagens do chat por meio de uma região dedicada `aria-live`, mantendo o rótulo do botão de copiar estático.

Documentação:
- Documentar o padrão acessível para feedback de estado transitório em `.Jules/palette.md`, incluindo orientações sobre o uso de regiões `aria-live` em vez de `aria-labels` dinâmicos.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button by using an aria-live region for transient copy confirmations and documenting the pattern.

New Features:
- Announce copy confirmations for chat messages via a dedicated aria-live region while keeping the copy button label static.

Documentation:
- Document the accessible pattern for transient state feedback in `.Jules/palette.md`, including guidance on using aria-live regions instead of dynamic aria-labels.

</details>