### PR TITLE
feat(emotion): add versioned state and appraisal models

### DIFF
--- a/backend/emotional_domain/__init__.py
+++ b/backend/emotional_domain/__init__.py
@@ -1,0 +1,38 @@
+"""
+Emotional domain models — pure, typed, versioned, infrastructure-free.
+
+This package defines the typed contracts for:
+- EmotionalStateV1: versioned emotional snapshot
+- AppraisalV1: versioned appraisal of messages/events
+- Migration utilities for legacy snapshots
+- Serialization helpers
+
+No FastAPI, Groq, Supabase, sentence_transformers, or I/O allowed here.
+"""
+
+from .models import (
+    EMOTIONAL_SCHEMA_VERSION,
+    VALID_COPING_MODES,
+    DISCRETE_EMOTIONS,
+    EmotionalStateV1,
+    AppraisalV1,
+    EmotionalDomainError,
+)
+from .migration import migrate_legacy_snapshot
+from .serialization import serialize_state, deserialize_state, serialize_appraisal, deserialize_appraisal
+from .appraisal_parser import parse_llm_appraisal
+
+__all__ = [
+    "EMOTIONAL_SCHEMA_VERSION",
+    "VALID_COPING_MODES",
+    "DISCRETE_EMOTIONS",
+    "EmotionalStateV1",
+    "AppraisalV1",
+    "EmotionalDomainError",
+    "migrate_legacy_snapshot",
+    "serialize_state",
+    "deserialize_state",
+    "serialize_appraisal",
+    "deserialize_appraisal",
+    "parse_llm_appraisal",
+]

--- a/backend/emotional_domain/__init__.py
+++ b/backend/emotional_domain/__init__.py
@@ -6,6 +6,7 @@ This package defines the typed contracts for:
 - AppraisalV1: versioned appraisal of messages/events
 - Migration utilities for legacy snapshots
 - Serialization helpers
+- LLM appraisal parser with explicit fallback
 
 No FastAPI, Groq, Supabase, sentence_transformers, or I/O allowed here.
 """
@@ -20,7 +21,7 @@ from .models import (
 )
 from .migration import migrate_legacy_snapshot
 from .serialization import serialize_state, deserialize_state, serialize_appraisal, deserialize_appraisal
-from .appraisal_parser import parse_llm_appraisal
+from .appraisal_parser import parse_llm_appraisal, ParseResult, ParseErrorCode
 
 __all__ = [
     "EMOTIONAL_SCHEMA_VERSION",
@@ -35,4 +36,6 @@ __all__ = [
     "serialize_appraisal",
     "deserialize_appraisal",
     "parse_llm_appraisal",
+    "ParseResult",
+    "ParseErrorCode",
 ]

--- a/backend/emotional_domain/appraisal_parser.py
+++ b/backend/emotional_domain/appraisal_parser.py
@@ -8,20 +8,54 @@ LLM output is untrusted. This module provides a single public function
 ``parse_llm_appraisal`` that:
 
 1. Accepts any object (the raw LLM-produced dict).
-2. Attempts to parse it as an AppraisalV1.
-3. On ANY validation failure, returns ``AppraisalV1.neutral()`` and
-   **does not propagate the exception** (fallback policy).
+2. Validates structure against an explicit top-level allowlist.
+3. Translates legacy production keys to v1 keys.
+4. Requires all three shift fields to be present and valid.
+5. On ANY validation failure, returns ``AppraisalV1.neutral()`` with an
+   observable, sanitised error code — never raw LLM/user text.
 
-The fallback is explicit and observable: callers receive a neutral appraisal
-rather than a silent empty dict or a bare exception that could be swallowed.
+Fallback codes
+==============
+``ParseErrorCode`` is an enum of stable codes:
 
-A companion ``ParseResult`` is returned so callers can distinguish
-"parsed successfully" from "fell back to neutral" for observability.
+- ``invalid_structure``       — not a dict, or structurally malformed
+- ``unknown_top_level_key``   — dict contains key not in the allowlist
+- ``missing_required_field``  — a shift field is absent
+- ``conflicting_aliases``     — both alias and canonical name present with different values
+- ``invalid_numeric_value``   — bad type, NaN/Inf, or out-of-range shift/intensity
+- ``unsupported_emotion``     — discrete_emotions present but not a mapping
+- ``unexpected_parser_failure`` — anything not covered by the above
+
+Legacy key translation (explicit, tested)
+==========================================
+The current production format uses:
+  ``valence``            → ``valence_shift``
+  ``arousal_shift``      → ``arousal_shift``  (unchanged)
+  ``dominance_shift``    → ``dominance_shift`` (unchanged)
+  ``triggered_emotions`` → ``discrete_emotions``
+
+If both alias and canonical name are present with *the same* value, the
+canonical is used. If they are present with *different* values, the parser
+produces ``conflicting_aliases`` fallback.
+
+Top-level key allowlist
+=======================
+Only the following keys are accepted at the top level of the raw dict::
+
+  valence, valence_shift, arousal_shift, dominance_shift,
+  triggered_emotions, discrete_emotions
+
+Any other key triggers ``unknown_top_level_key`` fallback.
+
+Empty-dict policy
+=================
+An empty dict ``{}`` is NOT a valid appraisal. It produces a fallback with
+code ``missing_required_field`` because the shift fields are absent.
 """
 
 from __future__ import annotations
 
-import math
+import enum
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
@@ -30,8 +64,29 @@ from .models import (
     DISCRETE_EMOTIONS,
     AppraisalV1,
     EmotionalDomainError,
+    _require_finite_float_in_range,
 )
 
+
+# ─── Fallback error codes ────────────────────────────────────────────────────
+
+class ParseErrorCode(str, enum.Enum):
+    """
+    Stable, sanitised error codes for ``ParseResult.error_code``.
+
+    These codes are safe to log and expose to callers. They contain no
+    raw LLM output, no user content, and no exception text.
+    """
+    invalid_structure = "invalid_structure"
+    unknown_top_level_key = "unknown_top_level_key"
+    missing_required_field = "missing_required_field"
+    conflicting_aliases = "conflicting_aliases"
+    invalid_numeric_value = "invalid_numeric_value"
+    unsupported_emotion = "unsupported_emotion"
+    unexpected_parser_failure = "unexpected_parser_failure"
+
+
+# ─── ParseResult ─────────────────────────────────────────────────────────────
 
 @dataclass(frozen=True)
 class ParseResult:
@@ -44,72 +99,113 @@ class ParseResult:
         The parsed ``AppraisalV1``, or ``AppraisalV1.neutral()`` on failure.
     is_fallback:
         ``True`` when the neutral fallback was used.
-    error:
-        The error message when ``is_fallback`` is ``True``; ``None`` otherwise.
+    error_code:
+        A ``ParseErrorCode`` value when ``is_fallback`` is ``True``; ``None``
+        otherwise. Never contains raw LLM text, user content, or exception repr.
     """
     appraisal: AppraisalV1
     is_fallback: bool
-    error: Optional[str]
+    error_code: Optional[ParseErrorCode]
 
+
+# ─── Top-level key allowlist ─────────────────────────────────────────────────
+
+_ALLOWED_TOP_LEVEL_KEYS = frozenset({
+    # Canonical v1 names
+    "valence_shift",
+    "arousal_shift",
+    "dominance_shift",
+    "discrete_emotions",
+    # Legacy production aliases
+    "valence",
+    "triggered_emotions",
+})
+
+# Required shift keys (canonical names, post-translation).
+_REQUIRED_SHIFTS = frozenset({"valence_shift", "arousal_shift", "dominance_shift"})
+
+
+# ─── Public API ──────────────────────────────────────────────────────────────
 
 def parse_llm_appraisal(raw: Any) -> ParseResult:
     """
     Parse untrusted LLM output into an ``AppraisalV1``.
 
-    The LLM output is expected to be a dict with keys compatible with the
-    informal ``perception_override`` format used in ``AffectiveEngine``:
-      - ``valence`` or ``valence_shift`` → ``valence_shift``
-      - ``arousal_shift``                → ``arousal_shift``
-      - ``dominance_shift``              → ``dominance_shift``
-      - ``discrete_emotions``            → ``discrete_emotions`` (optional)
-
-    On any error, returns a ``ParseResult`` with ``is_fallback=True`` and
-    ``appraisal=AppraisalV1.neutral()``. The error is recorded in
-    ``ParseResult.error``.
-
-    This function never raises.
+    On any error, returns a ``ParseResult`` with ``is_fallback=True`` and a
+    stable ``ParseErrorCode`` in ``error_code``. Never raises.
     """
     try:
         return _do_parse(raw)
-    except Exception as exc:  # noqa: BLE001  (intentional broad catch for LLM safety)
+    except _ParserFailure as exc:
         return ParseResult(
             appraisal=AppraisalV1.neutral(),
             is_fallback=True,
-            error=str(exc),
+            error_code=exc.code,
+        )
+    except EmotionalDomainError:
+        # Domain validation errors — map to a known code.
+        return ParseResult(
+            appraisal=AppraisalV1.neutral(),
+            is_fallback=True,
+            error_code=ParseErrorCode.invalid_numeric_value,
+        )
+    except Exception:  # noqa: BLE001
+        return ParseResult(
+            appraisal=AppraisalV1.neutral(),
+            is_fallback=True,
+            error_code=ParseErrorCode.unexpected_parser_failure,
         )
 
 
 # ─── Internal helpers ────────────────────────────────────────────────────────
 
+_ABSENT = object()  # Sentinel: discrete_emotions key was not in the dict.
+
+class _ParserFailure(Exception):
+    """Internal exception carrying a ParseErrorCode. Never surfaces to callers."""
+    def __init__(self, code: ParseErrorCode) -> None:
+        super().__init__(code.value)
+        self.code = code
+
+
 def _do_parse(raw: Any) -> ParseResult:
+    # 1. Must be a dict.
     if not isinstance(raw, dict):
-        raise EmotionalDomainError(
-            f"LLM appraisal must be a dict, got {type(raw).__name__}."
+        raise _ParserFailure(ParseErrorCode.invalid_structure)
+
+    # 2. Reject unknown top-level keys.
+    unknown_keys = set(raw.keys()) - _ALLOWED_TOP_LEVEL_KEYS
+    if unknown_keys:
+        raise _ParserFailure(ParseErrorCode.unknown_top_level_key)
+
+    # 3. Translate legacy aliases → canonical names, checking for conflicts.
+    translated = _translate_aliases(raw)
+
+    # 4. All three shift fields must be present.
+    missing = _REQUIRED_SHIFTS - set(translated.keys())
+    if missing:
+        raise _ParserFailure(ParseErrorCode.missing_required_field)
+
+    # 5. Validate and extract shift values.
+    try:
+        valence_shift = _require_finite_float_in_range(
+            translated["valence_shift"], "valence_shift", -1.0, 1.0
         )
+        arousal_shift = _require_finite_float_in_range(
+            translated["arousal_shift"], "arousal_shift", -1.0, 1.0
+        )
+        dominance_shift = _require_finite_float_in_range(
+            translated["dominance_shift"], "dominance_shift", -1.0, 1.0
+        )
+    except EmotionalDomainError:
+        raise _ParserFailure(ParseErrorCode.invalid_numeric_value)
 
-    # Support the legacy key name "valence" as well as "valence_shift".
-    valence_shift = raw.get("valence_shift", raw.get("valence", 0.0))
-    arousal_shift = raw.get("arousal_shift", 0.0)
-    dominance_shift = raw.get("dominance_shift", 0.0)
+    # 6. Process discrete_emotions.
+    # Use sentinel to distinguish key-absent from key-present-but-None.
+    de_raw = translated.get("discrete_emotions", _ABSENT)
+    filtered_emotions = _parse_discrete_emotions(de_raw)
 
-    raw_emotions = raw.get("discrete_emotions", {})
-
-    # Filter discrete_emotions: silently drop unknown keys (LLM output may be
-    # verbose), but reject invalid intensity values.
-    # Note: this is different from AppraisalV1.create() which REJECTS unknown
-    # emotion keys. Here we FILTER them from untrusted LLM output.
-    filtered_emotions: Dict[str, float] = {}
-    if isinstance(raw_emotions, dict):
-        for k, v in raw_emotions.items():
-            if not isinstance(k, str):
-                raise EmotionalDomainError(
-                    f"Emotion key must be a str, got {type(k).__name__}."
-                )
-            if k not in DISCRETE_EMOTIONS:
-                # Silently skip unknown emotions from LLM output.
-                continue
-            filtered_emotions[k] = v  # will be validated by AppraisalV1.create
-
+    # 7. Construct the validated AppraisalV1.
     appraisal = AppraisalV1.create(
         valence_shift=valence_shift,
         arousal_shift=arousal_shift,
@@ -118,4 +214,79 @@ def _do_parse(raw: Any) -> ParseResult:
         schema_version=EMOTIONAL_SCHEMA_VERSION,
     )
 
-    return ParseResult(appraisal=appraisal, is_fallback=False, error=None)
+    return ParseResult(appraisal=appraisal, is_fallback=False, error_code=None)
+
+
+def _translate_aliases(raw: dict) -> dict:
+    """
+    Translate legacy production keys to canonical v1 keys.
+
+    Alias pairs handled:
+      ``valence``            ↔ ``valence_shift``
+      ``triggered_emotions`` ↔ ``discrete_emotions``
+
+    Conflict policy:
+      If both alias and canonical key are present AND their values differ,
+      raise ``_ParserFailure(conflicting_aliases)``.
+      If they are the same value (or only one is present), use the canonical.
+    """
+    result = dict(raw)
+
+    # valence / valence_shift
+    has_alias = "valence" in raw
+    has_canonical = "valence_shift" in raw
+    if has_alias and has_canonical:
+        if raw["valence"] != raw["valence_shift"]:
+            raise _ParserFailure(ParseErrorCode.conflicting_aliases)
+        # Same value — drop alias, keep canonical
+        result.pop("valence", None)
+    elif has_alias:
+        result["valence_shift"] = result.pop("valence")
+
+    # triggered_emotions / discrete_emotions
+    has_alias_te = "triggered_emotions" in raw
+    has_canonical_de = "discrete_emotions" in raw
+    if has_alias_te and has_canonical_de:
+        if raw["triggered_emotions"] != raw["discrete_emotions"]:
+            raise _ParserFailure(ParseErrorCode.conflicting_aliases)
+        result.pop("triggered_emotions", None)
+    elif has_alias_te:
+        result["discrete_emotions"] = result.pop("triggered_emotions")
+
+    return result
+
+
+def _parse_discrete_emotions(de_raw: Any) -> Dict[str, float]:
+    """
+    Parse and filter the discrete_emotions mapping from LLM output.
+
+    - If absent (sentinel _ABSENT): return empty dict (key was not in the payload).
+    - If explicitly None, str, list, number, bool, or any non-mapping type:
+      raise _ParserFailure(unsupported_emotion).
+    - If a mapping: filter unknown emotion keys silently (LLM may produce extras),
+      validate intensities strictly.
+    """
+    if de_raw is _ABSENT:
+        # Key was entirely absent from the raw dict — treat as empty.
+        return {}
+
+    # Explicitly reject non-mapping types, including None.
+    if isinstance(de_raw, bool) or not isinstance(de_raw, dict):
+        raise _ParserFailure(ParseErrorCode.unsupported_emotion)
+
+    # Filter: keep only known emotions; validate intensities.
+    result: Dict[str, float] = {}
+    for k, v in de_raw.items():
+        if not isinstance(k, str):
+            raise _ParserFailure(ParseErrorCode.unsupported_emotion)
+        if k not in DISCRETE_EMOTIONS:
+            # Unknown emotions from LLM are silently filtered.
+            continue
+        try:
+            result[k] = _require_finite_float_in_range(
+                v, f"discrete_emotions['{k}']", 0.0, 1.0
+            )
+        except EmotionalDomainError:
+            raise _ParserFailure(ParseErrorCode.invalid_numeric_value)
+
+    return result

--- a/backend/emotional_domain/appraisal_parser.py
+++ b/backend/emotional_domain/appraisal_parser.py
@@ -1,0 +1,121 @@
+"""
+LLM appraisal parser: converts unvalidated LLM output to AppraisalV1 or
+returns the neutral fallback.
+
+Design
+======
+LLM output is untrusted. This module provides a single public function
+``parse_llm_appraisal`` that:
+
+1. Accepts any object (the raw LLM-produced dict).
+2. Attempts to parse it as an AppraisalV1.
+3. On ANY validation failure, returns ``AppraisalV1.neutral()`` and
+   **does not propagate the exception** (fallback policy).
+
+The fallback is explicit and observable: callers receive a neutral appraisal
+rather than a silent empty dict or a bare exception that could be swallowed.
+
+A companion ``ParseResult`` is returned so callers can distinguish
+"parsed successfully" from "fell back to neutral" for observability.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from .models import (
+    EMOTIONAL_SCHEMA_VERSION,
+    DISCRETE_EMOTIONS,
+    AppraisalV1,
+    EmotionalDomainError,
+)
+
+
+@dataclass(frozen=True)
+class ParseResult:
+    """
+    Result of ``parse_llm_appraisal``.
+
+    Attributes
+    ----------
+    appraisal:
+        The parsed ``AppraisalV1``, or ``AppraisalV1.neutral()`` on failure.
+    is_fallback:
+        ``True`` when the neutral fallback was used.
+    error:
+        The error message when ``is_fallback`` is ``True``; ``None`` otherwise.
+    """
+    appraisal: AppraisalV1
+    is_fallback: bool
+    error: Optional[str]
+
+
+def parse_llm_appraisal(raw: Any) -> ParseResult:
+    """
+    Parse untrusted LLM output into an ``AppraisalV1``.
+
+    The LLM output is expected to be a dict with keys compatible with the
+    informal ``perception_override`` format used in ``AffectiveEngine``:
+      - ``valence`` or ``valence_shift`` → ``valence_shift``
+      - ``arousal_shift``                → ``arousal_shift``
+      - ``dominance_shift``              → ``dominance_shift``
+      - ``discrete_emotions``            → ``discrete_emotions`` (optional)
+
+    On any error, returns a ``ParseResult`` with ``is_fallback=True`` and
+    ``appraisal=AppraisalV1.neutral()``. The error is recorded in
+    ``ParseResult.error``.
+
+    This function never raises.
+    """
+    try:
+        return _do_parse(raw)
+    except Exception as exc:  # noqa: BLE001  (intentional broad catch for LLM safety)
+        return ParseResult(
+            appraisal=AppraisalV1.neutral(),
+            is_fallback=True,
+            error=str(exc),
+        )
+
+
+# ─── Internal helpers ────────────────────────────────────────────────────────
+
+def _do_parse(raw: Any) -> ParseResult:
+    if not isinstance(raw, dict):
+        raise EmotionalDomainError(
+            f"LLM appraisal must be a dict, got {type(raw).__name__}."
+        )
+
+    # Support the legacy key name "valence" as well as "valence_shift".
+    valence_shift = raw.get("valence_shift", raw.get("valence", 0.0))
+    arousal_shift = raw.get("arousal_shift", 0.0)
+    dominance_shift = raw.get("dominance_shift", 0.0)
+
+    raw_emotions = raw.get("discrete_emotions", {})
+
+    # Filter discrete_emotions: silently drop unknown keys (LLM output may be
+    # verbose), but reject invalid intensity values.
+    # Note: this is different from AppraisalV1.create() which REJECTS unknown
+    # emotion keys. Here we FILTER them from untrusted LLM output.
+    filtered_emotions: Dict[str, float] = {}
+    if isinstance(raw_emotions, dict):
+        for k, v in raw_emotions.items():
+            if not isinstance(k, str):
+                raise EmotionalDomainError(
+                    f"Emotion key must be a str, got {type(k).__name__}."
+                )
+            if k not in DISCRETE_EMOTIONS:
+                # Silently skip unknown emotions from LLM output.
+                continue
+            filtered_emotions[k] = v  # will be validated by AppraisalV1.create
+
+    appraisal = AppraisalV1.create(
+        valence_shift=valence_shift,
+        arousal_shift=arousal_shift,
+        dominance_shift=dominance_shift,
+        discrete_emotions=filtered_emotions,
+        schema_version=EMOTIONAL_SCHEMA_VERSION,
+    )
+
+    return ParseResult(appraisal=appraisal, is_fallback=False, error=None)

--- a/backend/emotional_domain/appraisal_parser.py
+++ b/backend/emotional_domain/appraisal_parser.py
@@ -217,31 +217,47 @@ def _do_parse(raw: Any) -> ParseResult:
     return ParseResult(appraisal=appraisal, is_fallback=False, error_code=None)
 
 
-def _values_are_equivalent(a: object, b: object) -> bool:
+def _validate_normalize_shift(value: object, field_name: str) -> float:
     """
-    Type-strict equality check that prevents ``bool == int`` bypass.
+    Validate and normalise a shift value using the same rules as the parser.
 
-    In Python ``True == 1`` and ``False == 0``.  This helper returns
-    ``False`` when *either* side is a ``bool`` so that alias/canonical
-    pairs like ``valence=True`` / ``valence_shift=1`` are detected as
-    conflicting rather than silently accepted.
-
-    For dict values (e.g. ``triggered_emotions`` / ``discrete_emotions``)
-    the check recurses into values so that ``{"joy": True} != {"joy": 1}``
-    is correctly recognised as inequivalent.
+    Returns a normalised ``float``.  Raises ``_ParserFailure(invalid_numeric_value)``
+    when *value* is bool, None, str, list, NaN, Inf, or out of range.
     """
-    if isinstance(a, bool) or isinstance(b, bool):
-        return False  # Never treat bool as equivalent to int/float/dict/etc.
+    try:
+        return _require_finite_float_in_range(value, field_name, -1.0, 1.0)
+    except EmotionalDomainError:
+        raise _ParserFailure(ParseErrorCode.invalid_numeric_value)
 
-    if isinstance(a, dict) and isinstance(b, dict):
-        if set(a.keys()) != set(b.keys()):
-            return False
-        return all(_values_are_equivalent(a[k], b[k]) for k in a)
 
-    if isinstance(a, (int, float)) and isinstance(b, (int, float)):
-        return a == b  # 1 and 1.0 are equivalent; float comparison is fine
+def _validate_normalize_emotions(value: object) -> Dict[str, float]:
+    """
+    Validate and normalise an emotions mapping using the same rules as the parser.
 
-    return a == b
+    Unknown emotion keys are **filtered** (same policy as ``_parse_discrete_emotions``).
+    Invalid types (None, bool, str, list, number) raise ``_ParserFailure(unsupported_emotion)``.
+    Invalid intensities raise ``_ParserFailure(invalid_numeric_value)``.
+
+    Returns a plain ``dict`` with only known emotions and validated intensities.
+    """
+    if isinstance(value, bool) or not isinstance(value, dict):
+        raise _ParserFailure(ParseErrorCode.unsupported_emotion)
+
+    result: Dict[str, float] = {}
+    for k, v in value.items():
+        if not isinstance(k, str):
+            raise _ParserFailure(ParseErrorCode.unsupported_emotion)
+        if k not in DISCRETE_EMOTIONS:
+            # Unknown emotions from LLM are silently filtered (same as _parse_discrete_emotions).
+            continue
+        try:
+            result[k] = _require_finite_float_in_range(
+                v, f"discrete_emotions['{k}']", 0.0, 1.0
+            )
+        except EmotionalDomainError:
+            raise _ParserFailure(ParseErrorCode.invalid_numeric_value)
+
+    return result
 
 
 def _translate_aliases(raw: dict) -> dict:
@@ -252,13 +268,15 @@ def _translate_aliases(raw: dict) -> dict:
       ``valence``            ↔ ``valence_shift``
       ``triggered_emotions`` ↔ ``discrete_emotions``
 
-    Conflict policy:
-      A type-strict equality check (``_values_are_equivalent``) is used so
-      that ``bool == int`` does **not** bypass the comparison.
-
-      If both alias and canonical key are present AND their values are
-      *not* equivalent, raise ``_ParserFailure(conflicting_aliases)``.
-      If they are equivalent (or only one is present), use the canonical.
+    Policy (per audit requirement):
+    1. Validate alias and canonical **independently** using the same rules
+       as the parser (``_validate_normalize_shift`` / ``_validate_normalize_emotions``).
+    2. Produce normalised values/mappings (int → float, unknown emotions filtered).
+    3. Compare only the normalised results.
+    4. If either side is invalid, return the **validation error code**
+       (``invalid_numeric_value`` or ``unsupported_emotion``), not ``conflicting_aliases``.
+    5. If both are valid but differ, raise ``conflicting_aliases``.
+    6. ``1`` and ``1.0`` are equivalent only after both are validated as finite floats.
     """
     result = dict(raw)
 
@@ -266,7 +284,10 @@ def _translate_aliases(raw: dict) -> dict:
     has_alias = "valence" in raw
     has_canonical = "valence_shift" in raw
     if has_alias and has_canonical:
-        if not _values_are_equivalent(raw["valence"], raw["valence_shift"]):
+        # Validate + normalise each side independently
+        alias_norm = _validate_normalize_shift(raw["valence"], "valence")
+        canonical_norm = _validate_normalize_shift(raw["valence_shift"], "valence_shift")
+        if alias_norm != canonical_norm:
             raise _ParserFailure(ParseErrorCode.conflicting_aliases)
         # Same value — drop alias, keep canonical
         result.pop("valence", None)
@@ -277,7 +298,10 @@ def _translate_aliases(raw: dict) -> dict:
     has_alias_te = "triggered_emotions" in raw
     has_canonical_de = "discrete_emotions" in raw
     if has_alias_te and has_canonical_de:
-        if not _values_are_equivalent(raw["triggered_emotions"], raw["discrete_emotions"]):
+        # Validate + normalise each side independently
+        alias_norm = _validate_normalize_emotions(raw["triggered_emotions"])
+        canonical_norm = _validate_normalize_emotions(raw["discrete_emotions"])
+        if alias_norm != canonical_norm:
             raise _ParserFailure(ParseErrorCode.conflicting_aliases)
         result.pop("triggered_emotions", None)
     elif has_alias_te:

--- a/backend/emotional_domain/appraisal_parser.py
+++ b/backend/emotional_domain/appraisal_parser.py
@@ -217,6 +217,33 @@ def _do_parse(raw: Any) -> ParseResult:
     return ParseResult(appraisal=appraisal, is_fallback=False, error_code=None)
 
 
+def _values_are_equivalent(a: object, b: object) -> bool:
+    """
+    Type-strict equality check that prevents ``bool == int`` bypass.
+
+    In Python ``True == 1`` and ``False == 0``.  This helper returns
+    ``False`` when *either* side is a ``bool`` so that alias/canonical
+    pairs like ``valence=True`` / ``valence_shift=1`` are detected as
+    conflicting rather than silently accepted.
+
+    For dict values (e.g. ``triggered_emotions`` / ``discrete_emotions``)
+    the check recurses into values so that ``{"joy": True} != {"joy": 1}``
+    is correctly recognised as inequivalent.
+    """
+    if isinstance(a, bool) or isinstance(b, bool):
+        return False  # Never treat bool as equivalent to int/float/dict/etc.
+
+    if isinstance(a, dict) and isinstance(b, dict):
+        if set(a.keys()) != set(b.keys()):
+            return False
+        return all(_values_are_equivalent(a[k], b[k]) for k in a)
+
+    if isinstance(a, (int, float)) and isinstance(b, (int, float)):
+        return a == b  # 1 and 1.0 are equivalent; float comparison is fine
+
+    return a == b
+
+
 def _translate_aliases(raw: dict) -> dict:
     """
     Translate legacy production keys to canonical v1 keys.
@@ -226,9 +253,12 @@ def _translate_aliases(raw: dict) -> dict:
       ``triggered_emotions`` ↔ ``discrete_emotions``
 
     Conflict policy:
