### PR TITLE
🎨 Palette: Improve Copy Button Accessibility and Focus States

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Transient State Accessibility]
+**Learning:** For transient button states (like "Copied!"), dynamically changing the `aria-label` can confuse screen readers or be missed if focus shifts. An adjacent, permanently mounted `aria-live="polite"` region that toggles text content is more reliable for announcing status changes while keeping the button's primary identity static.
+**Action:** Use a static `aria-label` on buttons and a separate `aria-live` region for transient state announcements.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus-visible:opacity-100"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
-                            {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                            {isCopied ? <Check size={16} className="text-green-500" aria-hidden="true" /> : <Copy size={16} aria-hidden="true" />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Copiado" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
This PR improves the UX and accessibility of the copy button inside `MessageBubble.jsx`. 

💡 **What**: The copy button now uses a static `aria-label` while announcing the "Copiado" transient state via a visually hidden, permanently mounted `aria-live` region. It also adds explicit `focus-visible` offset classes for better keyboard navigation visibility and hides the internal SVG icons from screen readers.
🎯 **Why**: Changing `aria-label` dynamically for transient states (like "Copied!") can confuse screen readers or be missed if focus shifts. A dedicated `aria-live` region provides a reliable announcement pattern. Additionally, proper focus rings ensure the button is fully accessible to keyboard users against the dark background.
♿ **Accessibility**: Enhanced screen reader reliability for state changes, improved keyboard focus visibility, and removed redundant SVG reading.

---
*PR created automatically by Jules for task [8550005021454780126](https://jules.google.com/task/8550005021454780126) started by @RenyEnnos*

## Summary by Sourcery

Melhorar a acessibilidade e a visibilidade do foco para o botão de copiar mensagens do chat e documentar o padrão de acessibilidade de estado transitório nas notas do Palette.

Novos recursos:
- Anunciar o estado de confirmação da cópia por meio de uma região dedicada de `aria-live`, mantendo o `aria-label` do botão de copiar estático.

Melhorias:
- Adicionar estilos explícitos de anel de `focus-visible` e deslocamento ao botão de copiar para melhor visibilidade via teclado em fundos escuros.
- Ocultar ícones SVG decorativos no botão de copiar dos leitores de tela por meio de `aria-hidden`.
- Documentar o padrão recomendado para lidar com estados de acessibilidade transitórios usando regiões `aria-live` nas notas do Palette.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility and focus visibility for the chat message copy button and document the transient state accessibility pattern in the Palette notes.

New Features:
- Announce the copy confirmation state via a dedicated aria-live region while keeping the copy button’s aria-label static.

Enhancements:
- Add explicit focus-visible ring and offset styles to the copy button for better keyboard visibility on dark backgrounds.
- Hide decorative SVG icons in the copy button from screen readers via aria-hidden.
- Document the recommended pattern for handling transient accessibility states using aria-live regions in the Palette notes.

</details>