### PR TITLE
🎨 Palette: Improve Copy button accessibility and focus styles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible State Confirmations]
+**Learning:** For accessibility, state confirmations (like 'Copied!') should use a visually hidden 'aria-live' region rather than dynamically updating the 'aria-label' of the triggered button. Updating `aria-label` dynamically on an element that has focus isn't reliably announced by all screen readers. Keeping the `aria-label` static and using a separate `aria-live` element ensures the confirmation is announced without losing the initial label.
+**Action:** Always pair a static `aria-label` on buttons with a permanent, visually hidden `aria-live` region for announcing transient state changes like success or error messages.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,12 +46,15 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <div role="status" aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
- 💡 What: Changed dynamic aria-label to a static one with an aria-live region for state announcement, and added clear focus-visible styles.
- 🎯 Why: Dynamic aria-labels on active elements are unreliably read by screen readers. Added focus ring to ensure the button is clearly visible when focused via keyboard on dark backgrounds.
- ♿ Accessibility: Improved screen reader announcements for the "Copiado" state and added keyboard focus indicator.

---
*PR created automatically by Jules for task [554678827181962957](https://jules.google.com/task/554678827181962957) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade do botão de copiar mensagens do chat e documenta as melhores práticas para anunciar mudanças de estado.

Novos recursos:
- Anunciar o estado de confirmação de cópia por meio de uma região dedicada de status `aria-live` para leitores de tela.

Aprimoramentos:
- Adicionar estilos de contorno (`focus-visible`) mais claros ao botão de copiar mensagens do chat para melhor visibilidade via teclado em fundos escuros.
- Documentar diretrizes de acessibilidade para uso de `aria-labels` estáticos com regiões `aria-live` nas notas do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button and document best practices for announcing state changes.

New Features:
- Announce the copy confirmation state via a dedicated aria-live status region for screen readers.

Enhancements:
- Add clearer focus-visible ring styles to the chat message copy button for better keyboard visibility on dark backgrounds.
- Document accessibility guidelines for using static aria-labels with aria-live regions in the Palette notes.

</details>