### PR TITLE
🧹 Remove unused math import in backend/emotional_core.py

### DIFF
--- a/backend/emotional_core.py
+++ b/backend/emotional_core.py
@@ -4,7 +4,6 @@ import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 from datetime import datetime
-import math
 import random
 
 @dataclass


### PR DESCRIPTION
## Description

🎯 **What:** Removed the unused `import math` module in `backend/emotional_core.py`.
💡 **Why:** To improve code health and maintainability by removing dead code. This prevents namespace clutter and adheres to best practices.
✅ **Verification:** Verified via tests in the `backend` directory using `pytest`. No failures or regressions observed.
✨ **Result:** A cleaner file.

## Root Cause
An unused import statement existed in `backend/emotional_core.py`.

## Solution
Deleted the line containing `import math`.

## Changed Files
- `backend/emotional_core.py`

## Executed Tests
- Executed `pytest` in the `backend/` directory targeting `tests/`, `test_negative_emotions.py`, `test_relationship.py`, `test_script.py`, `test_keys.py`, and `test_smoke.py`. All functional tests passed.

## Risks
Minimal. It's a removal of an unused native library module import.

## Rollback Plan
Revert this specific commit.

## Out-of-Scope
No other refactoring was done in the codebase.

---
*PR created automatically by Jules for task [7388833576919332222](https://jules.google.com/task/7388833576919332222) started by @RenyEnnos*

## Summary by Sourcery

Melhorias:
- Limpar `backend/emotional_core.py` removendo uma importação não utilizada do módulo `math`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Clean up backend/emotional_core.py by removing an unused math module import.

</details>