### PR TITLE
🎨 Palette: Improve Copy Button Accessibility in MessageBubble

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient States on Interactive Elements]
+**Learning:** Updating the `aria-label` of a focused element dynamically (e.g. from "Copy message" to "Copied!") can confuse screen readers or fail to announce correctly because the accessible name of the currently focused element changed underneath them.
+**Action:** Keep the primary `aria-label` of interactive buttons static. Provide transient state feedback (like "Copied!") using an adjacent, permanently mounted `aria-live` region (`<div aria-live="polite" className="sr-only">`) that updates its text content when the state changes.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <div aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado!" : ""}
+                        </div>
                     </div>
                 )}
             </div>

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,24 @@
+--- frontend/src/features/chat/components/MessageBubble.jsx
++++ frontend/src/features/chat/components/MessageBubble.jsx
+@@ -43,15 +43,18 @@
+
+                 {/* Copy Button - Visible on mobile, hover on desktop */}
+                 {!isUser && (
+-                    <div className="flex flex-col justify-center">
++                    <div className="flex flex-col justify-center relative">
+                         <button
+                             onClick={handleCopy}
+-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
+-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
++                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
++                            aria-label="Copiar mensagem"
+                             title={isCopied ? "Copiado" : "Copiar mensagem"}
+                         >
+                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                         </button>
++                        <div aria-live="polite" className="sr-only">
++                            {isCopied ? "Copiado!" : ""}
++                        </div>
+                     </div>
+                 )}
+             </div>


### PR DESCRIPTION
🎨 Palette: Improve Copy Button Accessibility in MessageBubble

💡 What: Replaced the dynamic `aria-label` on the Copy button with a static one and added an adjacent `aria-live` region to announce the transient "Copiado!" state. Improved the keyboard focus indicator using `focus-visible` classes.
🎯 Why: Changing the `aria-label` of a focused element dynamically confuses screen readers. A dedicated `aria-live` region reliably announces state changes. Improved focus visibility makes the element more usable for keyboard-only users.
♿ Accessibility: Ensures reliable screen reader feedback and visible keyboard focus states.

---
*PR created automatically by Jules for task [14368956112937776273](https://jules.google.com/task/14368956112937776273) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade de foco do botão de copiar mensagem em bolhas de chat.

Melhorias:
- Tornar o nome acessível do botão de copiar mensagem estático e mover o feedback transitório do estado de cópia para uma região separada com `aria-live`, para um melhor comportamento com leitores de tela.
- Aprimorar a visibilidade do foco de teclado para o botão de copiar mensagem usando estilos `focus-visible`.
- Documentar orientações de acessibilidade para estados transitórios e uso de `aria-live` nas notas do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility for the message copy button in chat bubbles.

Enhancements:
- Make the message copy button’s accessible name static and move transient copied-state feedback into a separate aria-live region for better screen reader behavior.
- Enhance keyboard focus visibility for the message copy button using focus-visible styles.
- Document accessibility guidance for transient states and aria-live usage in the Palette notes.

</details>