### PR TITLE
🎨 Palette: Accessible Copy Feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2026-06-03 - [Accessible Transient States]
+**Learning:** When a button action triggers a brief state change (like "Copied!"), dynamically changing the button's `aria-label` is unreliable for screen readers, as the focus is already on the button and the change might not be announced. A better approach is to use a permanently mounted, visually hidden `span` with `aria-live="polite"` that updates its text content. This ensures the change is reliably announced without overriding the button's primary identity.
+**Action:** Use an adjacent `aria-live` region for temporary status feedback on interactive elements instead of toggling the `aria-label`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,12 +46,15 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
### 💡 What
Improved the accessibility and keyboard navigation of the `MessageBubble` copy button. Added a dedicated `aria-live` region for screen readers to reliably announce when text has been copied, added robust `focus-visible` styles, and corrected the use of dynamic `aria-labels`.

### 🎯 Why
Dynamically changing an element's `aria-label` while it is currently focused is an unreliable pattern for screen readers. Using a visually hidden, permanently mounted `aria-live` region is the best practice for transient state feedback. Additionally, the button lacked strong keyboard focus indicators on dark backgrounds, making keyboard navigation difficult.

### ♿ Accessibility
- Added `focus-visible` offset rings tailored for dark backgrounds.
- Replaced dynamic `aria-label` with a robust `aria-live` status region.
- Hid decorative icons from the accessibility tree using `aria-hidden="true"`.

---
*PR created automatically by Jules for task [11768539646575126884](https://jules.google.com/task/11768539646575126884) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e o comportamento de feedback do botão de copiar mensagem do chat e documentar o padrão escolhido nas diretrizes da paleta.

Novos recursos:
- Adicionar uma região aria-live visível apenas para leitores de tela para anunciar quando uma mensagem do chat tiver sido copiada.

Aperfeiçoamentos:
- Reforçar o estilo de foco visível pelo teclado para o botão de copiar mensagem do chat, adaptado para fundos escuros.
- Ocultar ícones decorativos de status de cópia das tecnologias assistivas usando aria-hidden.
- Documentar, nas diretrizes da paleta, as melhores práticas para lidar com feedback de status transitório usando regiões aria-live em vez de aria-labels dinâmicos.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and feedback behavior for the chat message copy button and document the chosen pattern in the palette guidelines.

New Features:
- Add a screen-reader-only aria-live region to announce when a chat message has been copied.

Enhancements:
- Strengthen keyboard focus-visible styling for the chat message copy button, tailored for dark backgrounds.
- Hide decorative copy-status icons from assistive technologies using aria-hidden.
- Document best practices for handling transient status feedback using aria-live regions instead of dynamic aria-labels in the palette guidelines.

</details>