### PR TITLE
🧹 [code health] Remove unused math import from emotional_core.py

### DIFF
--- a/backend/emotional_core.py
+++ b/backend/emotional_core.py
@@ -4,7 +4,6 @@ import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 from datetime import datetime
-import math
 import random
 
 @dataclass


### PR DESCRIPTION
## 🎯 What
Removed the unused `import math` statement from `backend/emotional_core.py`.

## 💡 Why
The `math` module was imported but never used anywhere in the `emotional_core.py` file. Removing dead code and unused imports improves the maintainability and readability of the codebase, preventing confusion for future developers.

## ✅ Verification
- I verified the issue by checking for usages of the `math` module within the file, finding none.
- After removing the import, I ran the entire backend test suite (`pytest backend/tests backend/test*.py`) using the CI isolation command setup, and confirmed that all 15 tests passed and 3 were skipped, meaning no functionality was broken.

## ✨ Result
A cleaner file with only the necessary imports.

---
*PR created automatically by Jules for task [13557305490967011797](https://jules.google.com/task/13557305490967011797) started by @RenyEnnos*

## Summary by Sourcery

Enhancements:
- Limpeza de `backend/emotional_core.py` removendo uma importação inutilizada de `math`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Clean up backend/emotional_core.py by removing an unused math import.

</details>