### PR TITLE
🎨 Palette: Accessible Copy Button in MessageBubble

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2026-06-11 - Accessible Copy Button
+**Learning:** Dynamic `aria-label`s on buttons that change state (like copy buttons changing from 'Copy' to 'Copied') are not reliably announced by all screen readers and can disrupt context. The proper pattern for transient state announcements is to keep the interactive element's `aria-label` static, while updating a permanently mounted `aria-live='polite'` adjacent region.
+**Action:** Use static `aria-label`s for primary actions and hidden `aria-live` containers for transient state feedback going forward.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 What: Refactored the `MessageBubble` copy button for better accessibility. Added an `aria-live="polite"` region to announce the "Copiado" state to screen readers instead of dynamically changing the `aria-label`. Hid decorative SVG icons from screen readers, and improved the keyboard focus styles (`focus-visible:ring-offset-gray-900`) so the focus ring is clear on the dark background.
🎯 Why: Dynamic `aria-label`s are inconsistently announced by screen readers. A permanent `aria-live` region guarantees reliable state announcements without disrupting focus, improving the experience for visually impaired users. Improved focus styling aids keyboard-only users.
📸 Before/After: Visuals updated in the focus and transient states (tested via Playwright).
♿ Accessibility: Static `aria-label` on the interactive element, explicit `aria-live` region for state feedback, `aria-hidden` on internal SVGs, and distinct `focus-visible` styling for dark mode.

---
*PR created automatically by Jules for task [3851985800937854613](https://jules.google.com/task/3851985800937854613) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e o comportamento de feedback do botão de copiar mensagem nas bolhas de mensagens do chat e documentar o padrão adotado na paleta de design.

Melhorias:
- Refinar o botão de copiar mensagem de não usuário com um `aria-label` estático, ícones decorativos ocultos, estilo de anel de foco (`focus-visible`) mais claro e uma região `aria-live` para anunciar o estado de “copiado” às tecnologias assistivas.
- Documentar o padrão acessível de botão de cópia e o uso de `aria-live` nas diretrizes da paleta para trabalhos futuros de UI.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and feedback behavior of the message copy button in chat message bubbles and document the adopted pattern in the design palette.

Enhancements:
- Refine the non-user message copy button with a static aria-label, hidden decorative icons, clearer focus-visible ring styling, and an aria-live region to announce the copied state to assistive technologies.
- Document the accessible copy-button pattern and aria-live usage in the palette guidelines for future UI work.

</details>