### PR TITLE
🎨 Palette: Improve accessibility of copy button transient state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient States]
+**Learning:** Dynamically swapping the `aria-label` of a button (e.g., from "Copy" to "Copied!") when clicked can cause screen readers to miss the announcement or announce the new state ambiguously. Visual users need the updated tooltip (`title`), but assistive tech needs a reliable live region.
+**Action:** Keep `aria-label` static for the primary action. Use a permanently mounted, visually hidden `aria-live="polite"` region that toggles its text content (e.g., from `""` to `"Copied!"`) to reliably announce transient state changes without breaking button semantics.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada!" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
### 💡 What:
- Updated the `MessageBubble`'s copy button to use a static `aria-label` ("Copiar mensagem").
- Added a visually hidden, permanently mounted `aria-live="polite"` `span` to announce the "Copied!" state reliably to screen readers.
- Added explicit `focus-visible` styles with a gray-900 offset ring to ensure the focus state is clearly visible against dark backgrounds.
- Updated `.Jules/palette.md` to document the learnings regarding transient state accessibility.

### 🎯 Why:
Dynamically changing the `aria-label` of a button when its state changes (from "Copy" to "Copied!") can confuse screen readers, causing them to either miss the announcement entirely or misrepresent the action semantics of the button. Keeping the action label static and using a dedicated `aria-live` region is the recommended pattern for transient UI feedback. Additionally, relying solely on hover visibility without explicit focus styles can make icon buttons inaccessible to keyboard users, especially against dark backgrounds where default focus rings get lost.

### ♿ Accessibility:
- Improves screen reader experience by reliably announcing transient feedback without mutating core interactive semantics.
- Improves keyboard accessibility by ensuring the button appears with a high-contrast focus ring when navigated to via `Tab`.

---
*PR created automatically by Jules for task [6431551688905872902](https://jules.google.com/task/6431551688905872902) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do botão de copiar mensagem do chat e documentar o padrão recomendado para estados de UI transitórios.

Novos recursos:
- Anunciar o resultado da ação de cópia por meio de uma região aria-live dedicada, visualmente oculta, vinculada ao botão de copiar mensagem.

Aprimoramentos:
- Tornar estático o rótulo acessível do botão de copiar mensagem, preservando o feedback visual por meio de alterações no ícone e na dica de ferramenta (tooltip).
- Adicionar estilos explícitos de foco visível em alto contraste ao botão de copiar mensagem para melhorar a visibilidade do foco de teclado em fundos escuros.

Documentação:
- Documentar as melhores práticas para estados transitórios acessíveis e uso estático de aria-label nas diretrizes da paleta.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button and document the recommended pattern for transient UI states.

New Features:
- Announce the copy action result via a dedicated, visually hidden aria-live region tied to the message copy button.

Enhancements:
- Make the message copy button’s accessible label static while preserving visual feedback through icon and tooltip changes.
- Add explicit high-contrast focus-visible styles to the message copy button to improve keyboard focus visibility on dark backgrounds.

Documentation:
- Document best practices for accessible transient states and static aria-label usage in the palette guidelines.

</details>