### PR TITLE
🎨 Palette: Improve copy button accessibility and focus states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2024-07-06 - Accessible Transient States on Icon Buttons
+**Learning:** Transient confirmation states like "Copiado!" on icon buttons should not dynamically update `aria-label`, as this can result in inconsistent screen reader announcements.
+**Action:** Use an adjacent permanently mounted `aria-live="polite"` region (e.g., `<span aria-live="polite" className="sr-only">`) to announce state changes, while keeping the interactive element's `aria-label` static (e.g., "Copiar mensagem").

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus:outline-none"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What:** The UX enhancement added:
- Improved the keyboard focus state of the `MessageBubble`'s copy button.
- Replaced dynamic `aria-label` updates on the copy button with a robust, permanently-mounted `aria-live` region for screen reader transient state announcements ("Copiado").
- Hid decorative icons from screen readers.

🎯 **Why:** The user problem it solves:
- Transient state updates via `aria-label` can cause inconsistent or missed screen reader announcements. Using an `aria-live` region provides reliable feedback when content is copied to the clipboard.
- The copy button previously lacked clear, high-contrast focus rings when navigated via keyboard.

📸 **Before/After:** See verification screenshots for focus rings.
♿ **Accessibility:** Added `aria-live="polite"`, `aria-hidden="true"` to icons, and `focus-visible` ring enhancements.

---
*PR created automatically by Jules for task [5924182314118609756](https://jules.google.com/task/5924182314118609756) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e o comportamento de foco do botão de copiar mensagem do chat.

Novos recursos:
- Adicionar uma região `aria-live` para anunciar a confirmação de cópia para leitores de tela.

Aprimoramentos:
- Reforçar o estilo de foco visível via teclado para o botão de copiar mensagem em temas escuros.
- Ocultar ícones decorativos de copiar/confirmar dos leitores de tela, mantendo os rótulos estáticos.

Documentação:
- Documentar práticas recomendadas para estados temporários acessíveis em botões de ícone no arquivo de diretrizes do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus behavior of the chat message copy button.

New Features:
- Add an aria-live region to announce copy confirmation for screen readers.

Enhancements:
- Strengthen keyboard focus-visible styling for the message copy button in dark themes.
- Hide decorative copy/check icons from screen readers while keeping labels static.

Documentation:
- Document best practices for accessible transient states on icon buttons in the Palette guidance file.

</details>