### PR TITLE
🎨 Palette: Accessible Copy Button State

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient States on Buttons]
+**Learning:** Dynamically updating the `aria-label` of a button for transient state confirmations (e.g., from "Copy message" to "Copied!") can be unreliable for screen readers, as the button may need to lose focus or the screen reader might not announce the label change predictably. Keeping a static `aria-label` while utilizing an adjacent, permanently mounted `aria-live="polite"` region (toggling its text content) is much more reliable for accessibility.
+**Action:** For accessible transient states, keep primary labels static, use dynamic `title` attributes for sighted users, and use an adjacent visually hidden `aria-live` element to announce the state to screen readers.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Mensagem copiada' : ''}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
🎨 Palette: Accessible Copy Button State

💡 What: Updated the copy button on the message bubble to use a static `aria-label` while announcing the "Copied" transient state through an adjacent, permanently mounted `aria-live` region.
🎯 Why: Dynamically changing `aria-label`s on focused buttons isn't reliably announced by screen readers. A static label with an `aria-live` region ensures robust and consistent feedback.
♿ Accessibility: Added `aria-live` for proper screen reader announcements, and included `focus-visible:ring-offset-gray-900` to ensure the focus ring is clearly visible against the dark background.

---
*PR created automatically by Jules for task [12799654770058526902](https://jules.google.com/task/12799654770058526902) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do botão de copiar mensagem do chat e documentar o padrão de acessibilidade no guia do Palette.

Melhorias:
- Fazer com que o botão de copiar mensagem use um `aria-label` estático com uma região `aria-live` adjacente para anunciar o estado de mensagem copiada para tecnologias assistivas.
- Aprimorar a visibilidade do foco de teclado no botão de copiar com um anel de `focus-visible` explícito e estilização de deslocamento do anel em fundos escuros.

Documentação:
- Documentar o padrão acessível para estados transitórios de botões usando rótulos estáticos e regiões `aria-live` adjacentes no guia de acessibilidade do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button and document the accessibility pattern in the Palette guide.

Enhancements:
- Make the message copy button use a static aria-label with an adjacent aria-live region to announce the copied state for assistive technologies.
- Enhance keyboard focus visibility on the copy button with explicit focus-visible ring and ring offset styling against dark backgrounds.

Documentation:
- Document the accessible pattern for transient button states using static labels and adjacent aria-live regions in the Palette accessibility guide.

</details>