-      If both alias and canonical key are present AND their values differ,
-      raise ``_ParserFailure(conflicting_aliases)``.
-      If they are the same value (or only one is present), use the canonical.
+      A type-strict equality check (``_values_are_equivalent``) is used so
+      that ``bool == int`` does **not** bypass the comparison.
+
+      If both alias and canonical key are present AND their values are
+      *not* equivalent, raise ``_ParserFailure(conflicting_aliases)``.
+      If they are equivalent (or only one is present), use the canonical.
     """
     result = dict(raw)
 
@@ -236,7 +266,7 @@ def _translate_aliases(raw: dict) -> dict:
     has_alias = "valence" in raw
     has_canonical = "valence_shift" in raw
     if has_alias and has_canonical:
-        if raw["valence"] != raw["valence_shift"]:
+        if not _values_are_equivalent(raw["valence"], raw["valence_shift"]):
             raise _ParserFailure(ParseErrorCode.conflicting_aliases)
         # Same value — drop alias, keep canonical
         result.pop("valence", None)
@@ -247,7 +277,7 @@ def _translate_aliases(raw: dict) -> dict:
     has_alias_te = "triggered_emotions" in raw
     has_canonical_de = "discrete_emotions" in raw
     if has_alias_te and has_canonical_de:
-        if raw["triggered_emotions"] != raw["discrete_emotions"]:
+        if not _values_are_equivalent(raw["triggered_emotions"], raw["discrete_emotions"]):
             raise _ParserFailure(ParseErrorCode.conflicting_aliases)
         result.pop("triggered_emotions", None)
     elif has_alias_te:

--- a/backend/emotional_domain/appraisal_parser.py
+++ b/backend/emotional_domain/appraisal_parser.py
@@ -21,9 +21,9 @@ Fallback codes
 - ``invalid_structure``       — not a dict, or structurally malformed
 - ``unknown_top_level_key``   — dict contains key not in the allowlist
 - ``missing_required_field``  — a shift field is absent
-- ``conflicting_aliases``     — both alias and canonical name present with different values
-- ``invalid_numeric_value``   — bad type, NaN/Inf, or out-of-range shift/intensity
-- ``unsupported_emotion``     — discrete_emotions present but not a mapping
+- ``conflicting_aliases``     — alias and canonical both valid but **normalised** values differ
+- ``invalid_numeric_value``   — bad type (bool, None, str), NaN/Inf, out-of-range, or overflow in shift/intensity
+- ``unsupported_emotion``     — ``discrete_emotions``/``triggered_emotions`` is not a mapping (None, bool, str, list, number)
 - ``unexpected_parser_failure`` — anything not covered by the above
 
 Legacy key translation (explicit, tested)
@@ -34,9 +34,22 @@ The current production format uses:
   ``dominance_shift``    → ``dominance_shift`` (unchanged)
   ``triggered_emotions`` → ``discrete_emotions``
 
-If both alias and canonical name are present with *the same* value, the
-canonical is used. If they are present with *different* values, the parser
-produces ``conflicting_aliases`` fallback.
+If both alias and canonical key are present, each side is **validated and
+normalised independently** using the same rules as the parser
+(``_validate_normalize_shift`` for scalars,
+``_validate_normalize_emotions`` for mappings).
+
+- If **either** side is invalid (bool, None, string, NaN, Inf, out-of-range,
+  non-mapping emotions, invalid intensity), the parser returns the
+  corresponding validation error code (``invalid_numeric_value`` or
+  ``unsupported_emotion``), **not** ``conflicting_aliases``.
+- If **both** sides are valid, their **normalised** values are compared:
+  * ``1`` and ``1.0`` are equivalent after normalisation.
+  * Unknown emotion keys in mappings are **filtered** before comparison
+    (e.g. ``{"invented": 0.5}`` normalises to ``{}``).
+  * If normalised values differ, the parser produces
+    ``conflicting_aliases`` fallback.
+  * If normalised values match, the canonical is used.
 
 Top-level key allowlist
 =======================

--- a/backend/emotional_domain/migration.py
+++ b/backend/emotional_domain/migration.py
@@ -1,0 +1,115 @@
+"""
+Migration utilities: legacy snapshot → EmotionalStateV1.
+
+The legacy snapshot is the dict produced by the current ``EmotionalState.to_dict()``
+which uses the field ``last_update`` (a float Unix epoch) instead of ``timestamp``,
+and has no ``schema_version``.
+
+Migration policy
+================
+- Accepts a dict with the legacy structure (no ``schema_version`` key OR
+  ``schema_version`` absent entirely).
+- Rejects: non-dict, missing required legacy fields, incompatible types.
+- Returns a new ``EmotionalStateV1`` with ``schema_version=1``.
+- Does NOT modify the input dict.
+- Idempotent when given a v1 snapshot (re-validates and returns equivalent object).
+
+Legacy required fields
+======================
+  pleasure, arousal, dominance, libido, aggression, connection,
+  energy, tension, coping_mode, last_update
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Dict
+
+from .models import (
+    EMOTIONAL_SCHEMA_VERSION,
+    EmotionalStateV1,
+    EmotionalDomainError,
+)
+
+# Fields that must exist in a legacy snapshot (no schema_version).
+_LEGACY_REQUIRED_FIELDS = frozenset({
+    "pleasure",
+    "arousal",
+    "dominance",
+    "libido",
+    "aggression",
+    "connection",
+    "energy",
+    "tension",
+    "coping_mode",
+    "last_update",
+})
+
+
+def migrate_legacy_snapshot(raw: object) -> EmotionalStateV1:
+    """
+    Convert a legacy ``EmotionalState.to_dict()`` payload to ``EmotionalStateV1``.
+
+    Parameters
+    ----------
+    raw:
+        The raw dict as loaded from persistent storage. Must be a dict;
+        must contain the legacy fields; must NOT already be v1 (or if it is,
+        it is re-validated and returned as-is).
+
+    Returns
+    -------
+    EmotionalStateV1
+        A fully validated v1 snapshot.
+
+    Raises
+    ------
+    EmotionalDomainError
+        If the payload is incompatible, missing required fields, or contains
+        structurally invalid values.
+    """
+    if not isinstance(raw, dict):
+        raise EmotionalDomainError(
+            f"migrate_legacy_snapshot: expected a dict, got {type(raw).__name__}."
+        )
+
+    # Work on a shallow copy to guarantee we do not mutate the input.
+    data: Dict[str, object] = dict(raw)
+
+    schema_version = data.get("schema_version")
+
+    # ── Already v1: re-validate and return ───────────────────────────────────
+    if schema_version is not None:
+        if schema_version != EMOTIONAL_SCHEMA_VERSION:
+            raise EmotionalDomainError(
+                f"migrate_legacy_snapshot: snapshot has schema_version "
+                f"{schema_version!r}, which is not supported. "
+                f"Expected {EMOTIONAL_SCHEMA_VERSION} or absent (legacy)."
+            )
+        # Re-validate via from_dict (which rejects unknown keys, etc.).
+        return EmotionalStateV1.from_dict(data)
+
+    # ── Legacy snapshot (no schema_version) ──────────────────────────────────
+    missing = _LEGACY_REQUIRED_FIELDS - set(data.keys())
+    if missing:
+        raise EmotionalDomainError(
+            f"migrate_legacy_snapshot: legacy snapshot missing required fields: "
+            f"{sorted(missing)}."
+        )
+
+    # Map last_update → timestamp
+    timestamp = data["last_update"]
+
+    return EmotionalStateV1.create(
+        pleasure=data["pleasure"],
+        arousal=data["arousal"],
+        dominance=data["dominance"],
+        libido=data["libido"],
+        aggression=data["aggression"],
+        connection=data["connection"],
+        energy=data["energy"],
+        tension=data["tension"],
+        coping_mode=data["coping_mode"],
+        timestamp=timestamp,
+        schema_version=EMOTIONAL_SCHEMA_VERSION,
+    )

--- a/backend/emotional_domain/migration.py
+++ b/backend/emotional_domain/migration.py
@@ -3,36 +3,46 @@ Migration utilities: legacy snapshot → EmotionalStateV1.
 
 The legacy snapshot is the dict produced by the current ``EmotionalState.to_dict()``
 which uses the field ``last_update`` (a float Unix epoch) instead of ``timestamp``,
-and has no ``schema_version``.
+and has no ``schema_version`` key.
 
 Migration policy
 ================
-- Accepts a dict with the legacy structure (no ``schema_version`` key OR
-  ``schema_version`` absent entirely).
-- Rejects: non-dict, missing required legacy fields, incompatible types.
+- Accepts EXACTLY the legacy structure: no extra keys, no ``schema_version`` key.
+- Rejects: non-dict, missing required legacy fields, any extra/unknown field.
+- Rejects: ``schema_version=None`` (None is treated as an explicitly invalid version,
+  not as "absent"; absent means the key is not in the dict at all).
+- Rejects: payload containing both ``last_update`` and ``timestamp`` simultaneously.
+- Rejects: fields from other layers (prompt, memory, relationship, presentation).
 - Returns a new ``EmotionalStateV1`` with ``schema_version=1``.
 - Does NOT modify the input dict.
-- Idempotent when given a v1 snapshot (re-validates and returns equivalent object).
 
-Legacy required fields
-======================
+V1 idempotent path
+==================
+If ``schema_version`` is present and equals ``EMOTIONAL_SCHEMA_VERSION``:
+- Requires exactly the v1 field set (no legacy-only fields, no extras).
+- Delegates to ``EmotionalStateV1.from_dict`` for strict validation.
+
+Any other ``schema_version`` value (including None) is rejected.
+
+Legacy required fields (exactly)
+=================================
   pleasure, arousal, dominance, libido, aggression, connection,
   energy, tension, coping_mode, last_update
 """
 
 from __future__ import annotations
 
-import copy
 from typing import Dict
 
 from .models import (
     EMOTIONAL_SCHEMA_VERSION,
+    _STATE_FIELDS,
     EmotionalStateV1,
     EmotionalDomainError,
 )
 
-# Fields that must exist in a legacy snapshot (no schema_version).
-_LEGACY_REQUIRED_FIELDS = frozenset({
+# Exactly the fields a legacy snapshot may contain (no schema_version, uses last_update).
+_LEGACY_EXACT_FIELDS = frozenset({
     "pleasure",
     "arousal",
     "dominance",
@@ -53,9 +63,7 @@ def migrate_legacy_snapshot(raw: object) -> EmotionalStateV1:
     Parameters
     ----------
     raw:
-        The raw dict as loaded from persistent storage. Must be a dict;
-        must contain the legacy fields; must NOT already be v1 (or if it is,
-        it is re-validated and returned as-is).
+        The raw dict as loaded from persistent storage.
 
     Returns
     -------
@@ -65,39 +73,84 @@ def migrate_legacy_snapshot(raw: object) -> EmotionalStateV1:
     Raises
     ------
     EmotionalDomainError
-        If the payload is incompatible, missing required fields, or contains
-        structurally invalid values.
+        For any of the following:
+        - Not a dict.
+        - ``schema_version`` key is present but its value is ``None``.
+        - ``schema_version`` key is present with an unsupported version.
+        - Both ``last_update`` and ``timestamp`` present simultaneously.
+        - Missing required fields for the detected format.
+        - Extra/unknown keys beyond the allowed set for the detected format.
+        - Any field value that violates an invariant.
     """
     if not isinstance(raw, dict):
         raise EmotionalDomainError(
-            f"migrate_legacy_snapshot: expected a dict, got {type(raw).__name__}."
+            "migrate_legacy_snapshot: expected a dict."
         )
 
     # Work on a shallow copy to guarantee we do not mutate the input.
     data: Dict[str, object] = dict(raw)
 
-    schema_version = data.get("schema_version")
-
-    # ── Already v1: re-validate and return ───────────────────────────────────
-    if schema_version is not None:
-        if schema_version != EMOTIONAL_SCHEMA_VERSION:
-            raise EmotionalDomainError(
-                f"migrate_legacy_snapshot: snapshot has schema_version "
-                f"{schema_version!r}, which is not supported. "
-                f"Expected {EMOTIONAL_SCHEMA_VERSION} or absent (legacy)."
-            )
-        # Re-validate via from_dict (which rejects unknown keys, etc.).
-        return EmotionalStateV1.from_dict(data)
-
-    # ── Legacy snapshot (no schema_version) ──────────────────────────────────
-    missing = _LEGACY_REQUIRED_FIELDS - set(data.keys())
-    if missing:
+    # ── Check for conflicting timestamp/last_update ───────────────────────────
+    if "last_update" in data and "timestamp" in data:
         raise EmotionalDomainError(
-            f"migrate_legacy_snapshot: legacy snapshot missing required fields: "
-            f"{sorted(missing)}."
+            "migrate_legacy_snapshot: payload contains both 'last_update' and "
+            "'timestamp'; these are mutually exclusive."
         )
 
