### PR TITLE
🎨 Palette: [A11y] Reliable transient state feedback for Copy Button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-13 - [Transient State Feedback Accessibility]
+**Learning:** For transient state feedback (like a "Copied!" checkmark) on buttons, dynamically updating the `aria-label` is unreliable because screen readers may not announce the change if focus is maintained. Keeping the `aria-label` static and using an adjacent, permanently mounted `aria-live="polite"` container that conditionally renders its text is a robust way to ensure reliable announcements.
+**Action:** Use permanently mounted `aria-live` containers for transient feedback instead of dynamically updating primary `aria-label`s.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
                             className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What:** Modified the copy button to use a static `aria-label` and introduced an adjacent, permanently mounted `aria-live` region to handle the "Copiado" state announcement. The `title` attribute remains dynamic for visual tooltips.

🎯 **Why:** Dynamically changing the `aria-label` of a focused element is unreliable for screen readers (they often won't announce the change if the element maintains focus). Using a permanently mounted `aria-live="polite"` region guarantees that the transient state change (from "Copy" to "Copied!") is announced reliably to assistive technologies without disrupting visual UI.

♿ **Accessibility:**
- Ensures screen reader users get clear, reliable feedback when a message is successfully copied.
- Maintains static semantic labeling (`aria-label`) for the action button itself.

---
*PR created automatically by Jules for task [6494663983475350764](https://jules.google.com/task/6494663983475350764) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade do estado de feedback do botão de copiar mensagem do chat.

Novos recursos:
- Anunciar o sucesso da cópia por meio de uma região `aria-live` dedicada, montada permanentemente, adjacente ao botão de copiar.

Aperfeiçoamentos:
- Manter o atributo `aria-label` do botão de copiar estático enquanto se usa o atributo `title` e o estado do ícone para refletir visualmente o sucesso da cópia.
- Documentar uma diretriz de acessibilidade para feedback de estados transitórios e uso de `aria-live` no playbook do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of the chat message copy button’s feedback state.

New Features:
- Announce copy success via a dedicated, permanently mounted aria-live region adjacent to the copy button.

Enhancements:
- Keep the copy button’s aria-label static while using the title attribute and icon state to reflect copy success visually.
- Document an accessibility guideline for transient state feedback and aria-live usage in the Palette playbook.

</details>