### PR TITLE
feat(emotion): add deterministic emotional transition v1

### DIFF
--- a/backend/emotional_domain/__init__.py
+++ b/backend/emotional_domain/__init__.py
@@ -7,6 +7,7 @@ This package defines the typed contracts for:
 - Migration utilities for legacy snapshots
 - Serialization helpers
 - LLM appraisal parser with explicit fallback
+- Transition (decay, appraisal shift, tension, coping regulation)
 
 No FastAPI, Groq, Supabase, sentence_transformers, or I/O allowed here.
 """
@@ -22,6 +23,13 @@ from .models import (
 from .migration import migrate_legacy_snapshot
 from .serialization import serialize_state, deserialize_state, serialize_appraisal, deserialize_appraisal
 from .appraisal_parser import parse_llm_appraisal, ParseResult, ParseErrorCode
+from .transition import (
+    TransitionConfig,
+    RegulationResult,
+    RegulationReason,
+    TransitionResult,
+    transition,
+)
 
 __all__ = [
     "EMOTIONAL_SCHEMA_VERSION",
@@ -38,4 +46,9 @@ __all__ = [
     "parse_llm_appraisal",
     "ParseResult",
     "ParseErrorCode",
+    "TransitionConfig",
+    "RegulationResult",
+    "RegulationReason",
+    "TransitionResult",
+    "transition",
 ]

--- a/backend/emotional_domain/transition.py
+++ b/backend/emotional_domain/transition.py
@@ -355,11 +355,21 @@ class RegulationResult:
     def __post_init__(self) -> None:
         """Validate all fields on every construction path."""
 
-        # Validate modes belong to the allowlist
+        # Validate modes belong to the allowlist.
+        # Must check isinstance(str) first because non-hashable types
+        # (list, dict) would raise TypeError on frozenset membership.
+        if not isinstance(self.previous_mode, str):
+            raise EmotionalDomainError(
+                "RegulationResult: previous_mode must be a valid coping mode string."
+            )
         if self.previous_mode not in VALID_COPING_MODES:
             raise EmotionalDomainError(
                 "RegulationResult: previous_mode must be one of "
                 f"{sorted(VALID_COPING_MODES)}."
+            )
+        if not isinstance(self.current_mode, str):
+            raise EmotionalDomainError(
+                "RegulationResult: current_mode must be a valid coping mode string."
             )
         if self.current_mode not in VALID_COPING_MODES:
             raise EmotionalDomainError(

--- a/backend/emotional_domain/transition.py
+++ b/backend/emotional_domain/transition.py
@@ -1,0 +1,647 @@
+"""
+Pure, deterministic emotional transition v1.
+
+Applies temporal decay, appraisal shifts, tension update, and coping
+regulation in a fixed order to produce a new ``EmotionalStateV1``
+and a ``RegulationResult``.
+
+Design principles
+=================
+- **Pure**: no I/O, no randomness, no global state, no ``time.time()``.
+- **Deterministic**: same inputs always produce the same outputs.
+- **Immutable**: never mutates inputs.
+- **Infrastructure-free**: no FastAPI, Groq, Supabase, embeddings, network.
+- **No production integration**: this module does **not** integrate with
+  ``ConversationEngine``, ``AffectiveEngine``, or any production flow.
+  That integration belongs exclusively to issue #234.
+
+Order of operations
+===================
+1. Validate ``current_time`` (reject invalid types and non-positive values).
+2. Compute elapsed seconds (clock regression → elapsed = 0.0).
+3. Apply exponential decay to PAD and tension toward their baselines.
+4. Apply capped appraisal shifts to PAD.
+5. Clamp PAD to [-1.0, +1.0].
+6. Update tension based on pleasure level.
+7. Clamp tension to [0.0, 1.0].
+8. Determine coping mode (with hysteresis for the intermediate range
+   and with MANIC handling as documented).
+9. Apply regulation effects (DEFENSIVE → no-op beyond mode;
+   DISSOCIATED → scale arousal by factor).
+10. Build the new ``EmotionalStateV1`` via its validated factory.
+11. Return ``TransitionResult``.
+
+Boundary
+========
+This function belongs to the **transition** layer. It receives exactly
+one canonically validated ``AppraisalV1``. It does **not** execute:
+
+- ``OCCAppraisal`` heuristics
+- keyword analysis
+- implicit combination of heuristic + classifier
+- alias or LLM payload parsing
+- any textual analysis
+
+Two appraisals with identical scalar shifts but different
+``discrete_emotions`` produce the same emotional snapshot.
+
+Parameters and defaults
+=======================
+All default values are engineering choices with **no claim of clinical
+validity**. See also ``TransitionConfig``.
+"""
+
+from __future__ import annotations
+
+import enum
+import math
+from dataclasses import dataclass
+from typing import Dict, Final
+
+from .models import (
+    EMOTIONAL_SCHEMA_VERSION,
+    VALID_COPING_MODES,
+    AppraisalV1,
+    EmotionalDomainError,
+    EmotionalStateV1,
+    _require_finite_float,
+    _require_finite_float_in_range,
+)
+
+# ─── Constants ───────────────────────────────────────────────────────────────
+
+# Cap on a single appraisal's shift contribution per axis (engineering default).
+_DEFAULT_MAX_SHIFT: Final[float] = 0.25
+
+# PAD decay defaults.
+_DEFAULT_PAD_HALF_LIFE: Final[float] = 3600.0  # seconds
+_DEFAULT_TENSION_HALF_LIFE: Final[float] = 7200.0  # seconds
+_DEFAULT_PAD_BASELINE: Final[float] = 0.0
+_DEFAULT_TENSION_BASELINE: Final[float] = 0.0
+
+# Tension update defaults.
+_DEFAULT_NEGATIVE_PLEASURE_THRESHOLD: Final[float] = -0.3
+_DEFAULT_POSITIVE_PLEASURE_THRESHOLD: Final[float] = 0.3
+_DEFAULT_TENSION_INCREASE: Final[float] = 0.05
+_DEFAULT_TENSION_RELIEF: Final[float] = 0.05
+
+# Coping thresholds.
+_DEFAULT_ACTIVATION_THRESHOLD: Final[float] = 0.8
+_DEFAULT_RECOVERY_THRESHOLD: Final[float] = 0.3
+
+# Dissociation factor.
+_DEFAULT_DISSOCIATION_AROUSAL_FACTOR: Final[float] = 0.5
+
+
+# ─── Regulation reason ────────────────────────────────────────────────────────
+
+class RegulationReason(str, enum.Enum):
+    """Stable, sanitised reasons for coping mode changes.
+
+    These values contain no user content, no LLM output, and no prompt text.
+    """
+    NONE = "none"
+    HIGH_TENSION_POSITIVE_DOMINANCE = "high_tension_positive_dominance"
+    HIGH_TENSION_NONPOSITIVE_DOMINANCE = "high_tension_nonpositive_dominance"
+    RECOVERED = "recovered"
+
+
+# ─── Validation helpers ──────────────────────────────────────────────────────
+
+# Fields accepted by TransitionConfig (used for unknown-key rejection).
+_CONFIG_FIELDS = frozenset({
+    "pad_half_life",
+    "tension_half_life",
+    "pad_baseline",
+    "tension_baseline",
+    "max_pleasure_shift",
+    "max_arousal_shift",
+    "max_dominance_shift",
+    "negative_pleasure_threshold",
+    "positive_pleasure_threshold",
+    "tension_increase",
+    "tension_relief",
+    "activation_threshold",
+    "recovery_threshold",
+    "dissociation_arousal_factor",
+})
+
+
+def _require_positive_finite(value: object, name: str) -> float:
+    """Reject bool, None, str, list, dict, NaN, Inf, and non-positive values."""
+    f = _require_finite_float(value, name)
+    if f <= 0:
+        raise EmotionalDomainError(
+            f"Field '{name}' must be a positive finite float."
+        )
+    return f
+
+
+def _require_nonnegative_finite(value: object, name: str) -> float:
+    """Reject bool, None, str, list, dict, NaN, Inf, and negative values."""
+    f = _require_finite_float(value, name)
+    if f < 0:
+        raise EmotionalDomainError(
+            f"Field '{name}' must be a non-negative finite float."
+        )
+    return f
+
+
+# ─── TransitionConfig ────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class TransitionConfig:
+    """Immutable configuration for the emotional transition function.
+
+    All numeric fields are validated on construction. Default values are
+    engineering choices with **no claim of clinical validity**.
+
+    Parameters
+    ==========
+    pad_half_life:
+        Half-life in seconds for exponential decay of PAD toward baseline.
+        Must be positive and finite. Default: 3600.0 (1 hour).
+    tension_half_life:
+        Half-life in seconds for exponential decay of tension toward baseline.
+        Must be positive and finite. Default: 7200.0 (2 hours).
+    pad_baseline:
+        Baseline toward which PAD decays. Must be in [-1.0, 1.0]. Default: 0.0.
+    tension_baseline:
+        Baseline toward which tension decays. Must be in [0.0, 1.0]. Default: 0.0.
+    max_pleasure_shift:
+        Maximum absolute contribution of a single appraisal's valence_shift.
+        Must be positive and <= 1.0. Default: 0.25.
+    max_arousal_shift:
+        Maximum absolute contribution of a single appraisal's arousal_shift.
+        Must be positive and <= 1.0. Default: 0.25.
+    max_dominance_shift:
+        Maximum absolute contribution of a single appraisal's dominance_shift.
+        Must be positive and <= 1.0. Default: 0.25.
+    negative_pleasure_threshold:
+        Pleasure below this value increases tension. Must be in [-1.0, 1.0].
+        Default: -0.3.
+    positive_pleasure_threshold:
+        Pleasure above this value decreases tension. Must be in [-1.0, 1.0].
+        Default: 0.3.
+    tension_increase:
+        Delta added to tension when pleasure < negative_pleasure_threshold.
+        Must be non-negative and finite. Default: 0.05.
+    tension_relief:
+        Delta subtracted from tension when pleasure > positive_pleasure_threshold.
+        Must be non-negative and finite. Default: 0.05.
+    activation_threshold:
+        Tension at or above this value activates DEFENSIVE or DISSOCIATED coping.
+        Must be in [0.0, 1.0]. Default: 0.8.
+    recovery_threshold:
+        Tension at or below this value activates HEALTHY coping.
+        Must be in [0.0, 1.0]. Default: 0.3.
+        Invariant: recovery_threshold < activation_threshold.
+    dissociation_arousal_factor:
+        Factor by which arousal is multiplied in DISSOCIATED mode.
+        Must be in [0.0, 1.0]. Default: 0.5.
+    """
+
+    # Decay
+    pad_half_life: float = _DEFAULT_PAD_HALF_LIFE
+    tension_half_life: float = _DEFAULT_TENSION_HALF_LIFE
+    pad_baseline: float = _DEFAULT_PAD_BASELINE
+    tension_baseline: float = _DEFAULT_TENSION_BASELINE
+
+    # Appraisal caps
+    max_pleasure_shift: float = _DEFAULT_MAX_SHIFT
+    max_arousal_shift: float = _DEFAULT_MAX_SHIFT
+    max_dominance_shift: float = _DEFAULT_MAX_SHIFT
+
+    # Tension pleasure thresholds
+    negative_pleasure_threshold: float = _DEFAULT_NEGATIVE_PLEASURE_THRESHOLD
+    positive_pleasure_threshold: float = _DEFAULT_POSITIVE_PLEASURE_THRESHOLD
+    tension_increase: float = _DEFAULT_TENSION_INCREASE
+    tension_relief: float = _DEFAULT_TENSION_RELIEF
+
+    # Coping thresholds
+    activation_threshold: float = _DEFAULT_ACTIVATION_THRESHOLD
+    recovery_threshold: float = _DEFAULT_RECOVERY_THRESHOLD
+
+    # Dissociation regulation
+    dissociation_arousal_factor: float = _DEFAULT_DISSOCIATION_AROUSAL_FACTOR
+
+    def __post_init__(self) -> None:
+        """Validate all fields on every construction path."""
+
+        # Decay parameters
+        _validate_positive_finite(self.pad_half_life, "pad_half_life")
+        _validate_positive_finite(self.tension_half_life, "tension_half_life")
+        _validate_range(self.pad_baseline, "pad_baseline", -1.0, 1.0)
+        _validate_range(self.tension_baseline, "tension_baseline", 0.0, 1.0)
+
+        # Appraisal caps — positive, <= 1.0
+        _validate_shift_cap(self.max_pleasure_shift, "max_pleasure_shift")
+        _validate_shift_cap(self.max_arousal_shift, "max_arousal_shift")
+        _validate_shift_cap(self.max_dominance_shift, "max_dominance_shift")
+
+        # Pleasure thresholds
+        _validate_range(self.negative_pleasure_threshold, "negative_pleasure_threshold", -1.0, 1.0)
+        _validate_range(self.positive_pleasure_threshold, "positive_pleasure_threshold", -1.0, 1.0)
+
+        # Tension delta magnitudes — must be non-negative (they are magnitudes)
+        _validate_nonnegative(
+            self.tension_increase, "tension_increase"
+        )
+        _validate_nonnegative(self.tension_relief, "tension_relief")
+
+        # Coping thresholds — must be in [0.0, 1.0]
+        _validate_range(self.activation_threshold, "activation_threshold", 0.0, 1.0)
+        _validate_range(self.recovery_threshold, "recovery_threshold", 0.0, 1.0)
+
+        # recovery_threshold must be strictly less than activation_threshold
+        if self.recovery_threshold >= self.activation_threshold:
+            raise EmotionalDomainError(
+                "TransitionConfig: recovery_threshold must be strictly less than "
+                "activation_threshold."
+            )
+
+        # Dissociation factor — must be in [0.0, 1.0]
+        _validate_range(
+            self.dissociation_arousal_factor,
+            "dissociation_arousal_factor",
+            0.0,
+            1.0,
+        )
+
+    # ── Factory ──────────────────────────────────────────────────────────────
+
+    @classmethod
+    def create(cls, **kwargs: object) -> "TransitionConfig":
+        """Validated factory. Raises ``EmotionalDomainError`` on violation."""
+        # Reject unexpected keys
+        unexpected = set(kwargs.keys()) - _CONFIG_FIELDS
+        if unexpected:
+            raise EmotionalDomainError(
+                "TransitionConfig: unexpected fields."
+            )
+        return cls(**{k: v for k, v in kwargs.items()})  # type: ignore[arg-type]
+
+    @classmethod
+    def defaults(cls) -> "TransitionConfig":
+        """Return a default-configured instance."""
+        return cls()
+
+
+def _validate_positive_finite(raw: object, name: str) -> float:
+    _validate_not_bool(raw, name)
+    f = _require_positive_finite(raw, name)
+    return f
+
+
+def _validate_range(raw: object, name: str, lo: float, hi: float) -> float:
+    _validate_not_bool(raw, name)
+    return _require_finite_float_in_range(raw, name, lo, hi)
+
+
+def _validate_shift_cap(raw: object, name: str) -> None:
+    _validate_not_bool(raw, name)
+    f = _require_finite_float(raw, name)
+    if f <= 0 or f > 1.0:
+        raise EmotionalDomainError(
+            f"Field '{name}' must be in (0.0, 1.0]."
+        )
+
+
+def _validate_nonnegative(raw: object, name: str) -> float:
+    _validate_not_bool(raw, name)
+    return _require_nonnegative_finite(raw, name)
+
+
+def _validate_not_bool(raw: object, name: str) -> None:
+    if isinstance(raw, bool):
+        raise EmotionalDomainError(
+            f"Field '{name}' must be a finite float, got bool."
+        )
+
+
+# ─── RegulationResult ────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class RegulationResult:
+    """Structured result of coping regulation.
+
+    Attributes
+    ==========
+    previous_mode:
+        The coping mode before regulation.
+    current_mode:
+        The coping mode after regulation.
+    changed:
+        ``True`` when ``previous_mode != current_mode``.
+    reason:
+        A ``RegulationReason`` enum value indicating why the mode changed.
+        Never contains user content, LLM output, prompt text, or instructions.
+    """
+
+    previous_mode: str
+    current_mode: str
+    changed: bool
+    reason: RegulationReason
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "previous_mode": self.previous_mode,
+            "current_mode": self.current_mode,
+            "changed": self.changed,
+            "reason": self.reason.value,
+        }
+
+
+# ─── TransitionResult ────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class TransitionResult:
+    """Result of a complete emotional transition.
+
+    Attributes
+    ==========
+    state:
+        The new ``EmotionalStateV1`` after decay, appraisal, tension update,
+        coping determination, and regulation effects.
+    regulation:
+        The ``RegulationResult`` describing the coping mode transition.
+    """
+
+    state: EmotionalStateV1
+    regulation: RegulationResult
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "state": self.state.to_dict(),
+            "regulation": self.regulation.to_dict(),
+        }
+
+
+# ─── Core maths ──────────────────────────────────────────────────────────────
+
+def _exponential_decay(
+    value: float,
+    baseline: float,
+    elapsed: float,
+    half_life: float,
+) -> float:
+    """Apply exponential decay toward baseline.
+
+    ``factor = 0.5 ** (elapsed / half_life)``
+    ``result = baseline + (value - baseline) * factor``
+
+    When *elapsed* is zero, the result equals *value*.
+    As *elapsed* tends to infinity, the result tends to *baseline*.
+    """
+    if half_life <= 0:
+        return value
+    factor = 0.5 ** (elapsed / half_life)
+    return baseline + (value - baseline) * factor
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    """Clamp *value* to the inclusive range [lo, hi]."""
+    if value < lo:
+        return lo
+    if value > hi:
+        return hi
+    return value
+
+
+def _clamp_shift(raw_shift: float, cap: float) -> float:
+    """Clamp an appraisal shift to *[-cap, cap]*.
+
+    No single appraisal can move an axis more than *cap*, regardless of
+    the original shift magnitude.
+    """
+    return _clamp(raw_shift, -cap, cap)
+
+
+# ─── Current-time validation ─────────────────────────────────────────────────
+
+def _validate_current_time(raw_time: object) -> float:
+    """Validate and return *raw_time* as a positive finite float.
+
+    Rejects: bool, None, str, list, dict, NaN, Inf, <= 0.
+
+    Raises ``EmotionalDomainError`` on any violation.
+    """
+    if isinstance(raw_time, bool):
+        raise EmotionalDomainError(
+            "current_time must be a finite positive float, got bool."
+        )
+    if raw_time is None:
+        raise EmotionalDomainError(
+            "current_time must be a finite positive float, got None."
+        )
+    if not isinstance(raw_time, (int, float)):
+        raise EmotionalDomainError(
+            f"current_time must be a finite positive float, "
+            f"got {type(raw_time).__name__}."
+        )
+    try:
+        f = float(raw_time)
+    except (OverflowError, ValueError, TypeError):
+        raise EmotionalDomainError(
+            "current_time must be a finite positive float, "
+            "got non-convertible value."
+        )
+    if not math.isfinite(f):
+        raise EmotionalDomainError(
+            "current_time must be finite."
+        )
+    if f <= 0:
+        raise EmotionalDomainError(
+            "current_time must be positive."
+        )
+    return f
+
+
+# ─── Coping mode determination ───────────────────────────────────────────────
+
+def _determine_coping_mode(
+    tension: float,
+    dominance: float,
+    previous_mode: str,
+    config: TransitionConfig,
+) -> str:
+    """Determine the new coping mode based on tension and dominance.
+
+    Uses a hysteresis policy: the intermediate range preserves the
+    previous mode. ``MANIC`` stays ``MANIC`` in the intermediate range,
+    transitions to ``HEALTHY`` on recovery, and to ``DEFENSIVE`` or
+    ``DISSOCIATED`` on activation.
+    """
+    # Activation zone
+    if tension >= config.activation_threshold:
+        if dominance > 0.0:
+            return "DEFENSIVE"
+        else:
+            return "DISSOCIATED"
+
+    # Recovery zone
+    if tension <= config.recovery_threshold:
+        return "HEALTHY"
+
+    # Intermediate zone — preserve previous mode
+    return previous_mode
+
+
+# ─── Public transition API ───────────────────────────────────────────────────
+
+def transition(
+    previous_state: EmotionalStateV1,
+    appraisal: AppraisalV1,
+    current_time: float,
+    config: TransitionConfig,
+) -> TransitionResult:
+    """Execute a complete emotional transition.
+
+    This function is **pure** and **deterministic**: identical inputs
+    always produce identical outputs.
+
+    Parameters
+    ----------
+    previous_state:
+        The emotional state before this transition.
+    appraisal:
+        The canonical ``AppraisalV1`` for this turn.
+    current_time:
+        The explicit current time as a positive finite float (Unix epoch
+        seconds). Must not be ``bool``, ``None``, ``str``, ``list``,
+        ``dict``, ``NaN``, ``Inf``, or <= 0.
+    config:
+        The ``TransitionConfig`` with validated parameters.
+
+    Returns
+    -------
+    TransitionResult
+        An immutable result containing the new ``EmotionalStateV1`` and
+        the ``RegulationResult``.
+
+    Raises
+    ------
+    EmotionalDomainError
+        If *current_time* is invalid or *config* is invalid.
+    """
+    # ── 1. Validate current_time ────────────────────────────────────────────
+    validated_time = _validate_current_time(current_time)
+
+    # ── 2. Handle clock regression ──────────────────────────────────────────
+    if validated_time < previous_state.timestamp:
+        elapsed_seconds = 0.0
+        output_timestamp = previous_state.timestamp
+    else:
+        elapsed_seconds = validated_time - previous_state.timestamp
+        output_timestamp = validated_time
+
+    # ── 3. Apply exponential decay (PAD + tension only) ────────────────────
+    post_decay_pleasure = _exponential_decay(
+        previous_state.pleasure,
+        config.pad_baseline,
+        elapsed_seconds,
+        config.pad_half_life,
+    )
+    post_decay_arousal = _exponential_decay(
+        previous_state.arousal,
+        config.pad_baseline,
+        elapsed_seconds,
+        config.pad_half_life,
+    )
+    post_decay_dominance = _exponential_decay(
+        previous_state.dominance,
+        config.pad_baseline,
+        elapsed_seconds,
+        config.pad_half_life,
+    )
+    post_decay_tension = _exponential_decay(
+        previous_state.tension,
+        config.tension_baseline,
+        elapsed_seconds,
+        config.tension_half_life,
+    )
+
+    # ── 4. Apply capped appraisal shifts ────────────────────────────────────
+    effective_valence = _clamp_shift(
+        appraisal.valence_shift, config.max_pleasure_shift
+    )
+    effective_arousal = _clamp_shift(
+        appraisal.arousal_shift, config.max_arousal_shift
+    )
+    effective_dominance = _clamp_shift(
+        appraisal.dominance_shift, config.max_dominance_shift
+    )
+
+    post_shift_pleasure = post_decay_pleasure + effective_valence
+    post_shift_arousal = post_decay_arousal + effective_arousal
+    post_shift_dominance = post_decay_dominance + effective_dominance
+
+    # ── 5. Clamp PAD to [-1.0, 1.0] ────────────────────────────────────────
+    clamped_pleasure = _clamp(post_shift_pleasure, -1.0, 1.0)
+    clamped_arousal = _clamp(post_shift_arousal, -1.0, 1.0)
+    clamped_dominance = _clamp(post_shift_dominance, -1.0, 1.0)
+
+    # ── 6. Update tension based on pleasure ────────────────────────────────
+    tension_delta = 0.0
+    if clamped_pleasure < config.negative_pleasure_threshold:
+        tension_delta = config.tension_increase
+    elif clamped_pleasure > config.positive_pleasure_threshold:
+        tension_delta = -config.tension_relief
+
+    post_tension = post_decay_tension + tension_delta
+
+    # ── 7. Clamp tension to [0.0, 1.0] ────────────────────────────────────
+    clamped_tension = _clamp(post_tension, 0.0, 1.0)
+
+    # ── 8. Determine coping mode ────────────────────────────────────────────
+    new_coping_mode = _determine_coping_mode(
+        clamped_tension,
+        clamped_dominance,
+        previous_state.coping_mode,
+        config,
+    )
+
+    # ── 9. Apply regulation effects ─────────────────────────────────────────
+    reg_arousal = clamped_arousal
+    if new_coping_mode == "DISSOCIATED":
+        reg_arousal = _clamp(
+            clamped_arousal * config.dissociation_arousal_factor, -1.0, 1.0
+        )
+    # DEFENSIVE: no additional effects beyond mode change in this version.
+
+    # ── 10. Build RegulationResult ──────────────────────────────────────────
+    mode_changed = previous_state.coping_mode != new_coping_mode
+    if not mode_changed:
+        reason = RegulationReason.NONE
+    elif new_coping_mode == "HEALTHY":
+        reason = RegulationReason.RECOVERED
+    elif new_coping_mode == "DEFENSIVE":
+        reason = RegulationReason.HIGH_TENSION_POSITIVE_DOMINANCE
+    elif new_coping_mode == "DISSOCIATED":
+        reason = RegulationReason.HIGH_TENSION_NONPOSITIVE_DOMINANCE
+    else:
+        reason = RegulationReason.NONE
+
+    regulation = RegulationResult(
+        previous_mode=previous_state.coping_mode,
+        current_mode=new_coping_mode,
+        changed=mode_changed,
+        reason=reason,
+    )
+
+    # ── 11. Build new EmotionalStateV1 ──────────────────────────────────────
+    new_state = EmotionalStateV1.create(
+        pleasure=clamped_pleasure,
+        arousal=reg_arousal,
+        dominance=clamped_dominance,
+        libido=previous_state.libido,
+        aggression=previous_state.aggression,
+        connection=previous_state.connection,
+        energy=previous_state.energy,
+        tension=clamped_tension,
+        coping_mode=new_coping_mode,
+        timestamp=output_timestamp,
+        schema_version=EMOTIONAL_SCHEMA_VERSION,
+    )
+
+    return TransitionResult(state=new_state, regulation=regulation)

--- a/backend/emotional_domain/transition.py
+++ b/backend/emotional_domain/transition.py
@@ -170,13 +170,16 @@ class TransitionConfig:
         Baseline toward which tension decays. Must be in [0.0, 1.0]. Default: 0.0.
     max_pleasure_shift:
         Maximum absolute contribution of a single appraisal's valence_shift.
-        Must be positive and <= 1.0. Default: 0.25.
+        Must be in [0.0, 1.0]. A value of 0.0 disables valence shifts.
+        Default: 0.25.
     max_arousal_shift:
         Maximum absolute contribution of a single appraisal's arousal_shift.
-        Must be positive and <= 1.0. Default: 0.25.
+        Must be in [0.0, 1.0]. A value of 0.0 disables arousal shifts.
+        Default: 0.25.
     max_dominance_shift:
         Maximum absolute contribution of a single appraisal's dominance_shift.
-        Must be positive and <= 1.0. Default: 0.25.
+        Must be in [0.0, 1.0]. A value of 0.0 disables dominance shifts.
+        Default: 0.25.
     negative_pleasure_threshold:
         Pleasure below this value increases tension. Must be in [-1.0, 1.0].
         Default: -0.3.
@@ -185,10 +188,10 @@ class TransitionConfig:
         Default: 0.3.
     tension_increase:
         Delta added to tension when pleasure < negative_pleasure_threshold.
-        Must be non-negative and finite. Default: 0.05.
+        Must be in [0.0, 1.0]. Default: 0.05.
     tension_relief:
         Delta subtracted from tension when pleasure > positive_pleasure_threshold.
-        Must be non-negative and finite. Default: 0.05.
+        Must be in [0.0, 1.0]. Default: 0.05.
     activation_threshold:
         Tension at or above this value activates DEFENSIVE or DISSOCIATED coping.
         Must be in [0.0, 1.0]. Default: 0.8.
@@ -239,15 +242,19 @@ class TransitionConfig:
         _validate_shift_cap(self.max_arousal_shift, "max_arousal_shift")
         _validate_shift_cap(self.max_dominance_shift, "max_dominance_shift")
 
-        # Pleasure thresholds
+        # Pleasure thresholds — must be in [-1.0, 1.0] and strictly ordered
         _validate_range(self.negative_pleasure_threshold, "negative_pleasure_threshold", -1.0, 1.0)
         _validate_range(self.positive_pleasure_threshold, "positive_pleasure_threshold", -1.0, 1.0)
 
-        # Tension delta magnitudes — must be non-negative (they are magnitudes)
-        _validate_nonnegative(
-            self.tension_increase, "tension_increase"
-        )
-        _validate_nonnegative(self.tension_relief, "tension_relief")
+        if self.negative_pleasure_threshold >= self.positive_pleasure_threshold:
+            raise EmotionalDomainError(
+                "TransitionConfig: negative_pleasure_threshold must be strictly less than "
+                "positive_pleasure_threshold."
+            )
+
+        # Tension delta magnitudes — must be in [0.0, 1.0]
+        _validate_range(self.tension_increase, "tension_increase", 0.0, 1.0)
+        _validate_range(self.tension_relief, "tension_relief", 0.0, 1.0)
 
         # Coping thresholds — must be in [0.0, 1.0]
         _validate_range(self.activation_threshold, "activation_threshold", 0.0, 1.0)
@@ -301,9 +308,9 @@ def _validate_range(raw: object, name: str, lo: float, hi: float) -> float:
 def _validate_shift_cap(raw: object, name: str) -> None:
     _validate_not_bool(raw, name)
     f = _require_finite_float(raw, name)
-    if f <= 0 or f > 1.0:
+    if f < 0 or f > 1.0:
         raise EmotionalDomainError(
-            f"Field '{name}' must be in (0.0, 1.0]."
+            f"Field '{name}' must be in [0.0, 1.0]."
         )
 
 
@@ -328,20 +335,80 @@ class RegulationResult:
     Attributes
     ==========
     previous_mode:
-        The coping mode before regulation.
+        The coping mode before regulation. Must belong to ``VALID_COPING_MODES``.
     current_mode:
-        The coping mode after regulation.
+        The coping mode after regulation. Must belong to ``VALID_COPING_MODES``.
     changed:
-        ``True`` when ``previous_mode != current_mode``.
+        ``True`` when ``previous_mode != current_mode``. Must be ``bool``, not
+        ``int``, ``str``, or ``None``. Must be consistent with the modes.
     reason:
         A ``RegulationReason`` enum value indicating why the mode changed.
         Never contains user content, LLM output, prompt text, or instructions.
+        Semantically validated against ``current_mode``.
     """
 
     previous_mode: str
     current_mode: str
     changed: bool
     reason: RegulationReason
