### PR TITLE
🎨 Palette: [UX] Improve copy button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient State Feedback]
+**Learning:** For transient feedback states on buttons (like a "Copied!" confirmation), dynamically updating the `aria-label` is often missed by screen readers because the element's name changes but focus doesn't move. Using a static `aria-label` for the action, combined with a separate, permanently mounted visually hidden container with `aria-live="polite"` that toggles text content, provides much more reliable announcements.
+**Action:** Use permanently mounted `aria-live` regions for transient state confirmations (e.g., "Copied!", "Saved!") instead of modifying the button's `aria-label`.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado!" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
Implemented micro-UX improvements to the MessageBubble copy button to enhance accessibility. Specifically, improved keyboard focus visibility against dark backgrounds, stabilized the `aria-label`, and introduced an `aria-live` region for more reliable screen reader announcements of the transient "Copied!" state. Recorded the learnings in the `.Jules/palette.md` journal.

---
*PR created automatically by Jules for task [7293538777166046081](https://jules.google.com/task/7293538777166046081) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e o comportamento de leitores de tela para o botão de cópia de mensagens do chat e documentar o padrão no diário do Palette.

Novos recursos:
- Anunciar o estado transitório "Copied!" para a ação de cópia de mensagem por meio de uma região dedicada de `aria-live`.

Aperfeiçoamentos:
- Reforçar a visibilidade do foco de teclado para o botão de cópia de mensagens em temas escuros usando estilização explícita do anel de foco.
- Estabilizar o nome acessível do botão de cópia usando um `aria-label` estático e marcando conteúdo apenas de ícone como `aria-hidden`.
- Registrar aprendizados e diretrizes de acessibilidade para feedback de estados transitórios no diário do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and screen reader behavior for the chat message copy button and document the pattern in the Palette journal.

New Features:
- Announce the transient "Copied!" state for the message copy action via a dedicated aria-live region.

Enhancements:
- Strengthen keyboard focus visibility for the message copy button in dark themes using explicit focus ring styling.
- Stabilize the copy button's accessible name by using a static aria-label and marking icon-only content as aria-hidden.
- Record accessibility learnings and guidelines for transient state feedback in the Palette journal.

</details>