### PR TITLE
🎨 Palette: Improve copy button accessibility and focus visibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Transient State Feedback & Hover Elements]
+**Learning:** For transient feedback (e.g., "Copied!"), dynamically updating the `aria-label` of the triggered button is poorly supported by screen readers. Furthermore, interactive elements that are revealed only on hover (`md:group-hover:opacity-100`) often lack adequate focus visibility, trapping keyboard users in an "invisible" state.
+**Action:** Use a statically mounted, visually hidden `aria-live="polite"` region for transient feedback alongside a button with a static `aria-label`. Always pair `group-hover:opacity-100` with `focus-visible:opacity-100` and robust `focus-visible:ring-*` classes for interactive elements.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
🎨 Palette: Improve copy button accessibility and focus visibility

💡 What: Updated the copy button in `MessageBubble` to use a statically mounted, visually hidden `span` with `aria-live="polite"` for the transient "Copiado" state. Also replaced `focus:opacity-100` with robust `focus-visible` ring utilities.
🎯 Why: Dynamically changing an `aria-label` for transient state feedback is poorly supported by screen readers. The hidden `aria-live` region reliably announces the copy success. Furthermore, elements that appear only on hover must maintain explicit keyboard focus rings to prevent trapping keyboard users on "invisible" focused elements.
♿ Accessibility:
- Added `aria-live="polite"` region for screen reader confirmation of copied state.
- Changed button `aria-label` from dynamic to a static "Copiar mensagem".
- Added `focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900` to ensure keyboard navigation visibility, especially in the dark theme.

---
*PR created automatically by Jules for task [1312119080487589651](https://jules.google.com/task/1312119080487589651) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco para o botão de copiar mensagens do chat e documentar aprendizados relacionados ao Palette.

Novos recursos:
- Anunciar ações de cópia bem-sucedidas por meio de uma região aria-live estaticamente montada e visualmente oculta na interface de cópia de mensagens.

Melhorias:
- Tornar o nome acessível do botão de cópia estático, mantendo o feedback visual do estado “copiado” por meio de ícone e título.
- Reforçar a visibilidade do foco de teclado para o botão de cópia revelado no hover usando um contorno explícito com `focus-visible` e utilitários de opacidade.
- Documentar aprendizados e padrões de acessibilidade para feedback transitório e elementos interativos exibidos apenas em hover no guia do Palette.

Documentação:
- Adicionar orientação no Palette sobre o uso de regiões aria-live para feedback transitório e sobre como garantir visibilidade de foco em elementos interativos revelados apenas em hover.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility for the chat message copy button and document related Palette learnings.

New Features:
- Announce successful copy actions via a statically mounted, visually hidden aria-live region in the message copy UI.

Enhancements:
- Make the copy button’s accessible name static while keeping visual copied-state feedback via icon and title.
- Strengthen keyboard focus visibility for the hover-revealed copy button using explicit focus-visible ring and opacity utilities.
- Document accessibility learnings and patterns for transient feedback and hover-only interactive elements in the Palette guide.

Documentation:
- Add Palette guidance on using aria-live regions for transient feedback and ensuring focus visibility on hover-revealed interactive elements.

</details>