### PR TITLE
🧹 Remove unused math import from emotional_core.py

### DIFF
--- a/backend/emotional_core.py
+++ b/backend/emotional_core.py
@@ -4,7 +4,6 @@ import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 from datetime import datetime
-import math
 import random
 
 @dataclass


### PR DESCRIPTION
🎯 **What:** Removed the unused `import math` statement from `backend/emotional_core.py`.

💡 **Why:** This improves maintainability and readability by reducing namespace clutter and adhering to Python best practices for dead code removal.

✅ **Verification:** Verified by inspecting the file and successfully running the backend test suite via `PYTHONPATH=. HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 pytest backend/tests/`.

✨ **Result:** A cleaner `emotional_core.py` with no functional changes or impact on the broader application logic.

---
*PR created automatically by Jules for task [17677341870772688459](https://jules.google.com/task/17677341870772688459) started by @RenyEnnos*

## Summary by Sourcery

Melhorias:
- Limpar o arquivo `emotional_core.py` removendo uma declaração de importação `math` não utilizada.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Clean up emotional_core.py by removing an unused math import statement.

</details>