+
+    def __post_init__(self) -> None:
+        """Validate all fields on every construction path."""
+
+        # Validate modes belong to the allowlist
+        if self.previous_mode not in VALID_COPING_MODES:
+            raise EmotionalDomainError(
+                "RegulationResult: previous_mode must be one of "
+                f"{sorted(VALID_COPING_MODES)}."
+            )
+        if self.current_mode not in VALID_COPING_MODES:
+            raise EmotionalDomainError(
+                "RegulationResult: current_mode must be one of "
+                f"{sorted(VALID_COPING_MODES)}."
+            )
+
+        # changed must be a strict bool (not int, not str, not None)
+        if not isinstance(self.changed, bool):
+            raise EmotionalDomainError(
+                "RegulationResult: changed must be a bool."
+            )
+
+        # changed must be consistent with previous and current modes
+        expected_changed = (self.previous_mode != self.current_mode)
+        if self.changed != expected_changed:
+            raise EmotionalDomainError(
+                "RegulationResult: changed is inconsistent with mode values."
+            )
+
+        # reason must be a RegulationReason enum instance
+        if not isinstance(self.reason, RegulationReason):
+            raise EmotionalDomainError(
+                "RegulationResult: reason must be a RegulationReason enum value."
+            )
+
+        # Semantic validation of reason against current_mode and changed
+        if not self.changed and self.reason != RegulationReason.NONE:
+            raise EmotionalDomainError(
+                "RegulationResult: reason must be NONE when changed is False."
+            )
+        if self.changed and self.reason == RegulationReason.NONE:
+            raise EmotionalDomainError(
+                "RegulationResult: reason cannot be NONE when changed is True."
+            )
+        if self.reason == RegulationReason.RECOVERED and self.current_mode != "HEALTHY":
+            raise EmotionalDomainError(
+                "RegulationResult: RECOVERED reason requires current_mode == 'HEALTHY'."
+            )
+        if self.reason == RegulationReason.HIGH_TENSION_POSITIVE_DOMINANCE and self.current_mode != "DEFENSIVE":
+            raise EmotionalDomainError(
+                "RegulationResult: HIGH_TENSION_POSITIVE_DOMINANCE reason "
+                "requires current_mode == 'DEFENSIVE'."
+            )
+        if self.reason == RegulationReason.HIGH_TENSION_NONPOSITIVE_DOMINANCE and self.current_mode != "DISSOCIATED":
+            raise EmotionalDomainError(
+                "RegulationResult: HIGH_TENSION_NONPOSITIVE_DOMINANCE reason "
+                "requires current_mode == 'DISSOCIATED'."
+            )
 
     def to_dict(self) -> Dict[str, object]:
         return {
@@ -369,6 +436,17 @@ class TransitionResult:
 
     state: EmotionalStateV1
     regulation: RegulationResult
+
+    def __post_init__(self) -> None:
+        """Validate that state and regulation are of the correct types."""
+        if not isinstance(self.state, EmotionalStateV1):
+            raise EmotionalDomainError(
+                "TransitionResult: state must be an EmotionalStateV1 instance."
+            )
+        if not isinstance(self.regulation, RegulationResult):
+            raise EmotionalDomainError(
+                "TransitionResult: regulation must be a RegulationResult instance."
+            )
 
     def to_dict(self) -> Dict[str, object]:
         return {
@@ -522,8 +600,22 @@ def transition(
     Raises
     ------
     EmotionalDomainError
-        If *current_time* is invalid or *config* is invalid.
+        If any argument has an incorrect type or *current_time* is invalid.
     """
+    # ── 0. Validate argument types ──────────────────────────────────────────
+    if not isinstance(previous_state, EmotionalStateV1):
+        raise EmotionalDomainError(
+            "transition: previous_state must be an EmotionalStateV1 instance."
+        )
+    if not isinstance(appraisal, AppraisalV1):
+        raise EmotionalDomainError(
+            "transition: appraisal must be an AppraisalV1 instance."
+        )
+    if not isinstance(config, TransitionConfig):
+        raise EmotionalDomainError(
+            "transition: config must be a TransitionConfig instance."
+        )
+
     # ── 1. Validate current_time ────────────────────────────────────────────
     validated_time = _validate_current_time(current_time)
 

--- a/backend/tests/test_emotional_transition.py
+++ b/backend/tests/test_emotional_transition.py
@@ -221,7 +221,6 @@ class TestInvalidConfig:
         {"tension_baseline": -0.1},
         {"tension_baseline": 2.0},
         {"max_pleasure_shift": -0.1},
-        {"max_pleasure_shift": 0.0},
         {"max_pleasure_shift": 1.5},
         {"max_arousal_shift": True},
         {"max_dominance_shift": None},
@@ -229,12 +228,16 @@ class TestInvalidConfig:
         {"positive_pleasure_threshold": 2.0},
         {"tension_increase": -0.1},
         {"tension_relief": -0.1},
+        {"tension_increase": 1.5},
+        {"tension_relief": 1.5},
         {"activation_threshold": 1.5},
         {"recovery_threshold": -0.1},
         {"recovery_threshold": 0.7, "activation_threshold": 0.5},
         {"dissociation_arousal_factor": -0.1},
         {"dissociation_arousal_factor": 1.5},
         {"dissociation_arousal_factor": True},
+        {"negative_pleasure_threshold": 0.0, "positive_pleasure_threshold": 0.0},  # equal
+        {"negative_pleasure_threshold": 0.3, "positive_pleasure_threshold": -0.3},  # inverted
     ])
     def test_invalid_config_rejected(self, kw):
         with pytest.raises(EmotionalDomainError):
@@ -245,6 +248,9 @@ class TestInvalidConfig:
         {"tension_half_life": 3600.0},
         {"tension_baseline": 0.1},
         {"max_pleasure_shift": 0.5},
+        {"max_pleasure_shift": 0.0},  # zero disables the axis
+        {"max_arousal_shift": 0.0},
+        {"max_dominance_shift": 0.0},
         {"dissociation_arousal_factor": 0.3},
     ])
     def test_valid_configs_accepted(self, kw):
@@ -262,6 +268,30 @@ class TestInvalidConfig:
     def test_unknown_field_rejected(self):
         with pytest.raises(EmotionalDomainError):
             TransitionConfig.create(unknown_field=42.0)
+
+    # ── New: cap zero blocks the axis ────────────────────────────────────────
+    def test_cap_zero_blocks_pleasure_shift(self):
+        """A cap of 0.0 prevents appraisal shifts from affecting pleasure."""
+        state = _state(pleasure=0.0)
+        ap = _appraisal(valence_shift=0.5)  # would normally be capped to 0.25
+        cfg = TransitionConfig.create(max_pleasure_shift=0.0)
+        result = transition(state, ap, _T0, cfg)
+        # pleasure should remain at 0.0 (no shift applied)
+        assert result.state.pleasure == pytest.approx(0.0, abs=1e-10)
+
+    def test_cap_zero_blocks_arousal_shift(self):
+        state = _state(arousal=0.0)
+        ap = _appraisal(arousal_shift=0.5)
+        cfg = TransitionConfig.create(max_arousal_shift=0.0)
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.arousal == pytest.approx(0.0, abs=1e-10)
+
+    def test_cap_zero_blocks_dominance_shift(self):
+        state = _state(dominance=0.0)
+        ap = _appraisal(dominance_shift=0.5)
+        cfg = TransitionConfig.create(max_dominance_shift=0.0)
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.dominance == pytest.approx(0.0, abs=1e-10)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -742,6 +772,100 @@ class TestManicPolicy:
 # Requirement 36: RegulationResult structure
 # ═══════════════════════════════════════════════════════════════════════════════
 
+class TestRegulationResultValidation:
+    """Validation of RegulationResult construction."""
+
+    def test_invalid_previous_mode_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            RegulationResult(
+                previous_mode="INVALID",
+                current_mode="HEALTHY",
+                changed=True,
+                reason=RegulationReason.RECOVERED,
+            )
+
+    def test_invalid_current_mode_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            RegulationResult(
+                previous_mode="HEALTHY",
+                current_mode="INVALID",
+                changed=True,
+                reason=RegulationReason.HIGH_TENSION_POSITIVE_DOMINANCE,
+            )
+
+    def test_changed_not_bool_rejected(self):
+        for bad in (0, 1, "True", None, [True], {"c": True}):
+            with pytest.raises(EmotionalDomainError):
+                RegulationResult(
+                    previous_mode="HEALTHY",
+                    current_mode="DEFENSIVE",
+                    changed=bad,  # type: ignore[arg-type]
+                    reason=RegulationReason.HIGH_TENSION_POSITIVE_DOMINANCE,
+                )
+
+    def test_changed_inconsistent_with_modes_rejected(self):
+        # changed=True but modes are equal
+        with pytest.raises(EmotionalDomainError):
+            RegulationResult(
+                previous_mode="HEALTHY",
+                current_mode="HEALTHY",
+                changed=True,
+                reason=RegulationReason.HIGH_TENSION_POSITIVE_DOMINANCE,
+            )
+        # changed=False but modes differ
+        with pytest.raises(EmotionalDomainError):
+            RegulationResult(
+                previous_mode="HEALTHY",
+                current_mode="DEFENSIVE",
+                changed=False,
+                reason=RegulationReason.NONE,
+            )
+
+    def test_reason_as_string_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            RegulationResult(
+                previous_mode="HEALTHY",
+                current_mode="HEALTHY",
+                changed=False,
+                reason="none",  # type: ignore[arg-type]
+            )
+
+    def test_reason_none_with_change_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            RegulationResult(
+                previous_mode="HEALTHY",
+                current_mode="DEFENSIVE",
+                changed=True,
+                reason=RegulationReason.NONE,
+            )
+
+    def test_reason_incompatible_with_current_mode_rejected(self):
+        # RECOVERED requires HEALTHY
+        with pytest.raises(EmotionalDomainError):
+            RegulationResult(
+                previous_mode="HEALTHY",
+                current_mode="DEFENSIVE",
+                changed=True,
+                reason=RegulationReason.RECOVERED,
+            )
+        # HIGH_TENSION_POSITIVE_DOMINANCE requires DEFENSIVE
+        with pytest.raises(EmotionalDomainError):
+            RegulationResult(
+                previous_mode="HEALTHY",
+                current_mode="DISSOCIATED",
+                changed=True,
+                reason=RegulationReason.HIGH_TENSION_POSITIVE_DOMINANCE,
+            )
+        # HIGH_TENSION_NONPOSITIVE_DOMINANCE requires DISSOCIATED
+        with pytest.raises(EmotionalDomainError):
+            RegulationResult(
+                previous_mode="HEALTHY",
+                current_mode="DEFENSIVE",
+                changed=True,
+                reason=RegulationReason.HIGH_TENSION_NONPOSITIVE_DOMINANCE,
+            )
+
+
 class TestRegulationResult:
     """RegulationResult reports correct previous_mode, current_mode, changed, reason."""
 
@@ -911,6 +1035,48 @@ class TestIsolatedImport:
 # Additional structural tests
 # ═══════════════════════════════════════════════════════════════════════════════
 
+class TestTransitionResultValidation:
+    """Validation of TransitionResult construction."""
+
+    def test_state_none_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            TransitionResult(
+                state=None,  # type: ignore[arg-type]
+                regulation=RegulationResult(
+                    previous_mode="HEALTHY",
+                    current_mode="HEALTHY",
+                    changed=False,
+                    reason=RegulationReason.NONE,
+                ),
+            )
+
+    def test_state_wrong_type_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            TransitionResult(
+                state={"pleasure": 0.5},  # type: ignore[arg-type]
+                regulation=RegulationResult(
+                    previous_mode="HEALTHY",
+                    current_mode="HEALTHY",
+                    changed=False,
+                    reason=RegulationReason.NONE,
+                ),
+            )
+
+    def test_regulation_none_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            TransitionResult(
+                state=_neutral_state(),
+                regulation=None,  # type: ignore[arg-type]
+            )
+
+    def test_regulation_wrong_type_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            TransitionResult(
+                state=_neutral_state(),
+                regulation={"previous_mode": "HEALTHY"},  # type: ignore[arg-type]
+            )
+
+
 class TestTransitionResultStructure:
     """TransitionResult and RegulationResult serialisation."""
 
@@ -1004,6 +1170,72 @@ class TestValidateCurrentTime:
     def test_invalid_times(self, bad_time):
         with pytest.raises(EmotionalDomainError):
             _validate_current_time(bad_time)
+
+
+class TestTransitionArgumentValidation:
+    """Validation of transition() argument types."""
+
+    def test_state_none_rejected(self):
+        ap = _appraisal()
+        cfg = _default_config()
+        with pytest.raises(EmotionalDomainError):
+            transition(None, ap, _T0, cfg)  # type: ignore[arg-type]
+
+    def test_state_dict_rejected(self):
+        ap = _appraisal()
+        cfg = _default_config()
+        with pytest.raises(EmotionalDomainError):
+            transition({"pleasure": 0.5}, ap, _T0, cfg)  # type: ignore[arg-type]
+
+    def test_state_string_rejected(self):
+        ap = _appraisal()
+        cfg = _default_config()
+        with pytest.raises(EmotionalDomainError):
+            transition("not_a_state", ap, _T0, cfg)  # type: ignore[arg-type]
+
+    def test_appraisal_none_rejected(self):
+        state = _neutral_state()
+        cfg = _default_config()
+        with pytest.raises(EmotionalDomainError):
+            transition(state, None, _T0, cfg)  # type: ignore[arg-type]
+
+    def test_appraisal_dict_rejected(self):
+        state = _neutral_state()
+        cfg = _default_config()
+        with pytest.raises(EmotionalDomainError):
+            transition(state, {"valence_shift": 0.1}, _T0, cfg)  # type: ignore[arg-type]
+
+    def test_appraisal_string_rejected(self):
+        state = _neutral_state()
+        cfg = _default_config()
+        with pytest.raises(EmotionalDomainError):
+            transition(state, "not_an_appraisal", _T0, cfg)  # type: ignore[arg-type]
+
+    def test_config_none_rejected(self):
+        state = _neutral_state()
+        ap = _appraisal()
+        with pytest.raises(EmotionalDomainError):
+            transition(state, ap, _T0, None)  # type: ignore[arg-type]
+
+    def test_config_dict_rejected(self):
+        state = _neutral_state()
+        ap = _appraisal()
+        with pytest.raises(EmotionalDomainError):
+            transition(state, ap, _T0, {"pad_half_life": 3600.0})  # type: ignore[arg-type]
+
+    def test_config_string_rejected(self):
+        state = _neutral_state()
+        ap = _appraisal()
+        with pytest.raises(EmotionalDomainError):
+            transition(state, ap, _T0, "bad_config")  # type: ignore[arg-type]
+
+    def test_state_appraisal_swapped_rejected(self):
+        """Swapping state and appraisal should be rejected."""
+        state = _neutral_state()
+        ap = _appraisal()
+        cfg = _default_config()
+        with pytest.raises(EmotionalDomainError):
+            transition(ap, state, _T0, cfg)  # type: ignore[arg-type]
 
 
 class TestDetermineCopingMode:

--- a/backend/tests/test_emotional_transition.py
+++ b/backend/tests/test_emotional_transition.py
@@ -793,6 +793,73 @@ class TestRegulationResultValidation:
                 reason=RegulationReason.HIGH_TENSION_POSITIVE_DOMINANCE,
             )
 
+    # ── Non-string previous_mode values (must not raise TypeError) ───────────
+
+    @pytest.mark.parametrize("bad_previous_mode", [
+        None,
+        [],
+        {},
+        42,
+        True,
+        False,
+        object(),
+    ])
+    def test_previous_mode_non_string_rejected(self, bad_previous_mode):
+        with pytest.raises(EmotionalDomainError):
+            RegulationResult(
+                previous_mode=bad_previous_mode,  # type: ignore[arg-type]
+                current_mode="HEALTHY",
+                changed=True,
+                reason=RegulationReason.RECOVERED,
+            )
+
+    @pytest.mark.parametrize("bad_current_mode", [
+        None,
+        [],
+        {},
+        42,
+        True,
+        False,
+        object(),
+    ])
+    def test_current_mode_non_string_rejected(self, bad_current_mode):
+        with pytest.raises(EmotionalDomainError):
+            RegulationResult(
+                previous_mode="HEALTHY",
+                current_mode=bad_current_mode,  # type: ignore[arg-type]
+                changed=True,
+                reason=RegulationReason.HIGH_TENSION_POSITIVE_DOMINANCE,
+            )
+
+    def test_non_string_modes_never_raise_type_error(self):
+        """Explicitly confirm that non-hashable types produce EmotionalDomainError, not TypeError."""
+        for bad_mode in ([], {}, None, 42, True, object()):
+            try:
+                RegulationResult(
+                    previous_mode=bad_mode,  # type: ignore[arg-type]
+                    current_mode="HEALTHY",
+                    changed=True,
+                    reason=RegulationReason.RECOVERED,
+                )
+                pytest.fail(f"Expected EmotionalDomainError for previous_mode={bad_mode!r}")
+            except TypeError:
+                pytest.fail(f"TypeError escaped for previous_mode={bad_mode!r}")
+            except EmotionalDomainError:
+                pass
+
+            try:
+                RegulationResult(
+                    previous_mode="HEALTHY",
+                    current_mode=bad_mode,  # type: ignore[arg-type]
+                    changed=True,
+                    reason=RegulationReason.HIGH_TENSION_POSITIVE_DOMINANCE,
+                )
+                pytest.fail(f"Expected EmotionalDomainError for current_mode={bad_mode!r}")
+            except TypeError:
+                pytest.fail(f"TypeError escaped for current_mode={bad_mode!r}")
+            except EmotionalDomainError:
+                pass
+
     def test_changed_not_bool_rejected(self):
         for bad in (0, 1, "True", None, [True], {"c": True}):
             with pytest.raises(EmotionalDomainError):

--- a/backend/tests/test_emotional_transition.py
+++ b/backend/tests/test_emotional_transition.py
@@ -1,0 +1,1097 @@
+"""
+Tests for backend/emotional_domain/transition — issue #233.
+
+Coverage map (42 requirements):
+─────────────────────────────────────────────────────────────────────────────
+ 1. Same arguments produce exactly the same result (determinism)
+ 2. previous_state remains identical
+ 3. appraisal remains identical
+ 4. config remains identical
+ 5. Invalid config fails closed
+ 6. current_time invalid is rejected
+ 7. Elapsed zero does not apply decay
+ 8. At one half-life, deviation from baseline halves
+ 9. Two half-life steps with neutral appraisal equal one full half-life step
+10. Continuous decay over seconds, minutes, hours is monotonic
+11. Clock regression uses elapsed zero
+12. Output timestamp never decreases
+13. Positive shift respects cap of 0.25
+14. Negative shift respects cap of 0.25
+15. Saturation keeps PAD in [-1.0, 1.0]
+16. Neutral appraisal produces no turn shifts beyond decay and regulation
+17. Different discrete emotions with same shifts produce same snapshot
+18. libido does not increase automatically
+19. aggression does not increase automatically
+20. connection remains unchanged
+21. energy remains unchanged
+22. Tension increases when pleasure < -0.3
+23. Tension decreases when pleasure > 0.3
+24. Tension unchanged in neutral pleasure range
+25. Tension stays in [0.0, 1.0]
+26. Activation threshold 0.8 is inclusive
+27. Recovery threshold 0.3 is inclusive
+28. Intermediate range preserves coping mode (hysteresis)
+29. Positive dominance at activation triggers DEFENSIVE
+30. DEFENSIVE does not increase aggression
+31. Zero dominance at activation triggers DISSOCIATED
+32. Negative dominance at activation triggers DISSOCIATED
+33. DISSOCIATED reduces arousal by configured factor
+34. Recovery triggers HEALTHY
+35. MANIC follows documented policy
+36. RegulationResult reports correct mode, change, and reason
+37. No RegulationResult contains prompt text or user content
+38. Module imports without FastAPI, Groq, Supabase, embeddings, network
+39. No tests use real clock, sleep, randomness, or external services
+40. All existing backend tests still pass
+41. Frontend audit, tests, lint, and build stay green
+42. Full CI passes
+"""
+
+from __future__ import annotations
+
+import copy
+import math
+import subprocess
+import sys
+import textwrap
+from typing import Any
+
+import pytest
+
+from backend.emotional_domain.models import (
+    EMOTIONAL_SCHEMA_VERSION,
+    AppraisalV1,
+    EmotionalDomainError,
+    EmotionalStateV1,
+)
+from backend.emotional_domain.transition import (
+    RegulationReason,
+    RegulationResult,
+    TransitionConfig,
+    TransitionResult,
+    _clamp,
+    _clamp_shift,
+    _determine_coping_mode,
+    _exponential_decay,
+    _validate_current_time,
+    transition,
+)
+from backend.emotional_domain import (
+    RegulationResult as PkgRegulationResult,
+    RegulationReason as PkgRegulationReason,
+    TransitionConfig as PkgTransitionConfig,
+    TransitionResult as PkgTransitionResult,
+    transition as pkg_transition,
+)
+
+
+# ─── Constants ───────────────────────────────────────────────────────────────
+
+_T0 = 1_700_000_000.0  # Base timestamp
+_T1 = _T0 + 3600.0  # One hour later
+_HALF_PAD = 3600.0
+_HALF_TENSION = 7200.0
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+def _neutral_state(timestamp: float = _T0) -> EmotionalStateV1:
+    return EmotionalStateV1.neutral(timestamp=timestamp)
+
+
+def _state(
+    pleasure: float = 0.0,
+    arousal: float = 0.0,
+    dominance: float = 0.0,
+    libido: float = 0.0,
+    aggression: float = 0.0,
+    connection: float = 0.5,
+    energy: float = 0.8,
+    tension: float = 0.0,
+    coping_mode: str = "HEALTHY",
+    timestamp: float = _T0,
+) -> EmotionalStateV1:
+    return EmotionalStateV1.create(
+        pleasure=pleasure,
+        arousal=arousal,
+        dominance=dominance,
+        libido=libido,
+        aggression=aggression,
+        connection=connection,
+        energy=energy,
+        tension=tension,
+        coping_mode=coping_mode,
+        timestamp=timestamp,
+    )
+
+
+def _appraisal(
+    valence_shift: float = 0.0,
+    arousal_shift: float = 0.0,
+    dominance_shift: float = 0.0,
+    discrete_emotions: dict[str, float] | None = None,
+) -> AppraisalV1:
+    return AppraisalV1.create(
+        valence_shift=valence_shift,
+        arousal_shift=arousal_shift,
+        dominance_shift=dominance_shift,
+        discrete_emotions=discrete_emotions or {},
+    )
+
+
+def _default_config() -> TransitionConfig:
+    return TransitionConfig.defaults()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Requirement 1: Determinism — same inputs → same outputs
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestDeterminism:
+    """Same arguments produce exactly the same result."""
+
+    def test_deterministic_repeated_call(self):
+        state = _state(pleasure=0.3, arousal=0.2, dominance=0.1, tension=0.5)
+        ap = _appraisal(valence_shift=0.1, arousal_shift=-0.05, dominance_shift=0.02)
+        cfg = _default_config()
+        result1 = transition(state, ap, _T1, cfg)
+        result2 = transition(state, ap, _T1, cfg)
+        assert result1 == result2
+        assert result1.state == result2.state
+        assert result1.regulation == result2.regulation
+
+    def test_deterministic_three_calls(self):
+        state = _neutral_state()
+        ap = _appraisal()
+        cfg = _default_config()
+        results = [transition(state, ap, _T0 + 1, cfg) for _ in range(3)]
+        assert all(r == results[0] for r in results)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Requirements 2-4: Input immutability
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestInputImmutability:
+    """previous_state, appraisal, and config remain identical."""
+
+    def test_previous_state_unchanged(self):
+        state = _state(pleasure=0.5, arousal=0.3, tension=0.4)
+        original = copy.deepcopy(state)
+        ap = _appraisal(valence_shift=0.1)
+        cfg = _default_config()
+        transition(state, ap, _T1, cfg)
+        assert state == original
+
+    def test_appraisal_unchanged(self):
+        state = _state(pleasure=0.5)
+        ap = _appraisal(valence_shift=0.1, arousal_shift=-0.2)
+        original_dict = ap.to_dict()
+        cfg = _default_config()
+        transition(state, ap, _T1, cfg)
+        assert ap.to_dict() == original_dict
+
+    def test_config_unchanged(self):
+        state = _state(pleasure=0.5)
+        ap = _appraisal(valence_shift=0.1)
+        cfg = _default_config()
+        original = copy.deepcopy(cfg)
+        transition(state, ap, _T1, cfg)
+        assert cfg == original
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Requirement 5: Invalid config fails closed
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestInvalidConfig:
+    """Invalid TransitionConfig is rejected."""
+
+    @pytest.mark.parametrize("kw", [
+        {"pad_half_life": -1.0},
+        {"pad_half_life": 0.0},
+        {"pad_half_life": None},
+        {"pad_half_life": True},
+        {"pad_half_life": float("nan")},
+        {"pad_half_life": float("inf")},
+        {"tension_half_life": -1.0},
+        {"tension_half_life": 0.0},
+        {"pad_baseline": -2.0},
+        {"pad_baseline": 2.0},
+        {"tension_baseline": -0.1},
+        {"tension_baseline": 2.0},
+        {"max_pleasure_shift": -0.1},
+        {"max_pleasure_shift": 0.0},
+        {"max_pleasure_shift": 1.5},
+        {"max_arousal_shift": True},
+        {"max_dominance_shift": None},
+        {"negative_pleasure_threshold": -2.0},
+        {"positive_pleasure_threshold": 2.0},
+        {"tension_increase": -0.1},
+        {"tension_relief": -0.1},
+        {"activation_threshold": 1.5},
+        {"recovery_threshold": -0.1},
+        {"recovery_threshold": 0.7, "activation_threshold": 0.5},
+        {"dissociation_arousal_factor": -0.1},
+        {"dissociation_arousal_factor": 1.5},
+        {"dissociation_arousal_factor": True},
+    ])
+    def test_invalid_config_rejected(self, kw):
+        with pytest.raises(EmotionalDomainError):
+            TransitionConfig.create(**kw)
+
+    @pytest.mark.parametrize("kw", [
+        {"pad_half_life": 1800.0},
+        {"tension_half_life": 3600.0},
+        {"tension_baseline": 0.1},
+        {"max_pleasure_shift": 0.5},
+        {"dissociation_arousal_factor": 0.3},
+    ])
+    def test_valid_configs_accepted(self, kw):
+        cfg = TransitionConfig.create(**kw)
+        for k, v in kw.items():
+            assert getattr(cfg, k) == v
+
+    def test_defaults_create(self):
+        cfg = TransitionConfig.defaults()
+        assert cfg.pad_half_life == 3600.0
+        assert cfg.tension_half_life == 7200.0
+        assert cfg.pad_baseline == 0.0
+        assert cfg.tension_baseline == 0.0
+
+    def test_unknown_field_rejected(self):
+        with pytest.raises(EmotionalDomainError):
+            TransitionConfig.create(unknown_field=42.0)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Requirement 6: current_time invalid is rejected
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestInvalidCurrentTime:
+    """current_time validation rejects invalid types and non-positive values."""
+
+    @pytest.mark.parametrize("bad_time", [
+        True,
+        False,
+        None,
+        "now",
+        [1.0],
+        {"time": 1.0},
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        0.0,
+        -1.0,
+        -0.001,
+    ])
+    def test_invalid_current_time_rejected(self, bad_time):
+        state = _neutral_state()
+        ap = _appraisal()
+        cfg = _default_config()
+        with pytest.raises(EmotionalDomainError):
+            transition(state, ap, bad_time, cfg)
+
+    def test_valid_current_time_accepted(self):
+        state = _neutral_state()
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0 + 1.0, cfg)
+        assert result.state.timestamp == _T0 + 1.0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Requirements 7-10: Decay behaviour
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestDecay:
+    """Exponential decay toward baseline."""
+
+    def test_elapsed_zero_no_decay(self):
+        """Req 7: No elapsed time → no decay applied."""
+        state = _state(pleasure=0.5, arousal=-0.3, dominance=0.2, tension=0.7)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        # With NO appraisal shifts (neutral), pleasure stays at 0.5
+        assert result.state.pleasure == pytest.approx(0.5, abs=1e-10)
+
+    def test_one_half_life_decay(self):
+        """Req 8: At one half-life the deviation from baseline halves."""
+        state = _state(pleasure=0.8, arousal=0.0, dominance=0.0, tension=0.0)
+        ap = _appraisal()
+        cfg = _default_config()
+        # One PAD half-life (3600 seconds)
+        result = transition(state, ap, _T0 + _HALF_PAD, cfg)
+        # Deviation from baseline (0.0): 0.8 → should be ~0.4
+        expected = 0.0 + (0.8 - 0.0) * (0.5 ** (3600.0 / 3600.0))
+        assert result.state.pleasure == pytest.approx(expected, abs=1e-10)
+
+    def test_two_half_steps_equal_one_full_step_neutral(self):
+        """Req 9: Two steps of half a half-life with neutral appraisal equal one full half-life step."""
+        cfg = _default_config()
+        state = _state(pleasure=0.6, arousal=0.0, dominance=0.0, tension=0.0)
+        ap = _appraisal()
+
+        # One step of one half-life
+        result_one = transition(state, ap, _T0 + _HALF_PAD, cfg)
+        value_after_full = result_one.state.pleasure
+
+        # Two steps of half a half-life each
+        half_half = _HALF_PAD / 2.0
+        r1 = transition(state, ap, _T0 + half_half, cfg)
+        r2 = transition(r1.state, ap, _T0 + _HALF_PAD, cfg)
+        value_after_two = r2.state.pleasure
+
+        assert value_after_full == pytest.approx(value_after_two, abs=1e-10)
+
+    def test_continuous_decay_monotonic(self):
+        """Req 10: Decay is continuous and monotonic over various time scales."""
+        state = _state(pleasure=0.5, arousal=0.0, dominance=0.0, tension=0.0)
+        ap = _appraisal()
+        cfg = _default_config()
+
+        times = [1.0, 60.0, 300.0, 1800.0, 3600.0, 7200.0, 14400.0]  # seconds to hours
+        values = []
+        for t in times:
+            result = transition(state, ap, _T0 + t, cfg)
+            values.append(result.state.pleasure)
+
+        # Values should be monotonically decreasing toward baseline
+        for i in range(1, len(values)):
+            assert values[i] < values[i - 1], f"Not monotonic at index {i}: {values[i-1]} -> {values[i]}"
+
+        # Final value should be closer to baseline than initial
+        assert values[-1] < 0.5
+
+    def test_decay_preserves_drives(self):
+        """Drives (libido, aggression, connection, energy) do not decay."""
+        state = _state(
+            libido=0.3, aggression=0.2, connection=0.7, energy=0.9,
+        )
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0 + 7200, cfg)
+        assert result.state.libido == 0.3
+        assert result.state.aggression == 0.2
+        assert result.state.connection == 0.7
+        assert result.state.energy == 0.9
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Requirements 11-12: Clock regression
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestClockRegression:
+    """Clock regression uses elapsed zero and preserves previous timestamp."""
+
+    def test_regression_uses_elapsed_zero(self):
+        """Req 11: When current_time < previous_state.timestamp, elapsed = 0."""
+        state = _state(pleasure=0.7, timestamp=_T0 + 3600)
+        ap = _appraisal()
+        cfg = _default_config()
+        # current_time is BEFORE the previous state's timestamp
+        result = transition(state, ap, _T0, cfg)
+        # No decay should happen due to elapsed=0
+        assert result.state.pleasure == pytest.approx(0.7, abs=1e-10)
+
+    def test_output_timestamp_never_decreases(self):
+        """Req 12: Output timestamp never decreases below previous timestamp."""
+        state = _state(timestamp=_T0)
+        ap = _appraisal()
+        cfg = _default_config()
+
+        # Normal forward time
+        r1 = transition(state, ap, _T0 + 100, cfg)
+        assert r1.state.timestamp == _T0 + 100
+
+        # Regression
+        r2 = transition(state, ap, _T0 - 100, cfg)
+        assert r2.state.timestamp == _T0  # previous timestamp preserved
+
+    def test_regression_with_appraisal(self):
+        """Clock regression: appraisal shifts apply but decay does not."""
+        state = _state(pleasure=0.0, timestamp=_T0 + 100)
+        ap = _appraisal(valence_shift=0.2)
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        # Shift applies but no decay
+        assert result.state.pleasure == pytest.approx(0.2, abs=1e-10)
+        assert result.state.timestamp == _T0 + 100
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Requirements 13-16: Appraisal shifts and caps
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestAppraisalShifts:
+    """Appraisal shifts are capped and PAD is clamped."""
+
+    def test_positive_shift_capped(self):
+        """Req 13: Positive shift respects cap of 0.25."""
+        state = _state(pleasure=0.0, arousal=0.0, dominance=0.0)
+        # Huge positive shift should be capped
+        ap = _appraisal(valence_shift=1.0, arousal_shift=1.0, dominance_shift=1.0)
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.pleasure == pytest.approx(0.25, abs=1e-10)
+        assert result.state.arousal == pytest.approx(0.25, abs=1e-10)
+        assert result.state.dominance == pytest.approx(0.25, abs=1e-10)
+
+    def test_negative_shift_capped(self):
+        """Req 14: Negative shift respects cap of 0.25."""
+        state = _state(pleasure=0.0, arousal=0.0, dominance=0.0)
+        ap = _appraisal(valence_shift=-1.0, arousal_shift=-1.0, dominance_shift=-1.0)
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.pleasure == pytest.approx(-0.25, abs=1e-10)
+        assert result.state.arousal == pytest.approx(-0.25, abs=1e-10)
+        assert result.state.dominance == pytest.approx(-0.25, abs=1e-10)
+
+    def test_saturation_keeps_pad_in_range(self):
+        """Req 15: Saturation keeps PAD in [-1.0, 1.0]."""
+        state = _state(pleasure=0.9, arousal=0.9, dominance=0.9)
+        ap = _appraisal(valence_shift=0.2, arousal_shift=0.2, dominance_shift=0.2)
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert -1.0 <= result.state.pleasure <= 1.0
+        assert -1.0 <= result.state.arousal <= 1.0
+        assert -1.0 <= result.state.dominance <= 1.0
+
+    def test_saturation_from_underflow(self):
+        state = _state(pleasure=-0.9, arousal=-0.9, dominance=-0.9)
+        ap = _appraisal(valence_shift=-0.2, arousal_shift=-0.2, dominance_shift=-0.2)
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert -1.0 <= result.state.pleasure <= 1.0
+        assert -1.0 <= result.state.arousal <= 1.0
+        assert -1.0 <= result.state.dominance <= 1.0
+
+    def test_neutral_appraisal_no_turn_changes(self):
+        """Req 16: Neutral appraisal with no elapsed time produces no changes beyond regulation."""
+        state = _state(pleasure=0.0, arousal=0.0, dominance=0.0, tension=0.0)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.pleasure == pytest.approx(0.0, abs=1e-10)
+        assert result.state.tension == pytest.approx(0.0, abs=1e-10)
+
+    def test_different_discrete_emotions_same_shifts_same_snapshot(self):
+        """Req 17: Different discrete_emotions with same shifts produce same snapshot."""
+        state = _state(pleasure=0.0)
+        ap1 = _appraisal(valence_shift=0.1, discrete_emotions={"joy": 0.8})
+        ap2 = _appraisal(valence_shift=0.1, discrete_emotions={"sadness": 0.9})
+        cfg = _default_config()
+        r1 = transition(state, ap1, _T0, cfg)
+        r2 = transition(state, ap2, _T0, cfg)
+        # Both should have same pleasure (discrete_emotions don't affect PAD)
+        assert r1.state.pleasure == r2.state.pleasure
+        assert r1.state.arousal == r2.state.arousal
+        assert r1.state.dominance == r2.state.dominance
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Requirements 18-21: Drives not automatically changed
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestDrivesUnchanged:
+    """libido, aggression, connection, energy do not change automatically."""
+
+    def test_libido_does_not_increase(self):
+        """Req 18."""
+        state = _state(libido=0.0, arousal=0.6, pleasure=0.3)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0 + 1, cfg)
+        assert result.state.libido == 0.0
+
+    def test_aggression_does_not_increase(self):
+        """Req 19."""
+        state = _state(aggression=0.0, tension=0.9, dominance=0.5)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0 + 1, cfg)
+        assert result.state.aggression == 0.0
+
+    def test_connection_unchanged(self):
+        """Req 20."""
+        state = _state(connection=0.3)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0 + 1, cfg)
+        assert result.state.connection == 0.3
+
+    def test_energy_unchanged(self):
+        """Req 21."""
+        state = _state(energy=0.5)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0 + 1, cfg)
+        assert result.state.energy == 0.5
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Requirements 22-25: Tension update
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestTensionUpdate:
+    """Tension responds to pleasure thresholds."""
+
+    def test_tension_increases_when_pleasure_below_negative(self):
+        """Req 22: pleasure < -0.3 → tension delta +0.05."""
+        state = _state(pleasure=-0.5, tension=0.0)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.tension == pytest.approx(0.05, abs=1e-10)
+
+    def test_tension_decreases_when_pleasure_above_positive(self):
+        """Req 23: pleasure > 0.3 → tension delta -0.05."""
+        state = _state(pleasure=0.5, tension=0.5)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.tension == pytest.approx(0.45, abs=1e-10)
+
+    def test_tension_unchanged_in_neutral_pleasure(self):
+        """Req 24: Tension unchanged in neutral range -0.3 <= pleasure <= 0.3."""
+        state = _state(pleasure=0.0, tension=0.4)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.tension == pytest.approx(0.4, abs=1e-10)
+
+    @pytest.mark.parametrize("pleasure,initial_tension,expected_tension", [
+        (-0.301, 0.0, 0.05),  # below negative threshold → +0.05
+        (-0.3, 0.0, 0.0),     # exactly at negative threshold (NOT below)
+        (0.3, 0.0, 0.0),      # exactly at positive threshold (NOT above)
+        (0.301, 0.1, 0.05),   # above positive threshold → -0.05 from 0.1
+    ])
+    def test_tension_threshold_boundaries(self, pleasure, initial_tension, expected_tension):
+        """Test exact boundary behaviour of pleasure thresholds."""
+        state = _state(pleasure=pleasure, tension=initial_tension)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.tension == pytest.approx(expected_tension, abs=1e-10)
+
+    def test_tension_stays_in_range(self):
+        """Req 25: Tension stays in [0.0, 1.0]."""
+        state = _state(pleasure=-1.0, tension=0.98)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert 0.0 <= result.state.tension <= 1.0
+
+        state2 = _state(pleasure=1.0, tension=0.02)
+        result2 = transition(state2, ap, _T0, cfg)
+        assert 0.0 <= result2.state.tension <= 1.0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Requirements 26-28: Coping thresholds and hysteresis
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestCopingThresholds:
+    """Activation and recovery thresholds."""
+
+    def test_activation_inclusive(self):
+        """Req 26: Activation threshold 0.8 is inclusive."""
+        state = _state(tension=0.8, dominance=0.5)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.regulation.current_mode in ("DEFENSIVE", "DISSOCIATED")
+
+    def test_recovery_inclusive(self):
+        """Req 27: Recovery threshold 0.3 is inclusive."""
+        state = _state(tension=0.3, coping_mode="DEFENSIVE")
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.regulation.current_mode == "HEALTHY"
+
+    def test_intermediate_preserves_coping(self):
+        """Req 28: Intermediate range (0.3 < tension < 0.8) preserves coping mode."""
+        for mode in ("HEALTHY", "DEFENSIVE", "DISSOCIATED", "MANIC"):
+            state = _state(tension=0.5, coping_mode=mode)
+            ap = _appraisal()
+            cfg = _default_config()
+            result = transition(state, ap, _T0, cfg)
+            assert result.state.coping_mode == mode
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Requirements 29-33: Coping mode activation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestCopingActivation:
+    """DEFENSIVE and DISSOCIATED activation."""
+
+    def test_positive_dominance_activates_defensive(self):
+        """Req 29: Positive dominance at activation triggers DEFENSIVE."""
+        state = _state(tension=0.9, dominance=0.1)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.coping_mode == "DEFENSIVE"
+        assert result.regulation.current_mode == "DEFENSIVE"
+
+    def test_defensive_does_not_increase_aggression(self):
+        """Req 30: DEFENSIVE does not increase aggression."""
+        state = _state(tension=0.9, dominance=0.1, aggression=0.0)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.coping_mode == "DEFENSIVE"
+        assert result.state.aggression == 0.0  # unchanged
+
+    def test_zero_dominance_activates_dissociated(self):
+        """Req 31: Zero dominance at activation triggers DISSOCIATED."""
+        state = _state(tension=0.9, dominance=0.0)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.coping_mode == "DISSOCIATED"
+
+    def test_negative_dominance_activates_dissociated(self):
+        """Req 32: Negative dominance at activation triggers DISSOCIATED."""
+        state = _state(tension=0.9, dominance=-0.3)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.coping_mode == "DISSOCIATED"
+
+    def test_dissociated_reduces_arousal(self):
+        """Req 33: DISSOCIATED reduces arousal by configured factor (0.5)."""
+        state = _state(tension=0.9, dominance=-0.3, arousal=0.8)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.coping_mode == "DISSOCIATED"
+        expected_arousal = 0.8 * cfg.dissociation_arousal_factor
+        assert result.state.arousal == pytest.approx(expected_arousal, abs=1e-10)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Requirement 34: Recovery triggers HEALTHY
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestRecovery:
+    """Recovery activates HEALTHY."""
+
+    def test_recovery_from_defensive(self):
+        state = _state(tension=0.2, coping_mode="DEFENSIVE")
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.coping_mode == "HEALTHY"
+
+    def test_recovery_from_dissociated(self):
+        state = _state(tension=0.0, coping_mode="DISSOCIATED")
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.coping_mode == "HEALTHY"
+
+    def test_recovery_from_manic(self):
+        state = _state(tension=0.0, coping_mode="MANIC")
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.coping_mode == "HEALTHY"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Requirement 35: MANIC follows documented policy
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestManicPolicy:
+    """MANIC stays MANIC in intermediate range, changes at boundaries."""
+
+    def test_manic_stays_manic_in_intermediate(self):
+        state = _state(tension=0.5, coping_mode="MANIC")
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.coping_mode == "MANIC"
+
+    def test_manic_recovers_to_healthy(self):
+        state = _state(tension=0.2, coping_mode="MANIC")
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.coping_mode == "HEALTHY"
+
+    def test_manic_activates_defensive_with_positive_dominance(self):
+        state = _state(tension=0.9, dominance=0.5, coping_mode="MANIC")
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.coping_mode == "DEFENSIVE"
+
+    def test_manic_activates_dissociated_with_nonpositive_dominance(self):
+        state = _state(tension=0.9, dominance=-0.2, coping_mode="MANIC")
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.coping_mode == "DISSOCIATED"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Requirement 36: RegulationResult structure
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestRegulationResult:
+    """RegulationResult reports correct previous_mode, current_mode, changed, reason."""
+
+    def test_no_change_when_no_regulation(self):
+        state = _state(tension=0.5, coping_mode="HEALTHY")
+        ap = _appraisal(valence_shift=0.1)
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.regulation.changed is False
+        assert result.regulation.reason == RegulationReason.NONE
+        assert result.regulation.previous_mode == "HEALTHY"
+        assert result.regulation.current_mode == "HEALTHY"
+
+    def test_defensive_reason(self):
+        state = _state(tension=0.9, dominance=0.1, coping_mode="HEALTHY")
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.regulation.changed is True
+        assert result.regulation.reason == RegulationReason.HIGH_TENSION_POSITIVE_DOMINANCE
+        assert result.regulation.previous_mode == "HEALTHY"
+        assert result.regulation.current_mode == "DEFENSIVE"
+
+    def test_dissociated_reason(self):
+        state = _state(tension=0.9, dominance=-0.1, coping_mode="HEALTHY")
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.regulation.changed is True
+        assert result.regulation.reason == RegulationReason.HIGH_TENSION_NONPOSITIVE_DOMINANCE
+        assert result.regulation.current_mode == "DISSOCIATED"
+
+    def test_recovered_reason(self):
+        state = _state(tension=0.2, coping_mode="DEFENSIVE")
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.regulation.changed is True
+        assert result.regulation.reason == RegulationReason.RECOVERED
+        assert result.regulation.current_mode == "HEALTHY"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Requirement 37: No prompt/user content in results
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestNoPromptInResults:
+    """No RegulationResult contains prompt text or user content."""
+
+    def test_regulation_result_no_prompt_text(self):
+        state = _state(tension=0.9, dominance=0.5)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        reg = result.regulation
+        assert isinstance(reg.reason, RegulationReason)
+        assert reg.reason.value not in ("", "prompt", "instruction")
+        assert "prompt" not in reg.reason.value
+        assert "user" not in reg.reason.value
+
+    def test_regulation_result_no_instruction_field(self):
+        state = _state(tension=0.9, dominance=0.5)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        d = result.regulation.to_dict()
+        assert "instruction" not in d
+        assert "prompt" not in d
+        assert "acting_instruction" not in d
+
+    def test_transition_result_no_prompt(self):
+        state = _state(tension=0.9, dominance=0.5)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        d = result.to_dict()
+        assert "prompt" not in d
+        assert "instruction" not in str(d)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Requirement 38: Module imports without infrastructure
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestIsolatedImport:
+    """Module imports without FastAPI, Groq, Supabase, embeddings, network."""
+
+    def _run_script(self, script: str) -> subprocess.CompletedProcess:
+        import os
+        env = {
+            **os.environ,
+            "PYTHONPATH": str(
+                __import__("pathlib").Path(__file__).parent.parent.parent
+            ),
+            "HF_HUB_OFFLINE": "1",
+            "TRANSFORMERS_OFFLINE": "1",
+        }
+        return subprocess.run(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+
+    def test_transition_import_no_fastapi(self):
+        proc = self._run_script("""
+            import sys
+            from backend.emotional_domain.transition import transition, TransitionConfig
+            for mod in sys.modules:
+                assert 'fastapi' not in mod, f'fastapi loaded: {mod}'
+            print('OK')
+        """)
+        assert proc.returncode == 0, proc.stderr
+        assert "OK" in proc.stdout
+
+    def test_transition_import_no_groq(self):
+        proc = self._run_script("""
+            import sys
+            from backend.emotional_domain.transition import TransitionResult
+            for mod in sys.modules:
+                assert 'groq' not in mod, f'groq loaded: {mod}'
+            print('OK')
+        """)
+        assert proc.returncode == 0, proc.stderr
+        assert "OK" in proc.stdout
+
+    def test_transition_import_no_supabase(self):
+        proc = self._run_script("""
+            import sys
+            from backend.emotional_domain import transition
+            for mod in sys.modules:
+                assert 'supabase' not in mod, f'supabase loaded: {mod}'
+            print('OK')
+        """)
+        assert proc.returncode == 0, proc.stderr
+        assert "OK" in proc.stdout
+
+    def test_transition_works_in_isolation(self):
+        proc = self._run_script("""
+            from backend.emotional_domain import (
+                EmotionalStateV1, AppraisalV1,
+                TransitionConfig, transition, TransitionResult, RegulationResult,
+            )
+            state = EmotionalStateV1.neutral(timestamp=1_700_000_000.0)
+            ap = AppraisalV1.neutral()
+            cfg = TransitionConfig.defaults()
+            result = transition(state, ap, 1_700_001_000.0, cfg)
+            assert isinstance(result, TransitionResult)
+            assert isinstance(result.regulation, RegulationResult)
+            print('OK')
+        """)
+        assert proc.returncode == 0, proc.stderr
+        assert "OK" in proc.stdout
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Requirement 39: No real clock, sleep, randomness, or external services
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# (This requirement is satisfied by the design of all tests above — none use
+# time.time(), time.sleep(), random, or external services. This annotation
+# serves as documentation.)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Additional structural tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestTransitionResultStructure:
+    """TransitionResult and RegulationResult serialisation."""
+
+    def test_transition_result_to_dict(self):
+        state = _state(tension=0.5)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0 + 1, cfg)
+        d = result.to_dict()
+        assert "state" in d
+        assert "regulation" in d
+        assert "pleasure" in d["state"]
+        assert "coping_mode" in d["state"]
+
+    def test_regulation_result_to_dict(self):
+        reg = RegulationResult(
+            previous_mode="HEALTHY",
+            current_mode="DEFENSIVE",
+            changed=True,
+            reason=RegulationReason.HIGH_TENSION_POSITIVE_DOMINANCE,
+        )
+        d = reg.to_dict()
+        assert d["previous_mode"] == "HEALTHY"
+        assert d["current_mode"] == "DEFENSIVE"
+        assert d["changed"] is True
+        assert d["reason"] == "high_tension_positive_dominance"
+
+    def test_regulation_reason_values(self):
+        assert RegulationReason.NONE.value == "none"
+        assert RegulationReason.HIGH_TENSION_POSITIVE_DOMINANCE.value == "high_tension_positive_dominance"
+        assert RegulationReason.HIGH_TENSION_NONPOSITIVE_DOMINANCE.value == "high_tension_nonpositive_dominance"
+        assert RegulationReason.RECOVERED.value == "recovered"
+
+
+class TestMathematicalHelpers:
+    """Unit tests for internal maths helpers."""
+
+    def test_exponential_decay_no_elapsed(self):
+        result = _exponential_decay(0.8, 0.0, 0.0, 3600.0)
+        assert result == pytest.approx(0.8, abs=1e-10)
+
+    def test_exponential_decay_half_life(self):
+        result = _exponential_decay(0.8, 0.0, 3600.0, 3600.0)
+        assert result == pytest.approx(0.4, abs=1e-10)
+
+    def test_exponential_decay_to_baseline(self):
+        result = _exponential_decay(0.8, 0.5, 3600.0, 3600.0)
+        expected = 0.5 + (0.8 - 0.5) * 0.5
+        assert result == pytest.approx(expected, abs=1e-10)
+
+    def test_clamp_within_range(self):
+        assert _clamp(0.5, -1.0, 1.0) == 0.5
+
+    def test_clamp_below_range(self):
+        assert _clamp(-2.0, -1.0, 1.0) == -1.0
+
+    def test_clamp_above_range(self):
+        assert _clamp(2.0, -1.0, 1.0) == 1.0
+
+    def test_clamp_shift_within_cap(self):
+        assert _clamp_shift(0.1, 0.25) == 0.1
+
+    def test_clamp_shift_above_cap(self):
+        assert _clamp_shift(0.5, 0.25) == 0.25
+
+    def test_clamp_shift_below_cap(self):
+        assert _clamp_shift(-0.5, 0.25) == -0.25
+
+
+class TestValidateCurrentTime:
+    """Unit tests for current_time validation."""
+
+    @pytest.mark.parametrize("good_time", [1.0, 0.001, 1_700_000_000.0, 1e100])
+    def test_valid_times(self, good_time):
+        result = _validate_current_time(good_time)
+        assert result == pytest.approx(float(good_time))
+
+    @pytest.mark.parametrize("bad_time", [
+        True,
+        False,
+        None,
+        "string",
+        [1.0],
+        {"t": 1.0},
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        0.0,
+        -1.0,
+    ])
+    def test_invalid_times(self, bad_time):
+        with pytest.raises(EmotionalDomainError):
+            _validate_current_time(bad_time)
+
+
+class TestDetermineCopingMode:
+    """Unit tests for coping mode determination."""
+
+    def test_activation_defensive(self):
+        state = _state(tension=0.8, dominance=0.1)
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.coping_mode == "DEFENSIVE"
+
+    def test_activation_dissociated_zero_dominance(self):
+        cfg = _default_config()
+        mode = _determine_coping_mode(0.8, 0.0, "HEALTHY", cfg)
+        assert mode == "DISSOCIATED"
+
+    def test_activation_dissociated_negative_dominance(self):
+        cfg = _default_config()
+        mode = _determine_coping_mode(0.8, -0.1, "HEALTHY", cfg)
+        assert mode == "DISSOCIATED"
+
+    def test_recovery_healthy(self):
+        cfg = _default_config()
+        mode = _determine_coping_mode(0.3, 0.5, "DEFENSIVE", cfg)
+        assert mode == "HEALTHY"
+
+    def test_intermediate_preserves_mode(self):
+        cfg = _default_config()
+        mode = _determine_coping_mode(0.5, 0.5, "DEFENSIVE", cfg)
+        assert mode == "DEFENSIVE"
+
+    def test_debug_tension_exactly_point_three(self):
+        state = _state(tension=0.3, coping_mode="DEFENSIVE")
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        # tension=0.3 is recovery threshold (inclusive) → HEALTHY
+        assert result.state.coping_mode == "HEALTHY"
+
+    def test_debug_tension_exactly_point_eight(self):
+        state = _state(tension=0.8, dominance=0.1, coping_mode="HEALTHY")
+        ap = _appraisal()
+        cfg = _default_config()
+        result = transition(state, ap, _T0, cfg)
+        assert result.state.coping_mode == "DEFENSIVE"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Package exports
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestPackageExports:
+    """Transition types are exported from the package."""
+
+    def test_transition_config_exported(self):
+        assert PkgTransitionConfig is TransitionConfig
+
+    def test_regulation_result_exported(self):
+        assert PkgRegulationResult is RegulationResult
+
+    def test_regulation_reason_exported(self):
+        assert PkgRegulationReason is RegulationReason
+
+    def test_transition_result_exported(self):
+        assert PkgTransitionResult is TransitionResult
+
+    def test_package_transition_works(self):
+        state = _neutral_state()
+        ap = _appraisal()
+        cfg = _default_config()
+        r = pkg_transition(state, ap, _T0 + 1, cfg)
+        assert isinstance(r, TransitionResult)
+
+    def test_appraisal_same_shifts_different_emotions_produce_same_pad(self):
+        """Same shift values regardless of discrete emotions produce same PAD."""
+        state = _state(pleasure=0.3, arousal=-0.1, dominance=0.2)
+        ap_joy = _appraisal(
+            valence_shift=0.1, arousal_shift=0.05, dominance_shift=-0.02,
+            discrete_emotions={"joy": 0.7},
+        )
+        ap_anger = _appraisal(
+            valence_shift=0.1, arousal_shift=0.05, dominance_shift=-0.02,
+            discrete_emotions={"anger": 0.6},
+        )
+        cfg = _default_config()
+        r1 = transition(state, ap_joy, _T0, cfg)
+        r2 = transition(state, ap_anger, _T0, cfg)
+        assert r1.state.pleasure == r2.state.pleasure
+        assert r1.state.arousal == r2.state.arousal
+        assert r1.state.dominance == r2.state.dominance

--- a/docs/architecture/emotional-core-v1.md
+++ b/docs/architecture/emotional-core-v1.md
@@ -431,13 +431,14 @@ value_after_decay = baseline + (value_before - baseline) * factor
 
 ### Appraisal shift caps
 
-No single appraisal can move an axis more than **0.25** (configurable via `TransitionConfig`):
+No single appraisal can move an axis more than the configured maximum (default **0.25**, configurable via `TransitionConfig`):
 
 ```python
 effective_shift = clamp(appraisal_shift, -configured_max, configured_max)
 ```
 
-Each axis (`pleasure`, `arousal`, `dominance`) has its own configurable cap.
+Each axis (`pleasure`, `arousal`, `dominance`) has its own configurable cap in `[0.0, 1.0]`.
+A cap of `0.0` disables the axis entirely (no shift is applied).
 
 ### Discrete emotions are not accumulated
 

--- a/docs/architecture/emotional-core-v1.md
+++ b/docs/architecture/emotional-core-v1.md
@@ -3,10 +3,14 @@
 ## Scope
 
 This document describes the typed, versioned domain contracts introduced in issue #232
-and hardened in issue #232 v1.1.
+and hardened in issue #232 v1.1, plus the deterministic emotional transition introduced
+in issue #233.
+
 It covers construction invariants, deep immutability, serialisation, migration, parser,
-fallback policy, and alias translation.
-It does **not** describe transition logic, decay, or production integration (#233/#234).
+fallback policy, alias translation, and the transition layer (decay, appraisal shifts,
+tension update, and coping regulation).
+
+It does **not** describe production integration (#234).
 
 ---
 
@@ -16,13 +20,15 @@ It does **not** describe transition logic, decay, or production integration (#23
 ┌────────────────────────────────────────────────────────────────┐
 │  Presentation  (prompt builder, acting instruction)            │
 ├────────────────────────────────────────────────────────────────┤
-│  Transition    (AffectiveEngine — decay, PAD update, coping)   │
-│                          ▲ uses (not replaced in #232)         │
+│  Transition    (transition.transition — #233)                  │
+│     pure, deterministic, infrastructure-free                   │
+│     no I/O, no time.time(), no randomness                      │
+│     decay → appraisal shifts → tension → regulation            │
 ├────────────────────────────────────────────────────────────────┤
-│  Appraisal     (parse_llm_appraisal, OCCAppraisal)             │
+│  Appraisal     (parse_llm_appraisal, AppraisalV1)              │
 │                          ▲ produces AppraisalV1                │
 ├────────────────────────────────────────────────────────────────┤
-│  State         (EmotionalStateV1) — this document              │
+│  State         (EmotionalStateV1)                              │
 ├────────────────────────────────────────────────────────────────┤
 │  Migration     (migrate_legacy_snapshot)                       │
 └────────────────────────────────────────────────────────────────┘
@@ -42,6 +48,7 @@ backend/emotional_domain/
     migration.py          — migrate_legacy_snapshot
     serialization.py      — serialize_*/deserialize_* (JSON)
     appraisal_parser.py   — parse_llm_appraisal (with ParseResult and ParseErrorCode)
+    transition.py         — transition(), TransitionConfig, RegulationResult (added in #233)
 ```
 
 No file in this package imports FastAPI, Groq, Supabase, sentence_transformers,
@@ -360,9 +367,167 @@ else:
 
 ---
 
-## Out of scope (this document / issue #232)
+## Transition layer — `transition.py`
 
-- Transition logic, decay, or PAD update formulas (→ #233).
+### Public API
+
+```python
+from backend.emotional_domain import transition, TransitionConfig, RegulationResult, TransitionResult
+
+result = transition(
+    previous_state=EmotionalStateV1,
+    appraisal=AppraisalV1,
+    current_time=float,            # Unix epoch seconds, explicit
+    config=TransitionConfig,
+)
+# → TransitionResult with .state (EmotionalStateV1) and .regulation (RegulationResult)
+```
+
+### Design principles
+
+- **Pure**: no I/O, no randomness, no global state, no `time.time()`, no environment variables.
+- **Deterministic**: same inputs always produce identical outputs.
+- **Immutable**: never mutates `previous_state`, `appraisal`, or `config`.
+- **Infrastructure-free**: no FastAPI, Groq, Supabase, embeddings, or network.
+- **Single source of appraisal**: receives exactly one canonical `AppraisalV1`. Does **not**
+  execute `OCCAppraisal`, keyword heuristics, alias translation, or LLM payload parsing.
+
+### Order of operations
+
+```
+1. Validate current_time (reject bool, None, str, list, dict, NaN, Inf, <= 0)
+2. Compute elapsed seconds (clock regression → elapsed = 0.0)
+3. Apply exponential decay to PAD and tension toward baselines
+4. Apply capped appraisal shifts to PAD
+5. Clamp PAD to [-1.0, +1.0]
+6. Update tension based on pleasure level
+7. Clamp tension to [0.0, 1.0]
+8. Determine coping mode (with hysteresis + MANIC handling)
+9. Apply regulation effects
+10. Build new EmotionalStateV1 via validated factory
+11. Return TransitionResult
+```
+
+### Exponential decay formula
+
+```python
+factor = 0.5 ** (elapsed_seconds / half_life_seconds)
+value_after_decay = baseline + (value_before - baseline) * factor
+```
+
+#### Default parameters
+
+| Parameter | Value | Domain |
+|---|---|---|
+| PAD half-life | 3600.0 s (1 hour) | pleasure, arousal, dominance |
+| tension half-life | 7200.0 s (2 hours) | tension |
+| PAD baseline | 0.0 | pleasure, arousal, dominance |
+| tension baseline | 0.0 | tension |
+
+**Not decayed in v1:** `libido`, `aggression`, `connection`, `energy` — these remain unchanged.
+
+> ⚠️ All default parameters are **engineering choices**. They have **no claim of clinical
+> validity**.
+
+### Appraisal shift caps
+
+No single appraisal can move an axis more than **0.25** (configurable via `TransitionConfig`):
+
+```python
+effective_shift = clamp(appraisal_shift, -configured_max, configured_max)
+```
+
+Each axis (`pleasure`, `arousal`, `dominance`) has its own configurable cap.
+
+### Discrete emotions are not accumulated
+
+Two appraisals with the same scalar shifts but different `discrete_emotions` produce the
+**same emotional snapshot** (same PAD, drives, tension, coping mode). Discrete emotions
+are signals of the event, not accumulated in the persistent snapshot.
+
+### Current time and clock regression
+
+- `current_time` must be a finite positive float (Unix epoch seconds).
+- `bool`, `None`, `str`, `list`, `dict`, `NaN`, `Inf`, and values ≤ 0 are rejected.
+- If `current_time < previous_state.timestamp`, elapsed is set to 0.0 and the output
+  timestamp equals `previous_state.timestamp`.
+- The output timestamp **never decreases** below `previous_state.timestamp`.
+
+```python
+output_timestamp = max(previous_state.timestamp, current_time)
+```
+
+### Tension update (pleasure-reactive)
+
+| Condition | Tension delta |
+|---|---|
+| `pleasure < negative_pleasure_threshold` (default −0.3) | `+tension_increase` (+0.05) |
+| `pleasure > positive_pleasure_threshold` (default +0.3) | `−tension_relief` (−0.05) |
+| Otherwise | 0.0 |
+
+Tension is always clamped to `[0.0, 1.0]`.
+
+### Coping mode determination (hysteresis)
+
+#### Default thresholds
+
+| Threshold | Value |
+|---|---|
+| `activation_threshold` | 0.8 (inclusive) |
+| `recovery_threshold` | 0.3 (inclusive) |
+
+#### Rules
+
+| Condition | Coping mode |
+|---|---|
+| `tension ≥ 0.8` and `dominance > 0.0` | `DEFENSIVE` |
+| `tension ≥ 0.8` and `dominance ≤ 0.0` | `DISSOCIATED` |
+| `tension ≤ 0.3` | `HEALTHY` |
+| `0.3 < tension < 0.8` | Preserve previous mode (hysteresis) |
+
+#### MANIC handling
+
+- In the intermediate range (`0.3 < tension < 0.8`), MANIC **remains MANIC**.
+- On recovery (`tension ≤ 0.3`), MANIC transitions to **HEALTHY**.
+- On activation (`tension ≥ 0.8`), MANIC transitions to **DEFENSIVE** (if
+  `dominance > 0.0`) or **DISSOCIATED** (if `dominance ≤ 0.0`).
+
+#### Regulation effects
+
+| Mode | Effects |
+|---|---|
+| `HEALTHY` | No additional effects. |
+| `DEFENSIVE` | No additional effects in v1. **Does not increase aggression.** |
+| `DISSOCIATED` | Arousal is multiplied by `dissociation_arousal_factor` (default 0.5), then clamped to `[-1.0, 1.0]`. |
+
+No mode produces prompt text, acting instructions, or user-facing content.
+
+### RegulationResult
+
+```python
+@dataclass(frozen=True)
+class RegulationResult:
+    previous_mode: str          # Coping mode before regulation
+    current_mode: str           # Coping mode after regulation
+    changed: bool               # True when previous_mode != current_mode
+    reason: RegulationReason    # Enum: NONE, HIGH_TENSION_POSITIVE_DOMINANCE,
+                                #       HIGH_TENSION_NONPOSITIVE_DOMINANCE, RECOVERED
+```
+
+`RegulationReason` is a `str` enum with the following values:
+
+| Value | Meaning |
+|---|---|
+| `none` | No change in coping mode |
+| `high_tension_positive_dominance` | Activation with dominance > 0 (→ DEFENSIVE) |
+| `high_tension_nonpositive_dominance` | Activation with dominance ≤ 0 (→ DISSOCIATED) |
+| `recovered` | Tension dropped to recovery threshold (→ HEALTHY) |
+
+`RegulationResult` contains no prompt text, no user content, no LLM output, no
+acting instruction, and no metacognitive strategy.
+
+## Out of scope (this document)
+
 - Integration of these models into `ConversationEngine` (→ #234).
 - Persistence changes.
 - API or frontend changes.


### PR DESCRIPTION
Closes #233

## Problema e causa raiz

O domínio tipado criado na #232 ainda não possuía uma função canônica de transição emocional. O fluxo legado aplicava decay dependente de chamada, misturava appraisal heurístico e LLM, permitia shifts excessivos e continha efeitos automáticos indesejados sobre libido e agressividade.

## Solução implementada

Adiciona uma transição emocional v1 pura, determinística e imutável em `backend/emotional_domain/transition.py`.

A API recebe:

- `EmotionalStateV1` anterior;
- um único `AppraisalV1` canônico;
- `current_time` explícito;
- `TransitionConfig` imutável e validado.

Retorna `TransitionResult`, contendo o novo `EmotionalStateV1` e um `RegulationResult` estruturado.

## Arquitetura e fronteiras

- Sem I/O, rede, relógio global, aleatoriedade ou estado global mutável.
- Sem FastAPI, Groq, Supabase ou embeddings.
- Sem análise de texto, `OCCAppraisal`, heurísticas de palavras-chave ou combinação implícita de appraisals.
- Sem integração com `ConversationEngine`; essa etapa permanece reservada para a #234.
- Sem alterações de persistência, API, frontend, relacionamento, memória, metacognição ou personalidade.

## Comportamento

1. Valida os argumentos públicos.
2. Calcula o tempo decorrido, sem permitir regressão de timestamp.
3. Aplica decay exponencial a PAD e tensão.
4. Aplica shifts limitados por eixo.
5. Atualiza e limita tensão.
6. Determina coping com thresholds inclusivos e histerese.
7. Aplica apenas a redução configurada de arousal em `DISSOCIATED`.
8. Constrói um novo snapshot validado.

## Validações e invariantes

- Threshold negativo deve ser menor que o positivo.
- Deltas de tensão e caps permanecem em `[0.0, 1.0]`; cap zero desativa o eixo.
- `RegulationResult` valida tipos, allowlist, `changed` e coerência reason-mode.
- Modos não-string e não-hashable falham com `EmotionalDomainError`, nunca `TypeError`.
- `TransitionResult` valida `state` e `regulation`.
- Tipos incorretos na API pública falham de forma controlada.
- Libido, agressividade, conexão e energia não recebem alterações automáticas.
- Emoções discretas não são acumuladas no snapshot.
- Nenhum resultado contém prompt, instrução de atuação ou conteúdo do usuário.

## Arquivos alterados

- `backend/emotional_domain/transition.py`
- `backend/emotional_domain/__init__.py`
- `backend/tests/test_emotional_transition.py`
- `docs/architecture/emotional-core-v1.md`

## Testes e CI

- Testes unitários e de isolamento adicionados para decay, shifts, tensão, coping, validação e fail-closed.
- Suite completa de backend aprovada.
- Testes, lint, build e auditoria do frontend aprovados.
- GitHub Actions CI run `29379576289` concluída com sucesso no HEAD final.

HEAD auditado: `d6dcfc83f91293acffb8e1e5a14a6b53f01ea8ee`

## Riscos

O novo domínio ainda não é usado em produção. Portanto, esta PR não altera o comportamento atual do `AffectiveEngine` ou do `ConversationEngine`.

## Rollback

Reverter o squash desta PR. Não existe migração de dados ou mudança de contrato público em produção para desfazer.

## Fora de escopo

- Integração da transição no fluxo de conversa.
- Persistência do novo estado.
- Mudanças de API ou frontend.
- Relacionamento, memória emocional ou metacognição.
- Alterações em prompts ou personalidade.