### PR TITLE
🎨 Palette: Improve accessibility of copy message feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient State Feedback]
+**Learning:** Updating the `aria-label` dynamically to indicate transient states (e.g., changing "Copiar mensagem" to "Copiado!" on a button) is unreliable for screen readers, as focus may remain on the element or it might not be announced correctly. It's better to keep `aria-label` static and use an adjacent, permanently mounted `aria-live="polite"` region that toggles its text content.
+**Action:** Use visually hidden, permanently mounted `aria-live` regions for state announcements instead of dynamic `aria-label` values on buttons.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -47,11 +47,14 @@ const MessageBubble = ({ message, isUser }) => {
                         <button
                             onClick={handleCopy}
                             className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What:** Added a permanent, visually hidden `aria-live` region to announce the "Copiado!" state when a user copies a message, and made the button's `aria-label` statically "Copiar mensagem".
🎯 **Why:** Dynamically changing the `aria-label` of a button immediately after it is clicked is an unreliable pattern for screen readers, as focus may remain on the element or the change may go unannounced. A dedicated `aria-live` region guarantees the success feedback is conveyed to visually impaired users.
📸 **Before/After:** No visual changes for sighted users (the tooltip still appears as expected).
♿ **Accessibility:** Screen readers will now reliably announce "Copiado" exactly when the action succeeds.

---
*PR created automatically by Jules for task [3272383144752557838](https://jules.google.com/task/3272383144752557838) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade da ação de copiar mensagens do chat, fornecendo um feedback de sucesso confiável e não visual para usuários de leitores de tela.

Melhorias:
- Manter o aria-label do botão de copiar estático enquanto utiliza o texto do tooltip para refletir o estado de “copiado”.
- Introduzir uma região aria-live discreta (visualmente oculta), com anúncio em modo “polite”, para informar a ação de cópia bem-sucedida sem mudanças visuais para usuários videntes.

Documentação:
- Documentar o padrão de acessibilidade que usa aria-labels estáticos com regiões aria-live adjacentes para anúncios de estados transitórios nas diretrizes do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy action by providing reliable, non-visual success feedback for screen reader users.

Enhancements:
- Keep the copy button’s aria-label static while using the tooltip text to reflect the copied state.
- Introduce a visually hidden, polite aria-live region to announce the successful copy action without visual changes for sighted users.

Documentation:
- Document the accessibility pattern of using static aria-labels with adjacent aria-live regions for transient state announcements in the Palette guidelines.

</details>