### PR TITLE
🎨 Palette: Improve accessibility of MessageBubble copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient State Feedback]
+**Learning:** Dynamically changing the `aria-label` of a button for transient state feedback (like "Copied!") can be unreliable for screen readers as they might miss the quick change.
+**Action:** Keep the button's `aria-label` static (e.g., "Copy message") and use an adjacent, permanently mounted `aria-live="polite"` visually hidden (`sr-only`) element to announce transient state changes reliably. Additionally, when using `group-hover` for opacity-based visibility, explicitly use `focus-visible:opacity-100` alongside explicit focus rings to ensure keyboard users can find and see the focused element.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
This PR addresses an accessibility gap in the `MessageBubble` component where the copy button's `aria-label` was being dynamically updated to indicate a "Copied!" state. This approach is notoriously unreliable for screen readers.

Instead, the `aria-label` is now kept static ("Copiar mensagem"), and a permanently mounted, visually hidden (`sr-only`) `span` with `aria-live="polite"` handles the transient state announcement. 

Additionally, because the button uses opacity for responsive visibility (revealed on hover on desktop), it now includes explicit `focus-visible:opacity-100` alongside robust `focus-visible` ring utilities to ensure keyboard users can see the button when tabbing to it.

A corresponding entry has been added to `.Jules/palette.md` to document this critical learning pattern.

---
*PR created automatically by Jules for task [15745164582261810303](https://jules.google.com/task/15745164582261810303) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade de foco do botão de copiar em MessageBubble e documentar o padrão de acessibilidade associado no guia de paleta.

Melhorias:
- Garantir que o botão de copiar em MessageBubble permaneça visível e com contorno claro quando estiver em foco via navegação por teclado, mesmo quando normalmente é exibido apenas ao passar o mouse.
- Substituir as atualizações dinâmicas de `aria-label` no botão de copiar em MessageBubble por um rótulo estático e uma região `aria-live` para anúncios confiáveis por leitores de tela.
- Documentar o padrão de feedback acessível de estado transitório e o tratamento de foco para controles baseados em opacidade no guia de paleta compartilhado.

Documentação:
- Adicionar uma entrada na paleta descrevendo as melhores práticas para feedback acessível de estado transitório usando `aria-label`s estáticos e regiões `aria-live`, e para visibilidade de foco ao usar comportamentos de hover baseados em opacidade.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility of the MessageBubble copy button and document the associated accessibility pattern in the palette guide.

Enhancements:
- Ensure the MessageBubble copy button remains visible and clearly outlined when focused via keyboard navigation, even when normally shown only on hover.
- Replace dynamic aria-label updates on the MessageBubble copy button with a static label and an aria-live region for reliable screen reader announcements.
- Document the accessible transient state feedback pattern and focus handling for opacity-based controls in the shared palette guide.

Documentation:
- Add a palette entry describing best practices for accessible transient state feedback using static aria-labels and aria-live regions, and for focus visibility when using opacity-based hover behaviors.

</details>