### PR TITLE
🎨 Palette: Accessibility improvements for transient feedback and dark mode focus rings

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Transient State Feedback]
+**Learning:** Dynamically updating a button's `aria-label` to announce transient states (like "Copied!") is unreliable for screen readers, as the update may be missed. Additionally, buttons that rely on hover for visibility need explicit `focus-visible` styling to maintain keyboard accessibility.
+**Action:** Use a static `aria-label` for the button and add an adjacent, permanently mounted `aria-live="polite"` region (e.g. `<span className="sr-only">`) to announce state changes. Always pair hover-based visibility with explicit `focus-visible` ring classes.

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -59,7 +59,7 @@ const ChatHeader = ({ clearHistory }) => {
                     </span>
                     <button
                         onClick={handleClear}
-                        className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-red-400 focus:outline-none"
+                        className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none"
                         title="Confirmar limpeza"
                         aria-label="Confirmar limpeza"
                         aria-describedby="confirm-text"
@@ -69,7 +69,7 @@ const ChatHeader = ({ clearHistory }) => {
                     <button
                         onClick={() => setShowConfirm(false)}
                         autoFocus
-                        className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-gray-400 focus:outline-none"
+                        className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none"
                         title="Cancelar"
                         aria-label="Cancelar"
                     >
@@ -81,7 +81,7 @@ const ChatHeader = ({ clearHistory }) => {
                     onClick={handleTrashClick}
                     ref={trashRef}
                     autoFocus={shouldFocusTrash}
-                    className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-red-400 focus:outline-none"
+                    className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none"
                     title="Limpar conversa"
                     aria-label="Limpar conversa"
                 >

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Mensagem copiada' : ''}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 What: Improved accessibility of transient state feedback by replacing dynamically changing `aria-label` with a permanently mounted `aria-live` region. Improved keyboard navigability by adding dark-theme `focus-visible:ring-offset` and `focus-visible:opacity-100` classes to interactive buttons in `MessageBubble` and `ChatHeader`.
🎯 Why: Dynamically changing `aria-label` isn't reliably read by screen readers. Providing a separate `aria-live` region is the best practice. Furthermore, default focus rings were blending into the dark backgrounds and the copy button remained hidden for keyboard navigators if hover was not active.
♿ Accessibility:
- Added `aria-live="polite"` region to announce transient state ("Copied!") safely.
- Made the copy button visible upon focus.
- Add focus ring offsets to buttons in `ChatHeader` and `MessageBubble` to ensure good visibility against dark backgrounds.

---
*PR created automatically by Jules for task [12387231261540667871](https://jules.google.com/task/12387231261540667871) started by @RenyEnnos*

## Summary by Sourcery

Melhora a acessibilidade dos controles de copiar do chat e do cabeçalho, aprimorando o feedback para leitores de tela e a visibilidade do foco no modo escuro.

Novas funcionalidades:
- Anunciar o sucesso da ação de copiar para a área de transferência por meio de uma região dedicada `aria-live` nas mensagens (message bubbles).

Aprimoramentos:
- Garantir que o botão de copiar mensagem se torne visível e com foco claramente perceptível para usuários de teclado em layouts com tema escuro.
- Adicionar deslocamentos do anel de foco (focus ring offsets) aos botões de ação do `ChatHeader` para melhor contraste em fundos escuros.
- Documentar aprendizados de acessibilidade e boas práticas para feedback transitório e estilização de `focus-visible` no guia do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility of chat copy and header controls by enhancing screen reader feedback and focus visibility in dark mode.

New Features:
- Announce copy-to-clipboard success via a dedicated aria-live region in message bubbles.

Enhancements:
- Ensure the message copy button becomes visible and clearly focused for keyboard users in dark theme layouts.
- Add focus ring offsets to ChatHeader action buttons for better contrast on dark backgrounds.
- Document accessibility learnings and best practices for transient feedback and focus-visible styling in the Palette guide.

</details>