### PR TITLE
🎨 Palette: Fix accessibility on MessageBubble copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [Screen Reader Feedback for Transient States]
+**Learning:** Changing the `aria-label` of a button dynamically (e.g., from "Copy" to "Copied!") is unreliable because screen readers may not announce changes to a button's label after it has been focused and activated.
+**Action:** Use a permanently mounted adjacent element with `aria-live="polite"` (e.g., visually hidden with `sr-only`) to announce state changes like "Copied!", while keeping the interactive button's `aria-label` static and semantic.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
                             className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What**: Added an `aria-live="polite"` visually hidden span next to the copy button in `MessageBubble.jsx` to handle transient states instead of dynamically changing the `aria-label`.
🎯 **Why**: Changing a button's `aria-label` dynamically after it is focused and activated is unreliable and often ignored by screen readers, meaning users were missing crucial "Copied!" feedback. By providing a permanently mounted `aria-live` region, the screen reader reliably announces "Mensagem copiada" when the button is clicked. 
♿ **Accessibility**: Significant improvement to assistive technology feedback on auxiliary actions, strictly adhering to recommended ARIA patterns for state changes.
📝 **Palette Journal**: Added this robust pattern to the learning journal for future UX implementations.

---
*PR created automatically by Jules for task [14896850085320203543](https://jules.google.com/task/14896850085320203543) started by @RenyEnnos*

## Summary by Sourcery

Melhorar o retorno do leitor de tela para a ação de copiar mensagem do chat e documentar o padrão no diário do Palette.

Correções de bug:
- Garantir que o botão de copiar mensagem forneça anúncios confiáveis de “mensagem copiada” por meio de uma região dedicada `aria-live`, em vez de alterar o `aria-label` do botão.

Documentação:
- Documentar a boa prática de acessibilidade para anúncios de estado transitório usando regiões `aria-live` no diário do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve screen reader feedback for the chat message copy action and document the pattern in the Palette journal.

Bug Fixes:
- Ensure the message copy button provides reliable 'message copied' announcements via a dedicated aria-live region instead of changing the button's aria-label.

Documentation:
- Document accessibility best practice for transient state announcements using aria-live regions in the Palette journal.

</details>