### PR TITLE
🎨 Palette: Improve copy button accessibility and focus visibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient States & Hover Focus]
+**Learning:** For transient feedback on buttons (like a "Copied!" state), dynamically updating the `aria-label` is unreliable for screen readers and breaks the button's core identity. Additionally, elements revealed solely on hover (`group-hover:opacity-100`) become invisible during keyboard navigation unless explicitly styled.
+**Action:** Use a static `aria-label` for identity, a dynamic `title` for sighted user tooltips, and a permanently mounted `aria-live` region for reliable screen reader announcements. Always pair hover visibility classes with robust `focus-visible` styles to ensure keyboard accessibility.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
### 💡 What
- Updated `MessageBubble.jsx` to use a static `aria-label` for the copy button.
- Added an invisible `aria-live` region that updates when a message is copied.
- Added explicit `focus-visible` styles to the copy button.

### 🎯 Why
- **Accessibility (Transient States):** Dynamically updating an `aria-label` (e.g., from "Copiar" to "Copiado") confuses screen readers as it changes the element's core identity while focused. An `aria-live` region is the robust standard for announcing transient state changes.
- **Accessibility (Keyboard Navigation):** The copy button was hidden on desktop via `opacity-0` and revealed via `group-hover:opacity-100`. Without explicit `focus-visible` styles, navigating to it via the keyboard left it completely invisible.

### ♿ Accessibility
- Improved screen reader reliability for copy confirmation.
- Fixed invisible keyboard focus state on hover-revealed buttons.
- Maintained contrast ratios in dark mode with `ring-offset-gray-900`.

---
*PR created automatically by Jules for task [14198735425787256304](https://jules.google.com/task/14198735425787256304) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do botão de copiar mensagens do chat e documentar os aprendizados relacionados à acessibilidade.

Melhorias:
- Preservar um `aria-label` estático para o botão de copiar e mover a confirmação de cópia transitória para uma região `aria-live` para melhor suporte a leitores de tela.
- Adicionar estilos explícitos de `focus-visible` para garantir que o botão de copiar, revelado ao passar o mouse, permaneça visível durante a navegação por teclado.
- Documentar diretrizes de acessibilidade para estados transitórios e visibilidade apenas em hover nas notas da paleta.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button and document related accessibility learnings.

Enhancements:
- Preserve a static aria-label for the copy button and move transient copy confirmation to an aria-live region for better screen reader support.
- Add explicit focus-visible styles to ensure the hover-revealed copy button remains visible during keyboard navigation.
- Document accessibility guidelines for transient states and hover-only visibility in the palette notes.

</details>