### PR TITLE
🎨 Palette: Accessible Copy Button Transient State

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient States]
+**Learning:** For accessibility, changing the `aria-label` of a button dynamically (e.g., from "Copy" to "Copied!") can be unreliable for screen readers, as the updated state might not be announced predictably. Using an adjacent, permanently mounted `aria-live="polite"` region that conditionally renders the text "Copied!" provides a reliable and robust way to communicate transient success states without losing the button's core identity.
+**Action:** When a button triggers a temporary state change (like copying to clipboard), use a visually hidden `aria-live` sibling element to announce the state, and keep the button's main `aria-label` static.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -44,10 +44,13 @@ const MessageBubble = ({ message, isUser }) => {
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
                     <div className="flex flex-col justify-center">
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Copiado!' : ''}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800 focus:outline-none"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}

--- a/frontend/verification-entry.jsx
+++ b/frontend/verification-entry.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import MessageBubble from './src/features/chat/components/MessageBubble.jsx';
+import './src/index.css';
+
+const App = () => (
+    <div className="bg-gray-900 min-h-screen p-8 text-white">
+        <MessageBubble message="Este é um teste de cópia de mensagem" isUser={false} />
+    </div>
+);
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/frontend/verification.html
+++ b/frontend/verification.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Verification</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/verification-entry.jsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
🎨 **Palette: Accessible Copy Button Feedback**

💡 **What:** 
- Updated the `MessageBubble` component to manage its copy button accessibility more effectively.
- Instead of dynamically swapping the `aria-label` of the button from "Copiar mensagem" to "Copiado!" (which screen readers often fail to announce correctly on focus change), we now use an adjacent, visually hidden `<span aria-live="polite" className="sr-only">` region to announce the state change.
- The button's `aria-label` remains static, but the `title` attribute still updates for sighted users as a tooltip.
- Added robust keyboard focus styling (`focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800`) to ensure the button is clearly visible when navigated via keyboard against the dark background.
- Documented this learning in `.Jules/palette.md`.

🎯 **Why:** 
Dynamically mutating an `aria-label` is an anti-pattern for transient states like "copied to clipboard" because users with screen readers might miss the confirmation if the focus state or DOM update timing isn't perfect. Using a dedicated `aria-live` sibling element ensures the success message is reliably read out without altering the control's core identity.

♿ **Accessibility:** 
- Reliable screen reader announcements for transient success states using `aria-live`.
- Clearer keyboard focus indicators with offset rings specifically designed for dark mode interfaces.

---
*PR created automatically by Jules for task [3097004696263948587](https://jules.google.com/task/3097004696263948587) started by @RenyEnnos*

## Summary by Sourcery

Melhora o feedback de acessibilidade e a configuração de verificação local para o botão de copiar mensagem do chat.

Novos recursos:
- Adicionar um ponto de entrada dedicado de verificação em React e uma página HTML para testar manualmente o componente MessageBubble de forma isolada.

Aperfeiçoamentos:
- Anunciar o estado de sucesso de copiar para a área de transferência por meio de uma região aria-live visualmente oculta, mantendo o aria-label do botão de copiar estático.
- Reforçar a visibilidade do foco de teclado para o botão de copiar com uma estilização explícita de focus-visible adequada para fundos escuros.

Documentação:
- Documentar o padrão recomendado para estados transitórios acessíveis e uso de aria-label estático nas diretrizes da paleta.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility feedback and local verification setup for the chat message copy button.

New Features:
- Add a dedicated React verification entry point and HTML page to manually test the MessageBubble component in isolation.

Enhancements:
- Announce the copy-to-clipboard success state via a visually hidden aria-live region while keeping the copy button aria-label static.
- Strengthen keyboard focus visibility for the copy button with explicit focus-visible ring styling suitable for dark backgrounds.

Documentation:
- Document the recommended pattern for accessible transient states and static aria-label usage in the palette guidelines.

</details>