### PR TITLE
chore(governance): clarify status:ready semantics

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -24,7 +24,7 @@
   {"name":"status:blocked","color":"000000","description":"Não pode avançar até resolver uma dependência"},
   {"name":"status:needs-review","color":"0E8A16","description":"Implementação pronta para auditoria"},
   {"name":"status:changes-requested","color":"E99695","description":"Precisa de nova tarefa corretiva antes do merge"},
-  {"name":"status:ready","color":"2CBE4E","description":"Critérios atendidos e pronta para merge"},
+  {"name":"status:ready","color":"2CBE4E","description":"Pronta para avançar na etapa atual do fluxo"},
 
   {"name":"agent:jules","color":"FAD8C7","description":"Trabalho implementado pelo Jules"},
   {"name":"agent:maintainer","color":"BFD4F2","description":"Trabalho de governança/manutenção"},


### PR DESCRIPTION
Ajusta somente a descrição de `status:ready` para que a label represente itens prontos para avançar na etapa atual, incluindo issues liberadas para implementação e PRs liberadas para a próxima etapa.

## Summary by Sourcery

Documentação:
- Atualizar a descrição do rótulo status:ready para indicar itens prontos para avançar na etapa atual do fluxo de trabalho, incluindo issues prontas para implementação e PRs prontos para a próxima etapa.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the description of the status:ready label to indicate items ready to advance in the current workflow stage, including issues ready for implementation and PRs ready for the next step.

</details>