### PR TITLE
🎨 Palette: Enhance accessibility of transient copy state and focus indicators

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-28 - [Accessible Transient States]
+**Learning:** For transient feedback (like "Copied!"), dynamically updating a button's `aria-label` can result in screen readers missing the update or behaving unreliably. Instead, maintaining a static `aria-label` while using a permanently mounted, visually hidden `aria-live="polite"` region ensures that state changes are reliably announced without disrupting standard focus and labeling.
+**Action:** Use visually hidden `aria-live` containers for transient confirmation messages rather than updating interactive element labels dynamically.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -46,12 +46,15 @@ const MessageBubble = ({ message, isUser }) => {
                     <div className="flex flex-col justify-center">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What:** The UX enhancement updates the Copy button in the `MessageBubble` component. It replaces the dynamic `aria-label` approach with a static label and a visually hidden `aria-live="polite"` region for announcing the "Copied!" state. It also adds robust `focus-visible` ring and offset styles.
🎯 **Why:** Dynamically changing the `aria-label` of a focused interactive element can result in screen readers missing the update or getting confused. The `aria-live` region is the robust standard for transient notifications. Additionally, relying solely on `focus:opacity-100` without a visible ring creates an invisible focus state for keyboard users, which the new ring offset styles rectify.
📸 **Before/After:** The visual change ensures that when navigating via keyboard, the copy button now has a distinct, gray ring indicator on dark backgrounds instead of just becoming opaque without an outline.
♿ **Accessibility:**
- Improved screen reader reliability for transient states using `aria-live="polite"`.
- Improved keyboard navigation visibility by adding high-contrast focus indicators (`focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900`).

---
*PR created automatically by Jules for task [8539803601175216880](https://jules.google.com/task/8539803601175216880) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade de foco para a ação de copiar mensagem do chat.

Novos recursos:
- Anunciar o estado de confirmação de cópia por meio de uma região visualmente oculta com aria-live="polite" em vez de alterar o rótulo do botão.

Melhorias:
- Adicionar estilos de anel de foco visível de alto contraste e deslocamento ao botão de copiar mensagem para melhor indicação de foco via teclado.
- Documentar orientações de acessibilidade para estados transitórios e o uso de aria-live nas notas do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility for the chat message copy action.

New Features:
- Announce the copy confirmation state via a visually hidden aria-live="polite" region instead of changing the button label.

Enhancements:
- Add high-contrast focus-visible ring and offset styles to the message copy button for better keyboard focus indication.
- Document accessibility guidance for transient states and aria-live usage in the Palette notes.

</details>