### PR TITLE
🎨 Palette: Improve copy button accessibility with aria-live and focus rings

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [Transient State Feedback Accessibility]
+**Learning:** For accessibility, state confirmations (like 'Copied!') should use a visually hidden 'aria-live' region rather than dynamically updating the 'aria-label' of the triggered button. A dynamic `aria-label` might not be read immediately or reliably by all screen readers after a click. Also, `aria-live` containers must be permanently mounted (toggling their text content) rather than conditionally rendered, to ensure screen readers reliably catch the initial announcement.
+**Action:** When providing transient text feedback (like "Copied" after clicking a Copy button), maintain a static `aria-label` on the button and use an adjacent, permanent `<span aria-live="polite" className="sr-only">` element whose text content updates to announce the state.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado!" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What:** Enhanced the accessibility of the copy button in the `MessageBubble` component.
🎯 **Why:** Dynamically toggling `aria-label` attributes on buttons after they've been clicked is often missed by screen readers. Replacing it with a permanently mounted visually hidden `<span aria-live="polite">` provides reliable feedback. Additionally, the button lacked explicit focus indicators for keyboard users.
📸 **Before/After:** Not a large visual change, but focus states are now clearly visible on keyboard navigation.
♿ **Accessibility:**
- Static `aria-label` for clear identification.
- `aria-live` region for reliable transient state feedback ('Copiado!').
- `focus-visible:ring-2` styling for keyboard navigation.

---
*PR created automatically by Jules for task [17495913494577039200](https://jules.google.com/task/17495913494577039200) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e o controle de foco para o botão de copiar no componente MessageBubble do chat.

Melhorias:
- Adicionar uma região aria-live permanentemente oculta visualmente para anunciar confirmações de cópia sem alterar o aria-label do botão.
- Reforçar a visibilidade do foco de teclado no botão de copiar com estilização explícita de anel de focus-visible.
- Documentar aprendizados de acessibilidade e diretrizes para feedback de estado transitório nas notas da paleta Jules.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus handling for the copy button in the chat MessageBubble component.

Enhancements:
- Add a permanent visually hidden aria-live region to announce copy confirmations without changing the button’s aria-label.
- Strengthen keyboard focus visibility on the copy button with explicit focus-visible ring styling.
- Document accessibility learnings and guidelines for transient state feedback in the Jules palette notes.

</details>