### PR TITLE
🎨 Palette: Improve accessibility of the copy button in MessageBubble

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2026-06-18 - [Transient State Accessibility]
+**Learning:** When providing feedback for transient actions like copy-to-clipboard, modifying a button's `aria-label` dynamically is unreliable for screen readers. Instead, the `aria-label` on the interactive element should remain static, while a permanently mounted sibling element with `aria-live="polite"` is used to announce state changes (e.g., 'Copied!') when the content updates.
+**Action:** Use a static `aria-label` for the main action and a hidden `aria-live` region for state confirmations.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,12 +46,15 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800 focus:outline-none"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Copiado' : ''}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
This PR implements a micro-UX and accessibility enhancement to the Copy button located in the `MessageBubble` component.

1.  **Static `aria-label` & `aria-live` Region:** Previously, the `aria-label` of the button changed dynamically from "Copiar mensagem" to "Copiado". This pattern is historically unreliable for screen readers, which might not re-announce the label change while focus remains on the button. The label is now static, and a permanently mounted `span` with `aria-live="polite"` has been added adjacent to the button to reliably announce the transient state change.
2.  **Focus Visibility:** The Copy button is designed to be invisible (`opacity-0`) on desktop unless its parent group is hovered (`group-hover:opacity-100`). This PR adds explicit `focus-visible` styling (`focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800`) so that keyboard users tabbing through the interface can clearly see the button when it receives focus, even if they aren't using a mouse to trigger the hover state. The dark theme offsets are explicitly handled.
3.  **Documentation:** Added a journal entry to `.Jules/palette.md` detailing the preferred pattern for transient state accessibility.

Verified locally with linting, building, and a headless Playwright script demonstrating the keyboard focus state and interaction.

---
*PR created automatically by Jules for task [15224349278296915687](https://jules.google.com/task/15224349278296915687) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade e a visibilidade de foco do botão de copiar no balão de mensagem do chat e documenta o padrão preferido para anúncios de estados transitórios.

Melhorias:
- Adicionar estilos para `focus-visible` e tratamento de contorno para que o botão de copiar permaneça visível e claramente focado para usuários de teclado, incluindo no modo escuro.
- Alterar o botão de copiar para usar um `aria-label` estático e introduzir uma região viva (live region) para anunciar mudanças de estado de cópia para tecnologias assistivas.
- Documentar o padrão de acessibilidade recomendado para feedback de estados transitórios, como ações de copiar para a área de transferência, no palette journal.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the accessibility and focus visibility of the copy button in the chat message bubble and document the preferred pattern for transient state announcements.

Enhancements:
- Add focus-visible styles and outline handling so the copy button remains visible and clearly focused for keyboard users, including in dark mode.
- Change the copy button to use a static aria-label and introduce a live region to announce copy state changes for assistive technologies.
- Document the recommended accessibility pattern for transient state feedback like copy-to-clipboard actions in the palette journal.

</details>