### PR TITLE
🎨 Palette: Improve copy button screen reader accessibility in MessageBubble

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2024-06-24 - [Aria-live vs Dynamic Aria-label for State Confirmation]
+**Learning:** Dynamically changing the `aria-label` of a button to confirm a state change (like changing "Copy" to "Copied!") can be unreliable for screen readers. Some may not announce the updated text reliably.
+**Action:** Use a static `aria-label` for the action, and use a permanently mounted sibling `aria-live="polite"` region (e.g., `className="sr-only"`) that toggles its text content (e.g., "Mensagem copiada") to reliably announce the transient confirmation state to screen reader users.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
                             className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
This PR addresses an accessibility (UX) improvement in the `MessageBubble` component's copy button.

**💡 What:** 
Updated the copy button to use a static `aria-label` ("Copiar mensagem") and added an adjacent `aria-live="polite"` visually hidden region. This region briefly displays "Mensagem copiada" when a message is successfully copied. Also updated the `.Jules/palette.md` journal with this critical learning.

**🎯 Why:** 
Dynamically updating an `aria-label` to provide transient state feedback (e.g., confirming a successful copy) is notoriously unreliable for screen reader users. Screen readers often don't announce the change because the button is already focused. A dedicated `aria-live` region is the best practice for reliably announcing transient state updates without interrupting the user's flow or losing the context of the focused button.

**♿ Accessibility:**
- Ensures screen reader users get a reliable confirmation when they trigger the copy action.
- Retains the visual tooltip (`title`) for sighted users.
- Does not affect visual layout or keyboard tab ordering.

---
*PR created automatically by Jules for task [3039684151593189486](https://jules.google.com/task/3039684151593189486) started by @RenyEnnos*

## Summary by Sourcery

Melhorar o feedback de acessibilidade para leitores de tela no botão de copiar do MessageBubble e documentar o padrão de aria-live no diário do Palette.

Melhorias:
- Ajustar o botão de copiar do MessageBubble para usar um `aria-label` estático com uma região `aria-live` adjacente para anúncios de confirmação de cópia.
- Adicionar orientações de acessibilidade sobre o uso de regiões `aria-live` em vez de `aria-labels` dinâmicos para confirmação de estados transitórios no diário do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve screen reader accessibility feedback for the MessageBubble copy button and document the aria-live pattern in the Palette journal.

Enhancements:
- Adjust MessageBubble copy button to use a static aria-label with an adjacent aria-live region for copy confirmation announcements.
- Add accessibility guidance on using aria-live regions instead of dynamic aria-labels for transient state confirmation to the Palette journal.

</details>