### PR TITLE
🎨 Palette: Improve accessibility of message copy feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient State Feedback]
+**Learning:** Dynamically changing the `aria-label` of a button to provide feedback (like changing "Copy" to "Copied!") is often unreliable for screen readers, as they may not re-announce the label if focus remains on the element. A more robust pattern is keeping the `aria-label` static and using an adjacent, permanently mounted `aria-live="polite"` region (visually hidden) that toggles its text content to announce the state change.
+**Action:** Use static `aria-label`s on buttons and offload transient success/error announcements to adjacent `aria-live` containers.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,11 +43,14 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Copiado' : ''}
+                        </span>
                         <button
                             onClick={handleCopy}
                             className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}


### PR DESCRIPTION
💡 **What**: Added an `aria-live="polite"` region to the `MessageBubble` component to handle the "Copiado" feedback for screen readers, and changed the dynamic `aria-label` to a static "Copiar mensagem".
🎯 **Why**: Changing an `aria-label` dynamically while the element has focus is often not announced by screen readers. A permanently mounted `aria-live` region provides robust, reliable transient state feedback for accessibility.
📸 **Before/After**: The visual appearance is identical, as the new span uses `sr-only` to remain visually hidden.
♿ **Accessibility**: Screen readers will now reliably announce "Copiado" when the user clicks the copy button.

---
*PR created automatically by Jules for task [10022402531126683733](https://jules.google.com/task/10022402531126683733) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do feedback de cópia de mensagens do chat e documentar o padrão no guia do Palette.

Melhorias:
- Fazer com que o botão de copiar mensagem use um `aria-label` estático e anuncie o sucesso da cópia por meio de uma região `aria-live` visualmente oculta, para melhor compatibilidade com leitores de tela.

Documentação:
- Documentar o padrão acessível para feedback de estado transitório usando `aria-labels` estáticos e regiões `aria-live` adjacentes nas diretrizes do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy feedback and document the pattern in the Palette guide.

Enhancements:
- Make the message copy button use a static aria-label and announce copy success via a visually hidden aria-live region for better screen reader support.

Documentation:
- Document the accessible pattern for transient state feedback using static aria-labels and adjacent aria-live regions in the Palette guidelines.

</details>