### PR TITLE
🎨 Palette: Improve copy button accessibility and focus states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2026-07-04 - [Accessible Transient State Feedback]
+**Learning:** Dynamically updating a button's `aria-label` for transient states (like 'Copied!') is often missed by screen readers or overrides the static function label incorrectly. A dedicated, permanently mounted `aria-live='polite'` region adjacent to the button ensures the state change is reliably announced while preserving the original static `aria-label` of the button.
+**Action:** Use an adjacent `aria-live` span for transient feedback instead of mutating the `aria-label` of interactive elements.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado!" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 What: Improved the accessibility of the copy button in `MessageBubble.jsx`. Refactored the button to use a static `aria-label` along with a dedicated adjacent `aria-live="polite"` span to announce the "Copied!" state reliably to screen readers without losing the core button identity. Added explicit `focus-visible` utilities to ensure clear focus rings on keyboard navigation. Hid decorative icons from screen readers.
🎯 Why: Dynamically updating `aria-label` values for transient states is an accessibility anti-pattern as screen readers may miss the announcement or override the core function of the button.
📸 Before/After: Verified visual focus state changes correctly.
♿ Accessibility: Ensures reliable transient state announcements and solid keyboard navigation support.

---
*PR created automatically by Jules for task [13616336136512032565](https://jules.google.com/task/13616336136512032565) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e o comportamento de foco para o botão de copiar mensagens do chat e documentar o padrão para anúncios de estados transitórios.

Novos recursos:
- Anunciar o sucesso da cópia por meio de uma região `aria-live` adjacente, mantendo um `aria-label` estático no botão de copiar.

Melhorias:
- Fortalecer a visibilidade do foco de teclado para o botão de copiar com estilização explícita de anel de `focus-visible`.
- Ocultar ícones decorativos de copiar e de confirmação dos leitores de tela com `aria-hidden` para evitar anúncios redundantes.
- Documentar o padrão acessível de feedback de estado transitório e as orientações nas notas da paleta.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus handling for the chat message copy button and document the pattern for transient state announcements.

New Features:
- Announce copy success via an adjacent aria-live region while keeping a static aria-label on the copy button.

Enhancements:
- Strengthen keyboard focus visibility for the copy button with explicit focus-visible ring styling.
- Hide decorative copy and check icons from screen readers with aria-hidden to avoid redundant announcements.
- Document the accessible transient state feedback pattern and guidance in the palette notes.

</details>