### PR TITLE
🎨 Palette: Improve copy button accessibility with aria-live and focus rings

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient State Feedback]
+**Learning:** For transient button states (like a copy button changing to a checkmark to indicate "Copied!"), dynamically updating the `aria-label` is unreliable for screen readers, as focus may shift or the update might not be announced. A better approach is keeping the button's `aria-label` static (e.g., "Copy message") and using an adjacent, visually hidden element with `aria-live="polite"` to announce the state change textually.
+**Action:** Use static `aria-label`s on buttons combined with adjacent `aria-live` spans to announce transient success/error states to assistive technologies.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,11 +43,14 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
+                        <span className="sr-only" aria-live="polite">
+                            {isCopied ? 'Mensagem copiada' : ''}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}


### PR DESCRIPTION
💡 **What**: Improved the accessibility of the transient "Copied!" state on the message copy button and added missing keyboard focus styles.
🎯 **Why**: Dynamically changing `aria-label`s on buttons to indicate temporary success states (like "Copied!") is unreliable and often ignored by screen readers, particularly if focus shifts. An adjacent `aria-live` region is the standard, reliable pattern. Additionally, the icon-only button lacked clear focus indicators when navigated via keyboard.
♿ **Accessibility**: Replaced dynamic `aria-label` with a static one, added an `aria-live` span for transient announcements, and added comprehensive `focus-visible` offset ring styles suitable for the dark theme.

---
*PR created automatically by Jules for task [16477004005468231117](https://jules.google.com/task/16477004005468231117) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e o tratamento de foco para o botão de copiar mensagem e atualizar a documentação das diretrizes de acessibilidade.

Novos recursos:
- Anunciar o resultado da ação de cópia por meio de uma região aria-live adjacente, visível apenas para leitores de tela, em vez de alterar o rótulo do botão.

Melhorias:
- Adicionar estilos claros de contorno de `focus-visible` ao botão de copiar mensagem para melhorar a visibilidade na navegação por teclado.

Documentação:
- Documentar as melhores práticas para feedback acessível de estado transitório usando `aria-labels` estáticos e regiões `aria-live` nas diretrizes do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus handling for the message copy button and update accessibility guidelines documentation.

New Features:
- Announce the copy action result via an adjacent, screen-reader-only aria-live region instead of changing the button label.

Enhancements:
- Add clear focus-visible ring styles to the message copy button for better keyboard navigation visibility.

Documentation:
- Document best practices for accessible transient state feedback using static aria-labels and aria-live regions in the Palette guidelines.

</details>