-    # Map last_update → timestamp
+    # ── Determine format from schema_version presence ─────────────────────────
+    has_schema_version_key = "schema_version" in data
+
+    if has_schema_version_key:
+        # Key is present: validate its value strictly.
+        sv = data["schema_version"]
+
+        # Reject None explicitly (distinct from "key absent").
+        if sv is None:
+            raise EmotionalDomainError(
+                "migrate_legacy_snapshot: 'schema_version' is None. "
+                "Only absent (legacy) or 1 (v1) are accepted."
+            )
+
+        # Reject bool, float, str before int check.
+        if isinstance(sv, bool) or not isinstance(sv, int):
+            raise EmotionalDomainError(
+                "migrate_legacy_snapshot: 'schema_version' must be an int."
+            )
+
+        if sv != EMOTIONAL_SCHEMA_VERSION:
+            raise EmotionalDomainError(
+                "migrate_legacy_snapshot: unsupported schema_version. "
+                f"Expected {EMOTIONAL_SCHEMA_VERSION}."
+            )
+
+        # ── Already v1: require exact v1 field set ────────────────────────────
+        unknown = set(data.keys()) - _STATE_FIELDS
+        if unknown:
+            raise EmotionalDomainError(
+                "migrate_legacy_snapshot: v1 snapshot contains unknown fields."
+            )
+        # 'last_update' must not be present in a v1 snapshot.
+        if "last_update" in data:
+            raise EmotionalDomainError(
+                "migrate_legacy_snapshot: v1 snapshot must not contain 'last_update'."
+            )
+        return EmotionalStateV1.from_dict(data)
+
+    # ── Legacy snapshot: schema_version key is entirely absent ────────────────
+    # Reject any field not in the legacy allowlist.
+    extra = set(data.keys()) - _LEGACY_EXACT_FIELDS
+    if extra:
+        raise EmotionalDomainError(
+            "migrate_legacy_snapshot: legacy snapshot contains unexpected fields."
+        )
+
+    missing = _LEGACY_EXACT_FIELDS - set(data.keys())
+    if missing:
+        raise EmotionalDomainError(
+            "migrate_legacy_snapshot: legacy snapshot missing required fields."
+        )
+
+    # Map last_update → timestamp.
     timestamp = data["last_update"]
 
     return EmotionalStateV1.create(

--- a/backend/emotional_domain/models.py
+++ b/backend/emotional_domain/models.py
@@ -39,14 +39,22 @@ VALID_COPING_MODES: FrozenSet[str] = frozenset({
 })
 
 DISCRETE_EMOTIONS: FrozenSet[str] = frozenset({
+    # Core emotions
     "joy",
     "sadness",
     "anger",
     "fear",
     "disgust",
     "surprise",
+    # Extended emotions (from v1 model)
     "trust",
     "anticipation",
+    # Production emotions (consumed by RelationshipManager via _perceive)
+    "tenderness",
+    "guilt",
+    "pride",
+    "jealousy",
+    "gratitude",
 })
 
 # ─── Domain error ────────────────────────────────────────────────────────────
@@ -232,11 +240,12 @@ class EmotionalStateV1:
 
     def __post_init__(self) -> None:
         """
-        Validate all fields on every construction path (including direct __init__).
-        Because the dataclass is frozen, we must use object.__setattr__ only
-        during __post_init__ if we need to normalise values; here we only validate.
+        Validate all fields on every construction path (including direct __init__)
+        AND normalize values (e.g. int → float) to ensure type-stable representation.
+        Because the dataclass is frozen, we must use object.__setattr__ during
+        __post_init__.
         """
-        _validate_state_fields(
+        sv, p, a, d, lib, agg, con, eng, ten, cm, ts = _validate_state_fields(
             schema_version=self.schema_version,
             pleasure=self.pleasure,
             arousal=self.arousal,
@@ -249,6 +258,17 @@ class EmotionalStateV1:
             coping_mode=self.coping_mode,
             timestamp=self.timestamp,
         )
+        # Assign normalized values back (int → float, etc.)
+        object.__setattr__(self, "pleasure", p)
+        object.__setattr__(self, "arousal", a)
+        object.__setattr__(self, "dominance", d)
+        object.__setattr__(self, "libido", lib)
+        object.__setattr__(self, "aggression", agg)
+        object.__setattr__(self, "connection", con)
+        object.__setattr__(self, "energy", eng)
+        object.__setattr__(self, "tension", ten)
+        object.__setattr__(self, "timestamp", ts)
+        object.__setattr__(self, "schema_version", sv)
 
     # ── Factory methods ───────────────────────────────────────────────────────
 
@@ -377,6 +397,11 @@ class EmotionalStateV1:
         }
 
 
+# ─── Sentinel for "argument omitted" vs "None" distinction ──────────────────────
+
+_UNSET = object()
+
+
 # ─── AppraisalV1 ─────────────────────────────────────────────────────────────
 
 _APPRAISAL_SCALAR_FIELDS: FrozenSet[str] = frozenset({
@@ -461,16 +486,21 @@ class AppraisalV1:
 
     def __post_init__(self) -> None:
         """
-        Validate all fields and enforce deep immutability on every construction path.
+        Validate all fields, normalize values (int → float), and enforce deep
+        immutability on every construction path.
         Converts a plain dict input into a MappingProxyType.
         """
         # schema_version
-        _require_schema_version(self.schema_version)
+        sv = _require_schema_version(self.schema_version)
+        object.__setattr__(self, "schema_version", sv)
 
-        # Scalar shifts
-        _require_finite_float_in_range(self.valence_shift, "valence_shift", -1.0, 1.0)
-        _require_finite_float_in_range(self.arousal_shift, "arousal_shift", -1.0, 1.0)
-        _require_finite_float_in_range(self.dominance_shift, "dominance_shift", -1.0, 1.0)
+        # Scalar shifts — validate AND normalize
+        vs = _require_finite_float_in_range(self.valence_shift, "valence_shift", -1.0, 1.0)
+        ar = _require_finite_float_in_range(self.arousal_shift, "arousal_shift", -1.0, 1.0)
+        ds = _require_finite_float_in_range(self.dominance_shift, "dominance_shift", -1.0, 1.0)
+        object.__setattr__(self, "valence_shift", vs)
+        object.__setattr__(self, "arousal_shift", ar)
+        object.__setattr__(self, "dominance_shift", ds)
 
         # Validate and convert discrete_emotions to an immutable proxy.
         # We always make a fresh copy to prevent the caller's dict from being
@@ -506,16 +536,17 @@ class AppraisalV1:
         valence_shift: object,
         arousal_shift: object,
         dominance_shift: object,
-        discrete_emotions: object = None,
+        discrete_emotions: object = _UNSET,
         schema_version: object = EMOTIONAL_SCHEMA_VERSION,
     ) -> "AppraisalV1":
         """
         Validated factory. Raises EmotionalDomainError on any invariant violation.
         ``__post_init__`` will also run and validate, providing defence-in-depth.
 
-        ``discrete_emotions=None`` is treated as an empty mapping (no emotions).
-        ``discrete_emotions={}`` is a valid empty mapping.
-        Any other non-dict type raises EmotionalDomainError.
+        - Omitted ``discrete_emotions`` (default) → empty mapping.
+        - Explicit ``discrete_emotions=None`` → raises EmotionalDomainError.
+        - ``discrete_emotions={}`` → valid empty mapping.
+        - Any other non-dict type raises EmotionalDomainError.
         """
         sv = _require_schema_version(schema_version)
 
@@ -523,8 +554,12 @@ class AppraisalV1:
         as_ = _require_finite_float_in_range(arousal_shift, "arousal_shift", -1.0, 1.0)
         ds = _require_finite_float_in_range(dominance_shift, "dominance_shift", -1.0, 1.0)
 
-        # None → empty mapping (only in the create() factory, not from_dict)
-        de_raw = {} if discrete_emotions is None else discrete_emotions
+        # Sentinel: omitted → empty dict. Explicit None → rejected.
+        if discrete_emotions is None:
+            raise EmotionalDomainError(
+                "discrete_emotions must be a dict, got None."
+            )
+        de_raw: object = {} if discrete_emotions is _UNSET else discrete_emotions
         de = _validate_discrete_emotions(de_raw)
 
         return cls(
@@ -566,12 +601,19 @@ class AppraisalV1:
                 "Missing required fields in AppraisalV1 payload."
             )
 
-        # discrete_emotions is optional in serialised form, but if present must be a dict
-        de_raw = data.get("discrete_emotions")
-        if de_raw is None:
-            de_input: object = {}
+        # discrete_emotions is optional in serialised form.
+        # If the key is absent → empty mapping.
+        # If the key is present with None → reject (fail-closed).
+        if "discrete_emotions" not in data:
+            de_input: object = _UNSET  # will resolve to empty in create()
         else:
+            de_raw = data["discrete_emotions"]
+            if de_raw is None:
+                raise EmotionalDomainError(
+                    "discrete_emotions must be a dict, got None."
+                )
             de_input = de_raw  # will be validated in create()
+        
 
         return cls.create(
             valence_shift=data["valence_shift"],

--- a/backend/emotional_domain/models.py
+++ b/backend/emotional_domain/models.py
@@ -92,6 +92,8 @@ def _require_finite_float(value: object, name: str) -> float:
     Returns ``float(value)`` when *value* is a finite real number.
 
     Rejects: bool, None, str, list, dict, NaN, ±Inf.
+    Also catches ``OverflowError`` for integers too large to represent as float
+    and converts it to a sanitised ``EmotionalDomainError`` (no raw value leaked).
     """
     if isinstance(value, bool):
         raise EmotionalDomainError(
@@ -101,7 +103,12 @@ def _require_finite_float(value: object, name: str) -> float:
         raise EmotionalDomainError(
             f"Field '{name}' must be a finite float, got {type(value).__name__}."
         )
-    f = float(value)
+    try:
+        f = float(value)
+    except (OverflowError, ValueError, TypeError):
+        raise EmotionalDomainError(
+            f"Field '{name}' must be a finite float, got non-convertible value."
+        )
     if not math.isfinite(f):
         raise EmotionalDomainError(
             f"Field '{name}' must be finite, got non-finite value."

--- a/backend/emotional_domain/models.py
+++ b/backend/emotional_domain/models.py
@@ -1,27 +1,29 @@
 """
 Core typed models for the emotional domain.
 
-Invariants enforced at construction:
+Invariants enforced on ALL public construction paths (including direct __init__):
 - All numeric fields are finite floats (not bool, not None, not NaN, not inf).
 - PAD fields (pleasure, arousal, dominance): float in [-1.0, 1.0].
 - Drive fields (libido, aggression, connection, energy, tension): float in [0.0, 1.0].
 - coping_mode: one of VALID_COPING_MODES.
 - timestamp: finite positive float (Unix epoch seconds).
-- schema_version: must equal EMOTIONAL_SCHEMA_VERSION.
-- No extra keys accepted (unknown fields are rejected).
+- schema_version: must equal EMOTIONAL_SCHEMA_VERSION; must be int, not bool/float/str/None.
+- No extra keys accepted via from_dict (unknown fields are rejected).
 
-Appraisal invariants:
+AppraisalV1 additional invariants:
 - valence_shift, arousal_shift, dominance_shift: finite float in [-1.0, 1.0].
-- discrete_emotions: dict mapping known emotion names to float intensities in [0.0, 1.0].
-- Unknown emotion keys are REJECTED (strict allowlist policy).
-- schema_version: must equal EMOTIONAL_SCHEMA_VERSION.
+- discrete_emotions: deeply immutable mapping of known emotion → intensity in [0.0, 1.0].
+  Unknown emotion keys are REJECTED (strict allowlist policy).
+  The stored mapping cannot be mutated by the caller after construction.
+- schema_version: same rules as above.
 """
 
 from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from typing import Dict, FrozenSet
+from types import MappingProxyType
+from typing import Dict, FrozenSet, Mapping
 
 # ─── Schema version ─────────────────────────────────────────────────────────
 
@@ -55,6 +57,28 @@ class EmotionalDomainError(ValueError):
 
 # ─── Validation helpers ──────────────────────────────────────────────────────
 
+def _require_schema_version(value: object) -> int:
+    """
+    Accepts only ``int`` (not bool) equal to ``EMOTIONAL_SCHEMA_VERSION``.
+    Raises ``EmotionalDomainError`` for bool, float, str, None, wrong version.
+    """
+    if value is None or isinstance(value, bool):
+        raise EmotionalDomainError(
+            f"schema_version must be an int equal to {EMOTIONAL_SCHEMA_VERSION}, "
+            f"got {type(value).__name__}."
+        )
+    if not isinstance(value, int):
+        raise EmotionalDomainError(
+            f"schema_version must be an int, got {type(value).__name__}."
+        )
+    if value != EMOTIONAL_SCHEMA_VERSION:
+        raise EmotionalDomainError(
+            f"Unsupported schema_version {value!r}. "
+            f"Expected {EMOTIONAL_SCHEMA_VERSION}."
+        )
+    return value
+
+
 def _require_finite_float(value: object, name: str) -> float:
     """
     Returns ``float(value)`` when *value* is a finite real number.
@@ -63,16 +87,16 @@ def _require_finite_float(value: object, name: str) -> float:
     """
     if isinstance(value, bool):
         raise EmotionalDomainError(
-            f"Field '{name}' must be a finite float, got bool ({value!r})."
+            f"Field '{name}' must be a finite float, got bool."
         )
     if not isinstance(value, (int, float)):
         raise EmotionalDomainError(
-            f"Field '{name}' must be a finite float, got {type(value).__name__} ({value!r})."
+            f"Field '{name}' must be a finite float, got {type(value).__name__}."
         )
     f = float(value)
     if not math.isfinite(f):
         raise EmotionalDomainError(
-            f"Field '{name}' must be finite, got {f!r}."
+            f"Field '{name}' must be finite, got non-finite value."
         )
     return f
 
@@ -81,7 +105,7 @@ def _require_range(value: float, name: str, lo: float, hi: float) -> float:
     """Raises if *value* is outside [lo, hi]."""
     if value < lo or value > hi:
         raise EmotionalDomainError(
-            f"Field '{name}' must be in [{lo}, {hi}], got {value!r}."
+            f"Field '{name}' must be in [{lo}, {hi}], got out-of-range value."
         )
     return value
 
@@ -96,7 +120,7 @@ def _require_positive_float(value: object, name: str) -> float:
     f = _require_finite_float(value, name)
     if f <= 0:
         raise EmotionalDomainError(
-            f"Field '{name}' must be a positive finite float (Unix epoch), got {f!r}."
+            f"Field '{name}' must be a positive finite float (Unix epoch)."
         )
     return f
 
@@ -119,16 +143,64 @@ _STATE_FIELDS: FrozenSet[str] = frozenset({
 })
 
 
+def _validate_state_fields(
+    *,
+    pleasure: object,
+    arousal: object,
+    dominance: object,
+    libido: object,
+    aggression: object,
+    connection: object,
+    energy: object,
+    tension: object,
+    coping_mode: object,
+    timestamp: object,
+    schema_version: object,
+) -> tuple:
+    """
+    Validate all EmotionalStateV1 fields and return a tuple of validated values
+    in order: (schema_version, pleasure, arousal, dominance, libido, aggression,
+               connection, energy, tension, coping_mode, timestamp).
+    Raises EmotionalDomainError on any violation.
+    """
+    sv = _require_schema_version(schema_version)
+
+    p = _require_finite_float_in_range(pleasure, "pleasure", -1.0, 1.0)
+    a = _require_finite_float_in_range(arousal, "arousal", -1.0, 1.0)
+    d = _require_finite_float_in_range(dominance, "dominance", -1.0, 1.0)
+
+    lib = _require_finite_float_in_range(libido, "libido", 0.0, 1.0)
+    agg = _require_finite_float_in_range(aggression, "aggression", 0.0, 1.0)
+    con = _require_finite_float_in_range(connection, "connection", 0.0, 1.0)
+    eng = _require_finite_float_in_range(energy, "energy", 0.0, 1.0)
+    ten = _require_finite_float_in_range(tension, "tension", 0.0, 1.0)
+
+    if not isinstance(coping_mode, str):
+        raise EmotionalDomainError(
+            f"coping_mode must be a str, got {type(coping_mode).__name__}."
+        )
+    if coping_mode not in VALID_COPING_MODES:
+        raise EmotionalDomainError(
+            f"Unknown coping_mode. Allowed: {sorted(VALID_COPING_MODES)}."
+        )
+
+    ts = _require_positive_float(timestamp, "timestamp")
+
+    return (sv, p, a, d, lib, agg, con, eng, ten, coping_mode, ts)
+
+
 @dataclass(frozen=True)
 class EmotionalStateV1:
     """
     Versioned, typed snapshot of the emotional state.
 
-    Construction
-    ============
-    Use ``EmotionalStateV1.create(...)`` or ``EmotionalStateV1.neutral()`` —
-    do NOT construct directly via ``EmotionalStateV1(...)`` unless you are
-    sure all arguments already satisfy invariants (e.g. in tests).
+    All public construction paths validate invariants:
+    - Direct ``EmotionalStateV1(...)`` calls ``__post_init__`` which validates.
+    - ``EmotionalStateV1.create(...)`` validates then delegates to ``__init__``.
+    - ``EmotionalStateV1.from_dict(...)`` validates structure then delegates to create.
+    - ``EmotionalStateV1.neutral(...)`` delegates to create.
+
+    There is no way to produce an invalid instance.
 
     Fields
     ======
@@ -140,23 +212,43 @@ class EmotionalStateV1:
     """
 
     # PAD — bipolar [-1.0, +1.0]
-    pleasure: float = 0.0
-    arousal: float = 0.0
-    dominance: float = 0.0
+    pleasure: float
+    arousal: float
+    dominance: float
 
     # Drives / system — unipolar [0.0, 1.0]
-    libido: float = 0.0
-    aggression: float = 0.0
-    connection: float = 0.5
-    energy: float = 0.8
-    tension: float = 0.0
+    libido: float
+    aggression: float
+    connection: float
+    energy: float
+    tension: float
 
     # Categorical
-    coping_mode: str = "HEALTHY"
+    coping_mode: str
 
     # Metadata
-    timestamp: float = field(default=0.0)
-    schema_version: int = EMOTIONAL_SCHEMA_VERSION
+    timestamp: float
+    schema_version: int
+
+    def __post_init__(self) -> None:
+        """
+        Validate all fields on every construction path (including direct __init__).
+        Because the dataclass is frozen, we must use object.__setattr__ only
+        during __post_init__ if we need to normalise values; here we only validate.
+        """
+        _validate_state_fields(
+            schema_version=self.schema_version,
+            pleasure=self.pleasure,
+            arousal=self.arousal,
+            dominance=self.dominance,
+            libido=self.libido,
+            aggression=self.aggression,
+            connection=self.connection,
+            energy=self.energy,
+            tension=self.tension,
+            coping_mode=self.coping_mode,
+            timestamp=self.timestamp,
+        )
 
     # ── Factory methods ───────────────────────────────────────────────────────
 
@@ -194,44 +286,21 @@ class EmotionalStateV1:
     ) -> "EmotionalStateV1":
         """
         Validated factory. Raises EmotionalDomainError on any invariant violation.
+        ``__post_init__`` will also run and validate, providing defence-in-depth.
         """
-        # schema_version
-        if not isinstance(schema_version, int) or isinstance(schema_version, bool):
-            raise EmotionalDomainError(
-                f"schema_version must be an int, got {type(schema_version).__name__}."
-            )
-        if schema_version != EMOTIONAL_SCHEMA_VERSION:
-            raise EmotionalDomainError(
-                f"Unsupported schema_version {schema_version!r}. "
-                f"Expected {EMOTIONAL_SCHEMA_VERSION}."
-            )
-
-        # PAD [-1, 1]
-        p = _require_finite_float_in_range(pleasure, "pleasure", -1.0, 1.0)
-        a = _require_finite_float_in_range(arousal, "arousal", -1.0, 1.0)
-        d = _require_finite_float_in_range(dominance, "dominance", -1.0, 1.0)
-
-        # Drives [0, 1]
-        lib = _require_finite_float_in_range(libido, "libido", 0.0, 1.0)
-        agg = _require_finite_float_in_range(aggression, "aggression", 0.0, 1.0)
-        con = _require_finite_float_in_range(connection, "connection", 0.0, 1.0)
-        eng = _require_finite_float_in_range(energy, "energy", 0.0, 1.0)
-        ten = _require_finite_float_in_range(tension, "tension", 0.0, 1.0)
-
-        # coping_mode
-        if not isinstance(coping_mode, str):
-            raise EmotionalDomainError(
-                f"coping_mode must be a str, got {type(coping_mode).__name__}."
-            )
-        if coping_mode not in VALID_COPING_MODES:
-            raise EmotionalDomainError(
-                f"Unknown coping_mode {coping_mode!r}. "
-                f"Allowed: {sorted(VALID_COPING_MODES)}."
-            )
-
-        # timestamp
-        ts = _require_positive_float(timestamp, "timestamp")
-
+        sv, p, a, d, lib, agg, con, eng, ten, cm, ts = _validate_state_fields(
+            schema_version=schema_version,
+            pleasure=pleasure,
+            arousal=arousal,
+            dominance=dominance,
+            libido=libido,
+            aggression=aggression,
+            connection=connection,
+            energy=energy,
+            tension=tension,
+            coping_mode=coping_mode,
+            timestamp=timestamp,
+        )
         return cls(
             pleasure=p,
             arousal=a,
@@ -241,9 +310,9 @@ class EmotionalStateV1:
             connection=con,
             energy=eng,
             tension=ten,
-            coping_mode=coping_mode,
+            coping_mode=cm,
             timestamp=ts,
-            schema_version=schema_version,
+            schema_version=sv,
         )
 
     @classmethod
@@ -261,7 +330,7 @@ class EmotionalStateV1:
         unknown = set(data.keys()) - _STATE_FIELDS
         if unknown:
             raise EmotionalDomainError(
-                f"Unknown fields in EmotionalStateV1 payload: {sorted(unknown)}."
+                "Unknown fields in EmotionalStateV1 payload."
             )
 
         # Require schema_version present
@@ -274,7 +343,7 @@ class EmotionalStateV1:
         missing = required - set(data.keys())
         if missing:
             raise EmotionalDomainError(
-                f"Missing required fields in EmotionalStateV1 payload: {sorted(missing)}."
+                "Missing required fields in EmotionalStateV1 payload."
             )
 
         return cls.create(
@@ -320,17 +389,61 @@ _APPRAISAL_SCALAR_FIELDS: FrozenSet[str] = frozenset({
 _APPRAISAL_ALL_FIELDS: FrozenSet[str] = _APPRAISAL_SCALAR_FIELDS | {"discrete_emotions"}
 
 
+def _validate_discrete_emotions(raw: object) -> Dict[str, float]:
+    """
+    Validate a discrete_emotions mapping. Returns a new plain dict.
+    Accepts: dict (including empty). Rejects: None, str, list, number, bool.
+    Unknown emotion keys are rejected (strict policy).
+    """
+    if raw is None or isinstance(raw, bool):
+        raise EmotionalDomainError(
+            f"discrete_emotions must be a dict, got {type(raw).__name__}."
+        )
+    if not isinstance(raw, dict):
+        raise EmotionalDomainError(
+            f"discrete_emotions must be a dict, got {type(raw).__name__}."
+        )
+    result: Dict[str, float] = {}
+    for emotion, intensity in raw.items():
+        if not isinstance(emotion, str):
+            raise EmotionalDomainError(
+                "Emotion key must be a str."
+            )
+        if emotion not in DISCRETE_EMOTIONS:
+            raise EmotionalDomainError(
+                f"Unknown discrete emotion. Allowed: {sorted(DISCRETE_EMOTIONS)}."
+            )
+        result[emotion] = _require_finite_float_in_range(
+            intensity, f"discrete_emotions['{emotion}']", 0.0, 1.0
+        )
+    return result
+
+
 @dataclass(frozen=True)
 class AppraisalV1:
     """
     Versioned appraisal produced by cognitive evaluation of a message or event.
+
+    Deep immutability
+    =================
+    ``discrete_emotions`` is stored as a ``MappingProxyType`` — it cannot be
+    mutated after construction, and the original dict provided by the caller
+    is copied defensively, so caller modifications have no effect.
+
+    ``to_dict()`` returns a fresh mutable copy of the mapping for serialisation,
+    but that copy does not share state with the stored proxy.
+
+    All public construction paths validate invariants:
+    - Direct ``AppraisalV1(...)`` calls ``__post_init__`` which validates.
+    - ``AppraisalV1.create(...)`` validates then delegates to ``__init__``.
+    - ``AppraisalV1.neutral()`` delegates to create.
 
     Fields
     ======
     valence_shift:   float in [-1.0, 1.0] — desired pleasure shift
     arousal_shift:   float in [-1.0, 1.0] — desired arousal shift
     dominance_shift: float in [-1.0, 1.0] — desired dominance shift
-    discrete_emotions: mapping from DISCRETE_EMOTIONS names to intensity [0.0, 1.0]
+    discrete_emotions: immutable mapping from DISCRETE_EMOTIONS names to [0.0, 1.0]
                        Unknown keys are REJECTED.
     schema_version:  must equal EMOTIONAL_SCHEMA_VERSION
 
@@ -339,11 +452,39 @@ class AppraisalV1:
     All shifts are 0.0 and discrete_emotions is empty. Use ``AppraisalV1.neutral()``.
     """
 
-    valence_shift: float = 0.0
-    arousal_shift: float = 0.0
-    dominance_shift: float = 0.0
-    discrete_emotions: Dict[str, float] = field(default_factory=dict)
-    schema_version: int = EMOTIONAL_SCHEMA_VERSION
+    valence_shift: float
+    arousal_shift: float
+    dominance_shift: float
+    # Stored as MappingProxyType for deep immutability.
+    discrete_emotions: Mapping[str, float]
+    schema_version: int
+
+    def __post_init__(self) -> None:
+        """
+        Validate all fields and enforce deep immutability on every construction path.
+        Converts a plain dict input into a MappingProxyType.
+        """
+        # schema_version
+        _require_schema_version(self.schema_version)
+
+        # Scalar shifts
+        _require_finite_float_in_range(self.valence_shift, "valence_shift", -1.0, 1.0)
+        _require_finite_float_in_range(self.arousal_shift, "arousal_shift", -1.0, 1.0)
+        _require_finite_float_in_range(self.dominance_shift, "dominance_shift", -1.0, 1.0)
+
+        # Validate and convert discrete_emotions to an immutable proxy.
+        # We always make a fresh copy to prevent the caller's dict from being
+        # aliased inside the model.
+        de = self.discrete_emotions
+        if isinstance(de, MappingProxyType):
+            # Already a proxy — validate its contents but keep it as-is.
+            validated = _validate_discrete_emotions(dict(de))
+        else:
+            validated = _validate_discrete_emotions(de)
+
+        # Replace discrete_emotions with an immutable proxy (works even on frozen
+        # dataclasses because __post_init__ runs before the object is "sealed").
+        object.__setattr__(self, "discrete_emotions", MappingProxyType(validated))
 
     # ── Factory methods ───────────────────────────────────────────────────────
 
@@ -370,52 +511,28 @@ class AppraisalV1:
     ) -> "AppraisalV1":
         """
         Validated factory. Raises EmotionalDomainError on any invariant violation.
-        """
-        # schema_version
-        if not isinstance(schema_version, int) or isinstance(schema_version, bool):
-            raise EmotionalDomainError(
-                f"schema_version must be an int, got {type(schema_version).__name__}."
-            )
-        if schema_version != EMOTIONAL_SCHEMA_VERSION:
-            raise EmotionalDomainError(
-                f"Unsupported schema_version {schema_version!r}. "
-                f"Expected {EMOTIONAL_SCHEMA_VERSION}."
-            )
+        ``__post_init__`` will also run and validate, providing defence-in-depth.
 
-        # Scalar shifts [-1, 1]
+        ``discrete_emotions=None`` is treated as an empty mapping (no emotions).
+        ``discrete_emotions={}`` is a valid empty mapping.
+        Any other non-dict type raises EmotionalDomainError.
+        """
+        sv = _require_schema_version(schema_version)
+
         vs = _require_finite_float_in_range(valence_shift, "valence_shift", -1.0, 1.0)
         as_ = _require_finite_float_in_range(arousal_shift, "arousal_shift", -1.0, 1.0)
         ds = _require_finite_float_in_range(dominance_shift, "dominance_shift", -1.0, 1.0)
 
-        # discrete_emotions
-        if discrete_emotions is None:
-            de: Dict[str, float] = {}
-        elif not isinstance(discrete_emotions, dict):
-            raise EmotionalDomainError(
-                f"discrete_emotions must be a dict, got {type(discrete_emotions).__name__}."
-            )
-        else:
-            de = {}
-            for emotion, intensity in discrete_emotions.items():
-                if not isinstance(emotion, str):
-                    raise EmotionalDomainError(
-                        f"Emotion key must be a str, got {type(emotion).__name__}."
-                    )
-                if emotion not in DISCRETE_EMOTIONS:
-                    raise EmotionalDomainError(
-                        f"Unknown discrete emotion {emotion!r}. "
-                        f"Allowed: {sorted(DISCRETE_EMOTIONS)}."
-                    )
-                de[emotion] = _require_finite_float_in_range(
-                    intensity, f"discrete_emotions[{emotion!r}]", 0.0, 1.0
-                )
+        # None → empty mapping (only in the create() factory, not from_dict)
+        de_raw = {} if discrete_emotions is None else discrete_emotions
+        de = _validate_discrete_emotions(de_raw)
 
         return cls(
             valence_shift=vs,
             arousal_shift=as_,
             dominance_shift=ds,
             discrete_emotions=de,
-            schema_version=schema_version,
+            schema_version=sv,
         )
 
     @classmethod
@@ -433,7 +550,7 @@ class AppraisalV1:
         unknown = set(data.keys()) - _APPRAISAL_ALL_FIELDS
         if unknown:
             raise EmotionalDomainError(
-                f"Unknown fields in AppraisalV1 payload: {sorted(unknown)}."
+                "Unknown fields in AppraisalV1 payload."
             )
 
         # Require schema_version present
@@ -446,19 +563,29 @@ class AppraisalV1:
         missing = required_scalars - set(data.keys())
         if missing:
             raise EmotionalDomainError(
-                f"Missing required fields in AppraisalV1 payload: {sorted(missing)}."
+                "Missing required fields in AppraisalV1 payload."
             )
+
+        # discrete_emotions is optional in serialised form, but if present must be a dict
+        de_raw = data.get("discrete_emotions")
+        if de_raw is None:
+            de_input: object = {}
+        else:
+            de_input = de_raw  # will be validated in create()
 
         return cls.create(
             valence_shift=data["valence_shift"],
             arousal_shift=data["arousal_shift"],
             dominance_shift=data["dominance_shift"],
-            discrete_emotions=data.get("discrete_emotions"),
+            discrete_emotions=de_input,
             schema_version=data["schema_version"],
         )
 
     def to_dict(self) -> Dict[str, object]:
-        """Serialise to a plain dict suitable for JSON encoding."""
+        """
+        Serialise to a plain dict suitable for JSON encoding.
+        The returned dict is a fresh copy — modifying it has no effect on this object.
+        """
         return {
             "schema_version": self.schema_version,
             "valence_shift": self.valence_shift,

--- a/backend/emotional_domain/models.py
+++ b/backend/emotional_domain/models.py
@@ -1,0 +1,468 @@
+"""
+Core typed models for the emotional domain.
+
+Invariants enforced at construction:
+- All numeric fields are finite floats (not bool, not None, not NaN, not inf).
+- PAD fields (pleasure, arousal, dominance): float in [-1.0, 1.0].
+- Drive fields (libido, aggression, connection, energy, tension): float in [0.0, 1.0].
+- coping_mode: one of VALID_COPING_MODES.
+- timestamp: finite positive float (Unix epoch seconds).
+- schema_version: must equal EMOTIONAL_SCHEMA_VERSION.
+- No extra keys accepted (unknown fields are rejected).
+
+Appraisal invariants:
+- valence_shift, arousal_shift, dominance_shift: finite float in [-1.0, 1.0].
+- discrete_emotions: dict mapping known emotion names to float intensities in [0.0, 1.0].
+- Unknown emotion keys are REJECTED (strict allowlist policy).
+- schema_version: must equal EMOTIONAL_SCHEMA_VERSION.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Dict, FrozenSet
+
+# ─── Schema version ─────────────────────────────────────────────────────────
+
+EMOTIONAL_SCHEMA_VERSION: int = 1
+
+# ─── Allowlists ─────────────────────────────────────────────────────────────
+
+VALID_COPING_MODES: FrozenSet[str] = frozenset({
+    "HEALTHY",
+    "DEFENSIVE",
+    "DISSOCIATED",
+    "MANIC",
+})
+
+DISCRETE_EMOTIONS: FrozenSet[str] = frozenset({
+    "joy",
+    "sadness",
+    "anger",
+    "fear",
+    "disgust",
+    "surprise",
+    "trust",
+    "anticipation",
+})
+
+# ─── Domain error ────────────────────────────────────────────────────────────
+
+class EmotionalDomainError(ValueError):
+    """Raised when an emotional domain invariant is violated."""
+
+
+# ─── Validation helpers ──────────────────────────────────────────────────────
+
+def _require_finite_float(value: object, name: str) -> float:
+    """
+    Returns ``float(value)`` when *value* is a finite real number.
+
+    Rejects: bool, None, str, list, dict, NaN, ±Inf.
+    """
+    if isinstance(value, bool):
+        raise EmotionalDomainError(
+            f"Field '{name}' must be a finite float, got bool ({value!r})."
+        )
+    if not isinstance(value, (int, float)):
+        raise EmotionalDomainError(
+            f"Field '{name}' must be a finite float, got {type(value).__name__} ({value!r})."
+        )
+    f = float(value)
+    if not math.isfinite(f):
+        raise EmotionalDomainError(
+            f"Field '{name}' must be finite, got {f!r}."
+        )
+    return f
+
+
+def _require_range(value: float, name: str, lo: float, hi: float) -> float:
+    """Raises if *value* is outside [lo, hi]."""
+    if value < lo or value > hi:
+        raise EmotionalDomainError(
+            f"Field '{name}' must be in [{lo}, {hi}], got {value!r}."
+        )
+    return value
+
+
+def _require_finite_float_in_range(value: object, name: str, lo: float, hi: float) -> float:
+    f = _require_finite_float(value, name)
+    return _require_range(f, name, lo, hi)
+
+
+def _require_positive_float(value: object, name: str) -> float:
+    """Used for timestamp: must be finite and positive."""
+    f = _require_finite_float(value, name)
+    if f <= 0:
+        raise EmotionalDomainError(
+            f"Field '{name}' must be a positive finite float (Unix epoch), got {f!r}."
+        )
+    return f
+
+
+# ─── EmotionalStateV1 ────────────────────────────────────────────────────────
+
+# Fields accepted by EmotionalStateV1 (used to detect unknown keys).
+_STATE_FIELDS: FrozenSet[str] = frozenset({
+    "pleasure",
+    "arousal",
+    "dominance",
+    "libido",
+    "aggression",
+    "connection",
+    "energy",
+    "tension",
+    "coping_mode",
+    "timestamp",
+    "schema_version",
+})
+
+
+@dataclass(frozen=True)
+class EmotionalStateV1:
+    """
+    Versioned, typed snapshot of the emotional state.
+
+    Construction
+    ============
+    Use ``EmotionalStateV1.create(...)`` or ``EmotionalStateV1.neutral()`` —
+    do NOT construct directly via ``EmotionalStateV1(...)`` unless you are
+    sure all arguments already satisfy invariants (e.g. in tests).
+
+    Fields
+    ======
+    PAD (Pleasure–Arousal–Dominance): float in [-1.0, 1.0]
+    Drives/System (libido…tension):   float in [0.0, 1.0]
+    coping_mode:                       one of VALID_COPING_MODES
+    timestamp:                         positive finite float (Unix epoch s)
+    schema_version:                    must equal EMOTIONAL_SCHEMA_VERSION
+    """
+
+    # PAD — bipolar [-1.0, +1.0]
+    pleasure: float = 0.0
+    arousal: float = 0.0
+    dominance: float = 0.0
+
+    # Drives / system — unipolar [0.0, 1.0]
+    libido: float = 0.0
+    aggression: float = 0.0
+    connection: float = 0.5
+    energy: float = 0.8
+    tension: float = 0.0
+
+    # Categorical
+    coping_mode: str = "HEALTHY"
+
+    # Metadata
+    timestamp: float = field(default=0.0)
+    schema_version: int = EMOTIONAL_SCHEMA_VERSION
+
+    # ── Factory methods ───────────────────────────────────────────────────────
+
+    @classmethod
+    def neutral(cls, timestamp: float = 1.0) -> "EmotionalStateV1":
+        """Return a valid neutral snapshot with all numeric fields at defaults."""
+        return cls.create(
+            pleasure=0.0,
+            arousal=0.0,
+            dominance=0.0,
+            libido=0.0,
+            aggression=0.0,
+            connection=0.5,
+            energy=0.8,
+            tension=0.0,
+            coping_mode="HEALTHY",
+            timestamp=timestamp,
+        )
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        pleasure: object,
+        arousal: object,
+        dominance: object,
+        libido: object,
+        aggression: object,
+        connection: object,
+        energy: object,
+        tension: object,
+        coping_mode: object,
+        timestamp: object,
+        schema_version: object = EMOTIONAL_SCHEMA_VERSION,
+    ) -> "EmotionalStateV1":
+        """
+        Validated factory. Raises EmotionalDomainError on any invariant violation.
+        """
+        # schema_version
+        if not isinstance(schema_version, int) or isinstance(schema_version, bool):
+            raise EmotionalDomainError(
+                f"schema_version must be an int, got {type(schema_version).__name__}."
+            )
+        if schema_version != EMOTIONAL_SCHEMA_VERSION:
+            raise EmotionalDomainError(
+                f"Unsupported schema_version {schema_version!r}. "
+                f"Expected {EMOTIONAL_SCHEMA_VERSION}."
+            )
+
+        # PAD [-1, 1]
+        p = _require_finite_float_in_range(pleasure, "pleasure", -1.0, 1.0)
+        a = _require_finite_float_in_range(arousal, "arousal", -1.0, 1.0)
+        d = _require_finite_float_in_range(dominance, "dominance", -1.0, 1.0)
+
+        # Drives [0, 1]
+        lib = _require_finite_float_in_range(libido, "libido", 0.0, 1.0)
+        agg = _require_finite_float_in_range(aggression, "aggression", 0.0, 1.0)
+        con = _require_finite_float_in_range(connection, "connection", 0.0, 1.0)
+        eng = _require_finite_float_in_range(energy, "energy", 0.0, 1.0)
+        ten = _require_finite_float_in_range(tension, "tension", 0.0, 1.0)
+
+        # coping_mode
+        if not isinstance(coping_mode, str):
+            raise EmotionalDomainError(
+                f"coping_mode must be a str, got {type(coping_mode).__name__}."
+            )
+        if coping_mode not in VALID_COPING_MODES:
+            raise EmotionalDomainError(
+                f"Unknown coping_mode {coping_mode!r}. "
+                f"Allowed: {sorted(VALID_COPING_MODES)}."
+            )
+
+        # timestamp
+        ts = _require_positive_float(timestamp, "timestamp")
+
+        return cls(
+            pleasure=p,
+            arousal=a,
+            dominance=d,
+            libido=lib,
+            aggression=agg,
+            connection=con,
+            energy=eng,
+            tension=ten,
+            coping_mode=coping_mode,
+            timestamp=ts,
+            schema_version=schema_version,
+        )
+
+    @classmethod
+    def from_dict(cls, data: object) -> "EmotionalStateV1":
+        """
+        Deserialise from a plain dict. Rejects unknown keys and missing
+        required fields, then delegates to ``create``.
+        """
+        if not isinstance(data, dict):
+            raise EmotionalDomainError(
+                f"Expected a dict, got {type(data).__name__}."
+            )
+
+        # Reject unknown keys
+        unknown = set(data.keys()) - _STATE_FIELDS
+        if unknown:
+            raise EmotionalDomainError(
+                f"Unknown fields in EmotionalStateV1 payload: {sorted(unknown)}."
+            )
+
+        # Require schema_version present
+        if "schema_version" not in data:
+            raise EmotionalDomainError(
+                "Field 'schema_version' is missing from EmotionalStateV1 payload."
+            )
+
+        required = _STATE_FIELDS - {"schema_version"}
+        missing = required - set(data.keys())
+        if missing:
+            raise EmotionalDomainError(
+                f"Missing required fields in EmotionalStateV1 payload: {sorted(missing)}."
+            )
+
+        return cls.create(
+            pleasure=data["pleasure"],
+            arousal=data["arousal"],
+            dominance=data["dominance"],
+            libido=data["libido"],
+            aggression=data["aggression"],
+            connection=data["connection"],
+            energy=data["energy"],
+            tension=data["tension"],
+            coping_mode=data["coping_mode"],
+            timestamp=data["timestamp"],
+            schema_version=data["schema_version"],
+        )
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialise to a plain dict suitable for JSON encoding."""
+        return {
+            "schema_version": self.schema_version,
+            "pleasure": self.pleasure,
+            "arousal": self.arousal,
+            "dominance": self.dominance,
+            "libido": self.libido,
+            "aggression": self.aggression,
+            "connection": self.connection,
+            "energy": self.energy,
+            "tension": self.tension,
+            "coping_mode": self.coping_mode,
+            "timestamp": self.timestamp,
+        }
+
+
+# ─── AppraisalV1 ─────────────────────────────────────────────────────────────
+
+_APPRAISAL_SCALAR_FIELDS: FrozenSet[str] = frozenset({
+    "valence_shift",
+    "arousal_shift",
+    "dominance_shift",
+    "schema_version",
+})
+
+_APPRAISAL_ALL_FIELDS: FrozenSet[str] = _APPRAISAL_SCALAR_FIELDS | {"discrete_emotions"}
+
+
+@dataclass(frozen=True)
+class AppraisalV1:
+    """
+    Versioned appraisal produced by cognitive evaluation of a message or event.
+
+    Fields
+    ======
+    valence_shift:   float in [-1.0, 1.0] — desired pleasure shift
+    arousal_shift:   float in [-1.0, 1.0] — desired arousal shift
+    dominance_shift: float in [-1.0, 1.0] — desired dominance shift
+    discrete_emotions: mapping from DISCRETE_EMOTIONS names to intensity [0.0, 1.0]
+                       Unknown keys are REJECTED.
+    schema_version:  must equal EMOTIONAL_SCHEMA_VERSION
+
+    Neutral appraisal
+    =================
+    All shifts are 0.0 and discrete_emotions is empty. Use ``AppraisalV1.neutral()``.
+    """
+
+    valence_shift: float = 0.0
+    arousal_shift: float = 0.0
+    dominance_shift: float = 0.0
+    discrete_emotions: Dict[str, float] = field(default_factory=dict)
+    schema_version: int = EMOTIONAL_SCHEMA_VERSION
+
+    # ── Factory methods ───────────────────────────────────────────────────────
+
+    @classmethod
+    def neutral(cls) -> "AppraisalV1":
+        """Return an explicitly neutral appraisal (all zeros, no emotions)."""
+        return cls(
+            valence_shift=0.0,
+            arousal_shift=0.0,
+            dominance_shift=0.0,
+            discrete_emotions={},
+            schema_version=EMOTIONAL_SCHEMA_VERSION,
+        )
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        valence_shift: object,
+        arousal_shift: object,
+        dominance_shift: object,
+        discrete_emotions: object = None,
+        schema_version: object = EMOTIONAL_SCHEMA_VERSION,
+    ) -> "AppraisalV1":
+        """
+        Validated factory. Raises EmotionalDomainError on any invariant violation.
+        """
+        # schema_version
+        if not isinstance(schema_version, int) or isinstance(schema_version, bool):
+            raise EmotionalDomainError(
+                f"schema_version must be an int, got {type(schema_version).__name__}."
+            )
+        if schema_version != EMOTIONAL_SCHEMA_VERSION:
+            raise EmotionalDomainError(
+                f"Unsupported schema_version {schema_version!r}. "
+                f"Expected {EMOTIONAL_SCHEMA_VERSION}."
+            )
+
+        # Scalar shifts [-1, 1]
+        vs = _require_finite_float_in_range(valence_shift, "valence_shift", -1.0, 1.0)
+        as_ = _require_finite_float_in_range(arousal_shift, "arousal_shift", -1.0, 1.0)
+        ds = _require_finite_float_in_range(dominance_shift, "dominance_shift", -1.0, 1.0)
+
+        # discrete_emotions
+        if discrete_emotions is None:
+            de: Dict[str, float] = {}
+        elif not isinstance(discrete_emotions, dict):
+            raise EmotionalDomainError(
+                f"discrete_emotions must be a dict, got {type(discrete_emotions).__name__}."
+            )
+        else:
+            de = {}
+            for emotion, intensity in discrete_emotions.items():
+                if not isinstance(emotion, str):
+                    raise EmotionalDomainError(
+                        f"Emotion key must be a str, got {type(emotion).__name__}."
+                    )
+                if emotion not in DISCRETE_EMOTIONS:
+                    raise EmotionalDomainError(
+                        f"Unknown discrete emotion {emotion!r}. "
+                        f"Allowed: {sorted(DISCRETE_EMOTIONS)}."
+                    )
+                de[emotion] = _require_finite_float_in_range(
+                    intensity, f"discrete_emotions[{emotion!r}]", 0.0, 1.0
+                )
+
+        return cls(
+            valence_shift=vs,
+            arousal_shift=as_,
+            dominance_shift=ds,
+            discrete_emotions=de,
+            schema_version=schema_version,
+        )
+
+    @classmethod
+    def from_dict(cls, data: object) -> "AppraisalV1":
+        """
+        Deserialise from a plain dict. Rejects unknown keys, missing required
+        fields, and any value that violates invariants.
+        """
+        if not isinstance(data, dict):
+            raise EmotionalDomainError(
+                f"Expected a dict, got {type(data).__name__}."
+            )
+
+        # Reject unknown keys
+        unknown = set(data.keys()) - _APPRAISAL_ALL_FIELDS
+        if unknown:
+            raise EmotionalDomainError(
+                f"Unknown fields in AppraisalV1 payload: {sorted(unknown)}."
+            )
+
+        # Require schema_version present
+        if "schema_version" not in data:
+            raise EmotionalDomainError(
+                "Field 'schema_version' is missing from AppraisalV1 payload."
+            )
+
+        required_scalars = {"valence_shift", "arousal_shift", "dominance_shift"}
+        missing = required_scalars - set(data.keys())
+        if missing:
+            raise EmotionalDomainError(
+                f"Missing required fields in AppraisalV1 payload: {sorted(missing)}."
+            )
+
+        return cls.create(
+            valence_shift=data["valence_shift"],
+            arousal_shift=data["arousal_shift"],
+            dominance_shift=data["dominance_shift"],
+            discrete_emotions=data.get("discrete_emotions"),
+            schema_version=data["schema_version"],
+        )
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialise to a plain dict suitable for JSON encoding."""
+        return {
+            "schema_version": self.schema_version,
+            "valence_shift": self.valence_shift,
+            "arousal_shift": self.arousal_shift,
+            "dominance_shift": self.dominance_shift,
+            "discrete_emotions": dict(self.discrete_emotions),
+        }

--- a/backend/emotional_domain/serialization.py
+++ b/backend/emotional_domain/serialization.py
@@ -1,0 +1,96 @@
+"""
+Stable JSON serialization and deserialization for domain models.
+
+Guarantees
+==========
+- Output always includes ``schema_version``.
+- Output contains only public domain fields (no prompt, metacognition, etc.).
+- Format is deterministic (sorted keys).
+- Round-trip: deserialise(serialise(obj)) produces an equivalent object.
+"""
+
+from __future__ import annotations
+
+import json
+
+from .models import EmotionalStateV1, AppraisalV1, EmotionalDomainError
+
+
+def serialize_state(state: EmotionalStateV1) -> str:
+    """
+    Serialise an ``EmotionalStateV1`` to a deterministic JSON string.
+
+    Parameters
+    ----------
+    state:
+        A valid ``EmotionalStateV1`` instance.
+
+    Returns
+    -------
+    str
+        JSON-encoded string with sorted keys.
+    """
+    if not isinstance(state, EmotionalStateV1):
+        raise EmotionalDomainError(
+            f"serialize_state: expected EmotionalStateV1, got {type(state).__name__}."
+        )
+    return json.dumps(state.to_dict(), sort_keys=True)
+
+
+def deserialize_state(payload: str) -> EmotionalStateV1:
+    """
+    Deserialise a JSON string produced by ``serialize_state`` back to
+    ``EmotionalStateV1``.
+
+    Raises
+    ------
+    EmotionalDomainError
+        If the JSON is malformed or the payload violates any invariant.
+    """
+    if not isinstance(payload, str):
+        raise EmotionalDomainError(
+            f"deserialize_state: expected a str, got {type(payload).__name__}."
+        )
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise EmotionalDomainError(
+            f"deserialize_state: invalid JSON — {exc}."
+        ) from exc
+
+    return EmotionalStateV1.from_dict(data)
+
+
+def serialize_appraisal(appraisal: AppraisalV1) -> str:
+    """
+    Serialise an ``AppraisalV1`` to a deterministic JSON string.
+    """
+    if not isinstance(appraisal, AppraisalV1):
+        raise EmotionalDomainError(
+            f"serialize_appraisal: expected AppraisalV1, got {type(appraisal).__name__}."
+        )
+    return json.dumps(appraisal.to_dict(), sort_keys=True)
+
+
+def deserialize_appraisal(payload: str) -> AppraisalV1:
+    """
+    Deserialise a JSON string produced by ``serialize_appraisal`` back to
+    ``AppraisalV1``.
+
+    Raises
+    ------
+    EmotionalDomainError
+        If the JSON is malformed or the payload violates any invariant.
+    """
+    if not isinstance(payload, str):
+        raise EmotionalDomainError(
+            f"deserialize_appraisal: expected a str, got {type(payload).__name__}."
+        )
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise EmotionalDomainError(
+            f"deserialize_appraisal: invalid JSON — {exc}."
+        ) from exc
+
+    return AppraisalV1.from_dict(data)

--- a/backend/tests/test_emotional_domain.py
+++ b/backend/tests/test_emotional_domain.py
@@ -1,0 +1,787 @@
+"""
+Tests for backend/emotional_domain — issue #232.
+
+Coverage map (issue requirements):
+ 1. Round-trip EmotionalStateV1           → test_state_round_trip
+ 2. Round-trip AppraisalV1               → test_appraisal_round_trip
+ 3. Version absent is rejected           → test_state_missing_version, test_appraisal_missing_version
+ 4. Unknown version is rejected          → test_state_unknown_version, test_appraisal_unknown_version
+ 5. bool/None/str/list/dict rejected     → test_state_invalid_types, test_appraisal_invalid_types
+ 6. NaN/Inf rejected                     → test_state_nan_inf, test_appraisal_nan_inf
+ 7. Out-of-range values follow policy    → test_state_out_of_range, test_appraisal_out_of_range
+ 8. Unknown keys not silently accepted   → test_state_unknown_keys, test_appraisal_unknown_keys
+ 9. Discrete emotion allowlist is exact  → test_discrete_emotion_allowlist
+10. Unknown emotion rejected             → test_appraisal_unknown_emotion_rejected
+11. Coping mode unknown rejected         → test_unknown_coping_mode
+12. Timestamp invalid rejected           → test_invalid_timestamp
+13. Legacy migration valid → v1 correct  → test_migration_valid_legacy
+14. Legacy invalid fails closed          → test_migration_invalid_legacy
+15. Migration does not mutate input      → test_migration_no_mutation
+16. Invalid appraisal → neutral fallback → test_parse_llm_appraisal_fallback
+17. Domain importable without infra      → test_domain_import_isolation
+18. No network use                       → (structural: no network calls in any test)
+19. Existing backend suite passes        → (verified by running full suite externally)
+20. CI remains green                     → (verified by CI after PR)
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import math
+import sys
+import time
+from typing import Any
+
+import pytest
+
+from backend.emotional_domain.models import (
+    DISCRETE_EMOTIONS,
+    EMOTIONAL_SCHEMA_VERSION,
+    VALID_COPING_MODES,
+    AppraisalV1,
+    EmotionalDomainError,
+    EmotionalStateV1,
+)
+from backend.emotional_domain.migration import migrate_legacy_snapshot
+from backend.emotional_domain.serialization import (
+    deserialize_appraisal,
+    deserialize_state,
+    serialize_appraisal,
+    serialize_state,
+)
+from backend.emotional_domain.appraisal_parser import parse_llm_appraisal, ParseResult
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+def _valid_state_dict(**overrides: Any) -> dict:
+    base = {
+        "schema_version": EMOTIONAL_SCHEMA_VERSION,
+        "pleasure": 0.1,
+        "arousal": -0.2,
+        "dominance": 0.3,
+        "libido": 0.0,
+        "aggression": 0.1,
+        "connection": 0.5,
+        "energy": 0.8,
+        "tension": 0.2,
+        "coping_mode": "HEALTHY",
+        "timestamp": 1_700_000_000.0,
+    }
+    base.update(overrides)
+    return base
+
+
+def _valid_appraisal_dict(**overrides: Any) -> dict:
+    base = {
+        "schema_version": EMOTIONAL_SCHEMA_VERSION,
+        "valence_shift": 0.2,
+        "arousal_shift": -0.1,
+        "dominance_shift": 0.0,
+        "discrete_emotions": {"joy": 0.5, "trust": 0.3},
+    }
+    base.update(overrides)
+    return base
+
+
+def _legacy_dict(**overrides: Any) -> dict:
+    base = {
+        "pleasure": 0.1,
+        "arousal": -0.2,
+        "dominance": 0.3,
+        "libido": 0.0,
+        "aggression": 0.1,
+        "connection": 0.5,
+        "energy": 0.8,
+        "tension": 0.2,
+        "coping_mode": "HEALTHY",
+        "last_update": 1_700_000_000.0,
+    }
+    base.update(overrides)
+    return base
+
+
+# ─── 1 & 2: Round-trips ──────────────────────────────────────────────────────
+
+class TestStateRoundTrip:
+    """Requirement 1: round-trip EmotionalStateV1."""
+
+    def test_to_dict_from_dict(self):
+        state = EmotionalStateV1.from_dict(_valid_state_dict())
+        reconstructed = EmotionalStateV1.from_dict(state.to_dict())
+        assert state == reconstructed
+
+    def test_serialize_deserialize(self):
+        state = EmotionalStateV1.from_dict(_valid_state_dict())
+        json_str = serialize_state(state)
+        reconstructed = deserialize_state(json_str)
+        assert state == reconstructed
+
+    def test_json_includes_schema_version(self):
+        state = EmotionalStateV1.from_dict(_valid_state_dict())
+        data = json.loads(serialize_state(state))
+        assert data["schema_version"] == EMOTIONAL_SCHEMA_VERSION
+
+    def test_json_sorted_keys(self):
+        state = EmotionalStateV1.from_dict(_valid_state_dict())
+        json_str = serialize_state(state)
+        keys = list(json.loads(json_str).keys())
+        assert keys == sorted(keys)
+
+    def test_json_no_extra_fields(self):
+        state = EmotionalStateV1.from_dict(_valid_state_dict())
+        data = json.loads(serialize_state(state))
+        expected_keys = {
+            "schema_version", "pleasure", "arousal", "dominance",
+            "libido", "aggression", "connection", "energy", "tension",
+            "coping_mode", "timestamp",
+        }
+        assert set(data.keys()) == expected_keys
+
+    def test_neutral_round_trip(self):
+        state = EmotionalStateV1.neutral(timestamp=1.0)
+        reconstructed = EmotionalStateV1.from_dict(state.to_dict())
+        assert state == reconstructed
+
+
+class TestAppraisalRoundTrip:
+    """Requirement 2: round-trip AppraisalV1."""
+
+    def test_to_dict_from_dict(self):
+        appraisal = AppraisalV1.from_dict(_valid_appraisal_dict())
+        reconstructed = AppraisalV1.from_dict(appraisal.to_dict())
+        assert appraisal == reconstructed
+
+    def test_serialize_deserialize(self):
+        appraisal = AppraisalV1.from_dict(_valid_appraisal_dict())
+        json_str = serialize_appraisal(appraisal)
+        reconstructed = deserialize_appraisal(json_str)
+        assert appraisal == reconstructed
+
+    def test_json_includes_schema_version(self):
+        appraisal = AppraisalV1.from_dict(_valid_appraisal_dict())
+        data = json.loads(serialize_appraisal(appraisal))
+        assert data["schema_version"] == EMOTIONAL_SCHEMA_VERSION
+
+    def test_json_no_extra_fields(self):
+        appraisal = AppraisalV1.from_dict(_valid_appraisal_dict())
+        data = json.loads(serialize_appraisal(appraisal))
+        expected_keys = {
+            "schema_version", "valence_shift", "arousal_shift",
+            "dominance_shift", "discrete_emotions",
+        }
+        assert set(data.keys()) == expected_keys
+
+    def test_neutral_round_trip(self):
+        neutral = AppraisalV1.neutral()
+        reconstructed = AppraisalV1.from_dict(neutral.to_dict())
+        assert neutral == reconstructed
+
+    def test_neutral_all_zeros(self):
+        neutral = AppraisalV1.neutral()
+        assert neutral.valence_shift == 0.0
+        assert neutral.arousal_shift == 0.0
+        assert neutral.dominance_shift == 0.0
+        assert neutral.discrete_emotions == {}
+        assert neutral.schema_version == EMOTIONAL_SCHEMA_VERSION
+
+
+# ─── 3: Version absent rejected ──────────────────────────────────────────────
+
+class TestMissingVersion:
+    """Requirement 3: absent schema_version is rejected."""
+
+    def test_state_missing_version(self):
+        d = _valid_state_dict()
+        del d["schema_version"]
+        with pytest.raises(EmotionalDomainError, match="schema_version"):
+            EmotionalStateV1.from_dict(d)
+
+    def test_appraisal_missing_version(self):
+        d = _valid_appraisal_dict()
+        del d["schema_version"]
+        with pytest.raises(EmotionalDomainError, match="schema_version"):
+            AppraisalV1.from_dict(d)
+
+
+# ─── 4: Unknown version rejected ─────────────────────────────────────────────
+
+class TestUnknownVersion:
+    """Requirement 4: unrecognised schema_version is rejected."""
+
+    @pytest.mark.parametrize("bad_version", [0, 2, 99, -1])
+    def test_state_unknown_version(self, bad_version):
+        d = _valid_state_dict(schema_version=bad_version)
+        with pytest.raises(EmotionalDomainError, match="schema_version|Unsupported"):
+            EmotionalStateV1.from_dict(d)
+
+    @pytest.mark.parametrize("bad_version", [0, 2, 99, -1])
+    def test_appraisal_unknown_version(self, bad_version):
+        d = _valid_appraisal_dict(schema_version=bad_version)
+        with pytest.raises(EmotionalDomainError, match="schema_version|Unsupported"):
+            AppraisalV1.from_dict(d)
+
+
+# ─── 5: Invalid types rejected ───────────────────────────────────────────────
+
+_STATE_NUMERIC_FIELDS = [
+    "pleasure", "arousal", "dominance",
+    "libido", "aggression", "connection", "energy", "tension",
+]
+_APPRAISAL_NUMERIC_FIELDS = ["valence_shift", "arousal_shift", "dominance_shift"]
+
+
+class TestInvalidTypesState:
+    """Requirement 5: bool, None, str, list, dict rejected for EmotionalStateV1 fields."""
+
+    @pytest.mark.parametrize("field_name", _STATE_NUMERIC_FIELDS)
+    @pytest.mark.parametrize("bad_value", [True, False, None, "0.5", [0.5], {"v": 0.5}])
+    def test_state_rejects_bad_type(self, field_name, bad_value):
+        d = _valid_state_dict(**{field_name: bad_value})
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.from_dict(d)
+
+    def test_state_rejects_bool_schema_version(self):
+        d = _valid_state_dict(schema_version=True)
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.from_dict(d)
+
+    def test_state_rejects_none_coping_mode(self):
+        d = _valid_state_dict(coping_mode=None)
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.from_dict(d)
+
+
+class TestInvalidTypesAppraisal:
+    """Requirement 5: bool, None, str, list, dict rejected for AppraisalV1 fields."""
+
+    @pytest.mark.parametrize("field_name", _APPRAISAL_NUMERIC_FIELDS)
+    @pytest.mark.parametrize("bad_value", [True, False, None, "0.5", [0.5], {"v": 0.5}])
+    def test_appraisal_rejects_bad_type(self, field_name, bad_value):
+        d = _valid_appraisal_dict(**{field_name: bad_value})
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1.from_dict(d)
+
+    def test_appraisal_rejects_bool_intensity(self):
+        d = _valid_appraisal_dict(discrete_emotions={"joy": True})
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1.from_dict(d)
+
+    def test_appraisal_rejects_none_intensity(self):
+        d = _valid_appraisal_dict(discrete_emotions={"joy": None})
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1.from_dict(d)
+
+    def test_appraisal_rejects_str_intensity(self):
+        d = _valid_appraisal_dict(discrete_emotions={"joy": "0.5"})
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1.from_dict(d)
+
+
+# ─── 6: NaN / Inf rejected ───────────────────────────────────────────────────
+
+class TestNanInf:
+    """Requirement 6: NaN and ±Inf are rejected."""
+
+    @pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+    @pytest.mark.parametrize("field_name", _STATE_NUMERIC_FIELDS)
+    def test_state_nan_inf(self, field_name, bad_value):
+        d = _valid_state_dict(**{field_name: bad_value})
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.from_dict(d)
+
+    @pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+    @pytest.mark.parametrize("field_name", _APPRAISAL_NUMERIC_FIELDS)
+    def test_appraisal_nan_inf(self, field_name, bad_value):
+        d = _valid_appraisal_dict(**{field_name: bad_value})
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1.from_dict(d)
+
+    @pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+    def test_appraisal_nan_inf_intensity(self, bad_value):
+        d = _valid_appraisal_dict(discrete_emotions={"joy": bad_value})
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1.from_dict(d)
+
+
+# ─── 7: Out-of-range values ───────────────────────────────────────────────────
+
+class TestOutOfRange:
+    """Requirement 7: out-of-range values are rejected (policy: reject, not clamp)."""
+
+    @pytest.mark.parametrize("field_name,lo,hi", [
+        ("pleasure", -1.0, 1.0),
+        ("arousal", -1.0, 1.0),
+        ("dominance", -1.0, 1.0),
+    ])
+    @pytest.mark.parametrize("bad_value", [-1.001, 1.001, -2.0, 2.0])
+    def test_state_pad_out_of_range(self, field_name, lo, hi, bad_value):
+        d = _valid_state_dict(**{field_name: bad_value})
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.from_dict(d)
+
+    @pytest.mark.parametrize("field_name", ["libido", "aggression", "connection", "energy", "tension"])
+    @pytest.mark.parametrize("bad_value", [-0.001, 1.001, -1.0, 2.0])
+    def test_state_drives_out_of_range(self, field_name, bad_value):
+        d = _valid_state_dict(**{field_name: bad_value})
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.from_dict(d)
+
+    @pytest.mark.parametrize("field_name", _APPRAISAL_NUMERIC_FIELDS)
+    @pytest.mark.parametrize("bad_value", [-1.001, 1.001, -2.0, 2.0])
+    def test_appraisal_shifts_out_of_range(self, field_name, bad_value):
+        d = _valid_appraisal_dict(**{field_name: bad_value})
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1.from_dict(d)
+
+    @pytest.mark.parametrize("bad_value", [-0.001, 1.001])
+    def test_appraisal_intensity_out_of_range(self, bad_value):
+        d = _valid_appraisal_dict(discrete_emotions={"joy": bad_value})
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1.from_dict(d)
+
+    def test_state_boundary_values_accepted(self):
+        """Boundary values -1.0, 0.0, 1.0 are valid."""
+        d = _valid_state_dict(pleasure=-1.0, arousal=0.0, dominance=1.0)
+        state = EmotionalStateV1.from_dict(d)
+        assert state.pleasure == -1.0
+        assert state.dominance == 1.0
+
+    def test_appraisal_boundary_values_accepted(self):
+        d = _valid_appraisal_dict(valence_shift=-1.0, arousal_shift=0.0, dominance_shift=1.0)
+        appraisal = AppraisalV1.from_dict(d)
+        assert appraisal.valence_shift == -1.0
+
+
+# ─── 8: Unknown keys not silently accepted ───────────────────────────────────
+
+class TestUnknownKeys:
+    """Requirement 8: unknown keys are rejected, not silently dropped."""
+
+    def test_state_rejects_unknown_key(self):
+        d = _valid_state_dict()
+        d["unknown_field"] = 42
+        with pytest.raises(EmotionalDomainError, match="Unknown fields"):
+            EmotionalStateV1.from_dict(d)
+
+    def test_appraisal_rejects_unknown_key(self):
+        d = _valid_appraisal_dict()
+        d["extra"] = "value"
+        with pytest.raises(EmotionalDomainError, match="Unknown fields"):
+            AppraisalV1.from_dict(d)
+
+    def test_state_rejects_prompt_field(self):
+        d = _valid_state_dict(system_prompt="do evil things")
+        with pytest.raises(EmotionalDomainError, match="Unknown fields"):
+            EmotionalStateV1.from_dict(d)
+
+    def test_state_rejects_memory_field(self):
+        d = _valid_state_dict(memory=[])
+        with pytest.raises(EmotionalDomainError, match="Unknown fields"):
+            EmotionalStateV1.from_dict(d)
+
+
+# ─── 9 & 10: Discrete emotion allowlist ──────────────────────────────────────
+
+class TestDiscreteEmotionAllowlist:
+    """Requirements 9 & 10: discrete emotion allowlist is exact; unknown rejected."""
+
+    def test_allowlist_is_exact(self):
+        expected = frozenset({
+            "joy", "sadness", "anger", "fear",
+            "disgust", "surprise", "trust", "anticipation",
+        })
+        assert DISCRETE_EMOTIONS == expected
+
+    def test_all_known_emotions_accepted(self):
+        emotions = {e: 0.5 for e in DISCRETE_EMOTIONS}
+        d = _valid_appraisal_dict(discrete_emotions=emotions)
+        appraisal = AppraisalV1.from_dict(d)
+        assert set(appraisal.discrete_emotions.keys()) == DISCRETE_EMOTIONS
+
+    def test_unknown_emotion_rejected(self):
+        d = _valid_appraisal_dict(discrete_emotions={"unknown_emotion": 0.5})
+        with pytest.raises(EmotionalDomainError, match="Unknown discrete emotion"):
+            AppraisalV1.from_dict(d)
+
+    def test_partially_unknown_emotion_rejected(self):
+        d = _valid_appraisal_dict(discrete_emotions={"joy": 0.5, "invalid": 0.3})
+        with pytest.raises(EmotionalDomainError, match="Unknown discrete emotion"):
+            AppraisalV1.from_dict(d)
+
+    def test_empty_discrete_emotions_accepted(self):
+        d = _valid_appraisal_dict(discrete_emotions={})
+        appraisal = AppraisalV1.from_dict(d)
+        assert appraisal.discrete_emotions == {}
+
+    def test_zero_intensity_accepted(self):
+        d = _valid_appraisal_dict(discrete_emotions={"joy": 0.0})
+        appraisal = AppraisalV1.from_dict(d)
+        assert appraisal.discrete_emotions["joy"] == 0.0
+
+    def test_max_intensity_accepted(self):
+        d = _valid_appraisal_dict(discrete_emotions={"anger": 1.0})
+        appraisal = AppraisalV1.from_dict(d)
+        assert appraisal.discrete_emotions["anger"] == 1.0
+
+
+# ─── 11: Coping mode allowlist ───────────────────────────────────────────────
+
+class TestCopingMode:
+    """Requirement 11: unknown coping_mode is rejected."""
+
+    @pytest.mark.parametrize("mode", sorted(VALID_COPING_MODES))
+    def test_known_coping_modes_accepted(self, mode):
+        d = _valid_state_dict(coping_mode=mode)
+        state = EmotionalStateV1.from_dict(d)
+        assert state.coping_mode == mode
+
+    @pytest.mark.parametrize("bad_mode", ["PANIC", "NORMAL", "healthy", "FREEZE", "", "0"])
+    def test_unknown_coping_mode_rejected(self, bad_mode):
+        d = _valid_state_dict(coping_mode=bad_mode)
+        with pytest.raises(EmotionalDomainError, match="coping_mode|Unknown"):
+            EmotionalStateV1.from_dict(d)
+
+    def test_coping_mode_allowlist_is_exact(self):
+        expected = frozenset({"HEALTHY", "DEFENSIVE", "DISSOCIATED", "MANIC"})
+        assert VALID_COPING_MODES == expected
+
+
+# ─── 12: Timestamp ───────────────────────────────────────────────────────────
+
+class TestTimestamp:
+    """Requirement 12: invalid timestamp is rejected."""
+
+    def test_valid_timestamp_accepted(self):
+        d = _valid_state_dict(timestamp=1_700_000_000.0)
+        state = EmotionalStateV1.from_dict(d)
+        assert state.timestamp == 1_700_000_000.0
+
+    def test_zero_timestamp_rejected(self):
+        d = _valid_state_dict(timestamp=0.0)
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.from_dict(d)
+
+    def test_negative_timestamp_rejected(self):
+        d = _valid_state_dict(timestamp=-1.0)
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.from_dict(d)
+
+    def test_nan_timestamp_rejected(self):
+        d = _valid_state_dict(timestamp=float("nan"))
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.from_dict(d)
+
+    def test_inf_timestamp_rejected(self):
+        d = _valid_state_dict(timestamp=float("inf"))
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.from_dict(d)
+
+    def test_string_timestamp_rejected(self):
+        d = _valid_state_dict(timestamp="2024-01-01")
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.from_dict(d)
+
+    def test_bool_timestamp_rejected(self):
+        d = _valid_state_dict(timestamp=True)
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.from_dict(d)
+
+    def test_none_timestamp_rejected(self):
+        d = _valid_state_dict(timestamp=None)
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.from_dict(d)
+
+
+# ─── 13: Migration valid legacy ──────────────────────────────────────────────
+
+class TestMigrationValidLegacy:
+    """Requirement 13: valid legacy snapshot → correct v1 model."""
+
+    def test_basic_migration(self):
+        legacy = _legacy_dict()
+        result = migrate_legacy_snapshot(legacy)
+        assert isinstance(result, EmotionalStateV1)
+        assert result.schema_version == EMOTIONAL_SCHEMA_VERSION
+
+    def test_field_mapping(self):
+        legacy = _legacy_dict(
+            pleasure=0.5,
+            arousal=-0.3,
+            dominance=0.2,
+            last_update=1_700_000_000.0,
+        )
+        result = migrate_legacy_snapshot(legacy)
+        assert result.pleasure == 0.5
+        assert result.arousal == -0.3
+        assert result.dominance == 0.2
+        assert result.timestamp == 1_700_000_000.0
+
+    def test_last_update_becomes_timestamp(self):
+        ts = 1_700_123_456.789
+        legacy = _legacy_dict(last_update=ts)
+        result = migrate_legacy_snapshot(legacy)
+        assert result.timestamp == ts
+
+    def test_all_fields_preserved(self):
+        legacy = _legacy_dict(
+            libido=0.4, aggression=0.2, connection=0.7,
+            energy=0.9, tension=0.1, coping_mode="DEFENSIVE",
+        )
+        result = migrate_legacy_snapshot(legacy)
+        assert result.libido == 0.4
+        assert result.aggression == 0.2
+        assert result.connection == 0.7
+        assert result.energy == 0.9
+        assert result.tension == 0.1
+        assert result.coping_mode == "DEFENSIVE"
+
+    def test_v1_snapshot_idempotent(self):
+        """A v1 snapshot passed to migrate is re-validated and returned."""
+        state = EmotionalStateV1.from_dict(_valid_state_dict())
+        v1_dict = state.to_dict()
+        result = migrate_legacy_snapshot(v1_dict)
+        assert result == state
+
+
+# ─── 14: Legacy invalid fails closed ─────────────────────────────────────────
+
+class TestMigrationInvalidLegacy:
+    """Requirement 14: invalid legacy snapshot fails closed (raises)."""
+
+    def test_non_dict_rejected(self):
+        for bad in [None, "string", 42, [], ()]:
+            with pytest.raises(EmotionalDomainError):
+                migrate_legacy_snapshot(bad)
+
+    def test_missing_last_update_rejected(self):
+        legacy = _legacy_dict()
+        del legacy["last_update"]
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(legacy)
+
+    def test_missing_pleasure_rejected(self):
+        legacy = _legacy_dict()
+        del legacy["pleasure"]
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(legacy)
+
+    def test_invalid_value_rejected(self):
+        legacy = _legacy_dict(pleasure="invalid")
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(legacy)
+
+    def test_out_of_range_rejected(self):
+        legacy = _legacy_dict(pleasure=99.0)
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(legacy)
+
+    def test_unknown_schema_version_rejected(self):
+        legacy = _legacy_dict()
+        legacy["schema_version"] = 999
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(legacy)
+
+    def test_empty_dict_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot({})
+
+
+# ─── 15: Migration does not mutate input ─────────────────────────────────────
+
+class TestMigrationNoMutation:
+    """Requirement 15: migration never mutates the input dict."""
+
+    def test_input_not_mutated(self):
+        import copy
+        legacy = _legacy_dict()
+        original = copy.deepcopy(legacy)
+        migrate_legacy_snapshot(legacy)
+        assert legacy == original
+
+    def test_input_not_mutated_on_v1(self):
+        import copy
+        v1 = _valid_state_dict()
+        original = copy.deepcopy(v1)
+        migrate_legacy_snapshot(v1)
+        assert v1 == original
+
+
+# ─── 16: Invalid appraisal → explicit neutral fallback ───────────────────────
+
+class TestAppraisalParserFallback:
+    """Requirement 16: invalid LLM appraisal produces observable neutral fallback."""
+
+    def test_valid_dict_parses_correctly(self):
+        raw = {
+            "valence_shift": 0.3,
+            "arousal_shift": -0.1,
+            "dominance_shift": 0.0,
+            "discrete_emotions": {"joy": 0.7},
+        }
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback
+        assert result.error is None
+        assert result.appraisal.valence_shift == 0.3
+        assert result.appraisal.discrete_emotions["joy"] == 0.7
+
+    def test_none_produces_fallback(self):
+        result = parse_llm_appraisal(None)
+        assert result.is_fallback
+        assert result.error is not None
+        assert result.appraisal == AppraisalV1.neutral()
+
+    def test_string_produces_fallback(self):
+        result = parse_llm_appraisal("bad output")
+        assert result.is_fallback
+        assert result.appraisal == AppraisalV1.neutral()
+
+    def test_out_of_range_produces_fallback(self):
+        result = parse_llm_appraisal({"valence_shift": 99.0, "arousal_shift": 0.0, "dominance_shift": 0.0})
+        assert result.is_fallback
+        assert result.appraisal == AppraisalV1.neutral()
+
+    def test_nan_produces_fallback(self):
+        result = parse_llm_appraisal({"valence_shift": float("nan"), "arousal_shift": 0.0, "dominance_shift": 0.0})
+        assert result.is_fallback
+        assert result.appraisal == AppraisalV1.neutral()
+
+    def test_bool_shift_produces_fallback(self):
+        result = parse_llm_appraisal({"valence_shift": True, "arousal_shift": 0.0, "dominance_shift": 0.0})
+        assert result.is_fallback
+        assert result.appraisal == AppraisalV1.neutral()
+
+    def test_unknown_emotion_silently_dropped(self):
+        """LLM output with unknown emotions: unknown keys are filtered, not rejected."""
+        raw = {
+            "valence_shift": 0.1,
+            "arousal_shift": 0.0,
+            "dominance_shift": 0.0,
+            "discrete_emotions": {"joy": 0.5, "invented_emotion": 0.9},
+        }
+        result = parse_llm_appraisal(raw)
+        # Should succeed, filtering out the unknown emotion
+        assert not result.is_fallback
+        assert "invented_emotion" not in result.appraisal.discrete_emotions
+        assert "joy" in result.appraisal.discrete_emotions
+
+    def test_missing_shifts_default_to_zero(self):
+        """Missing shift keys default to 0.0 (LLM may omit them)."""
+        raw = {}
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback
+        assert result.appraisal.valence_shift == 0.0
+        assert result.appraisal.arousal_shift == 0.0
+
+    def test_fallback_neutral_has_correct_schema_version(self):
+        result = parse_llm_appraisal(None)
+        assert result.appraisal.schema_version == EMOTIONAL_SCHEMA_VERSION
+
+    def test_legacy_key_valence_accepted(self):
+        """'valence' (without _shift) is accepted as alias for 'valence_shift'."""
+        raw = {"valence": 0.3, "arousal_shift": 0.0, "dominance_shift": 0.0}
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback
+        assert result.appraisal.valence_shift == 0.3
+
+    def test_parse_result_is_not_empty_dict(self):
+        """Neutral fallback is an explicit AppraisalV1, not an empty dict."""
+        result = parse_llm_appraisal("garbage")
+        assert isinstance(result.appraisal, AppraisalV1)
+        assert result.appraisal == AppraisalV1.neutral()
+
+
+# ─── 17: Domain importable without infrastructure ────────────────────────────
+
+class TestDomainImportIsolation:
+    """Requirement 17: domain module importable without FastAPI/Groq/Supabase/transformers."""
+
+    def test_models_importable_without_fastapi(self):
+        """
+        Import the module from scratch (bypass cache) and verify it doesn't
+        pull in FastAPI.
+        """
+        # If fastapi is not installed, the import would fail if it were a dependency.
+        # We verify that importing emotional_domain does not import fastapi.
+        import backend.emotional_domain.models as m
+        # Check that fastapi is not imported as a side effect
+        assert "fastapi" not in sys.modules or True  # fastapi may be installed but not required
+
+        # The real test: the module must be importable and functional
+        assert hasattr(m, "EmotionalStateV1")
+        assert hasattr(m, "AppraisalV1")
+        assert hasattr(m, "EMOTIONAL_SCHEMA_VERSION")
+
+    def test_no_groq_import(self):
+        import backend.emotional_domain.models as m
+        import inspect
+        source = inspect.getsource(m)
+        assert "groq" not in source.lower()
+
+    def test_no_supabase_import(self):
+        import backend.emotional_domain.models as m
+        import inspect
+        source = inspect.getsource(m)
+        assert "supabase" not in source.lower()
+
+    def test_no_sentence_transformers_import(self):
+        import backend.emotional_domain.models as m
+        import inspect
+        source = inspect.getsource(m)
+        assert "sentence_transformers" not in source.lower()
+
+    def test_no_fastapi_import(self):
+        import backend.emotional_domain.models as m
+        import inspect
+        source = inspect.getsource(m)
+        assert "fastapi" not in source.lower()
+
+    def test_no_os_environ_access(self):
+        """Domain module must not read environment variables."""
+        import backend.emotional_domain.models as m
+        import inspect
+        source = inspect.getsource(m)
+        assert "os.environ" not in source
+        assert "os.getenv" not in source
+
+    def test_migration_no_io(self):
+        import backend.emotional_domain.migration as mig
+        import inspect
+        source = inspect.getsource(mig)
+        # No file I/O or network
+        assert "open(" not in source
+        assert "urllib" not in source
+        assert "requests" not in source
+
+
+# ─── Serialization edge cases ────────────────────────────────────────────────
+
+class TestSerializationEdgeCases:
+    """Additional serialization guarantees."""
+
+    def test_deserialize_state_rejects_non_string(self):
+        with pytest.raises(EmotionalDomainError):
+            deserialize_state(42)
+
+    def test_deserialize_state_rejects_bad_json(self):
+        with pytest.raises(EmotionalDomainError):
+            deserialize_state("{not json}")
+
+    def test_deserialize_appraisal_rejects_non_string(self):
+        with pytest.raises(EmotionalDomainError):
+            deserialize_appraisal(None)
+
+    def test_serialize_state_rejects_wrong_type(self):
+        with pytest.raises(EmotionalDomainError):
+            serialize_state("not a state")
+
+    def test_serialize_appraisal_rejects_wrong_type(self):
+        with pytest.raises(EmotionalDomainError):
+            serialize_appraisal({"valence": 0.1})
+
+    def test_deterministic_output(self):
+        state = EmotionalStateV1.from_dict(_valid_state_dict())
+        s1 = serialize_state(state)
+        s2 = serialize_state(state)
+        assert s1 == s2

--- a/backend/tests/test_emotional_domain.py
+++ b/backend/tests/test_emotional_domain.py
@@ -65,12 +65,20 @@ O4.  Huge int in appraisal shift → EmotionalDomainError
 O5.  Huge int in emotion intensity → EmotionalDomainError
 O6.  Legacy migration with huge int → EmotionalDomainError
 O7.  Parser maps huge int to invalid_numeric_value (not unexpected_parser_failure)
-B1.  valence=True vs valence_shift=1 → conflicting_aliases
-B2.  valence=False vs valence_shift=0 → conflicting_aliases
-B3.  triggered_emotions with bool joy vs discrete_emotions with int joy → conflicting_aliases
-B4.  triggered_emotions with bool False vs discrete_emotions with int 0 → conflicting_aliases
+B1.  valence=True vs valence_shift=1 → invalid_numeric_value (bool invalid)
+B2.  valence=False vs valence_shift=0 → invalid_numeric_value (bool invalid)
+B3.  triggered_emotions with bool joy vs discrete_emotions with int joy → invalid_numeric_value
+B4.  triggered_emotions with bool False vs discrete_emotions with int 0 → invalid_numeric_value
 B5.  Both aliases equally invalid → predictable fallback (invalid_numeric_value)
 B6.  1 vs 1.0 policy: int/float equivalence accepted (not rejected)
+
+Hardening (v1.4 — fourth audit / alias validation+normalisation):
+C1.  Aliases differing only by filtered unknown emotions → equivalent (accepted)
+C2.  Alias valid, canonical invalid shift → invalid_numeric_value (not conflicting_aliases)
+C3.  Alias invalid, canonical valid shift → invalid_numeric_value
+C4.  Alias valid, canonical invalid emotions → unsupported_emotion
+C5.  Known+unknown emotions normalise to same known set → accepted
+C6.  int/float equivalence after normalisation → accepted
 """
 
 from __future__ import annotations
@@ -1689,25 +1697,27 @@ class TestOverflowError:
 
 class TestBoolAliasEquivalence:
     """
-    B1-B6 — bool and int must not be treated as equivalent in alias checking.
-    True == 1 and False == 0 in Python, which would otherwise allow bypass.
+    B1-B6 — Alias comparison now validates each side independently.
+    Bool values are invalid numeric types, so they produce validation
+    error codes (invalid_numeric_value / unsupported_emotion), not
+    conflicting_aliases.
     """
 
     _BASE = {"arousal_shift": 0.0, "dominance_shift": 0.0}
 
-    # B1: valence=True, valence_shift=1 → conflicting_aliases
+    # B1: valence=True, valence_shift=1 → invalid_numeric_value (bool invalid)
     def test_valence_true_vs_int_one(self):
         raw = {"valence": True, "valence_shift": 1, **self._BASE}
         result = parse_llm_appraisal(raw)
         assert result.is_fallback
-        assert result.error_code == ParseErrorCode.conflicting_aliases
+        assert result.error_code == ParseErrorCode.invalid_numeric_value
 
-    # B2: valence=False, valence_shift=0 → conflicting_aliases
+    # B2: valence=False, valence_shift=0 → invalid_numeric_value (bool invalid)
     def test_valence_false_vs_int_zero(self):
         raw = {"valence": False, "valence_shift": 0, **self._BASE}
         result = parse_llm_appraisal(raw)
         assert result.is_fallback
-        assert result.error_code == ParseErrorCode.conflicting_aliases
+        assert result.error_code == ParseErrorCode.invalid_numeric_value
 
     # B3: triggered_emotions with bool values vs discrete_emotions with int
     def test_triggered_bool_vs_discrete_int_joy(self):
@@ -1719,7 +1729,8 @@ class TestBoolAliasEquivalence:
         }
         result = parse_llm_appraisal(raw)
         assert result.is_fallback
-        assert result.error_code == ParseErrorCode.conflicting_aliases
+        # Bool intensity is invalid; validation happens before comparison
+        assert result.error_code == ParseErrorCode.invalid_numeric_value
 
     # B4: triggered_emotions with bool False vs discrete_emotions with int 0
     def test_triggered_bool_false_vs_discrete_int_zero(self):
@@ -1731,13 +1742,12 @@ class TestBoolAliasEquivalence:
         }
         result = parse_llm_appraisal(raw)
         assert result.is_fallback
-        assert result.error_code == ParseErrorCode.conflicting_aliases
+        assert result.error_code == ParseErrorCode.invalid_numeric_value
 
     # B5: Both aliases with equally invalid values → fallback (not success)
     def test_both_aliases_equally_invalid(self):
-        """Both alias and canonical have the same string value → they ARE
-        equivalent (same value), so no conflict.  The invalid string is caught
-        by later validation as invalid_numeric_value."""
+        """Both alias and canonical have the same invalid value.
+        Validation catches the first one; result is invalid_numeric_value."""
         raw = {
             "valence": "invalid",
             "valence_shift": "invalid",
@@ -1745,13 +1755,11 @@ class TestBoolAliasEquivalence:
         }
         result = parse_llm_appraisal(raw)
         assert result.is_fallback
-        # Same (invalid) value → no alias conflict; validation catches it.
         assert result.error_code == ParseErrorCode.invalid_numeric_value
 
     def test_both_triggered_equally_invalid(self):
         """Both triggered_emotions and discrete_emotions have the same
-        invalid intensity string → they ARE equivalent (same values inside).
-        No alias conflict; the invalid intensity is caught later."""
+        invalid intensity string. Validation catches the first one."""
         raw = {
             **self._BASE,
             "valence_shift": 0.0,
@@ -1762,7 +1770,7 @@ class TestBoolAliasEquivalence:
         assert result.is_fallback
         assert result.error_code == ParseErrorCode.invalid_numeric_value
 
-    # B6: 1 vs 1.0 is accepted (normal float equivalence)
+    # B6: 1 vs 1.0 is accepted (normal float equivalence after validation)
     def test_one_vs_one_point_zero_accepted(self):
         """1 and 1.0 are both valid floats with the same value."""
         raw = {"valence": 1.0, "valence_shift": 1, **self._BASE}
@@ -1775,6 +1783,106 @@ class TestBoolAliasEquivalence:
         raw = {"valence": 0, "valence_shift": 0.0, **self._BASE}
         result = parse_llm_appraisal(raw)
         assert not result.is_fallback, f"Should be accepted, got {result.error_code}"
+        assert result.appraisal.valence_shift == 0.0
+
+
+# ─── C1-C6: Alias validation+normalisation (fourth audit) ───────────────────
+
+class TestAliasValidationNormalisation:
+    """
+    C1-C6 — Alias comparison validates and normalises each side independently
+    before comparing, using the same rules as the parser.
+    """
+
+    _BASE = {"arousal_shift": 0.0, "dominance_shift": 0.0}
+
+    # C1: Aliases that differ only by filtered unknown emotions → accepted
+    def test_unknown_emotions_filtered_make_aliases_equal(self):
+        """triggered_emotions has unknown emotion 'invented' which is filtered
+        during normalisation, producing the same result as empty discrete_emotions."""
+        raw = {
+            **self._BASE,
+            "valence_shift": 0.0,
+            "triggered_emotions": {"invented": 0.5},
+            "discrete_emotions": {},
+        }
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback, f"Should be accepted, got {result.error_code}"
+        assert dict(result.appraisal.discrete_emotions) == {}
+
+    def test_both_unknown_emotions_filtered_make_aliases_equal(self):
+        """Both sides have only unknown emotions -> both normalise to {}."""
+        raw = {
+            **self._BASE,
+            "valence_shift": 0.0,
+            "triggered_emotions": {"unknown1": 0.5, "unknown2": 0.3},
+            "discrete_emotions": {"unknown3": 0.1},
+        }
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback, f"Should be accepted, got {result.error_code}"
+        assert dict(result.appraisal.discrete_emotions) == {}
+
+    # C2: Alias valid, canonical invalid → validation error code
+    def test_alias_valid_canonical_invalid_shift(self):
+        """valence is valid, valence_shift is a string -> invalid_numeric_value."""
+        raw = {"valence": 0.5, "valence_shift": "bad", **self._BASE}
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.invalid_numeric_value
+
+    # C3: Alias invalid, canonical valid → validation error code
+    def test_alias_invalid_canonical_valid_shift(self):
+        """valence is a string, valence_shift is valid -> invalid_numeric_value."""
+        raw = {"valence": "bad", "valence_shift": 0.5, **self._BASE}
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.invalid_numeric_value
+
+    # C4: Alias valid, canonical invalid emotion mapping
+    def test_alias_valid_canonical_invalid_emotions(self):
+        """triggered_emotions is valid, discrete_emotions is None -> unsupported_emotion."""
+        raw = {
+            **self._BASE,
+            "valence_shift": 0.0,
+            "triggered_emotions": {"joy": 0.5},
+            "discrete_emotions": None,
+        }
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.unsupported_emotion
+
+    def test_alias_invalid_canonical_valid_emotions(self):
+        """triggered_emotions is None, discrete_emotions is valid -> unsupported_emotion."""
+        raw = {
+            **self._BASE,
+            "valence_shift": 0.0,
+            "triggered_emotions": None,
+            "discrete_emotions": {"joy": 0.5},
+        }
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.unsupported_emotion
+
+    # C5: Not conflicting when known+unknown emotions equal after filtering
+    def test_known_plus_unknown_equals_same_known(self):
+        """triggered_emotions has known emotions 'joy': 0.5 plus unknown 'invented': 0.9.
+        After filtering, both sides normalise to {'joy': 0.5}. Should be accepted."""
+        raw = {
+            **self._BASE,
+            "valence_shift": 0.0,
+            "triggered_emotions": {"joy": 0.5, "invented": 0.9},
+            "discrete_emotions": {"joy": 0.5},
+        }
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback, f"Should be accepted, got {result.error_code}"
+        assert result.appraisal.discrete_emotions["joy"] == 0.5
+
+    # C6: Int and float equivalence (same as B6 but explicitly labeled)
+    def test_normalised_int_float_equivalence(self):
+        """Both sides normalise to 0.5 (int→float). Equals after validation."""
+        raw = {"valence": 0, "valence_shift": 0.0, **self._BASE}
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback
         assert result.appraisal.valence_shift == 0.0
 
 

--- a/backend/tests/test_emotional_domain.py
+++ b/backend/tests/test_emotional_domain.py
@@ -56,6 +56,21 @@ N5.  Explicit None discrete_emotions rejected by from_dict()
 N6.  Omitted discrete_emotions defaults to empty mapping
 N7.  Production _perceive() payload passes through parser without loss
 N8.  DISCRETE_EMOTIONS includes all production emotions used by RelationshipManager
+
+Hardening (v1.3 — third audit / PR #246 corrections):
+O1.  Huge int (10**10000) in PAD field → EmotionalDomainError
+O2.  Huge int in drive field → EmotionalDomainError
+O3.  Huge int in timestamp → EmotionalDomainError
+O4.  Huge int in appraisal shift → EmotionalDomainError
+O5.  Huge int in emotion intensity → EmotionalDomainError
+O6.  Legacy migration with huge int → EmotionalDomainError
+O7.  Parser maps huge int to invalid_numeric_value (not unexpected_parser_failure)
+B1.  valence=True vs valence_shift=1 → conflicting_aliases
+B2.  valence=False vs valence_shift=0 → conflicting_aliases
+B3.  triggered_emotions with bool joy vs discrete_emotions with int joy → conflicting_aliases
+B4.  triggered_emotions with bool False vs discrete_emotions with int 0 → conflicting_aliases
+B5.  Both aliases equally invalid → predictable fallback (invalid_numeric_value)
+B6.  1 vs 1.0 policy: int/float equivalence accepted (not rejected)
 """
 
 from __future__ import annotations
@@ -1526,6 +1541,243 @@ class TestAppraisalParserFallback:
     def test_parse_error_code_is_enum(self):
         result = parse_llm_appraisal(None)
         assert isinstance(result.error_code, ParseErrorCode)
+
+
+# ─── O1-O7: OverflowError tests ────────────────────────────────────────────
+
+class TestOverflowError:
+    """
+    O1-O7 — Integers too large to convert to float (e.g. 10**10000) must
+    produce EmotionalDomainError, never OverflowError.
+    """
+
+    _HUGE = 10 ** 10000
+
+    # -- State PAD fields (O1) --
+    @pytest.mark.parametrize("field", ["pleasure", "arousal", "dominance"])
+    def test_huge_int_in_pad_rejected(self, field):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1(**_valid_state_kwargs(**{field: self._HUGE}))
+
+    def test_huge_int_in_pad_create_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.create(
+                **_valid_state_kwargs(pleasure=self._HUGE, **{k: v for k, v in
+                    _valid_state_kwargs().items() if k != "pleasure" and k != "schema_version"},
+                    schema_version=EMOTIONAL_SCHEMA_VERSION
+                )
+            )
+
+    def test_huge_int_in_pad_from_dict_rejected(self):
+        d = _valid_state_dict(pleasure=self._HUGE)
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.from_dict(d)
+
+    # -- State drive fields (O2) --
+    @pytest.mark.parametrize("field", ["libido", "aggression", "connection", "energy", "tension"])
+    def test_huge_int_in_drive_rejected(self, field):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1(**_valid_state_kwargs(**{field: self._HUGE}))
+
+    def test_huge_int_in_drive_create_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.create(
+                **{k: v for k, v in _valid_state_kwargs(libido=self._HUGE).items()
+                   if k != "schema_version"},
+                schema_version=EMOTIONAL_SCHEMA_VERSION,
+            )
+
+    # -- State timestamp (O3) --
+    def test_huge_int_in_timestamp_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1(**_valid_state_kwargs(timestamp=self._HUGE))
+
+    def test_huge_int_in_timestamp_create_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.create(
+                **{k: v for k, v in _valid_state_kwargs().items()
+                   if k != "timestamp" and k != "schema_version"},
+                timestamp=self._HUGE,
+                schema_version=EMOTIONAL_SCHEMA_VERSION,
+            )
+
+    def test_huge_int_in_timestamp_from_dict_rejected(self):
+        d = _valid_state_dict(timestamp=self._HUGE)
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.from_dict(d)
+
+    def test_huge_int_in_timestamp_neutral_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1.neutral(timestamp=self._HUGE)
+
+    # -- Appraisal shift fields (O4) --
+    @pytest.mark.parametrize("field", ["valence_shift", "arousal_shift", "dominance_shift"])
+    def test_huge_int_in_shift_rejected(self, field):
+        d = _valid_appraisal_dict(**{field: self._HUGE})
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1.from_dict(d)
+
+    def test_huge_int_in_shift_direct_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1(
+                valence_shift=self._HUGE, arousal_shift=0.0, dominance_shift=0.0,
+                discrete_emotions={}, schema_version=EMOTIONAL_SCHEMA_VERSION,
+            )
+
+    def test_huge_int_in_shift_create_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1.create(
+                valence_shift=self._HUGE, arousal_shift=0.0, dominance_shift=0.0,
+            )
+
+    # -- Emotion intensity (O5) --
+    def test_huge_int_in_emotion_intensity_rejected(self):
+        d = _valid_appraisal_dict(discrete_emotions={"joy": self._HUGE})
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1.from_dict(d)
+
+    def test_huge_int_in_emotion_intensity_direct_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1(
+                valence_shift=0.0, arousal_shift=0.0, dominance_shift=0.0,
+                discrete_emotions={"joy": self._HUGE},
+                schema_version=EMOTIONAL_SCHEMA_VERSION,
+            )
+
+    def test_huge_int_in_emotion_intensity_create_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1.create(
+                valence_shift=0.0, arousal_shift=0.0, dominance_shift=0.0,
+                discrete_emotions={"joy": self._HUGE},
+            )
+
+    # -- Legacy migration with huge int (O6) --
+    def test_migration_legacy_huge_int_rejected(self):
+        legacy = _legacy_dict(pleasure=self._HUGE)
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(legacy)
+
+    def test_migration_v1_huge_int_rejected(self):
+        v1 = _valid_state_dict(timestamp=self._HUGE)
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(v1)
+
+    # -- Parser maps huge int to invalid_numeric_value (O7) --
+    def test_parser_huge_int_maps_to_invalid_numeric_value(self):
+        raw = {"valence_shift": 0.1, "arousal_shift": self._HUGE, "dominance_shift": 0.0}
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.invalid_numeric_value
+
+    def test_parser_huge_int_in_emotion_maps_to_invalid_numeric_value(self):
+        raw = {
+            "valence_shift": 0.0, "arousal_shift": 0.0, "dominance_shift": 0.0,
+            "discrete_emotions": {"joy": self._HUGE},
+        }
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        # huge int in emotion intensity goes through _parse_discrete_emotions
+        # which catches EmotionalDomainError and raises _ParserFailure(invalid_numeric_value)
+        assert result.error_code == ParseErrorCode.invalid_numeric_value
+
+    def test_parser_huge_int_in_valence_maps_to_invalid_numeric_value(self):
+        raw = {"valence": self._HUGE, "arousal_shift": 0.0, "dominance_shift": 0.0}
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.invalid_numeric_value
+
+
+# ─── B1-B6: Bool vs int alias tests ─────────────────────────────────────────
+
+class TestBoolAliasEquivalence:
+    """
+    B1-B6 — bool and int must not be treated as equivalent in alias checking.
+    True == 1 and False == 0 in Python, which would otherwise allow bypass.
+    """
+
+    _BASE = {"arousal_shift": 0.0, "dominance_shift": 0.0}
+
+    # B1: valence=True, valence_shift=1 → conflicting_aliases
+    def test_valence_true_vs_int_one(self):
+        raw = {"valence": True, "valence_shift": 1, **self._BASE}
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.conflicting_aliases
+
+    # B2: valence=False, valence_shift=0 → conflicting_aliases
+    def test_valence_false_vs_int_zero(self):
+        raw = {"valence": False, "valence_shift": 0, **self._BASE}
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.conflicting_aliases
+
+    # B3: triggered_emotions with bool values vs discrete_emotions with int
+    def test_triggered_bool_vs_discrete_int_joy(self):
+        raw = {
+            **self._BASE,
+            "valence_shift": 0.0,
+            "triggered_emotions": {"joy": True},
+            "discrete_emotions": {"joy": 1},
+        }
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.conflicting_aliases
+
+    # B4: triggered_emotions with bool False vs discrete_emotions with int 0
+    def test_triggered_bool_false_vs_discrete_int_zero(self):
+        raw = {
+            **self._BASE,
+            "valence_shift": 0.0,
+            "triggered_emotions": {"joy": False},
+            "discrete_emotions": {"joy": 0},
+        }
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.conflicting_aliases
+
+    # B5: Both aliases with equally invalid values → fallback (not success)
+    def test_both_aliases_equally_invalid(self):
+        """Both alias and canonical have the same string value → they ARE
+        equivalent (same value), so no conflict.  The invalid string is caught
+        by later validation as invalid_numeric_value."""
+        raw = {
+            "valence": "invalid",
+            "valence_shift": "invalid",
+            **self._BASE,
+        }
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        # Same (invalid) value → no alias conflict; validation catches it.
+        assert result.error_code == ParseErrorCode.invalid_numeric_value
+
+    def test_both_triggered_equally_invalid(self):
+        """Both triggered_emotions and discrete_emotions have the same
+        invalid intensity string → they ARE equivalent (same values inside).
+        No alias conflict; the invalid intensity is caught later."""
+        raw = {
+            **self._BASE,
+            "valence_shift": 0.0,
+            "triggered_emotions": {"joy": "high"},
+            "discrete_emotions": {"joy": "high"},
+        }
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.invalid_numeric_value
+
+    # B6: 1 vs 1.0 is accepted (normal float equivalence)
+    def test_one_vs_one_point_zero_accepted(self):
+        """1 and 1.0 are both valid floats with the same value."""
+        raw = {"valence": 1.0, "valence_shift": 1, **self._BASE}
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback, f"Should be accepted, got {result.error_code}"
+        assert result.appraisal.valence_shift == 1.0
+
+    def test_int_vs_float_equivalence(self):
+        """int and float with same value should be equivalent."""
+        raw = {"valence": 0, "valence_shift": 0.0, **self._BASE}
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback, f"Should be accepted, got {result.error_code}"
+        assert result.appraisal.valence_shift == 0.0
 
 
 # ─── Package public API exports ───────────────────────────────────────────────

--- a/backend/tests/test_emotional_domain.py
+++ b/backend/tests/test_emotional_domain.py
@@ -398,7 +398,6 @@ class TestStateNormalization:
             energy=0.8, tension=0, coping_mode="HEALTHY",
             timestamp=1_700_000_000.0,
         )
-        from backend.emotional_domain.serialization import serialize_state
         assert serialize_state(direct) == serialize_state(factory)
 
     def test_normalization_uses_float_in_to_dict(self):
@@ -442,7 +441,6 @@ class TestAppraisalNormalization:
             valence_shift=1, arousal_shift=0, dominance_shift=0,
             discrete_emotions={"joy": 0.5},
         )
-        from backend.emotional_domain.serialization import serialize_appraisal
         assert serialize_appraisal(direct) == serialize_appraisal(factory)
 
 

--- a/backend/tests/test_emotional_domain.py
+++ b/backend/tests/test_emotional_domain.py
@@ -1,36 +1,60 @@
 """
-Tests for backend/emotional_domain — issue #232.
+Tests for backend/emotional_domain — issue #232 (updated for v1.1 hardening).
 
-Coverage map (issue requirements):
- 1. Round-trip EmotionalStateV1           → test_state_round_trip
- 2. Round-trip AppraisalV1               → test_appraisal_round_trip
- 3. Version absent is rejected           → test_state_missing_version, test_appraisal_missing_version
- 4. Unknown version is rejected          → test_state_unknown_version, test_appraisal_unknown_version
- 5. bool/None/str/list/dict rejected     → test_state_invalid_types, test_appraisal_invalid_types
- 6. NaN/Inf rejected                     → test_state_nan_inf, test_appraisal_nan_inf
- 7. Out-of-range values follow policy    → test_state_out_of_range, test_appraisal_out_of_range
- 8. Unknown keys not silently accepted   → test_state_unknown_keys, test_appraisal_unknown_keys
- 9. Discrete emotion allowlist is exact  → test_discrete_emotion_allowlist
-10. Unknown emotion rejected             → test_appraisal_unknown_emotion_rejected
-11. Coping mode unknown rejected         → test_unknown_coping_mode
-12. Timestamp invalid rejected           → test_invalid_timestamp
-13. Legacy migration valid → v1 correct  → test_migration_valid_legacy
-14. Legacy invalid fails closed          → test_migration_invalid_legacy
-15. Migration does not mutate input      → test_migration_no_mutation
-16. Invalid appraisal → neutral fallback → test_parse_llm_appraisal_fallback
-17. Domain importable without infra      → test_domain_import_isolation
-18. No network use                       → (structural: no network calls in any test)
-19. Existing backend suite passes        → (verified by running full suite externally)
-20. CI remains green                     → (verified by CI after PR)
+Coverage map (original requirements from #232 + new hardening requirements):
+─────────────────────────────────────────────────────────────────────────────
+Original:
+ 1. Round-trip EmotionalStateV1
+ 2. Round-trip AppraisalV1
+ 3. Version absent is rejected
+ 4. Unknown version is rejected
+ 5. bool/None/str/list/dict rejected
+ 6. NaN/Inf rejected
+ 7. Out-of-range values follow policy (reject)
+ 8. Unknown keys not silently accepted
+ 9. Discrete emotion allowlist is exact
+10. Unknown emotion rejected
+11. Coping mode unknown rejected
+12. Timestamp invalid rejected
+13. Legacy migration valid → v1 correct
+14. Legacy invalid fails closed
+15. Migration does not mutate input
+16. Invalid appraisal → neutral fallback
+17. Domain importable without infra
+18. No network use
+19. Existing backend suite passes
+20. CI remains green
+
+Hardening (v1.1):
+H1.  Direct constructor of EmotionalStateV1 validates invariants
+H2.  Direct constructor rejects timestamp=0, invalid schema_version, bool, NaN, ranges
+H3.  Direct constructor of AppraisalV1 validates invariants
+H4.  Caller's mapping does not affect AppraisalV1 after construction
+H5.  discrete_emotions cannot be mutated on the object
+H6.  Serialization is valid after attempted mutation
+H7.  Empty dict produces observable fallback (missing_required_field)
+H8.  Absent shift fields produce fallback
+H9.  discrete_emotions=None/str/list/bool/number produces fallback
+H10. Unknown top-level key produces fallback (unknown_top_level_key)
+H11. triggered_emotions legacy alias converted correctly
+H12. valence legacy alias converted correctly
+H13. Conflicting aliases rejected (conflicting_aliases)
+H14. Unknown emotions filtered (not rejected) from LLM output
+H15. Sensitive marker not in error_code or observable result
+H16. Migration rejects extra fields
+H17. Migration rejects schema_version=None
+H18. Migration rejects both last_update and timestamp simultaneously
+H19. Migration v1 idempotent
+H20. Isolated subprocess import of package — no infra modules loaded
 """
 
 from __future__ import annotations
 
-import importlib
 import json
-import math
+import subprocess
 import sys
-import time
+import textwrap
+from types import MappingProxyType
 from typing import Any
 
 import pytest
@@ -50,27 +74,41 @@ from backend.emotional_domain.serialization import (
     serialize_appraisal,
     serialize_state,
 )
-from backend.emotional_domain.appraisal_parser import parse_llm_appraisal, ParseResult
+from backend.emotional_domain.appraisal_parser import (
+    parse_llm_appraisal,
+    ParseResult,
+    ParseErrorCode,
+)
+# Also test the public package API.
+from backend.emotional_domain import (
+    ParseResult as PackageParseResult,
+    ParseErrorCode as PackageParseErrorCode,
+    parse_llm_appraisal as package_parse,
+)
 
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
 
-def _valid_state_dict(**overrides: Any) -> dict:
-    base = {
-        "schema_version": EMOTIONAL_SCHEMA_VERSION,
-        "pleasure": 0.1,
-        "arousal": -0.2,
-        "dominance": 0.3,
-        "libido": 0.0,
-        "aggression": 0.1,
-        "connection": 0.5,
-        "energy": 0.8,
-        "tension": 0.2,
-        "coping_mode": "HEALTHY",
-        "timestamp": 1_700_000_000.0,
-    }
+def _valid_state_kwargs(**overrides: Any) -> dict:
+    base = dict(
+        pleasure=0.1,
+        arousal=-0.2,
+        dominance=0.3,
+        libido=0.0,
+        aggression=0.1,
+        connection=0.5,
+        energy=0.8,
+        tension=0.2,
+        coping_mode="HEALTHY",
+        timestamp=1_700_000_000.0,
+        schema_version=EMOTIONAL_SCHEMA_VERSION,
+    )
     base.update(overrides)
     return base
+
+
+def _valid_state_dict(**overrides: Any) -> dict:
+    return _valid_state_kwargs(**overrides)
 
 
 def _valid_appraisal_dict(**overrides: Any) -> dict:
@@ -102,7 +140,737 @@ def _legacy_dict(**overrides: Any) -> dict:
     return base
 
 
-# ─── 1 & 2: Round-trips ──────────────────────────────────────────────────────
+# ─── H1: Direct constructor validates (EmotionalStateV1) ─────────────────────
+
+class TestStateDirectConstructorValidates:
+    """H1 — Direct EmotionalStateV1(...) calls __post_init__ which validates."""
+
+    def test_direct_ctor_valid_passes(self):
+        s = EmotionalStateV1(**_valid_state_kwargs())
+        assert s.pleasure == 0.1
+
+    def test_direct_ctor_rejects_invalid_pleasure(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1(**_valid_state_kwargs(pleasure=99.0))
+
+    def test_direct_ctor_rejects_bool_field(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1(**_valid_state_kwargs(arousal=True))
+
+    def test_direct_ctor_rejects_none_field(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1(**_valid_state_kwargs(dominance=None))
+
+    def test_direct_ctor_rejects_nan(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1(**_valid_state_kwargs(pleasure=float("nan")))
+
+    def test_direct_ctor_rejects_inf(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1(**_valid_state_kwargs(energy=float("inf")))
+
+
+# ─── H2: Direct constructor specific cases ───────────────────────────────────
+
+class TestStateDirectConstructorSpecificCases:
+    """H2 — Direct ctor rejects timestamp=0, invalid schema_version, etc."""
+
+    def test_direct_ctor_rejects_zero_timestamp(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1(**_valid_state_kwargs(timestamp=0.0))
+
+    def test_direct_ctor_rejects_negative_timestamp(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1(**_valid_state_kwargs(timestamp=-1.0))
+
+    def test_direct_ctor_rejects_bool_schema_version(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1(**_valid_state_kwargs(schema_version=True))
+
+    def test_direct_ctor_rejects_wrong_schema_version(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1(**_valid_state_kwargs(schema_version=2))
+
+    def test_direct_ctor_rejects_none_schema_version(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1(**_valid_state_kwargs(schema_version=None))
+
+    def test_direct_ctor_rejects_float_schema_version(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1(**_valid_state_kwargs(schema_version=1.0))
+
+    def test_direct_ctor_rejects_string_schema_version(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1(**_valid_state_kwargs(schema_version="1"))
+
+    def test_direct_ctor_rejects_bool_timestamp(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1(**_valid_state_kwargs(timestamp=True))
+
+    def test_direct_ctor_rejects_unknown_coping_mode(self):
+        with pytest.raises(EmotionalDomainError):
+            EmotionalStateV1(**_valid_state_kwargs(coping_mode="PANIC"))
+
+
+# ─── H3: Direct constructor validates AppraisalV1 ────────────────────────────
+
+class TestAppraisalDirectConstructorValidates:
+    """H3 — Direct AppraisalV1(...) calls __post_init__ which validates."""
+
+    def test_direct_ctor_valid_passes(self):
+        a = AppraisalV1(
+            valence_shift=0.2, arousal_shift=-0.1, dominance_shift=0.0,
+            discrete_emotions={"joy": 0.5}, schema_version=EMOTIONAL_SCHEMA_VERSION,
+        )
+        assert a.valence_shift == 0.2
+
+    def test_direct_ctor_rejects_invalid_shift(self):
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1(
+                valence_shift=99.0, arousal_shift=0.0, dominance_shift=0.0,
+                discrete_emotions={}, schema_version=EMOTIONAL_SCHEMA_VERSION,
+            )
+
+    def test_direct_ctor_rejects_unknown_emotion(self):
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1(
+                valence_shift=0.0, arousal_shift=0.0, dominance_shift=0.0,
+                discrete_emotions={"invented": 0.5},
+                schema_version=EMOTIONAL_SCHEMA_VERSION,
+            )
+
+    def test_direct_ctor_rejects_invalid_intensity(self):
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1(
+                valence_shift=0.0, arousal_shift=0.0, dominance_shift=0.0,
+                discrete_emotions={"joy": 99.0},
+                schema_version=EMOTIONAL_SCHEMA_VERSION,
+            )
+
+    def test_direct_ctor_rejects_bool_intensity(self):
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1(
+                valence_shift=0.0, arousal_shift=0.0, dominance_shift=0.0,
+                discrete_emotions={"joy": True},
+                schema_version=EMOTIONAL_SCHEMA_VERSION,
+            )
+
+    def test_direct_ctor_rejects_none_schema_version(self):
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1(
+                valence_shift=0.0, arousal_shift=0.0, dominance_shift=0.0,
+                discrete_emotions={}, schema_version=None,
+            )
+
+    def test_direct_ctor_rejects_bool_schema_version(self):
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1(
+                valence_shift=0.0, arousal_shift=0.0, dominance_shift=0.0,
+                discrete_emotions={}, schema_version=True,
+            )
+
+
+# ─── H4: Caller mapping does not affect AppraisalV1 after construction ────────
+
+class TestAppraisalCallerMappingIsolation:
+    """H4 — Mutations to the caller's dict do not affect the constructed model."""
+
+    def test_create_isolates_from_caller_dict(self):
+        src = {"joy": 0.5}
+        ap = AppraisalV1.create(
+            valence_shift=0.0, arousal_shift=0.0, dominance_shift=0.0,
+            discrete_emotions=src,
+        )
+        src["joy"] = 99.0
+        src["anger"] = 0.8
+        assert ap.discrete_emotions["joy"] == 0.5
+        assert "anger" not in ap.discrete_emotions
+
+    def test_from_dict_isolates_from_caller_dict(self):
+        d = _valid_appraisal_dict(discrete_emotions={"joy": 0.5})
+        ap = AppraisalV1.from_dict(d)
+        d["discrete_emotions"]["joy"] = 99.0
+        assert ap.discrete_emotions["joy"] == 0.5
+
+    def test_direct_ctor_isolates_from_caller_dict(self):
+        src = {"joy": 0.3}
+        ap = AppraisalV1(
+            valence_shift=0.0, arousal_shift=0.0, dominance_shift=0.0,
+            discrete_emotions=src, schema_version=EMOTIONAL_SCHEMA_VERSION,
+        )
+        src["joy"] = 99.0
+        assert ap.discrete_emotions["joy"] == 0.3
+
+
+# ─── H5: discrete_emotions cannot be mutated on the object ───────────────────
+
+class TestAppraisalDeepImmutability:
+    """H5 — The stored discrete_emotions is immutable."""
+
+    def test_discrete_emotions_is_mappingproxy(self):
+        ap = AppraisalV1.neutral()
+        assert isinstance(ap.discrete_emotions, MappingProxyType)
+
+    def test_cannot_set_item_on_neutral(self):
+        ap = AppraisalV1.neutral()
+        with pytest.raises(TypeError):
+            ap.discrete_emotions["joy"] = 0.5
+
+    def test_cannot_set_item_on_created(self):
+        ap = AppraisalV1.create(
+            valence_shift=0.0, arousal_shift=0.0, dominance_shift=0.0,
+            discrete_emotions={"joy": 0.5},
+        )
+        with pytest.raises(TypeError):
+            ap.discrete_emotions["joy"] = 99.0
+
+    def test_cannot_delete_item(self):
+        ap = AppraisalV1.create(
+            valence_shift=0.0, arousal_shift=0.0, dominance_shift=0.0,
+            discrete_emotions={"joy": 0.5},
+        )
+        with pytest.raises(TypeError):
+            del ap.discrete_emotions["joy"]
+
+    def test_to_dict_returns_fresh_copy(self):
+        ap = AppraisalV1.create(
+            valence_shift=0.0, arousal_shift=0.0, dominance_shift=0.0,
+            discrete_emotions={"joy": 0.5},
+        )
+        d = ap.to_dict()
+        d["discrete_emotions"]["joy"] = 99.0
+        # Object is unchanged
+        assert ap.discrete_emotions["joy"] == 0.5
+
+
+# ─── H6: Serialization valid after mutation attempt ──────────────────────────
+
+class TestSerializationAfterMutationAttempt:
+    """H6 — Serialization output is valid even after to_dict() copy is mutated."""
+
+    def test_serialize_appraisal_valid_after_to_dict_mutation(self):
+        ap = AppraisalV1.create(
+            valence_shift=0.0, arousal_shift=0.0, dominance_shift=0.0,
+            discrete_emotions={"joy": 0.5},
+        )
+        copy1 = ap.to_dict()
+        copy1["discrete_emotions"]["joy"] = 99.0  # mutate the copy
+
+        # Original still produces valid JSON
+        json_str = serialize_appraisal(ap)
+        restored = deserialize_appraisal(json_str)
+        assert restored.discrete_emotions["joy"] == 0.5
+
+    def test_state_to_dict_is_independent(self):
+        state = EmotionalStateV1.create(**{k: v for k, v in _valid_state_kwargs().items()
+                                           if k != "schema_version"},
+                                        schema_version=EMOTIONAL_SCHEMA_VERSION)
+        d = state.to_dict()
+        d["pleasure"] = 99.0
+        assert state.pleasure == 0.1  # frozen, unchanged
+
+
+# ─── H7 & H8: Parser fallback for empty/incomplete dict ──────────────────────
+
+class TestParserEmptyAndMissingShifts:
+    """H7 — empty dict; H8 — missing shifts; both produce fallback."""
+
+    def test_empty_dict_produces_fallback(self):
+        result = parse_llm_appraisal({})
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.missing_required_field
+
+    def test_empty_dict_fallback_is_neutral(self):
+        result = parse_llm_appraisal({})
+        assert result.appraisal == AppraisalV1.neutral()
+
+    def test_missing_valence_produces_fallback(self):
+        result = parse_llm_appraisal({"arousal_shift": 0.0, "dominance_shift": 0.0})
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.missing_required_field
+
+    def test_missing_arousal_produces_fallback(self):
+        result = parse_llm_appraisal({"valence_shift": 0.0, "dominance_shift": 0.0})
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.missing_required_field
+
+    def test_missing_dominance_produces_fallback(self):
+        result = parse_llm_appraisal({"valence_shift": 0.0, "arousal_shift": 0.0})
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.missing_required_field
+
+    def test_all_three_required_present_succeeds(self):
+        result = parse_llm_appraisal({"valence_shift": 0.0, "arousal_shift": 0.0, "dominance_shift": 0.0})
+        assert not result.is_fallback
+        assert result.error_code is None
+
+
+# ─── H9: discrete_emotions type rejection ────────────────────────────────────
+
+class TestParserDiscreteEmotionsTypeRejection:
+    """H9 — Non-mapping discrete_emotions produces fallback."""
+
+    _BASE = {"valence_shift": 0.1, "arousal_shift": 0.0, "dominance_shift": 0.0}
+
+    @pytest.mark.parametrize("bad_de", [
+        None,
+        "joy",
+        ["joy"],
+        42,
+        0.5,
+        True,
+        False,
+    ])
+    def test_explicit_non_mapping_produces_fallback(self, bad_de):
+        raw = {**self._BASE, "discrete_emotions": bad_de}
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.unsupported_emotion
+
+    def test_explicit_empty_mapping_succeeds(self):
+        raw = {**self._BASE, "discrete_emotions": {}}
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback
+        assert result.appraisal.discrete_emotions == {}
+
+    def test_valid_mapping_with_known_emotion_succeeds(self):
+        raw = {**self._BASE, "discrete_emotions": {"joy": 0.5}}
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback
+        assert result.appraisal.discrete_emotions["joy"] == 0.5
+
+
+# ─── H10: Unknown top-level key produces fallback ────────────────────────────
+
+class TestParserUnknownTopLevelKey:
+    """H10 — Unknown top-level keys produce unknown_top_level_key fallback."""
+
+    _BASE = {"valence_shift": 0.1, "arousal_shift": 0.0, "dominance_shift": 0.0}
+
+    @pytest.mark.parametrize("bad_key", [
+        "extra_field",
+        "schema_version",
+        "coping_mode",
+        "timestamp",
+        "pleasure",
+    ])
+    def test_unknown_key_produces_fallback(self, bad_key):
+        raw = {**self._BASE, bad_key: "whatever"}
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.unknown_top_level_key
+
+
+# ─── H11: triggered_emotions alias ───────────────────────────────────────────
+
+class TestParserTriggeredEmotionsAlias:
+    """H11 — triggered_emotions legacy alias is converted to discrete_emotions."""
+
+    _BASE = {"valence_shift": 0.2, "arousal_shift": 0.0, "dominance_shift": 0.0}
+
+    def test_triggered_emotions_converted(self):
+        raw = {**self._BASE, "triggered_emotions": {"joy": 0.7}}
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback
+        assert result.appraisal.discrete_emotions["joy"] == 0.7
+
+    def test_triggered_emotions_empty_succeeds(self):
+        raw = {**self._BASE, "triggered_emotions": {}}
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback
+        assert dict(result.appraisal.discrete_emotions) == {}
+
+    def test_triggered_emotions_with_unknown_emotion_filtered(self):
+        raw = {**self._BASE, "triggered_emotions": {"joy": 0.5, "invented": 0.9}}
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback
+        assert "joy" in result.appraisal.discrete_emotions
+        assert "invented" not in result.appraisal.discrete_emotions
+
+    def test_triggered_emotions_invalid_value_produces_fallback(self):
+        raw = {**self._BASE, "triggered_emotions": {"joy": 99.0}}
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.invalid_numeric_value
+
+    def test_triggered_emotions_none_produces_fallback(self):
+        raw = {**self._BASE, "triggered_emotions": None}
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.unsupported_emotion
+
+
+# ─── H12: valence alias ──────────────────────────────────────────────────────
+
+class TestParserValenceAlias:
+    """H12 — valence legacy alias is converted to valence_shift."""
+
+    def test_valence_alias_converted(self):
+        raw = {"valence": 0.3, "arousal_shift": 0.0, "dominance_shift": 0.0}
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback
+        assert result.appraisal.valence_shift == 0.3
+
+    def test_valence_negative_accepted(self):
+        raw = {"valence": -0.5, "arousal_shift": 0.0, "dominance_shift": 0.0}
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback
+        assert result.appraisal.valence_shift == -0.5
+
+    def test_valence_alias_same_as_canonical_accepted(self):
+        """Both valence and valence_shift with the same value is accepted."""
+        raw = {"valence": 0.3, "valence_shift": 0.3, "arousal_shift": 0.0, "dominance_shift": 0.0}
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback
+        assert result.appraisal.valence_shift == 0.3
+
+
+# ─── H13: Conflicting aliases rejected ───────────────────────────────────────
+
+class TestParserConflictingAliases:
+    """H13 — Conflicting alias+canonical produce conflicting_aliases fallback."""
+
+    def test_valence_conflict_produces_fallback(self):
+        raw = {
+            "valence": 0.3,
+            "valence_shift": 0.5,  # different value!
+            "arousal_shift": 0.0,
+            "dominance_shift": 0.0,
+        }
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.conflicting_aliases
+
+    def test_triggered_emotions_conflict_produces_fallback(self):
+        raw = {
+            "valence_shift": 0.0,
+            "arousal_shift": 0.0,
+            "dominance_shift": 0.0,
+            "triggered_emotions": {"joy": 0.5},
+            "discrete_emotions": {"anger": 0.3},  # different value!
+        }
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        assert result.error_code == ParseErrorCode.conflicting_aliases
+
+    def test_triggered_emotions_same_as_discrete_accepted(self):
+        """Same object content in both aliases is accepted."""
+        raw = {
+            "valence_shift": 0.0,
+            "arousal_shift": 0.0,
+            "dominance_shift": 0.0,
+            "triggered_emotions": {"joy": 0.5},
+            "discrete_emotions": {"joy": 0.5},
+        }
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback
+
+
+# ─── H14: Unknown emotions filtered from LLM output ─────────────────────────
+
+class TestParserUnknownEmotionsFiltered:
+    """H14 — Unknown emotion keys from LLM are filtered, not rejected."""
+
+    def test_unknown_emotions_filtered_not_rejected(self):
+        raw = {
+            "valence_shift": 0.1,
+            "arousal_shift": 0.0,
+            "dominance_shift": 0.0,
+            "discrete_emotions": {"joy": 0.5, "invented_emotion": 0.9, "fake": 1.0},
+        }
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback
+        assert "joy" in result.appraisal.discrete_emotions
+        assert "invented_emotion" not in result.appraisal.discrete_emotions
+        assert "fake" not in result.appraisal.discrete_emotions
+
+    def test_all_unknown_emotions_filtered_gives_empty(self):
+        raw = {
+            "valence_shift": 0.1,
+            "arousal_shift": 0.0,
+            "dominance_shift": 0.0,
+            "discrete_emotions": {"invented": 0.5},
+        }
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback
+        assert dict(result.appraisal.discrete_emotions) == {}
+
+
+# ─── H15: Sensitive marker not in observable result ──────────────────────────
+
+class TestParserSensitiveMarkerNotLeaked:
+    """H15 — Raw LLM/user text does not appear in error_code or is_fallback."""
+
+    _SENSITIVE = "SUPER_SECRET_TOKEN_abc123"
+    _BASE = {"valence_shift": 99.0, "arousal_shift": 0.0, "dominance_shift": 0.0}
+
+    def test_sensitive_marker_not_in_error_code_value(self):
+        """When a sensitive value is embedded in a field, it must not appear in error_code."""
+        raw = {**self._BASE, self._SENSITIVE: "value"}
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        # error_code is an enum value (stable string), not raw input
+        code_str = result.error_code.value if result.error_code else ""
+        assert self._SENSITIVE not in code_str
+
+    def test_sensitive_value_not_in_error_code(self):
+        """Sensitive value in shift must not appear in error_code."""
+        raw = {"valence_shift": self._SENSITIVE, "arousal_shift": 0.0, "dominance_shift": 0.0}
+        result = parse_llm_appraisal(raw)
+        assert result.is_fallback
+        code_str = result.error_code.value if result.error_code else ""
+        assert self._SENSITIVE not in code_str
+
+    def test_parse_result_has_no_error_text_field(self):
+        """ParseResult has error_code (enum), not a free-text error field."""
+        result = parse_llm_appraisal(None)
+        assert hasattr(result, "error_code")
+        # Must NOT have a plain 'error' attribute with raw text
+        assert not hasattr(result, "error") or getattr(result, "error", None) is None
+
+    def test_parse_error_code_is_stable_enum(self):
+        result = parse_llm_appraisal(None)
+        assert isinstance(result.error_code, ParseErrorCode)
+        assert result.error_code == ParseErrorCode.invalid_structure
+
+
+# ─── H16: Migration rejects extra fields ─────────────────────────────────────
+
+class TestMigrationRejectsExtraFields:
+    """H16 — Legacy migration rejects any field beyond the exact allowed set."""
+
+    def test_extra_field_rejected(self):
+        legacy = _legacy_dict(extra_field="value")
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(legacy)
+
+    def test_timestamp_in_legacy_rejected(self):
+        """Legacy snapshots must not have 'timestamp' (v1 field)."""
+        legacy = _legacy_dict(timestamp=1_700_000_000.0)
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(legacy)
+
+    def test_prompt_field_rejected(self):
+        legacy = _legacy_dict(system_prompt="do things")
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(legacy)
+
+    def test_memory_field_rejected(self):
+        legacy = _legacy_dict(memory=[])
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(legacy)
+
+    def test_relationship_field_rejected(self):
+        legacy = _legacy_dict(relationship_score=0.8)
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(legacy)
+
+    def test_presentation_field_rejected(self):
+        legacy = _legacy_dict(acting_label="intense")
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(legacy)
+
+
+# ─── H17: Migration rejects schema_version=None ──────────────────────────────
+
+class TestMigrationRejectsSchemaVersionNone:
+    """H17 — schema_version key present with value None is rejected."""
+
+    def test_schema_version_none_rejected(self):
+        """Key present but value is None — distinct from absent."""
+        d = _legacy_dict()
+        d["schema_version"] = None
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(d)
+
+    def test_schema_version_absent_accepted_as_legacy(self):
+        """Key entirely absent — treated as legacy format."""
+        legacy = _legacy_dict()
+        result = migrate_legacy_snapshot(legacy)
+        assert isinstance(result, EmotionalStateV1)
+
+    def test_schema_version_bool_rejected(self):
+        d = _legacy_dict()
+        d["schema_version"] = True
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(d)
+
+    def test_schema_version_string_rejected(self):
+        d = _legacy_dict()
+        d["schema_version"] = "1"
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(d)
+
+
+# ─── H18: Migration rejects last_update + timestamp simultaneously ────────────
+
+class TestMigrationRejectsConflictingTimestampFields:
+    """H18 — Payload with both last_update and timestamp is rejected."""
+
+    def test_both_last_update_and_timestamp_rejected(self):
+        d = _legacy_dict(timestamp=1_700_000_000.0)  # also has last_update
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(d)
+
+    def test_only_last_update_accepted(self):
+        d = _legacy_dict()
+        assert "timestamp" not in d
+        result = migrate_legacy_snapshot(d)
+        assert result.timestamp == d["last_update"]
+
+    def test_only_timestamp_in_v1_accepted(self):
+        v1 = _valid_state_dict()
+        assert "last_update" not in v1
+        result = migrate_legacy_snapshot(v1)
+        assert isinstance(result, EmotionalStateV1)
+
+
+# ─── H19: Migration v1 idempotent ────────────────────────────────────────────
+
+class TestMigrationV1Idempotent:
+    """H19 — Passing a v1 snapshot to migrate_legacy_snapshot re-validates it."""
+
+    def test_v1_snapshot_idempotent(self):
+        state = EmotionalStateV1.create(**{k: v for k, v in _valid_state_kwargs().items()
+                                           if k != "schema_version"},
+                                        schema_version=EMOTIONAL_SCHEMA_VERSION)
+        v1_dict = state.to_dict()
+        result = migrate_legacy_snapshot(v1_dict)
+        assert result == state
+
+    def test_v1_snapshot_with_extra_field_rejected(self):
+        v1 = _valid_state_dict()
+        v1["extra"] = "bad"
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(v1)
+
+    def test_v1_snapshot_with_last_update_rejected(self):
+        """A v1 snapshot must not contain legacy 'last_update' field."""
+        v1 = _valid_state_dict()
+        v1["last_update"] = 1_700_000_000.0
+        with pytest.raises(EmotionalDomainError):
+            migrate_legacy_snapshot(v1)
+
+
+# ─── H20: Isolated subprocess import ─────────────────────────────────────────
+
+class TestIsolatedSubprocessImport:
+    """H20 — Package import in a clean subprocess does not load infra modules."""
+
+    def _run_isolation_script(self, script: str) -> subprocess.CompletedProcess:
+        """Run a Python snippet in a subprocess with PYTHONPATH set."""
+        import os
+        env = {
+            **os.environ,
+            "PYTHONPATH": str(
+                __import__("pathlib").Path(__file__).parent.parent.parent
+            ),
+            # Prevent HF/transformers network access
+            "HF_HUB_OFFLINE": "1",
+            "TRANSFORMERS_OFFLINE": "1",
+        }
+        return subprocess.run(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+
+    def test_import_does_not_load_fastapi(self):
+        proc = self._run_isolation_script("""
+            import sys
+            import backend.emotional_domain
+            for mod in sys.modules:
+                assert 'fastapi' not in mod, f'fastapi loaded: {mod}'
+            print('OK')
+        """)
+        assert proc.returncode == 0, proc.stderr
+        assert "OK" in proc.stdout
+
+    def test_import_does_not_load_groq(self):
+        proc = self._run_isolation_script("""
+            import sys
+            import backend.emotional_domain
+            for mod in sys.modules:
+                assert 'groq' not in mod, f'groq loaded: {mod}'
+            print('OK')
+        """)
+        assert proc.returncode == 0, proc.stderr
+        assert "OK" in proc.stdout
+
+    def test_import_does_not_load_supabase(self):
+        proc = self._run_isolation_script("""
+            import sys
+            import backend.emotional_domain
+            for mod in sys.modules:
+                assert 'supabase' not in mod, f'supabase loaded: {mod}'
+            print('OK')
+        """)
+        assert proc.returncode == 0, proc.stderr
+        assert "OK" in proc.stdout
+
+    def test_import_does_not_load_sentence_transformers(self):
+        proc = self._run_isolation_script("""
+            import sys
+            import backend.emotional_domain
+            for mod in sys.modules:
+                assert 'sentence_transformers' not in mod, f'loaded: {mod}'
+            print('OK')
+        """)
+        assert proc.returncode == 0, proc.stderr
+        assert "OK" in proc.stdout
+
+    def test_import_does_not_require_env_vars(self):
+        proc = self._run_isolation_script("""
+            import os
+            # Unset common env vars
+            for k in ['GROQ_API_KEY', 'GROQ_API_KEY_2', 'SUPABASE_URL', 'SUPABASE_KEY']:
+                os.environ.pop(k, None)
+            import backend.emotional_domain
+            from backend.emotional_domain import EmotionalStateV1, AppraisalV1
+            s = EmotionalStateV1.neutral(timestamp=1.0)
+            a = AppraisalV1.neutral()
+            print('OK')
+        """)
+        assert proc.returncode == 0, proc.stderr
+        assert "OK" in proc.stdout
+
+    def test_package_api_usable_in_isolation(self):
+        """Full package API works in isolation: create, serialise, migrate."""
+        proc = self._run_isolation_script("""
+            from backend.emotional_domain import (
+                EmotionalStateV1, AppraisalV1,
+                serialize_state, deserialize_state,
+                serialize_appraisal, deserialize_appraisal,
+                migrate_legacy_snapshot, parse_llm_appraisal,
+                ParseResult, ParseErrorCode,
+            )
+            # Create
+            state = EmotionalStateV1.neutral(timestamp=1_700_000_000.0)
+            ap = AppraisalV1.neutral()
+            # Round-trip
+            assert deserialize_state(serialize_state(state)) == state
+            assert deserialize_appraisal(serialize_appraisal(ap)) == ap
+            # Parser
+            r = parse_llm_appraisal({'valence_shift': 0.1, 'arousal_shift': 0.0, 'dominance_shift': 0.0})
+            assert not r.is_fallback
+            # Migration
+            legacy = {
+                'pleasure': 0.0, 'arousal': 0.0, 'dominance': 0.0,
+                'libido': 0.0, 'aggression': 0.0, 'connection': 0.5,
+                'energy': 0.8, 'tension': 0.0, 'coping_mode': 'HEALTHY',
+                'last_update': 1_700_000_000.0,
+            }
+            migrated = migrate_legacy_snapshot(legacy)
+            assert migrated.schema_version == 1
+            print('OK')
+        """)
+        assert proc.returncode == 0, proc.stderr
+        assert "OK" in proc.stdout
+
+
+# ─── Original round-trip tests (1 & 2) ───────────────────────────────────────
 
 class TestStateRoundTrip:
     """Requirement 1: round-trip EmotionalStateV1."""
@@ -183,15 +951,13 @@ class TestAppraisalRoundTrip:
         assert neutral.valence_shift == 0.0
         assert neutral.arousal_shift == 0.0
         assert neutral.dominance_shift == 0.0
-        assert neutral.discrete_emotions == {}
+        assert dict(neutral.discrete_emotions) == {}
         assert neutral.schema_version == EMOTIONAL_SCHEMA_VERSION
 
 
-# ─── 3: Version absent rejected ──────────────────────────────────────────────
+# ─── Version validation (3 & 4) ──────────────────────────────────────────────
 
 class TestMissingVersion:
-    """Requirement 3: absent schema_version is rejected."""
-
     def test_state_missing_version(self):
         d = _valid_state_dict()
         del d["schema_version"]
@@ -205,25 +971,21 @@ class TestMissingVersion:
             AppraisalV1.from_dict(d)
 
 
-# ─── 4: Unknown version rejected ─────────────────────────────────────────────
-
 class TestUnknownVersion:
-    """Requirement 4: unrecognised schema_version is rejected."""
-
     @pytest.mark.parametrize("bad_version", [0, 2, 99, -1])
     def test_state_unknown_version(self, bad_version):
         d = _valid_state_dict(schema_version=bad_version)
-        with pytest.raises(EmotionalDomainError, match="schema_version|Unsupported"):
+        with pytest.raises(EmotionalDomainError):
             EmotionalStateV1.from_dict(d)
 
     @pytest.mark.parametrize("bad_version", [0, 2, 99, -1])
     def test_appraisal_unknown_version(self, bad_version):
         d = _valid_appraisal_dict(schema_version=bad_version)
-        with pytest.raises(EmotionalDomainError, match="schema_version|Unsupported"):
+        with pytest.raises(EmotionalDomainError):
             AppraisalV1.from_dict(d)
 
 
-# ─── 5: Invalid types rejected ───────────────────────────────────────────────
+# ─── Type validation (5) ──────────────────────────────────────────────────────
 
 _STATE_NUMERIC_FIELDS = [
     "pleasure", "arousal", "dominance",
@@ -233,8 +995,6 @@ _APPRAISAL_NUMERIC_FIELDS = ["valence_shift", "arousal_shift", "dominance_shift"
 
 
 class TestInvalidTypesState:
-    """Requirement 5: bool, None, str, list, dict rejected for EmotionalStateV1 fields."""
-
     @pytest.mark.parametrize("field_name", _STATE_NUMERIC_FIELDS)
     @pytest.mark.parametrize("bad_value", [True, False, None, "0.5", [0.5], {"v": 0.5}])
     def test_state_rejects_bad_type(self, field_name, bad_value):
@@ -242,20 +1002,8 @@ class TestInvalidTypesState:
         with pytest.raises(EmotionalDomainError):
             EmotionalStateV1.from_dict(d)
 
-    def test_state_rejects_bool_schema_version(self):
-        d = _valid_state_dict(schema_version=True)
-        with pytest.raises(EmotionalDomainError):
-            EmotionalStateV1.from_dict(d)
-
-    def test_state_rejects_none_coping_mode(self):
-        d = _valid_state_dict(coping_mode=None)
-        with pytest.raises(EmotionalDomainError):
-            EmotionalStateV1.from_dict(d)
-
 
 class TestInvalidTypesAppraisal:
-    """Requirement 5: bool, None, str, list, dict rejected for AppraisalV1 fields."""
-
     @pytest.mark.parametrize("field_name", _APPRAISAL_NUMERIC_FIELDS)
     @pytest.mark.parametrize("bad_value", [True, False, None, "0.5", [0.5], {"v": 0.5}])
     def test_appraisal_rejects_bad_type(self, field_name, bad_value):
@@ -279,11 +1027,9 @@ class TestInvalidTypesAppraisal:
             AppraisalV1.from_dict(d)
 
 
-# ─── 6: NaN / Inf rejected ───────────────────────────────────────────────────
+# ─── NaN/Inf (6) ─────────────────────────────────────────────────────────────
 
 class TestNanInf:
-    """Requirement 6: NaN and ±Inf are rejected."""
-
     @pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
     @pytest.mark.parametrize("field_name", _STATE_NUMERIC_FIELDS)
     def test_state_nan_inf(self, field_name, bad_value):
@@ -305,11 +1051,9 @@ class TestNanInf:
             AppraisalV1.from_dict(d)
 
 
-# ─── 7: Out-of-range values ───────────────────────────────────────────────────
+# ─── Out-of-range (7) ────────────────────────────────────────────────────────
 
 class TestOutOfRange:
-    """Requirement 7: out-of-range values are rejected (policy: reject, not clamp)."""
-
     @pytest.mark.parametrize("field_name,lo,hi", [
         ("pleasure", -1.0, 1.0),
         ("arousal", -1.0, 1.0),
@@ -342,51 +1086,36 @@ class TestOutOfRange:
             AppraisalV1.from_dict(d)
 
     def test_state_boundary_values_accepted(self):
-        """Boundary values -1.0, 0.0, 1.0 are valid."""
         d = _valid_state_dict(pleasure=-1.0, arousal=0.0, dominance=1.0)
         state = EmotionalStateV1.from_dict(d)
         assert state.pleasure == -1.0
         assert state.dominance == 1.0
 
-    def test_appraisal_boundary_values_accepted(self):
-        d = _valid_appraisal_dict(valence_shift=-1.0, arousal_shift=0.0, dominance_shift=1.0)
-        appraisal = AppraisalV1.from_dict(d)
-        assert appraisal.valence_shift == -1.0
 
-
-# ─── 8: Unknown keys not silently accepted ───────────────────────────────────
+# ─── Unknown keys (8) ────────────────────────────────────────────────────────
 
 class TestUnknownKeys:
-    """Requirement 8: unknown keys are rejected, not silently dropped."""
-
     def test_state_rejects_unknown_key(self):
         d = _valid_state_dict()
         d["unknown_field"] = 42
-        with pytest.raises(EmotionalDomainError, match="Unknown fields"):
+        with pytest.raises(EmotionalDomainError):
             EmotionalStateV1.from_dict(d)
 
     def test_appraisal_rejects_unknown_key(self):
         d = _valid_appraisal_dict()
         d["extra"] = "value"
-        with pytest.raises(EmotionalDomainError, match="Unknown fields"):
+        with pytest.raises(EmotionalDomainError):
             AppraisalV1.from_dict(d)
 
     def test_state_rejects_prompt_field(self):
         d = _valid_state_dict(system_prompt="do evil things")
-        with pytest.raises(EmotionalDomainError, match="Unknown fields"):
-            EmotionalStateV1.from_dict(d)
-
-    def test_state_rejects_memory_field(self):
-        d = _valid_state_dict(memory=[])
-        with pytest.raises(EmotionalDomainError, match="Unknown fields"):
+        with pytest.raises(EmotionalDomainError):
             EmotionalStateV1.from_dict(d)
 
 
-# ─── 9 & 10: Discrete emotion allowlist ──────────────────────────────────────
+# ─── Discrete emotion allowlist (9 & 10) ─────────────────────────────────────
 
 class TestDiscreteEmotionAllowlist:
-    """Requirements 9 & 10: discrete emotion allowlist is exact; unknown rejected."""
-
     def test_allowlist_is_exact(self):
         expected = frozenset({
             "joy", "sadness", "anger", "fear",
@@ -402,35 +1131,18 @@ class TestDiscreteEmotionAllowlist:
 
     def test_unknown_emotion_rejected(self):
         d = _valid_appraisal_dict(discrete_emotions={"unknown_emotion": 0.5})
-        with pytest.raises(EmotionalDomainError, match="Unknown discrete emotion"):
-            AppraisalV1.from_dict(d)
-
-    def test_partially_unknown_emotion_rejected(self):
-        d = _valid_appraisal_dict(discrete_emotions={"joy": 0.5, "invalid": 0.3})
-        with pytest.raises(EmotionalDomainError, match="Unknown discrete emotion"):
+        with pytest.raises(EmotionalDomainError):
             AppraisalV1.from_dict(d)
 
     def test_empty_discrete_emotions_accepted(self):
         d = _valid_appraisal_dict(discrete_emotions={})
         appraisal = AppraisalV1.from_dict(d)
-        assert appraisal.discrete_emotions == {}
-
-    def test_zero_intensity_accepted(self):
-        d = _valid_appraisal_dict(discrete_emotions={"joy": 0.0})
-        appraisal = AppraisalV1.from_dict(d)
-        assert appraisal.discrete_emotions["joy"] == 0.0
-
-    def test_max_intensity_accepted(self):
-        d = _valid_appraisal_dict(discrete_emotions={"anger": 1.0})
-        appraisal = AppraisalV1.from_dict(d)
-        assert appraisal.discrete_emotions["anger"] == 1.0
+        assert dict(appraisal.discrete_emotions) == {}
 
 
-# ─── 11: Coping mode allowlist ───────────────────────────────────────────────
+# ─── Coping mode (11) ────────────────────────────────────────────────────────
 
 class TestCopingMode:
-    """Requirement 11: unknown coping_mode is rejected."""
-
     @pytest.mark.parametrize("mode", sorted(VALID_COPING_MODES))
     def test_known_coping_modes_accepted(self, mode):
         d = _valid_state_dict(coping_mode=mode)
@@ -440,7 +1152,7 @@ class TestCopingMode:
     @pytest.mark.parametrize("bad_mode", ["PANIC", "NORMAL", "healthy", "FREEZE", "", "0"])
     def test_unknown_coping_mode_rejected(self, bad_mode):
         d = _valid_state_dict(coping_mode=bad_mode)
-        with pytest.raises(EmotionalDomainError, match="coping_mode|Unknown"):
+        with pytest.raises(EmotionalDomainError):
             EmotionalStateV1.from_dict(d)
 
     def test_coping_mode_allowlist_is_exact(self):
@@ -448,11 +1160,9 @@ class TestCopingMode:
         assert VALID_COPING_MODES == expected
 
 
-# ─── 12: Timestamp ───────────────────────────────────────────────────────────
+# ─── Timestamp (12) ──────────────────────────────────────────────────────────
 
 class TestTimestamp:
-    """Requirement 12: invalid timestamp is rejected."""
-
     def test_valid_timestamp_accepted(self):
         d = _valid_state_dict(timestamp=1_700_000_000.0)
         state = EmotionalStateV1.from_dict(d)
@@ -473,11 +1183,6 @@ class TestTimestamp:
         with pytest.raises(EmotionalDomainError):
             EmotionalStateV1.from_dict(d)
 
-    def test_inf_timestamp_rejected(self):
-        d = _valid_state_dict(timestamp=float("inf"))
-        with pytest.raises(EmotionalDomainError):
-            EmotionalStateV1.from_dict(d)
-
     def test_string_timestamp_rejected(self):
         d = _valid_state_dict(timestamp="2024-01-01")
         with pytest.raises(EmotionalDomainError):
@@ -488,17 +1193,10 @@ class TestTimestamp:
         with pytest.raises(EmotionalDomainError):
             EmotionalStateV1.from_dict(d)
 
-    def test_none_timestamp_rejected(self):
-        d = _valid_state_dict(timestamp=None)
-        with pytest.raises(EmotionalDomainError):
-            EmotionalStateV1.from_dict(d)
 
-
-# ─── 13: Migration valid legacy ──────────────────────────────────────────────
+# ─── Migration valid legacy (13) ─────────────────────────────────────────────
 
 class TestMigrationValidLegacy:
-    """Requirement 13: valid legacy snapshot → correct v1 model."""
-
     def test_basic_migration(self):
         legacy = _legacy_dict()
         result = migrate_legacy_snapshot(legacy)
@@ -506,16 +1204,10 @@ class TestMigrationValidLegacy:
         assert result.schema_version == EMOTIONAL_SCHEMA_VERSION
 
     def test_field_mapping(self):
-        legacy = _legacy_dict(
-            pleasure=0.5,
-            arousal=-0.3,
-            dominance=0.2,
-            last_update=1_700_000_000.0,
-        )
+        legacy = _legacy_dict(pleasure=0.5, arousal=-0.3, dominance=0.2, last_update=1_700_000_000.0)
         result = migrate_legacy_snapshot(legacy)
         assert result.pleasure == 0.5
         assert result.arousal == -0.3
-        assert result.dominance == 0.2
         assert result.timestamp == 1_700_000_000.0
 
     def test_last_update_becomes_timestamp(self):
@@ -531,25 +1223,12 @@ class TestMigrationValidLegacy:
         )
         result = migrate_legacy_snapshot(legacy)
         assert result.libido == 0.4
-        assert result.aggression == 0.2
-        assert result.connection == 0.7
-        assert result.energy == 0.9
-        assert result.tension == 0.1
         assert result.coping_mode == "DEFENSIVE"
 
-    def test_v1_snapshot_idempotent(self):
-        """A v1 snapshot passed to migrate is re-validated and returned."""
-        state = EmotionalStateV1.from_dict(_valid_state_dict())
-        v1_dict = state.to_dict()
-        result = migrate_legacy_snapshot(v1_dict)
-        assert result == state
 
-
-# ─── 14: Legacy invalid fails closed ─────────────────────────────────────────
+# ─── Migration invalid (14) ──────────────────────────────────────────────────
 
 class TestMigrationInvalidLegacy:
-    """Requirement 14: invalid legacy snapshot fails closed (raises)."""
-
     def test_non_dict_rejected(self):
         for bad in [None, "string", 42, [], ()]:
             with pytest.raises(EmotionalDomainError):
@@ -577,22 +1256,14 @@ class TestMigrationInvalidLegacy:
         with pytest.raises(EmotionalDomainError):
             migrate_legacy_snapshot(legacy)
 
-    def test_unknown_schema_version_rejected(self):
-        legacy = _legacy_dict()
-        legacy["schema_version"] = 999
-        with pytest.raises(EmotionalDomainError):
-            migrate_legacy_snapshot(legacy)
-
     def test_empty_dict_rejected(self):
         with pytest.raises(EmotionalDomainError):
             migrate_legacy_snapshot({})
 
 
-# ─── 15: Migration does not mutate input ─────────────────────────────────────
+# ─── Migration no mutation (15) ──────────────────────────────────────────────
 
 class TestMigrationNoMutation:
-    """Requirement 15: migration never mutates the input dict."""
-
     def test_input_not_mutated(self):
         import copy
         legacy = _legacy_dict()
@@ -608,11 +1279,9 @@ class TestMigrationNoMutation:
         assert v1 == original
 
 
-# ─── 16: Invalid appraisal → explicit neutral fallback ───────────────────────
+# ─── Parser fallback (16) ────────────────────────────────────────────────────
 
 class TestAppraisalParserFallback:
-    """Requirement 16: invalid LLM appraisal produces observable neutral fallback."""
-
     def test_valid_dict_parses_correctly(self):
         raw = {
             "valence_shift": 0.3,
@@ -622,144 +1291,65 @@ class TestAppraisalParserFallback:
         }
         result = parse_llm_appraisal(raw)
         assert not result.is_fallback
-        assert result.error is None
+        assert result.error_code is None
         assert result.appraisal.valence_shift == 0.3
-        assert result.appraisal.discrete_emotions["joy"] == 0.7
 
     def test_none_produces_fallback(self):
         result = parse_llm_appraisal(None)
         assert result.is_fallback
-        assert result.error is not None
+        assert result.error_code == ParseErrorCode.invalid_structure
         assert result.appraisal == AppraisalV1.neutral()
 
     def test_string_produces_fallback(self):
         result = parse_llm_appraisal("bad output")
         assert result.is_fallback
-        assert result.appraisal == AppraisalV1.neutral()
 
     def test_out_of_range_produces_fallback(self):
         result = parse_llm_appraisal({"valence_shift": 99.0, "arousal_shift": 0.0, "dominance_shift": 0.0})
         assert result.is_fallback
-        assert result.appraisal == AppraisalV1.neutral()
+        assert result.error_code == ParseErrorCode.invalid_numeric_value
 
     def test_nan_produces_fallback(self):
         result = parse_llm_appraisal({"valence_shift": float("nan"), "arousal_shift": 0.0, "dominance_shift": 0.0})
         assert result.is_fallback
-        assert result.appraisal == AppraisalV1.neutral()
 
     def test_bool_shift_produces_fallback(self):
         result = parse_llm_appraisal({"valence_shift": True, "arousal_shift": 0.0, "dominance_shift": 0.0})
         assert result.is_fallback
-        assert result.appraisal == AppraisalV1.neutral()
-
-    def test_unknown_emotion_silently_dropped(self):
-        """LLM output with unknown emotions: unknown keys are filtered, not rejected."""
-        raw = {
-            "valence_shift": 0.1,
-            "arousal_shift": 0.0,
-            "dominance_shift": 0.0,
-            "discrete_emotions": {"joy": 0.5, "invented_emotion": 0.9},
-        }
-        result = parse_llm_appraisal(raw)
-        # Should succeed, filtering out the unknown emotion
-        assert not result.is_fallback
-        assert "invented_emotion" not in result.appraisal.discrete_emotions
-        assert "joy" in result.appraisal.discrete_emotions
-
-    def test_missing_shifts_default_to_zero(self):
-        """Missing shift keys default to 0.0 (LLM may omit them)."""
-        raw = {}
-        result = parse_llm_appraisal(raw)
-        assert not result.is_fallback
-        assert result.appraisal.valence_shift == 0.0
-        assert result.appraisal.arousal_shift == 0.0
 
     def test_fallback_neutral_has_correct_schema_version(self):
         result = parse_llm_appraisal(None)
         assert result.appraisal.schema_version == EMOTIONAL_SCHEMA_VERSION
 
-    def test_legacy_key_valence_accepted(self):
-        """'valence' (without _shift) is accepted as alias for 'valence_shift'."""
-        raw = {"valence": 0.3, "arousal_shift": 0.0, "dominance_shift": 0.0}
-        result = parse_llm_appraisal(raw)
-        assert not result.is_fallback
-        assert result.appraisal.valence_shift == 0.3
-
     def test_parse_result_is_not_empty_dict(self):
-        """Neutral fallback is an explicit AppraisalV1, not an empty dict."""
         result = parse_llm_appraisal("garbage")
         assert isinstance(result.appraisal, AppraisalV1)
         assert result.appraisal == AppraisalV1.neutral()
 
+    def test_parse_error_code_is_enum(self):
+        result = parse_llm_appraisal(None)
+        assert isinstance(result.error_code, ParseErrorCode)
 
-# ─── 17: Domain importable without infrastructure ────────────────────────────
 
-class TestDomainImportIsolation:
-    """Requirement 17: domain module importable without FastAPI/Groq/Supabase/transformers."""
+# ─── Package public API exports ───────────────────────────────────────────────
 
-    def test_models_importable_without_fastapi(self):
-        """
-        Import the module from scratch (bypass cache) and verify it doesn't
-        pull in FastAPI.
-        """
-        # If fastapi is not installed, the import would fail if it were a dependency.
-        # We verify that importing emotional_domain does not import fastapi.
-        import backend.emotional_domain.models as m
-        # Check that fastapi is not imported as a side effect
-        assert "fastapi" not in sys.modules or True  # fastapi may be installed but not required
+class TestPackageExports:
+    """ParseResult and ParseErrorCode are exported from the package."""
 
-        # The real test: the module must be importable and functional
-        assert hasattr(m, "EmotionalStateV1")
-        assert hasattr(m, "AppraisalV1")
-        assert hasattr(m, "EMOTIONAL_SCHEMA_VERSION")
+    def test_parse_result_exported(self):
+        assert PackageParseResult is ParseResult
 
-    def test_no_groq_import(self):
-        import backend.emotional_domain.models as m
-        import inspect
-        source = inspect.getsource(m)
-        assert "groq" not in source.lower()
+    def test_parse_error_code_exported(self):
+        assert PackageParseErrorCode is ParseErrorCode
 
-    def test_no_supabase_import(self):
-        import backend.emotional_domain.models as m
-        import inspect
-        source = inspect.getsource(m)
-        assert "supabase" not in source.lower()
-
-    def test_no_sentence_transformers_import(self):
-        import backend.emotional_domain.models as m
-        import inspect
-        source = inspect.getsource(m)
-        assert "sentence_transformers" not in source.lower()
-
-    def test_no_fastapi_import(self):
-        import backend.emotional_domain.models as m
-        import inspect
-        source = inspect.getsource(m)
-        assert "fastapi" not in source.lower()
-
-    def test_no_os_environ_access(self):
-        """Domain module must not read environment variables."""
-        import backend.emotional_domain.models as m
-        import inspect
-        source = inspect.getsource(m)
-        assert "os.environ" not in source
-        assert "os.getenv" not in source
-
-    def test_migration_no_io(self):
-        import backend.emotional_domain.migration as mig
-        import inspect
-        source = inspect.getsource(mig)
-        # No file I/O or network
-        assert "open(" not in source
-        assert "urllib" not in source
-        assert "requests" not in source
+    def test_package_parse_works(self):
+        r = package_parse({"valence_shift": 0.1, "arousal_shift": 0.0, "dominance_shift": 0.0})
+        assert not r.is_fallback
 
 
 # ─── Serialization edge cases ────────────────────────────────────────────────
 
 class TestSerializationEdgeCases:
-    """Additional serialization guarantees."""
-
     def test_deserialize_state_rejects_non_string(self):
         with pytest.raises(EmotionalDomainError):
             deserialize_state(42)

--- a/backend/tests/test_emotional_domain.py
+++ b/backend/tests/test_emotional_domain.py
@@ -46,6 +46,16 @@ H17. Migration rejects schema_version=None
 H18. Migration rejects both last_update and timestamp simultaneously
 H19. Migration v1 idempotent
 H20. Isolated subprocess import of package — no infra modules loaded
+
+Hardening (v1.2 — second audit):
+N1.  Direct constructor normalizes int→float (EmotionalStateV1)
+N2.  Direct constructor normalizes int→float (AppraisalV1 shifts)
+N3.  create() and direct ctor produce identical types and JSON
+N4.  Explicit None discrete_emotions rejected by create()
+N5.  Explicit None discrete_emotions rejected by from_dict()
+N6.  Omitted discrete_emotions defaults to empty mapping
+N7.  Production _perceive() payload passes through parser without loss
+N8.  DISCRETE_EMOTIONS includes all production emotions used by RelationshipManager
 """
 
 from __future__ import annotations
@@ -341,6 +351,187 @@ class TestAppraisalDeepImmutability:
         d["discrete_emotions"]["joy"] = 99.0
         # Object is unchanged
         assert ap.discrete_emotions["joy"] == 0.5
+
+
+# ─── N1 & N2: Normalization in direct constructors ──────────────────────────
+
+class TestStateNormalization:
+    """N1 — Direct EmotionalStateV1(...) normalizes int → float."""
+
+    def test_direct_ctor_normalizes_int_to_float(self):
+        state = EmotionalStateV1(**_valid_state_kwargs(pleasure=1, libido=0))
+        assert state.pleasure == 1.0
+        assert isinstance(state.pleasure, float)
+        assert isinstance(state.libido, float)
+
+    def test_factory_and_direct_ctor_equal(self):
+        direct = EmotionalStateV1(**_valid_state_kwargs(pleasure=1, arousal=0, tension=0))
+        factory = EmotionalStateV1.create(
+            pleasure=1, arousal=0, dominance=0.3,
+            libido=0.0, aggression=0.1, connection=0.5,
+            energy=0.8, tension=0, coping_mode="HEALTHY",
+            timestamp=1_700_000_000.0,
+        )
+        assert direct == factory
+        assert direct.to_dict() == factory.to_dict()
+
+    def test_direct_and_factory_json_identical(self):
+        direct = EmotionalStateV1(**_valid_state_kwargs(pleasure=1, arousal=0, tension=0))
+        factory = EmotionalStateV1.create(
+            pleasure=1, arousal=0, dominance=0.3,
+            libido=0.0, aggression=0.1, connection=0.5,
+            energy=0.8, tension=0, coping_mode="HEALTHY",
+            timestamp=1_700_000_000.0,
+        )
+        from backend.emotional_domain.serialization import serialize_state
+        assert serialize_state(direct) == serialize_state(factory)
+
+    def test_normalization_uses_float_in_to_dict(self):
+        state = EmotionalStateV1(**_valid_state_kwargs(pleasure=1))
+        d = state.to_dict()
+        assert d["pleasure"] == 1.0
+        assert isinstance(d["pleasure"], float)
+
+
+class TestAppraisalNormalization:
+    """N2 — Direct AppraisalV1(...) normalizes int → float for shifts."""
+
+    def test_direct_ctor_normalizes_int_shifts(self):
+        a = AppraisalV1(
+            valence_shift=1, arousal_shift=0, dominance_shift=-1,
+            discrete_emotions={}, schema_version=EMOTIONAL_SCHEMA_VERSION,
+        )
+        assert a.valence_shift == 1.0
+        assert isinstance(a.valence_shift, float)
+        assert isinstance(a.arousal_shift, float)
+        assert isinstance(a.dominance_shift, float)
+
+    def test_factory_and_direct_ctor_equal(self):
+        direct = AppraisalV1(
+            valence_shift=1, arousal_shift=0, dominance_shift=-1,
+            discrete_emotions={"joy": 0.5}, schema_version=EMOTIONAL_SCHEMA_VERSION,
+        )
+        factory = AppraisalV1.create(
+            valence_shift=1, arousal_shift=0, dominance_shift=-1,
+            discrete_emotions={"joy": 0.5},
+        )
+        assert direct == factory
+        assert direct.to_dict() == factory.to_dict()
+
+    def test_direct_and_factory_json_identical(self):
+        direct = AppraisalV1(
+            valence_shift=1, arousal_shift=0, dominance_shift=0,
+            discrete_emotions={"joy": 0.5}, schema_version=EMOTIONAL_SCHEMA_VERSION,
+        )
+        factory = AppraisalV1.create(
+            valence_shift=1, arousal_shift=0, dominance_shift=0,
+            discrete_emotions={"joy": 0.5},
+        )
+        from backend.emotional_domain.serialization import serialize_appraisal
+        assert serialize_appraisal(direct) == serialize_appraisal(factory)
+
+
+# ─── N4 & N5: None rejection in Appraisal API ────────────────────────────────
+
+class TestAppraisalNoneRejection:
+    """N4 — Explicit None in discrete_emotions raises EmotionalDomainError."""
+
+    _BASE = dict(valence_shift=0.0, arousal_shift=0.0, dominance_shift=0.0)
+
+    def test_create_explicit_none_rejected(self):
+        with pytest.raises(EmotionalDomainError, match="discrete_emotions"):
+            AppraisalV1.create(**self._BASE, discrete_emotions=None)
+
+    def test_create_omitted_defaults_to_empty(self):
+        """Omitting discrete_emotions entirely should produce empty mapping."""
+        a = AppraisalV1.create(**self._BASE)
+        assert dict(a.discrete_emotions) == {}
+
+    def test_create_explicit_empty_accepted(self):
+        a = AppraisalV1.create(**self._BASE, discrete_emotions={})
+        assert dict(a.discrete_emotions) == {}
+
+    def test_from_dict_explicit_none_rejected(self):
+        d = _valid_appraisal_dict(discrete_emotions=None)
+        with pytest.raises(EmotionalDomainError, match="discrete_emotions"):
+            AppraisalV1.from_dict(d)
+
+    def test_from_dict_absent_key_defaults_to_empty(self):
+        d = {k: v for k, v in _valid_appraisal_dict().items() if k != "discrete_emotions"}
+        a = AppraisalV1.from_dict(d)
+        assert dict(a.discrete_emotions) == {}
+
+    def test_from_dict_unknown_keys_still_rejected(self):
+        d = _valid_appraisal_dict()
+        d["extra"] = "value"
+        with pytest.raises(EmotionalDomainError):
+            AppraisalV1.from_dict(d)
+
+
+# ─── N7: Production _perceive() payload regression test ──────────────────────
+
+class TestParserProductionPayload:
+    """N7 — The actual _perceive() payload from engine.py must pass through
+    the parser without loss of emotions consumed by RelationshipManager."""
+
+    _PRODUCTION_EMOTIONS = [
+        "joy", "sadness", "anger", "fear", "disgust", "surprise",
+        "tenderness", "guilt", "pride", "jealousy", "gratitude",
+    ]
+
+    def test_parser_preserves_all_production_emotions(self):
+        """The full payload from engine.py _perceive() must preserve all 11
+        emotions used by RelationshipManager."""
+        triggered = {emo: 0.5 for emo in self._PRODUCTION_EMOTIONS}
+        raw = {
+            "valence": 0.3,
+            "arousal_shift": -0.1,
+            "dominance_shift": 0.0,
+            "triggered_emotions": triggered,
+        }
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback, f"Fallback: {result.error_code}"
+        parsed_emotions = dict(result.appraisal.discrete_emotions)
+        for emo in self._PRODUCTION_EMOTIONS:
+            assert emo in parsed_emotions, f"Missing emotion: {emo}"
+            assert parsed_emotions[emo] == 0.5
+
+    def test_tenderness_and_gratitude_preserved_for_relationship(self):
+        """Specifically test the emotions consumed by RelationshipManager:
+        tenderness (affection), joy (affection), gratitude (affection),
+        anger (tension), disgust (tension)."""
+        triggered = {
+            "tenderness": 0.8, "joy": 0.3, "gratitude": 0.6,
+            "anger": 0.4, "disgust": 0.0,
+        }
+        raw = {
+            "valence": 0.5,
+            "arousal_shift": 0.0,
+            "dominance_shift": 0.0,
+            "triggered_emotions": triggered,
+        }
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback
+        de = dict(result.appraisal.discrete_emotions)
+        assert de["tenderness"] == 0.8
+        assert de["gratitude"] == 0.6
+        assert de["anger"] == 0.4
+
+    def test_parser_preserves_all_emotions_from_legacy_triggered(self):
+        """Using triggered_emotions alias (as in _perceive output)."""
+        triggered = {emo: 0.3 for emo in self._PRODUCTION_EMOTIONS}
+        raw = {
+            "valence": -0.2,
+            "arousal_shift": 0.1,
+            "dominance_shift": -0.1,
+            "triggered_emotions": triggered,
+        }
+        result = parse_llm_appraisal(raw)
+        assert not result.is_fallback
+        de = dict(result.appraisal.discrete_emotions)
+        assert len(de) == len(self._PRODUCTION_EMOTIONS)
+        for emo in self._PRODUCTION_EMOTIONS:
+            assert de[emo] == 0.3
 
 
 # ─── H6: Serialization valid after mutation attempt ──────────────────────────
@@ -1116,10 +1307,16 @@ class TestUnknownKeys:
 # ─── Discrete emotion allowlist (9 & 10) ─────────────────────────────────────
 
 class TestDiscreteEmotionAllowlist:
-    def test_allowlist_is_exact(self):
+    def test_allowlist_includes_production_emotions(self):
+        """All emotions used by _perceive() and RelationshipManager must be present."""
+        for emo in ["tenderness", "guilt", "pride", "jealousy", "gratitude"]:
+            assert emo in DISCRETE_EMOTIONS, f"Missing production emotion: {emo}"
+
+    def test_allowlist_contains_expected_set(self):
         expected = frozenset({
             "joy", "sadness", "anger", "fear",
             "disgust", "surprise", "trust", "anticipation",
+            "tenderness", "guilt", "pride", "jealousy", "gratitude",
         })
         assert DISCRETE_EMOTIONS == expected
 

--- a/docs/architecture/emotional-core-v1.md
+++ b/docs/architecture/emotional-core-v1.md
@@ -1,0 +1,262 @@
+# Emotional Core v1 — Architecture
+
+## Scope
+
+This document describes the typed, versioned domain contracts introduced in issue #232.
+It covers boundaries, invariants, allowlists, serialisation, migration, and fallback policy.
+It does **not** describe transition logic, decay, or production integration (those are #233 and #234).
+
+---
+
+## Layer boundaries
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  Presentation  (prompt builder, acting instruction)            │
+├────────────────────────────────────────────────────────────────┤
+│  Transition    (AffectiveEngine — decay, PAD update, coping)   │
+│                          ▲ uses (not replaced in #232)         │
+├────────────────────────────────────────────────────────────────┤
+│  Appraisal     (parse_llm_appraisal, OCCAppraisal)             │
+│                          ▲ produces AppraisalV1                │
+├────────────────────────────────────────────────────────────────┤
+│  State         (EmotionalStateV1) — this document              │
+├────────────────────────────────────────────────────────────────┤
+│  Migration     (migrate_legacy_snapshot)                       │
+└────────────────────────────────────────────────────────────────┘
+```
+
+**What belongs to the state layer:** pleasure, arousal, dominance, drives, coping mode, timestamp.  
+**What does NOT belong:** relationship data, memory, prompt text, personality rules, metacognition.
+
+---
+
+## Module location
+
+```
+backend/emotional_domain/
+    __init__.py           — public API re-exports
+    models.py             — EmotionalStateV1, AppraisalV1, constants
+    migration.py          — migrate_legacy_snapshot
+    serialization.py      — serialize_*/deserialize_* (JSON)
+    appraisal_parser.py   — parse_llm_appraisal (with fallback)
+```
+
+No file in this package imports FastAPI, Groq, Supabase, sentence_transformers,
+environment variables, or any I/O.
+
+---
+
+## Schema version
+
+```python
+EMOTIONAL_SCHEMA_VERSION: int = 1
+```
+
+Single supported version. All models carry `schema_version` and reject any other value.
+
+---
+
+## EmotionalStateV1
+
+### Fields and invariants
+
+| Field         | Type    | Range / Allowlist       | Policy on violation |
+|---------------|---------|-------------------------|---------------------|
+| `schema_version` | `int` | must equal `1`        | `EmotionalDomainError` |
+| `pleasure`    | `float` | `[-1.0, 1.0]`          | `EmotionalDomainError` |
+| `arousal`     | `float` | `[-1.0, 1.0]`          | `EmotionalDomainError` |
+| `dominance`   | `float` | `[-1.0, 1.0]`          | `EmotionalDomainError` |
+| `libido`      | `float` | `[0.0, 1.0]`           | `EmotionalDomainError` |
+| `aggression`  | `float` | `[0.0, 1.0]`           | `EmotionalDomainError` |
+| `connection`  | `float` | `[0.0, 1.0]`           | `EmotionalDomainError` |
+| `energy`      | `float` | `[0.0, 1.0]`           | `EmotionalDomainError` |
+| `tension`     | `float` | `[0.0, 1.0]`           | `EmotionalDomainError` |
+| `coping_mode` | `str`   | see `VALID_COPING_MODES` | `EmotionalDomainError` |
+| `timestamp`   | `float` | finite, positive        | `EmotionalDomainError` |
+
+**Global rejections (all numeric fields):**
+- `bool` (including `True`/`False`)
+- `None`
+- `str`, `list`, `dict`, or any non-numeric type
+- `NaN`, `+Inf`, `-Inf`
+
+**Unknown keys:** always rejected via `EmotionalDomainError`.
+
+### Coping mode allowlist
+
+```python
+VALID_COPING_MODES = frozenset({"HEALTHY", "DEFENSIVE", "DISSOCIATED", "MANIC"})
+```
+
+### Construction
+
+```python
+# Validated factory (recommended)
+state = EmotionalStateV1.create(
+    pleasure=0.1, arousal=-0.2, dominance=0.3,
+    libido=0.0, aggression=0.1, connection=0.5,
+    energy=0.8, tension=0.2,
+    coping_mode="HEALTHY",
+    timestamp=1_700_000_000.0,
+)
+
+# Neutral default
+state = EmotionalStateV1.neutral(timestamp=time.time())
+
+# From persisted dict (validates all fields + rejects unknown keys)
+state = EmotionalStateV1.from_dict(stored_dict)
+```
+
+### Valid JSON example
+
+```json
+{
+  "aggression": 0.1,
+  "arousal": -0.2,
+  "connection": 0.5,
+  "coping_mode": "HEALTHY",
+  "dominance": 0.3,
+  "energy": 0.8,
+  "libido": 0.0,
+  "pleasure": 0.1,
+  "schema_version": 1,
+  "tension": 0.2,
+  "timestamp": 1700000000.0
+}
+```
+
+---
+
+## AppraisalV1
+
+### Fields and invariants
+
+| Field              | Type            | Range / Allowlist          | Policy on violation     |
+|--------------------|-----------------|----------------------------|-------------------------|
+| `schema_version`   | `int`           | must equal `1`             | `EmotionalDomainError`  |
+| `valence_shift`    | `float`         | `[-1.0, 1.0]`              | `EmotionalDomainError`  |
+| `arousal_shift`    | `float`         | `[-1.0, 1.0]`              | `EmotionalDomainError`  |
+| `dominance_shift`  | `float`         | `[-1.0, 1.0]`              | `EmotionalDomainError`  |
+| `discrete_emotions`| `dict[str, float]` | keys ∈ `DISCRETE_EMOTIONS`, values in `[0.0, 1.0]` | `EmotionalDomainError` |
+
+### Discrete emotion allowlist
+
+```python
+DISCRETE_EMOTIONS = frozenset({
+    "joy", "sadness", "anger", "fear",
+    "disgust", "surprise", "trust", "anticipation",
+})
+```
+
+Unknown emotion keys are **rejected** (strict policy). Intensities follow the same
+rejection rules as other numeric fields (no bool, no None, no NaN/Inf, range enforced).
+
+### Neutral appraisal
+
+```python
+neutral = AppraisalV1.neutral()
+# → valence_shift=0.0, arousal_shift=0.0, dominance_shift=0.0, discrete_emotions={}
+```
+
+### Valid JSON example
+
+```json
+{
+  "arousal_shift": -0.1,
+  "discrete_emotions": {
+    "joy": 0.5,
+    "trust": 0.3
+  },
+  "dominance_shift": 0.0,
+  "schema_version": 1,
+  "valence_shift": 0.2
+}
+```
+
+---
+
+## Serialisation
+
+```python
+from backend.emotional_domain import serialize_state, deserialize_state
+from backend.emotional_domain import serialize_appraisal, deserialize_appraisal
+
+# EmotionalStateV1
+json_str = serialize_state(state)    # deterministic JSON, sorted keys
+restored = deserialize_state(json_str)
+assert state == restored
+
+# AppraisalV1
+json_str = serialize_appraisal(appraisal)
+restored = deserialize_appraisal(json_str)
+assert appraisal == restored
+```
+
+**Guarantees:**
+- Output always includes `schema_version`.
+- Keys are sorted (deterministic format).
+- No prompt text, metacognition, relationship, or memory fields exposed.
+- Round-trip produces an equivalent object.
+
+---
+
+## Migration from legacy snapshots
+
+The legacy `EmotionalState.to_dict()` format uses `last_update` (float) instead of
+`timestamp` and has no `schema_version`.
+
+```python
+from backend.emotional_domain import migrate_legacy_snapshot
+
+# From storage (legacy format — no schema_version key)
+legacy = {
+    "pleasure": 0.1, "arousal": -0.2, "dominance": 0.3,
+    "libido": 0.0, "aggression": 0.1, "connection": 0.5,
+    "energy": 0.8, "tension": 0.2, "coping_mode": "HEALTHY",
+    "last_update": 1700000000.0,
+}
+state_v1 = migrate_legacy_snapshot(legacy)
+```
+
+**Migration contract:**
+- Input is never mutated.
+- `last_update` → `timestamp`.
+- Missing required fields → `EmotionalDomainError`.
+- Invalid values → `EmotionalDomainError` (fails closed).
+- If `schema_version=1` is already present, re-validates and returns as-is (idempotent).
+- Any other `schema_version` → `EmotionalDomainError`.
+- No I/O, no Supabase, pure function.
+
+---
+
+## Fallback policy for invalid LLM appraisal
+
+```python
+from backend.emotional_domain import parse_llm_appraisal
+
+result = parse_llm_appraisal(raw_llm_dict)
+
+if result.is_fallback:
+    # Log result.error — LLM produced invalid output
+    appraisal = result.appraisal  # always AppraisalV1.neutral()
+else:
+    appraisal = result.appraisal  # valid AppraisalV1
+```
+
+**Policy:**
+- Any validation error → neutral fallback, error recorded in `result.error`.
+- Never raises.
+- Unknown emotion keys from LLM output are silently filtered (not rejected).
+- Invalid intensity values → fallback.
+- Result is never an empty dict; always an explicit `AppraisalV1`.
+
+---
+
+## Out of scope (this document / issue #232)
+
+- Transition logic, decay, or PAD update formulas (→ #233).
+- Integration of these models into `ConversationEngine` (→ #234).
+- Persistence changes.
+- API or frontend changes.
+- Relationship, memory, prompt, or personality logic.

--- a/docs/architecture/emotional-core-v1.md
+++ b/docs/architecture/emotional-core-v1.md
@@ -153,10 +153,24 @@ state = EmotionalStateV1(pleasure=0.1, ..., schema_version=1)  # raises if inval
 
 ```python
 DISCRETE_EMOTIONS = frozenset({
+    # Core emotions
     "joy", "sadness", "anger", "fear",
-    "disgust", "surprise", "trust", "anticipation",
+    "disgust", "surprise",
+    # Extended emotions (from v1 model)
+    "trust", "anticipation",
+    # Production emotions (consumed by RelationshipManager via _perceive)
+    "tenderness", "guilt", "pride", "jealousy", "gratitude",
 })
 ```
+
+**Total: 13 emotions.** This allowlist is compatible with the production
+`_perceive()` output and the emotions used by `RelationshipManager`
+(tenderness and gratitude for affection, anger and disgust for tension).
+
+The LLM parser (`parse_llm_appraisal`) **filters** unknown emotion keys
+from LLM output silently, while the constructors (`create`, `from_dict`,
+direct `__init__`) **reject** unknown emotion keys with
+`EmotionalDomainError`.
 
 Unknown emotion keys are **rejected** via `create`/`from_dict`/direct constructor.
 In the LLM parser (`parse_llm_appraisal`), unknown emotions are **filtered silently**

--- a/docs/architecture/emotional-core-v1.md
+++ b/docs/architecture/emotional-core-v1.md
@@ -2,9 +2,11 @@
 
 ## Scope
 
-This document describes the typed, versioned domain contracts introduced in issue #232.
-It covers boundaries, invariants, allowlists, serialisation, migration, and fallback policy.
-It does **not** describe transition logic, decay, or production integration (those are #233 and #234).
+This document describes the typed, versioned domain contracts introduced in issue #232
+and hardened in issue #232 v1.1.
+It covers construction invariants, deep immutability, serialisation, migration, parser,
+fallback policy, and alias translation.
+It does **not** describe transition logic, decay, or production integration (#233/#234).
 
 ---
 
@@ -39,11 +41,11 @@ backend/emotional_domain/
     models.py             — EmotionalStateV1, AppraisalV1, constants
     migration.py          — migrate_legacy_snapshot
     serialization.py      — serialize_*/deserialize_* (JSON)
-    appraisal_parser.py   — parse_llm_appraisal (with fallback)
+    appraisal_parser.py   — parse_llm_appraisal (with ParseResult and ParseErrorCode)
 ```
 
 No file in this package imports FastAPI, Groq, Supabase, sentence_transformers,
-environment variables, or any I/O.
+environment variables, or any I/O. This is verified by an isolated subprocess test.
 
 ---
 
@@ -53,7 +55,27 @@ environment variables, or any I/O.
 EMOTIONAL_SCHEMA_VERSION: int = 1
 ```
 
-Single supported version. All models carry `schema_version` and reject any other value.
+Single supported version. All models carry `schema_version` and reject any other value,
+including: `None`, `bool`, `float`, `str`, and any integer ≠ 1.
+
+---
+
+## Validation on all public construction paths
+
+Every public construction path validates all invariants:
+
+| Path | Validation |
+|---|---|
+| `EmotionalStateV1(...)` | `__post_init__` validates all fields |
+| `EmotionalStateV1.create(...)` | validates, then delegates to `__init__` |
+| `EmotionalStateV1.from_dict(...)` | checks structure, then delegates to `create` |
+| `EmotionalStateV1.neutral(...)` | delegates to `create` |
+| `AppraisalV1(...)` | `__post_init__` validates all fields and enforces immutability |
+| `AppraisalV1.create(...)` | validates, then delegates to `__init__` |
+| `AppraisalV1.from_dict(...)` | checks structure, then delegates to `create` |
+| `AppraisalV1.neutral()` | delegates to `create` |
+
+> **There is no way to produce an invalid instance through any public path.**
 
 ---
 
@@ -63,7 +85,7 @@ Single supported version. All models carry `schema_version` and reject any other
 
 | Field         | Type    | Range / Allowlist       | Policy on violation |
 |---------------|---------|-------------------------|---------------------|
-| `schema_version` | `int` | must equal `1`        | `EmotionalDomainError` |
+| `schema_version` | `int` | must equal `1`; not bool, float, str, None | `EmotionalDomainError` |
 | `pleasure`    | `float` | `[-1.0, 1.0]`          | `EmotionalDomainError` |
 | `arousal`     | `float` | `[-1.0, 1.0]`          | `EmotionalDomainError` |
 | `dominance`   | `float` | `[-1.0, 1.0]`          | `EmotionalDomainError` |
@@ -81,7 +103,9 @@ Single supported version. All models carry `schema_version` and reject any other
 - `str`, `list`, `dict`, or any non-numeric type
 - `NaN`, `+Inf`, `-Inf`
 
-**Unknown keys:** always rejected via `EmotionalDomainError`.
+**Unknown keys in `from_dict`:** always rejected via `EmotionalDomainError`.
+
+**Error messages do not include raw values** (e.g., out-of-range numbers, enum values from input) to avoid leaking untrusted data.
 
 ### Coping mode allowlist
 
@@ -106,24 +130,9 @@ state = EmotionalStateV1.neutral(timestamp=time.time())
 
 # From persisted dict (validates all fields + rejects unknown keys)
 state = EmotionalStateV1.from_dict(stored_dict)
-```
 
-### Valid JSON example
-
-```json
-{
-  "aggression": 0.1,
-  "arousal": -0.2,
-  "connection": 0.5,
-  "coping_mode": "HEALTHY",
-  "dominance": 0.3,
-  "energy": 0.8,
-  "libido": 0.0,
-  "pleasure": 0.1,
-  "schema_version": 1,
-  "tension": 0.2,
-  "timestamp": 1700000000.0
-}
+# Direct construction also validates (via __post_init__)
+state = EmotionalStateV1(pleasure=0.1, ..., schema_version=1)  # raises if invalid
 ```
 
 ---
@@ -138,7 +147,7 @@ state = EmotionalStateV1.from_dict(stored_dict)
 | `valence_shift`    | `float`         | `[-1.0, 1.0]`              | `EmotionalDomainError`  |
 | `arousal_shift`    | `float`         | `[-1.0, 1.0]`              | `EmotionalDomainError`  |
 | `dominance_shift`  | `float`         | `[-1.0, 1.0]`              | `EmotionalDomainError`  |
-| `discrete_emotions`| `dict[str, float]` | keys ∈ `DISCRETE_EMOTIONS`, values in `[0.0, 1.0]` | `EmotionalDomainError` |
+| `discrete_emotions`| `MappingProxyType[str, float]` | keys ∈ `DISCRETE_EMOTIONS`, values in `[0.0, 1.0]` | `EmotionalDomainError` |
 
 ### Discrete emotion allowlist
 
@@ -149,29 +158,34 @@ DISCRETE_EMOTIONS = frozenset({
 })
 ```
 
-Unknown emotion keys are **rejected** (strict policy). Intensities follow the same
-rejection rules as other numeric fields (no bool, no None, no NaN/Inf, range enforced).
+Unknown emotion keys are **rejected** via `create`/`from_dict`/direct constructor.
+In the LLM parser (`parse_llm_appraisal`), unknown emotions are **filtered silently**
+(different policy — see Parser section).
+
+### Deep immutability
+
+`discrete_emotions` is stored as a `MappingProxyType`. This means:
+
+- The object passed by the caller is **copied defensively** at construction time.
+- Mutations to the original dict after construction have **no effect** on the model.
+- The stored mapping **cannot be mutated** (`TypeError` if attempted).
+- `to_dict()` returns a **fresh mutable copy** for serialisation; this copy does not
+  share state with the stored proxy.
+
+```python
+src = {"joy": 0.5}
+ap = AppraisalV1.create(..., discrete_emotions=src)
+src["joy"] = 99.0      # no effect
+ap.discrete_emotions["joy"] = 0.9  # raises TypeError
+d = ap.to_dict()
+d["discrete_emotions"]["joy"] = 0.9  # no effect on ap
+```
 
 ### Neutral appraisal
 
 ```python
 neutral = AppraisalV1.neutral()
 # → valence_shift=0.0, arousal_shift=0.0, dominance_shift=0.0, discrete_emotions={}
-```
-
-### Valid JSON example
-
-```json
-{
-  "arousal_shift": -0.1,
-  "discrete_emotions": {
-    "joy": 0.5,
-    "trust": 0.3
-  },
-  "dominance_shift": 0.0,
-  "schema_version": 1,
-  "valence_shift": 0.2
-}
 ```
 
 ---
@@ -182,74 +196,133 @@ neutral = AppraisalV1.neutral()
 from backend.emotional_domain import serialize_state, deserialize_state
 from backend.emotional_domain import serialize_appraisal, deserialize_appraisal
 
-# EmotionalStateV1
 json_str = serialize_state(state)    # deterministic JSON, sorted keys
 restored = deserialize_state(json_str)
 assert state == restored
-
-# AppraisalV1
-json_str = serialize_appraisal(appraisal)
-restored = deserialize_appraisal(json_str)
-assert appraisal == restored
 ```
 
 **Guarantees:**
 - Output always includes `schema_version`.
 - Keys are sorted (deterministic format).
-- No prompt text, metacognition, relationship, or memory fields exposed.
+- No prompt, metacognition, relationship, or memory fields.
 - Round-trip produces an equivalent object.
+- Output remains valid even after the `to_dict()` copy is mutated (deep immutability).
 
 ---
 
 ## Migration from legacy snapshots
 
-The legacy `EmotionalState.to_dict()` format uses `last_update` (float) instead of
-`timestamp` and has no `schema_version`.
+### Legacy format (exact field set)
+
+The legacy `EmotionalState.to_dict()` format uses `last_update` instead of `timestamp`,
+and has no `schema_version` key.
+
+**Exactly these fields are accepted in a legacy snapshot:**
+
+```
+pleasure, arousal, dominance, libido, aggression, connection,
+energy, tension, coping_mode, last_update
+```
+
+Any additional field (including `timestamp`, `schema_version`, `memory`, `system_prompt`,
+`relationship_score`, `acting_label`, etc.) causes `EmotionalDomainError`.
+
+### Migration contract
 
 ```python
 from backend.emotional_domain import migrate_legacy_snapshot
 
-# From storage (legacy format — no schema_version key)
-legacy = {
-    "pleasure": 0.1, "arousal": -0.2, "dominance": 0.3,
-    "libido": 0.0, "aggression": 0.1, "connection": 0.5,
-    "energy": 0.8, "tension": 0.2, "coping_mode": "HEALTHY",
-    "last_update": 1700000000.0,
-}
-state_v1 = migrate_legacy_snapshot(legacy)
+state_v1 = migrate_legacy_snapshot(legacy_dict)
 ```
 
-**Migration contract:**
-- Input is never mutated.
-- `last_update` → `timestamp`.
-- Missing required fields → `EmotionalDomainError`.
-- Invalid values → `EmotionalDomainError` (fails closed).
-- If `schema_version=1` is already present, re-validates and returns as-is (idempotent).
-- Any other `schema_version` → `EmotionalDomainError`.
-- No I/O, no Supabase, pure function.
+| Condition | Result |
+|---|---|
+| Key `schema_version` absent | Treated as legacy snapshot |
+| `schema_version` key present, value `None` | `EmotionalDomainError` (not "absent") |
+| `schema_version` key present, value `True`/`False`/`"1"` | `EmotionalDomainError` |
+| `schema_version=1` present | V1 idempotent path (re-validates) |
+| Both `last_update` and `timestamp` present | `EmotionalDomainError` (ambiguous) |
+| Any extra field in legacy snapshot | `EmotionalDomainError` |
+| Missing required legacy field | `EmotionalDomainError` |
+| Any field value violating invariants | `EmotionalDomainError` |
+
+Input dict is **never mutated**.
 
 ---
 
-## Fallback policy for invalid LLM appraisal
+## LLM appraisal parser
+
+### Minimum structure
+
+An appraisal from LLM output must contain all three shift fields (after alias
+translation). An empty dict `{}` is **not valid** and produces a fallback.
+
+### Top-level key allowlist
+
+Only these keys are accepted at the top level:
+
+```
+valence_shift, valence,          (canonical + legacy alias)
+arousal_shift,
+dominance_shift,
+discrete_emotions, triggered_emotions   (canonical + legacy alias)
+```
+
+Any unknown key produces `unknown_top_level_key` fallback.
+
+### Legacy alias translation (explicit, tested)
+
+| Production key | V1 canonical key |
+|---|---|
+| `valence` | `valence_shift` |
+| `triggered_emotions` | `discrete_emotions` |
+
+**Conflict policy:** if both alias and canonical key are present with **different** values,
+the result is `conflicting_aliases` fallback. If they carry the **same** value, the
+canonical is used.
+
+### discrete_emotions handling
+
+| `discrete_emotions` value | Result |
+|---|---|
+| Key absent from dict | Empty emotions (no fallback) |
+| `{}` (explicit empty dict) | Empty emotions (valid) |
+| `None` (key present, value None) | `unsupported_emotion` fallback |
+| `str`, `list`, `number`, `bool` | `unsupported_emotion` fallback |
+| Dict with unknown emotion keys | Keys silently filtered |
+| Dict with invalid intensity | `invalid_numeric_value` fallback |
+
+### Fallback codes (ParseErrorCode enum)
+
+| Code | Meaning |
+|---|---|
+| `invalid_structure` | Not a dict |
+| `unknown_top_level_key` | Dict contains key outside allowlist |
+| `missing_required_field` | A shift field is absent |
+| `conflicting_aliases` | Alias and canonical present with different values |
+| `invalid_numeric_value` | Bad type, NaN/Inf, or out-of-range shift/intensity |
+| `unsupported_emotion` | `discrete_emotions` is not a mapping |
+| `unexpected_parser_failure` | Anything else (unexpected error) |
+
+### Observable result
 
 ```python
-from backend.emotional_domain import parse_llm_appraisal
+from backend.emotional_domain import parse_llm_appraisal, ParseErrorCode
 
 result = parse_llm_appraisal(raw_llm_dict)
 
 if result.is_fallback:
-    # Log result.error — LLM produced invalid output
-    appraisal = result.appraisal  # always AppraisalV1.neutral()
+    # Log result.error_code — stable enum value, safe to log
+    # DO NOT log str(result.error_code) to an external system that sees LLM data
+    code = result.error_code  # ParseErrorCode enum
+    appraisal = result.appraisal  # AppraisalV1.neutral()
 else:
     appraisal = result.appraisal  # valid AppraisalV1
 ```
 
-**Policy:**
-- Any validation error → neutral fallback, error recorded in `result.error`.
-- Never raises.
-- Unknown emotion keys from LLM output are silently filtered (not rejected).
-- Invalid intensity values → fallback.
-- Result is never an empty dict; always an explicit `AppraisalV1`.
+> **Never log `str(exc)` from the parser.** Use `result.error_code.value` (a stable enum
+> string) for observability. The error code never contains raw LLM text, user content,
+> field names from untrusted input, or exception repr.
 
 ---
 

--- a/docs/architecture/emotional-core-v1.md
+++ b/docs/architecture/emotional-core-v1.md
@@ -291,9 +291,29 @@ Any unknown key produces `unknown_top_level_key` fallback.
 | `valence` | `valence_shift` |
 | `triggered_emotions` | `discrete_emotions` |
 
-**Conflict policy:** if both alias and canonical key are present with **different** values,
-the result is `conflicting_aliases` fallback. If they carry the **same** value, the
-canonical is used.
+**Conflict policy (validated+normalised comparison):**
+
+When both alias and canonical key are present, **each side is validated and
+normalised independently** using the same rules as the parser:
+
+1. **Validate** each side — reject bool, None, string, NaN, Inf, out-of-range,
+   non-mapping types, and invalid intensities.
+2. **Normalise** each side — convert int → float, filter unknown emotion keys
+   silently (mappings that differ only by unknown emotions normalise to the
+   same result).
+3. **Compare** only normalised values:
+   - If **either** side is invalid → the parser returns the corresponding
+     validation error code (`invalid_numeric_value` or `unsupported_emotion`),
+     **not** `conflicting_aliases`.
+   - If both are valid and normalised values **match** → drop the alias, use
+     the canonical key.
+   - If both are valid and normalised values **differ** → `conflicting_aliases`
+     fallback.
+
+`1` and `1.0` are equivalent **only after both are validated** as finite floats.
+
+`{"invented": 0.5}` and `{}` are equivalent because unknown emotion keys are
+filtered during normalisation, producing `{}` in both cases.
 
 ### discrete_emotions handling
 
@@ -313,9 +333,9 @@ canonical is used.
 | `invalid_structure` | Not a dict |
 | `unknown_top_level_key` | Dict contains key outside allowlist |
 | `missing_required_field` | A shift field is absent |
-| `conflicting_aliases` | Alias and canonical present with different values |
-| `invalid_numeric_value` | Bad type, NaN/Inf, or out-of-range shift/intensity |
-| `unsupported_emotion` | `discrete_emotions` is not a mapping |
+| `conflicting_aliases` | Alias and canonical both valid but **normalised** values differ |
+| `invalid_numeric_value` | Bad type (bool, None, string), NaN/Inf, out-of-range, or overflow in shift/intensity |
+| `unsupported_emotion` | `discrete_emotions`/`triggered_emotions` is not a mapping (None, bool, str, list, number) |
 | `unexpected_parser_failure` | Anything else (unexpected error) |
 
 ### Observable result


### PR DESCRIPTION
## Issue de origem

Closes #232

## Problema e causa raiz

O estado emocional persistido e o appraisal produzido pelo LLM não possuíam um contrato de domínio completo para versão, tipos, faixas, finitude, allowlists, serialização e migração. Isso permitia representações inconsistentes e dificultava validação determinística sem infraestrutura.

## Solução

Foi criado o pacote puro `backend/emotional_domain/`, sem FastAPI, Groq, Supabase, embeddings, ambiente, rede ou I/O, contendo:

- `EmotionalStateV1` e `AppraisalV1`, tipados, versionados e imutáveis;
- validação em toda construção pública, incluindo construtores diretos;
- normalização determinística de números para `float`;
- allowlists de coping e de 13 emoções compatíveis com a produção;
- serialização JSON determinística e round-trip validado;
- migração explícita e estrita de snapshots legados;
- parser de appraisal com fallback neutro observável e códigos sanitizados.

## Contratos de segurança e validação

- `bool`, `None`, strings, NaN, infinito, valores fora da faixa e overflow numérico são rejeitados de forma previsível.
- Nenhum `OverflowError` escapa das APIs públicas; o parser o classifica como `invalid_numeric_value`.
- `discrete_emotions` é profundamente imutável por `MappingProxyType`.
- Chaves desconhecidas são rejeitadas nos modelos e filtradas no parser somente conforme política documentada.
- Nenhum valor bruto ou texto do LLM aparece nos códigos de erro observáveis.

## Política final de aliases do parser

Aliases legados suportados:

- `valence` → `valence_shift`
- `triggered_emotions` → `discrete_emotions`

Quando alias e campo canônico coexistem:

1. cada lado é validado independentemente pelo mesmo contrato;
2. cada lado é normalizado (`int` → `float`; emoções desconhecidas são filtradas);
3. somente os valores normalizados são comparados;
4. qualquer lado inválido retorna `invalid_numeric_value` ou `unsupported_emotion`;
5. dois valores válidos e diferentes retornam `conflicting_aliases`;
6. `1` e `1.0` são equivalentes somente após validação.

## Allowlist de emoções

`joy`, `sadness`, `anger`, `fear`, `disgust`, `surprise`, `trust`, `anticipation`, `tenderness`, `guilt`, `pride`, `jealousy`, `gratitude`.

## Arquivos afetados

- `backend/emotional_domain/__init__.py`
- `backend/emotional_domain/models.py`
- `backend/emotional_domain/migration.py`
- `backend/emotional_domain/serialization.py`
- `backend/emotional_domain/appraisal_parser.py`
- `backend/tests/test_emotional_domain.py`
- `docs/architecture/emotional-core-v1.md`

Nenhum arquivo do fluxo de produção foi integrado ou alterado.

## Testes e CI

O workflow **CI**, run `29376947072` (run #44), passou integralmente no SHA final `90b254a5e180ef3d3e745ab8cf14ac975dcbe315`:

- backend: compilação e suíte completa aprovadas em Python 3.12 com modo offline;
- frontend: auditoria, testes, lint e build aprovados.

A suíte cobre versões, round-trip, migração, construtores diretos, imutabilidade, isolamento de infraestrutura, entradas inválidas, overflow, aliases, `bool == int`, normalização e compatibilidade com o payload emocional de produção.

## Riscos e rollback

O risco de regressão em produção é baixo porque o novo pacote ainda não está conectado ao `ConversationEngine`, persistência, API ou frontend. Rollback: remover `backend/emotional_domain/`, seus testes e a documentação associada.

## Fora de escopo

- transição e decay emocional (#233);
- integração com `ConversationEngine` (#234);
- persistência de produção, API e frontend;
- mudanças em relacionamento, memória, prompts, personalidade ou pesos emocionais.