### PR TITLE
🎨 Palette: Enhance Copy Button Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2025-02-12 - [Explicit Focus & Disabled States]
 **Learning:** Dynamic Tailwind class ternaries can sometimes inadvertently miss essential utility classes, especially focus rings. Also, inputs visually behave as enabled during loading states without explicit `disabled:` styles, causing confusion. In dark themes, focus rings require explicit offsets (e.g. `focus-visible:ring-offset-gray-800`).
 **Action:** Always verify `disabled:opacity-50 disabled:cursor-not-allowed` on input elements, and ensure buttons maintain strong, offset `focus-visible` styling regardless of state logic.
+
+## 2025-02-12 - [Accessible State Confirmations]
+**Learning:** Dynamically updating the `aria-label` of a button for transient states (like changing "Copy" to "Copied!") is unreliable because screen readers may not announce the change if focus doesn't move or if the state is too brief.
+**Action:** Use a static `aria-label` on the action button itself, and place a visually hidden (`sr-only`) `aria-live="polite"` element adjacent to it. Update the text content of the `aria-live` element when the state changes to ensure reliable screen reader announcements.

--- a/frontend/src/features/chat/components/MessageBubble.jsx
+++ b/frontend/src/features/chat/components/MessageBubble.jsx
@@ -43,15 +43,18 @@ const MessageBubble = ({ message, isUser }) => {
 
                 {/* Copy Button - Visible on mobile, hover on desktop */}
                 {!isUser && (
-                    <div className="flex flex-col justify-center">
+                    <div className="flex flex-col justify-center relative">
                         <button
                             onClick={handleCopy}
-                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"
-                            aria-label={isCopied ? "Copiado" : "Copiar mensagem"}
+                            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-all opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                            aria-label="Copiar mensagem"
                             title={isCopied ? "Copiado" : "Copiar mensagem"}
                         >
                             {isCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
                         </button>
+                        <span aria-live="polite" className="sr-only">
+                            {isCopied ? "Mensagem copiada" : ""}
+                        </span>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
💡 **What:** Improved the accessibility of the copy button on message bubbles. Changed the dynamically updating `aria-label` to a static one and added an `aria-live="polite"` region to handle state confirmation announcements. Also added explicit `focus-visible` ring classes.
🎯 **Why:** Dynamically updating an `aria-label` for brief state changes (like "Copied!") often goes unannounced by screen readers if focus doesn't move. Using an adjacent `aria-live` region guarantees the state change is reliably read aloud. The focus ring ensures keyboard-only sighted users can see which element they are targeting.
♿ **Accessibility:** Added `aria-live="polite"` container, static `aria-label`, and `focus-visible` outline rings with offset for dark backgrounds.

---
*PR created automatically by Jules for task [1128530682899409756](https://jules.google.com/task/1128530682899409756) started by @RenyEnnos*

## Summary by Sourcery

Melhora o feedback de acessibilidade e a visibilidade do foco para o botão de copiar mensagem do chat e documenta o padrão de acessibilidade associado nas diretrizes da paleta.

Novos recursos:
- Anunciar a confirmação de cópia para mensagens do chat por meio de uma região `aria-live` adjacente visualmente oculta, em vez de alterar o rótulo do botão.

Aprimoramentos:
- Tornar o botão de copiar mensagem do chat visível ao foco de teclado, com anel de foco explícito e estilo de deslocamento em fundos escuros.
- Adicionar documentação na paleta descrevendo o padrão recomendado para confirmações de estado acessíveis usando `aria-labels` estáticos e regiões `aria-live`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve accessibility feedback and focus visibility for the chat message copy button and document the associated accessibility pattern in the palette guidelines.

New Features:
- Announce copy confirmation for chat messages via an adjacent visually hidden aria-live region instead of changing the button label.

Enhancements:
- Make the chat message copy button keyboard focus-visible with explicit focus ring and offset styling on dark backgrounds.
- Add palette documentation describing the recommended pattern for accessible state confirmations using static aria-labels and aria-live regions.

</details>