### PR TITLE
🎨 Palette: Improve accessibility of copy message transient state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2026-06-12 - [Transient State Accessibility for Icon Buttons]
+**Learning:** Dynamically updating the `aria-label` of a button (e.g., from 'Copy' to 'Copied!') for transient state feedback is often unreliable for screen readers, as the announcement may be missed if the focus doesn't move or if the state change is brief. Using a dedicated `aria-live` region ensures the transient state ('Copied!') is reliably announced while keeping the main button action label ('Copy') clear and stable.
+**Action:** Use an adjacent, permanently mounted visually hidden element with `aria-live="polite"` to announce transient success/error states triggered by icon-only buttons, rather than mutating the `aria-label`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
                             className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
**🎨 Palette: Transient State Accessibility Improvement**

* **💡 What:** Replaced dynamic `aria-label` mutation on the "Copy Message" button with a static `aria-label` and an adjacent, visually hidden `aria-live="polite"` region.
* **🎯 Why:** Screen readers often miss transient state updates (like changing "Copy" to "Copied!") if the DOM node isn't re-focused or the state is too brief. An `aria-live` region guarantees the success feedback ("Mensagem copiada") is announced reliably without confusing the primary button action.
* **♿ Accessibility:** Provides robust feedback for visually impaired users without compromising the visual experience for sighted users (the `title` hover tooltip remains dynamic). Added learning to `.Jules/palette.md`.

---
*PR created automatically by Jules for task [1436193033527804998](https://jules.google.com/task/1436193033527804998) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do botão de copiar mensagem do chat, fornecendo um feedback confiável e compatível com leitores de tela para estados transitórios de cópia.

Correções de bugs:
- Garantir que o estado de sucesso ao copiar a mensagem seja anunciado de forma consistente para leitores de tela por meio de uma região `aria-live`, em vez de modificar o `aria-label` do botão.

Melhorias:
- Estabilizar o `aria-label` do botão de copiar enquanto se utiliza um elemento `aria-live` visualmente oculto adjacente para transmitir mensagens de sucesso de cópia em botões apenas com ícone.

Documentação:
- Documentar o padrão de acessibilidade para lidar com estados transitórios em botões de ícone usando regiões `aria-live` nas diretrizes do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button by providing reliable, screen-reader-friendly feedback for transient copy states.

Bug Fixes:
- Ensure the copy message success state is announced consistently to screen readers via an aria-live region instead of mutating the button aria-label.

Enhancements:
- Stabilize the copy button's aria-label while using an adjacent visually hidden aria-live element to convey copy success messages for icon-only buttons.

Documentation:
- Document the accessibility pattern for handling transient states on icon buttons using aria-live regions in the Palette guidelines.

</details>