### PR TITLE
🎨 Palette: Improve copy button accessibility and focus visibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,11 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Transient State Feedback Accessibility]
+**Learning:** Dynamically updating a button's `aria-label` to announce transient states (like "Copied!") is often unreliable because screen readers might not announce the change unless the element loses and regains focus.
+**Action:** Use a statically labeled button for the action itself, alongside an adjacent, permanently mounted `<span aria-live="polite" className="sr-only">` region to handle the transient state announcements.
+
+## 2025-02-12 - [Robust Focus States on Hover-Hidden UI]
+**Learning:** Components that are hidden until hover (e.g., using `md:opacity-0 md:group-hover:opacity-100`) often forget to account for keyboard users if they just use a basic `focus:opacity-100` utility without visible focus indicators (`focus-visible:ring-*`).
+**Action:** Ensure hover-revealed elements explicitly include `focus-visible:opacity-100 focus:outline-none focus-visible:ring-2` (and relevant ring offsets, especially for dark mode) to maintain accessibility parity for keyboard navigation.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado!" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What:** Added proper keyboard focus rings (`focus-visible`) and a dedicated `aria-live` region for the "Copied!" state in the `MessageBubble`'s copy button.
🎯 **Why:** Dynamically updating a focused element's `aria-label` does not always prompt screen readers to re-read the label. Using an `aria-live` region guarantees screen readers will announce transient states. Also, hover-hidden elements require robust visible focus indicators for keyboard users to know where they are navigating.
♿ **Accessibility:** Screen readers now accurately read the success state ("Copiado!"), and keyboard navigators can clearly see the copy button when tabbed to, even though it's hidden by default on desktop.

---
*PR created automatically by Jules for task [16147557405830497183](https://jules.google.com/task/16147557405830497183) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do botão de copiar mensagem do chat e documentar aprendizados relacionados à acessibilidade.

Novos recursos:
- Adicionar uma região `aria-live` para anunciar o estado transitório "Copied!" (Copiado!) na ação de copiar mensagem.

Melhorias:
- Refinar o estilo de `focus-visible` do botão de copiar para que controles ocultos em hover permaneçam visualmente focáveis para usuários de teclado.
- Atualizar a documentação do Palette com orientações sobre feedback de estados transitórios e tratamento robusto de foco para elementos de UI revelados em hover.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button and document related accessibility learnings.

New Features:
- Add an aria-live region to announce the transient "Copied!" state for the message copy action.

Enhancements:
- Refine copy button focus-visible styling so hover-hidden controls remain visibly focusable for keyboard users.
- Update Palette documentation with guidance on transient state feedback and robust focus handling for hover-revealed UI elements.

</details>