### PR TITLE
🎨 Palette: Improve MessageBubble Copy Button Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient State Feedback]
+**Learning:** Updating a button's `aria-label` to provide transient state feedback (e.g., from "Copy" to "Copied!") can cause issues with screen readers missing the announcement. A more robust pattern is to keep the `aria-label` static and place a permanently mounted, visually hidden `aria-live="polite"` region adjacent to the button that dynamically updates its text content. Also, don't forget `aria-hidden="true"` on the icon itself.
+**Action:** Use an adjacent `aria-live` region for transient state feedback rather than mutating `aria-label`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,14 +43,17 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </span>
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
                     </div>
                 )}


### PR DESCRIPTION
💡 **What:** Added a static `aria-label`, an adjacent `aria-live` region for transient state feedback ("Copied!"), properly hid icons from screen readers using `aria-hidden="true"`, and improved keyboard focus visibility.

🎯 **Why:** Dynamically swapping a button's `aria-label` (e.g. from "Copy" to "Copied!") often results in screen readers missing the transient confirmation. Providing a permanently mounted, visually hidden `aria-live` region ensures the "Copied!" state is reliably announced. The focus rings (`focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2`) make it significantly easier for keyboard users to see when the button has focus, especially against the dark background.

📸 **Before/After:** The button now exhibits a clear focus ring, and screen readers will reliably announce "Copied!" when triggered, while the `aria-label` correctly remains "Copiar mensagem".

♿ **Accessibility:** Replaced label mutation with `aria-live` regions, hid decorative SVGs, and added high-contrast keyboard focus indicators.

---
*PR created automatically by Jules for task [8185683503481870814](https://jules.google.com/task/8185683503481870814) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco do botão de copiar mensagem do chat.

Novos recursos:
- Anunciar a confirmação de cópia por meio de uma região aria-live próxima e visualmente oculta, em vez de modificar o rótulo do botão.

Aperfeiçoamentos:
- Manter o aria-label do botão de copiar estático enquanto se utiliza o atributo title para texto transitório, e ocultar ícones decorativos de leitores de tela com aria-hidden.
- Reforçar a visibilidade do foco pelo teclado no botão de copiar com estilização explícita de anel focus-visible e deslocamento (offset) para fundos escuros.
- Documentar o padrão acessível de feedback de estado transitório e o uso de aria-live nas diretrizes do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility of the chat message copy button.

New Features:
- Announce copy confirmation via a nearby visually hidden aria-live region instead of mutating the button label.

Enhancements:
- Keep the copy button aria-label static while using the title attribute for transient text, and hide decorative icons from screen readers with aria-hidden.
- Strengthen keyboard focus visibility on the copy button with explicit focus-visible ring and offset styling for dark backgrounds.
- Document the accessible transient state feedback pattern and aria-live usage in the Palette guidelines.

</details>