### PR TITLE
🎨 Palette: Improve copy button accessibility in MessageBubble

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible Copied States]
+**Learning:** For actions like "Copy to Clipboard", dynamically swapping the `aria-label` from "Copy" to "Copied" is unreliable because screen readers may not announce the change dynamically. Additionally, relying solely on `focus:opacity-100` for keyboard focus visibility is often insufficient, especially on dark themes.
+**Action:** Use a permanently mounted, visually hidden `aria-live="polite"` region to announce state changes like "Copiado!" while keeping the primary button `aria-label` static. Always ensure buttons have robust `focus-visible:ring-2` (with appropriate offsets) to make keyboard navigation explicit.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? 'Copiado!' : ''}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 What: Improved the accessibility of the Copy button inside the `MessageBubble` component.
🎯 Why: Previously, the copy button relied on dynamically updating its `aria-label` which can be unreliable for screen readers. It also lacked clear keyboard focus indicators making it difficult for keyboard users to navigate.
♿ Accessibility: 
- Swapped the dynamic `aria-label` for a static one ("Copiar mensagem").
- Added a visually hidden `aria-live="polite"` span to announce the success state ("Copiado!") dynamically.
- Added `aria-hidden="true"` to the Check and Copy icons so screen readers ignore them.
- Added explicit keyboard focus styling using `focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus-visible:opacity-100 focus:outline-none`.

---
*PR created automatically by Jules for task [1822960340554499304](https://jules.google.com/task/1822960340554499304) started by @RenyEnnos*

## Summary by Sourcery

Reforçar a acessibilidade da ação de copiar da MessageBubble do chat e registrar os aprendizados relacionados na documentação compartilhada da paleta.

Melhorias:
- Melhorar a acessibilidade do botão de copiar da MessageBubble com rótulos estáticos, anúncios em região viva oculta e estilos robustos de foco via teclado.

Documentação:
- Documentar diretrizes de acessibilidade para interações de copiar para a área de transferência e para estilos de `focus-visible` nas notas da paleta Jules.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen accessibility of the chat MessageBubble copy action and capture the related learnings in the shared palette documentation.

Enhancements:
- Improve MessageBubble copy button accessibility with static labels, hidden live region announcements, and robust keyboard focus styling.

Documentation:
- Document accessibility guidelines for copy-to-clipboard interactions and focus-visible styling in the Jules palette notes.

</details>