### PR TITLE
🧹 [code health improvement] Remove unused math import

### DIFF
--- a/backend/emotional_core.py
+++ b/backend/emotional_core.py
@@ -4,7 +4,7 @@ import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 from datetime import datetime
-import math
+
 import random
 
 @dataclass


### PR DESCRIPTION
### 🎯 What
Removed the unused `import math` from `backend/emotional_core.py`.

### 💡 Why
The `math` module was imported but never used anywhere in `backend/emotional_core.py`. Removing unused imports cleans up the namespace, reduces visual clutter, and improves maintainability of the codebase.

### ✅ Verification
- Ran `grep -n "math" backend/emotional_core.py` to confirm there were no references to the math module.
- Successfully ran the entire backend test suite using `PYTHONPATH=. pytest backend/tests/` to ensure no functionality broke.

### ✨ Result
Cleaner imports and a slightly more maintainable codebase in `emotional_core.py`.

### ⚠️ Risks & Rollback
No risks. If anything depends on this import implicitly (highly unlikely), rollback is just restoring the single line of code.

### 🚫 Out of Scope
No other unused imports or formatting issues were addressed in this PR.

---
*PR created automatically by Jules for task [14174197651291121923](https://jules.google.com/task/14174197651291121923) started by @RenyEnnos*

## Summary by Sourcery

Melhorias:
- Simplificar `backend/emotional_core.py` removendo a importação não utilizada do módulo `math`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Simplify backend/emotional_core.py by dropping the unused math module import.

</details>