### PR TITLE
🎨 Palette: Fix accessibility issue with dynamic aria-label on copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-03-02 - [Transient Button Feedback Accessibility]
+**Learning:** Updating a button's `aria-label` dynamically to indicate a temporary state (like changing "Copy" to "Copied!") can cause screen readers to fail to announce the change, or read it inconsistently. The more robust pattern is to keep the button's primary `aria-label` static and place a visually hidden element with `aria-live="polite"` adjacent to it, updating its text content instead.
+**Action:** Always use an adjacent `aria-live` region for transient button states instead of mutating the `aria-label` attribute.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -47,11 +47,14 @@ const MessageBubble = ({ message, isUser }) => {
                         <button
                             onClick={handleCopy}
                             className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 What: Replaced the dynamic `aria-label` on the copy button with a static label and added an adjacent `aria-live="polite"` region.
🎯 Why: Screen readers often fail to announce state changes when an element's `aria-label` is mutated while focused. The standard and most robust pattern for transient feedback (like "Copied!") is to update the text content of a permanently mounted `aria-live` element instead.
♿ Accessibility: Improved screen reader support for the copy-to-clipboard functionality on message bubbles.

---
*PR created automatically by Jules for task [10461794755388927231](https://jules.google.com/task/10461794755388927231) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade do feedback do botão de copiar mensagem do chat.

Correções de bugs:
- Garantir que o feedback de copiar para a área de transferência seja anunciado de forma confiável por leitores de tela, usando uma região `aria-live` dedicada em vez de um `aria-label` dinâmico.

Documentação:
- Documentar o padrão recomendado de `aria-live` para feedbacks transitórios de botões nas diretrizes de acessibilidade do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button feedback.

Bug Fixes:
- Ensure copy-to-clipboard feedback is announced reliably by screen readers using a dedicated aria-live region instead of a dynamic aria-label.

Documentation:
- Document the recommended aria-live pattern for transient button feedback in the Palette accessibility guidelines.

</details>