### PR TITLE
🎨 Palette: Improve copy button accessibility and focus state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient State Feedback]
+**Learning:** Updating the `aria-label` dynamically to indicate transient states (like "Copied!") can confuse screen reader users, as the label changes exactly when they might be interacting with it or immediately after. Keeping the `aria-label` static and using an adjacent, permanently mounted element with `aria-live="polite"` and `className="sr-only"` ensures the transient state is announced reliably without modifying the element's primary identity.
+**Action:** Always use an `aria-live` region for feedback like "Copied!" or "Saved!" instead of conditionally changing the `aria-label`. Ensure the `aria-live` container is permanently mounted in the DOM to avoid missed announcements on initial render.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
-                            title={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
+                            title={isCopied ? "Copiado!" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado!" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What:** 
- Modified the `MessageBubble` component's copy button to use a static `aria-label` instead of dynamically switching its text. 
- Introduced an adjacent `aria-live` region (`<span className="sr-only">`) to announce the "Copiado!" state to screen readers.
- Added explicit, dark-theme optimized `focus-visible` styles to the copy button.

🎯 **Why:** 
Dynamically changing an element's `aria-label` right after a user interacts with it can confuse screen readers. A static label combined with an `aria-live` region is the best practice for transient state feedback. Additionally, the previous hover-based opacity (`group-hover:opacity-100`) combined with just `focus:opacity-100` lacked a clear, accessible focus ring for keyboard users navigating dark UI.

♿ **Accessibility:** 
- Improved screen reader reliability for the "Copiado!" state announcement.
- Clearer keyboard navigation with visible focus rings.

---
*PR created automatically by Jules for task [9675942769761403532](https://jules.google.com/task/9675942769761403532) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e o comportamento de foco do botão de copiar mensagens do chat e documenta o padrão nas diretrizes do Palette.

Novos recursos:
- Anunciar o estado de sucesso da cópia por meio de uma região `aria-live` adjacente, mantendo o rótulo do botão de copiar estático.

Aprimoramentos:
- Refinar os estilos de `focus-visible` do botão de copiar para melhor visibilidade em temas escuros.
- Atualizar a documentação do Palette com orientações sobre o uso de regiões `aria-live` para feedback de estados transitórios em vez de alterar `aria-labels`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus behavior for the chat message copy button and document the pattern in the Palette guidelines.

New Features:
- Announce the copy success state via an adjacent aria-live region while keeping the copy button label static.

Enhancements:
- Refine the copy button focus-visible styles for better visibility in dark themes.
- Update Palette documentation with guidance on using aria-live regions for transient state feedback instead of changing aria-labels.

</details>