### PR TITLE
🎨 Palette: Improve copy button accessibility and focus states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient State Feedback]
+**Learning:** Updating a button's `aria-label` dynamically (e.g., from "Copy" to "Copied!") can cause screen readers to miss the announcement or confuse the user, especially if focus is lost. The robust pattern is to keep the interactive element's `aria-label` static and place a permanent `aria-live="polite"` `span` (visually hidden with `sr-only`) adjacent to it, updating *its* text content for the transient state.
+**Action:** Use visually hidden `aria-live` regions for transient state confirmations on buttons while keeping the primary `aria-label` static.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus-visible:opacity-100"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado!" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
### 🎨 Palette: Copy Button Accessibility Polish

**💡 What:** 
Improved the accessibility of the copy action within `MessageBubble.jsx`. I decoupled the dynamic state announcement from the button's primary `aria-label`, adding a permanent `aria-live` region, and enhanced the visual keyboard focus styling against the dark background.

**🎯 Why:**
Dynamically changing an `aria-label` (like swapping "Copy message" to "Copied!") often results in screen readers either not reading the update or becoming confused if focus shifts. A visually hidden `aria-live` region is the robust standard for announcing transient state changes. Additionally, when using Tailwind opacity for hover states (`md:group-hover:opacity-100`), native browser focus rings are sometimes insufficient, so an explicit `focus-visible:opacity-100` coupled with ring offsets is necessary for true keyboard support.

**♿ Accessibility:**
- Added robust screen reader announcements for the transient state via `aria-live="polite"`.
- Ensured keyboard users can actually *see* the focus ring when tabbing to the copy button, utilizing `focus-visible:ring-offset-gray-900`.

Appended a critical learning to `.Jules/palette.md` detailing this `aria-live` transient state pattern.

---
*PR created automatically by Jules for task [18085011896290588664](https://jules.google.com/task/18085011896290588664) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e o tratamento de foco do botão de copiar mensagens do chat e documentar o padrão de aria-live para estados transitórios.

Melhorias:
- Refinar os estilos de `focus-visible` do botão de copiar e o posicionamento do contêiner para garantir um anel de foco nítido em fundos escuros.

Documentação:
- Adicionar orientações à documentação da paleta sobre o uso de `aria-labels` estáticos com regiões `aria-live` adjacentes para anúncios de estados transitórios.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus handling for the chat message copy button and document the transient state aria-live pattern.

Enhancements:
- Refine the copy button’s focus-visible styles and container positioning to ensure a clear focus ring on dark backgrounds.

Documentation:
- Add guidance to the palette documentation on using static aria-labels with adjacent aria-live regions for transient state announcements.

</details>