### PR TITLE
fix(emotion): align public API and EmotionPanel contract

### DIFF
--- a/backend/emotion_presentation.py
+++ b/backend/emotion_presentation.py
@@ -30,6 +30,12 @@ from .emotional_domain.models import (
 )
 
 
+# ─── Domain error for presentation layer ────────────────────────────────────
+
+class PresentationError(ValueError):
+    """Raised when a presentation-layer invariant is violated."""
+
+
 # ─── Schema version ──────────────────────────────────────────────────────────
 
 PUBLIC_EMOTION_SCHEMA_VERSION: int = 1
@@ -174,6 +180,14 @@ class EmotionStateResponse(BaseModel):
     def _limit_to_three(cls, value: List[PublicDominantEmotion]) -> List[PublicDominantEmotion]:
         if len(value) > 3:
             raise ValueError("At most 3 dominant emotions are allowed per the public contract.")
+        # Reject duplicate emotion names
+        seen = set()
+        for item in value:
+            if item.name in seen:
+                raise ValueError(
+                    f"Duplicate dominant emotion '{item.name}' is not allowed."
+                )
+            seen.add(item.name)
         return value
 
     @field_validator("timestamp", mode="before")
@@ -211,6 +225,20 @@ def project_public_emotion(
 
     It does NOT mutate either input.
     """
+    # Validate inputs — fail predictably before AttributeError can escape
+    if state is None:
+        raise PresentationError("state cannot be None.")
+    if appraisal is None:
+        raise PresentationError("appraisal cannot be None.")
+    if not isinstance(state, EmotionalStateV1):
+        raise TypeError(
+            f"state must be an EmotionalStateV1, got {type(state).__name__}."
+        )
+    if not isinstance(appraisal, AppraisalV1):
+        raise TypeError(
+            f"appraisal must be an AppraisalV1, got {type(appraisal).__name__}."
+        )
+
     # 1. Mood label from PAD
     mood_label = classify_pad_mood(state.pleasure, state.arousal, state.dominance)
 

--- a/backend/emotion_presentation.py
+++ b/backend/emotion_presentation.py
@@ -10,9 +10,9 @@ Design rules
 - Receives only validated ``EmotionalStateV1`` and ``AppraisalV1``.
 - Does NOT access persistence, relationship, memory, meta-cognition.
 - Does NOT execute transition, coping, or appraisal.
-- ``classify_pad_mood`` is the public mood classification used by the DTO.
-  The internal prompt builder uses a separate ``AffectiveEngine.get_emotional_label``
-  (legacy). These two classifiers should be consolidated in a follow-up issue.
+- ``classify_pad_mood`` is the shared mood classification used by the public DTO
+  AND by the internal prompt builder (``AffectiveEngine.get_emotional_label``
+  delegates to this function). There is only one classifier.
 """
 
 from __future__ import annotations
@@ -22,7 +22,12 @@ from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from .emotional_domain.models import EmotionalStateV1, AppraisalV1, EmotionalDomainError
+from .emotional_domain.models import (
+    EmotionalStateV1,
+    AppraisalV1,
+    EmotionalDomainError,
+    DISCRETE_EMOTIONS,
+)
 
 
 # ─── Schema version ──────────────────────────────────────────────────────────
@@ -30,13 +35,14 @@ from .emotional_domain.models import EmotionalStateV1, AppraisalV1, EmotionalDom
 PUBLIC_EMOTION_SCHEMA_VERSION: int = 1
 
 
-# ─── Shared mood classification ──────────────────────────────────────────────
+# ─── Shared mood classification (single classifier) ──────────────────────────
 
 def classify_pad_mood(pleasure: float, arousal: float, dominance: float) -> str:
-    """Classify PAD coordinates into a human-readable mood label for the public DTO.
+    """Classify PAD coordinates into a human-readable mood label.
 
-    The internal prompt builder still uses ``AffectiveEngine.get_emotional_label``
-    (legacy path); these two classifiers should be consolidated in a follow-up issue.
+    This is the single shared classifier used by both:
+    - The public DTO (``EmotionStateResponse.mood_label``)
+    - The internal prompt builder (``AffectiveEngine.get_emotional_label``)
     """
     if arousal > 0.5:
         if pleasure > 0.5:
@@ -89,12 +95,26 @@ class PublicPAD(BaseModel):
 
 
 class PublicDominantEmotion(BaseModel):
-    """A single discrete emotion with its intensity."""
+    """A single discrete emotion with its intensity.
+
+    ``name`` must be a canonical emotion from ``DISCRETE_EMOTIONS`` allowlist.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
     name: str = Field(..., min_length=1)
     intensity: float = Field(..., ge=0.0, le=1.0)
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def _validate_emotion_name(cls, value: object) -> str:
+        if not isinstance(value, str):
+            raise ValueError(f"Emotion name must be a string, got {type(value).__name__}.")
+        if value not in DISCRETE_EMOTIONS:
+            raise ValueError(
+                f"Emotion name must be one of {sorted(DISCRETE_EMOTIONS)}, got {value!r}."
+            )
+        return value
 
     @field_validator("intensity", mode="before")
     @classmethod
@@ -115,21 +135,24 @@ class EmotionStateResponse(BaseModel):
     This is the **only** emotion payload the browser should see. It contains
     no internal state, no coping mode, no acting instruction, no drives, and
     no relationship data.
+
+    All fields are required at construction time. Validators enforce:
+    - ``schema_version`` must be 1 (int, not bool/float/str).
+    - ``dominant_emotions`` limited to 3 elements.
+    - Each emotion name must be in ``DISCRETE_EMOTIONS`` allowlist.
+    - ``timestamp`` must be a finite positive float.
+    - ``extra`` fields are forbidden on all nested models.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     schema_version: int = Field(
-        default=PUBLIC_EMOTION_SCHEMA_VERSION,
-        ge=1,
-        le=1,
-        description="Must be 1. Only version 1 is accepted.",
+        ..., ge=1, le=1, description="Must be 1. Only version 1 is accepted."
     )
     mood_label: str = Field(..., min_length=1)
     pad: PublicPAD
     dominant_emotions: List[PublicDominantEmotion] = Field(
-        default_factory=list,
-        description="At most 3 emotions, sorted by intensity desc then name asc.",
+        ..., description="At most 3 emotions, sorted by intensity desc then name asc."
     )
     timestamp: float = Field(
         ..., description="Unix epoch seconds from EmotionalStateV1.timestamp."
@@ -146,18 +169,27 @@ class EmotionStateResponse(BaseModel):
             raise ValueError(f"schema_version must be 1, got {value}.")
         return value
 
+    @field_validator("dominant_emotions", mode="after")
+    @classmethod
+    def _limit_to_three(cls, value: List[PublicDominantEmotion]) -> List[PublicDominantEmotion]:
+        if len(value) > 3:
+            raise ValueError("At most 3 dominant emotions are allowed per the public contract.")
+        return value
+
     @field_validator("timestamp", mode="before")
     @classmethod
     def _reject_non_finite_timestamp(cls, value: object) -> float:
         if isinstance(value, bool):
-            raise ValueError("Timestamp must be a finite float, got bool.")
+            raise ValueError("Timestamp must be a finite positive float, got bool.")
         if not isinstance(value, (int, float)):
             raise ValueError(
-                f"Timestamp must be a finite float, got {type(value).__name__}."
+                f"Timestamp must be a finite positive float, got {type(value).__name__}."
             )
         f = float(value)
         if not math.isfinite(f):
             raise ValueError("Timestamp must be finite.")
+        if f <= 0:
+            raise ValueError("Timestamp must be positive (Unix epoch seconds).")
         return f
 
 

--- a/backend/emotion_presentation.py
+++ b/backend/emotion_presentation.py
@@ -1,0 +1,216 @@
+"""
+Public emotion presentation — typed, versioned DTO for external API consumers.
+
+This module is the **only** place where the public emotion contract is defined.
+It produces ``EmotionStateResponse`` which is safe to send to the browser.
+
+Design rules
+============
+- Pure: no I/O, no FastAPI, no Supabase, no Groq, no network, no env vars.
+- Receives only validated ``EmotionalStateV1`` and ``AppraisalV1``.
+- Does NOT access persistence, relationship, memory, meta-cognition.
+- Does NOT execute transition, coping, or appraisal.
+- ``classify_pad_mood`` is the public mood classification used by the DTO.
+  The internal prompt builder uses a separate ``AffectiveEngine.get_emotional_label``
+  (legacy). These two classifiers should be consolidated in a follow-up issue.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from .emotional_domain.models import EmotionalStateV1, AppraisalV1, EmotionalDomainError
+
+
+# ─── Schema version ──────────────────────────────────────────────────────────
+
+PUBLIC_EMOTION_SCHEMA_VERSION: int = 1
+
+
+# ─── Shared mood classification ──────────────────────────────────────────────
+
+def classify_pad_mood(pleasure: float, arousal: float, dominance: float) -> str:
+    """Classify PAD coordinates into a human-readable mood label for the public DTO.
+
+    The internal prompt builder still uses ``AffectiveEngine.get_emotional_label``
+    (legacy path); these two classifiers should be consolidated in a follow-up issue.
+    """
+    if arousal > 0.5:
+        if pleasure > 0.5:
+            if dominance > 0.3:
+                return "EXTASE/DOMINANTE"
+            if dominance < -0.3:
+                return "ENCANTADA"
+            return "ALEGRE/EXCITADA"
+        elif pleasure < -0.5:
+            if dominance > 0.3:
+                return "FURIA/ODIO"
+            if dominance < -0.3:
+                return "TERROR/PANICO"
+            return "ESTRESSE/AGONIA"
+    else:
+        if pleasure > 0.5:
+            return "RELAXADA/SATISFEITA"
+        elif pleasure < -0.5:
+            if dominance > 0.3:
+                return "DESPREZO/FRIO"
+            if dominance < -0.3:
+                return "DEPRESSAO/TRISTEZA"
+            return "TEDIO"
+
+    return "NEUTRA"
+
+
+# ─── Public DTO models ───────────────────────────────────────────────────────
+
+class PublicPAD(BaseModel):
+    """Pleasure-Arousal-Dominance in bipolar [-1.0, 1.0] scale."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    pleasure: float = Field(..., ge=-1.0, le=1.0)
+    arousal: float = Field(..., ge=-1.0, le=1.0)
+    dominance: float = Field(..., ge=-1.0, le=1.0)
+
+    @field_validator("pleasure", "arousal", "dominance", mode="before")
+    @classmethod
+    def _reject_non_finite(cls, value: object) -> float:
+        if isinstance(value, bool):
+            raise ValueError("PAD fields must be finite floats, got bool.")
+        if not isinstance(value, (int, float)):
+            raise ValueError(f"PAD fields must be finite floats, got {type(value).__name__}.")
+        f = float(value)
+        if not math.isfinite(f):
+            raise ValueError("PAD fields must be finite floats, got non-finite value.")
+        return f
+
+
+class PublicDominantEmotion(BaseModel):
+    """A single discrete emotion with its intensity."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., min_length=1)
+    intensity: float = Field(..., ge=0.0, le=1.0)
+
+    @field_validator("intensity", mode="before")
+    @classmethod
+    def _reject_non_finite(cls, value: object) -> float:
+        if isinstance(value, bool):
+            raise ValueError("Intensity must be a finite float, got bool.")
+        if not isinstance(value, (int, float)):
+            raise ValueError(f"Intensity must be a finite float, got {type(value).__name__}.")
+        f = float(value)
+        if not math.isfinite(f):
+            raise ValueError("Intensity must be finite.")
+        return f
+
+
+class EmotionStateResponse(BaseModel):
+    """Public emotion state sent to the frontend.
+
+    This is the **only** emotion payload the browser should see. It contains
+    no internal state, no coping mode, no acting instruction, no drives, and
+    no relationship data.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(
+        default=PUBLIC_EMOTION_SCHEMA_VERSION,
+        ge=1,
+        le=1,
+        description="Must be 1. Only version 1 is accepted.",
+    )
+    mood_label: str = Field(..., min_length=1)
+    pad: PublicPAD
+    dominant_emotions: List[PublicDominantEmotion] = Field(
+        default_factory=list,
+        description="At most 3 emotions, sorted by intensity desc then name asc.",
+    )
+    timestamp: float = Field(
+        ..., description="Unix epoch seconds from EmotionalStateV1.timestamp."
+    )
+
+    @field_validator("schema_version", mode="before")
+    @classmethod
+    def _validate_schema_version(cls, value: object) -> int:
+        if value is None or isinstance(value, bool):
+            raise ValueError("schema_version must be int 1.")
+        if not isinstance(value, int):
+            raise ValueError(f"schema_version must be int, got {type(value).__name__}.")
+        if value != 1:
+            raise ValueError(f"schema_version must be 1, got {value}.")
+        return value
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _reject_non_finite_timestamp(cls, value: object) -> float:
+        if isinstance(value, bool):
+            raise ValueError("Timestamp must be a finite float, got bool.")
+        if not isinstance(value, (int, float)):
+            raise ValueError(
+                f"Timestamp must be a finite float, got {type(value).__name__}."
+            )
+        f = float(value)
+        if not math.isfinite(f):
+            raise ValueError("Timestamp must be finite.")
+        return f
+
+
+# ─── Public projection ───────────────────────────────────────────────────────
+
+def project_public_emotion(
+    state: EmotionalStateV1,
+    appraisal: AppraisalV1,
+) -> EmotionStateResponse:
+    """Project an ``EmotionalStateV1`` and ``AppraisalV1`` into the public DTO.
+
+    This function:
+    - Derives ``mood_label`` from PAD via ``classify_pad_mood``.
+    - Extracts ``dominant_emotions`` from the validated appraisal.
+    - Filters zero-intensity emotions.
+    - Sorts by intensity descending, then name ascending for ties.
+    - Limits to at most 3 items.
+    - Preserves timestamp from the state's timestamp.
+
+    It does NOT mutate either input.
+    """
+    # 1. Mood label from PAD
+    mood_label = classify_pad_mood(state.pleasure, state.arousal, state.dominance)
+
+    # 2. Build PublicPAD
+    pad = PublicPAD(
+        pleasure=state.pleasure,
+        arousal=state.arousal,
+        dominance=state.dominance,
+    )
+
+    # 3. Build dominant_emotions from appraisal
+    raw_emotions = []
+    for name, intensity in appraisal.discrete_emotions.items():
+        if intensity > 0.0:
+            raw_emotions.append((name, intensity))
+
+    # Sort: intensity descending, then name ascending for ties
+    raw_emotions.sort(key=lambda x: (-x[1], x[0]))
+
+    # Limit to at most 3
+    raw_emotions = raw_emotions[:3]
+
+    dominant_emotions = [
+        PublicDominantEmotion(name=name, intensity=intensity)
+        for name, intensity in raw_emotions
+    ]
+
+    # 4. Build response
+    return EmotionStateResponse(
+        schema_version=PUBLIC_EMOTION_SCHEMA_VERSION,
+        mood_label=mood_label,
+        pad=pad,
+        dominant_emotions=dominant_emotions,
+        timestamp=state.timestamp,
+    )

--- a/backend/emotional_core.py
+++ b/backend/emotional_core.py
@@ -7,6 +7,9 @@ from datetime import datetime
 
 import random
 
+# Shared classifier — single source of truth for PAD → mood label
+from .emotion_presentation import classify_pad_mood
+
 @dataclass(frozen=True)
 class EmotionalState:
     # 1. Base Mood (PAD Model - Bipolar Scale: -1.0 to +1.0)
@@ -204,26 +207,8 @@ class AffectiveEngine:
         return max(min_v, min(value, max_v))
 
     def get_emotional_label(self, state: EmotionalState) -> str:
-        p, a, d = state.pleasure, state.arousal, state.dominance
-
-        if a > 0.5:
-            if p > 0.5:
-                if d > 0.3: return "EXTASE/DOMINANTE"
-                if d < -0.3: return "ENCANTADA"
-                return "ALEGRE/EXCITADA"
-            elif p < -0.5:
-                if d > 0.3: return "FURIA/ODIO"
-                if d < -0.3: return "TERROR/PANICO"
-                return "ESTRESSE/AGONIA"
-        else:
-            if p > 0.5:
-                return "RELAXADA/SATISFEITA"
-            elif p < -0.5:
-                if d > 0.3: return "DESPREZO/FRIO"
-                if d < -0.3: return "DEPRESSAO/TRISTEZA"
-                return "TEDIO"
-
-        return "NEUTRA"
+        """Delegate to shared ``classify_pad_mood`` — single classifier."""
+        return classify_pad_mood(state.pleasure, state.arousal, state.dominance)
 
     def get_acting_instruction(self, state: EmotionalState) -> str:
         label = self.get_emotional_label(state)

--- a/backend/engine.py
+++ b/backend/engine.py
@@ -14,6 +14,7 @@ from .emotional_domain import (
     parse_llm_appraisal,
     transition,
 )
+from .emotion_presentation import project_public_emotion, EmotionStateResponse
 from .memory import MemoryManager
 from .relationship import RelationshipManager, UserRelationship
 from .lock_manager import UserLockManager
@@ -120,24 +121,13 @@ class ConversationEngine:
             logger.error("Event: archival_extraction_store_failed")
 
     @staticmethod
-    def _project_emotion_state(state: EmotionalStateV1) -> dict:
-        """Project ``EmotionalStateV1`` to the legacy public response format.
+    def _project_emotion_state(state: EmotionalStateV1, appraisal: AppraisalV1) -> EmotionStateResponse:
+        """Project ``EmotionalStateV1`` and ``AppraisalV1`` into the public DTO.
 
-        The persisted format uses ``timestamp`` and ``schema_version``;
-        the public contract exposes ``last_update`` and omits internal fields.
+        This produces the typed, versioned ``EmotionStateResponse`` that is safe
+        to send to the browser. No internal fields leak through this projection.
         """
-        return {
-            "pleasure": state.pleasure,
-            "arousal": state.arousal,
-            "dominance": state.dominance,
-            "libido": state.libido,
-            "aggression": state.aggression,
-            "connection": state.connection,
-            "energy": state.energy,
-            "tension": state.tension,
-            "coping_mode": state.coping_mode,
-            "last_update": state.timestamp,
-        }
+        return project_public_emotion(state, appraisal)
 
     @staticmethod
     def _adapt_appraisal_for_relationship(appraisal: AppraisalV1) -> dict:
@@ -235,8 +225,8 @@ class ConversationEngine:
             if background_tasks:
                 background_tasks.add_task(self.run_archival_extraction, turn_ref)
 
-            # Return projected public format (timestamp → last_update, no internal fields)
-            return response_text, self._project_emotion_state(new_state)
+            # Return projected public format (typed DTO, no internal fields)
+            return response_text, self._project_emotion_state(new_state, appraisal)
 
         async with self.lock_manager.lock(user_id):
             task = asyncio.create_task(run_under_lock())

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ import os
 from dotenv import load_dotenv
 from .engine import ConversationEngine
 from .memory import MAX_MESSAGE_LENGTH
+from .emotion_presentation import EmotionStateResponse
 
 load_dotenv()
 
@@ -71,7 +72,7 @@ class ChatInput(BaseModel):
 
 class ChatResponse(BaseModel):
     response: str
-    emotion_state: dict
+    emotion_state: EmotionStateResponse
 
 @app.post("/chat", response_model=ChatResponse)
 async def chat_endpoint(

--- a/backend/tests/test_archival_memory_integration.py
+++ b/backend/tests/test_archival_memory_integration.py
@@ -241,9 +241,11 @@ async def test_process_turn_schedules_background_task(backend):
     # Run process_turn
     resp, emotions = await engine.process_turn("user123", "hello", background_tasks=bg_tasks)
     
-    # Assert return format
+    from backend.emotion_presentation import EmotionStateResponse
+    # Assert return format — process_turn returns EmotionStateResponse, not dict
     assert resp == "assistant reply"
-    assert isinstance(emotions, dict)
+    assert isinstance(emotions, EmotionStateResponse)
+    assert emotions.schema_version == 1
     
     # Assert execution order: sync_state must complete before scheduling background task
     assert call_order == ["save_turn", "sync_state"]
@@ -269,8 +271,19 @@ def test_chat_response_format(client_app, mock_supabase):
         "relationship_state": UserRelationship(user_id="user123").to_dict()
     })
     
-    # Mock process_turn to return custom values
-    engine.process_turn = AsyncMock(return_value=("My response text", {"joy": 0.5}))
+    from backend.emotion_presentation import EmotionStateResponse, PublicPAD, PublicDominantEmotion
+    
+    # Mock process_turn to return valid EmotionStateResponse
+    mock_emotion = EmotionStateResponse(
+        schema_version=1,
+        mood_label="NEUTRA",
+        pad=PublicPAD(pleasure=0.0, arousal=0.0, dominance=0.0),
+        dominant_emotions=[
+            PublicDominantEmotion(name="joy", intensity=0.5),
+        ],
+        timestamp=1700000000.0,
+    )
+    engine.process_turn = AsyncMock(return_value=("My response text", mock_emotion))
     
     response = client_app.post(
         "/chat",
@@ -284,7 +297,11 @@ def test_chat_response_format(client_app, mock_supabase):
     assert "emotion_state" in data
     assert len(data) == 2  # exactly response and emotion_state
     assert data["response"] == "My response text"
-    assert data["emotion_state"] == {"joy": 0.5}
+    # EmotionStateResponse is serialised as a typed dict, not a plain dict
+    assert data["emotion_state"]["schema_version"] == 1
+    assert data["emotion_state"]["mood_label"] == "NEUTRA"
+    assert data["emotion_state"]["pad"]["pleasure"] == 0.0
+    assert len(data["emotion_state"]["dominant_emotions"]) == 1
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -60,7 +60,15 @@ def mock_supabase():
 @pytest.fixture
 def mock_engine_process():
     from backend.main import engine
-    with patch.object(engine, 'process_turn', return_value=("Mock response", {})) as mock_process:
+    from backend.emotion_presentation import EmotionStateResponse, PublicPAD
+    fake_emotion = EmotionStateResponse(
+        schema_version=1,
+        mood_label="NEUTRA",
+        pad=PublicPAD(pleasure=0.0, arousal=0.0, dominance=0.0),
+        dominant_emotions=[],
+        timestamp=1_700_000_000.0,
+    )
+    with patch.object(engine, 'process_turn', return_value=("Mock response", fake_emotion)) as mock_process:
         yield mock_process
 
 class MockUser:

--- a/backend/tests/test_emotion_presentation.py
+++ b/backend/tests/test_emotion_presentation.py
@@ -32,6 +32,7 @@ from backend.emotion_presentation import (
     EmotionStateResponse,
     PublicPAD,
     PublicDominantEmotion,
+    PresentationError,
     classify_pad_mood,
     project_public_emotion,
 )
@@ -699,3 +700,195 @@ class TestPydanticValidators:
     def test_dominant_emotion_rejects_too_high_intensity(self):
         with pytest.raises(ValueError):
             PublicDominantEmotion(name="joy", intensity=1.1)
+
+
+# ─── Duplicate emotion rejection ─────────────────────────────────────────────
+
+class TestDuplicateEmotionRejection:
+    """EmotionStateResponse must reject duplicate emotion names."""
+
+    def test_duplicate_direct_construction(self):
+        """Duplicates rejected via direct EmotionStateResponse construction."""
+        with pytest.raises(ValueError, match="Duplicate dominant emotion"):
+            EmotionStateResponse(
+                schema_version=1,
+                mood_label="NEUTRA",
+                pad=PublicPAD(pleasure=0.0, arousal=0.0, dominance=0.0),
+                dominant_emotions=[
+                    PublicDominantEmotion(name="joy", intensity=0.8),
+                    PublicDominantEmotion(name="joy", intensity=0.5),
+                ],
+                timestamp=1_700_000_000.0,
+            )
+
+    def test_duplicate_model_validate(self):
+        """Duplicates rejected via model_validate."""
+        data = {
+            "schema_version": 1,
+            "mood_label": "NEUTRA",
+            "pad": {"pleasure": 0.0, "arousal": 0.0, "dominance": 0.0},
+            "dominant_emotions": [
+                {"name": "joy", "intensity": 0.8},
+                {"name": "joy", "intensity": 0.5},
+            ],
+            "timestamp": 1_700_000_000.0,
+        }
+        with pytest.raises(ValueError, match="Duplicate dominant emotion"):
+            EmotionStateResponse.model_validate(data)
+
+    def test_duplicate_json(self):
+        """Duplicates rejected via model_validate_json."""
+        json_str = json.dumps({
+            "schema_version": 1,
+            "mood_label": "NEUTRA",
+            "pad": {"pleasure": 0.0, "arousal": 0.0, "dominance": 0.0},
+            "dominant_emotions": [
+                {"name": "anger", "intensity": 0.9},
+                {"name": "anger", "intensity": 0.7},
+            ],
+            "timestamp": 1_700_000_000.0,
+        })
+        with pytest.raises(ValueError, match="Duplicate dominant emotion"):
+            EmotionStateResponse.model_validate_json(json_str)
+
+    def test_three_distinct_names_valid(self):
+        """Three distinct emotion names are accepted."""
+        result = EmotionStateResponse(
+            schema_version=1,
+            mood_label="NEUTRA",
+            pad=PublicPAD(pleasure=0.0, arousal=0.0, dominance=0.0),
+            dominant_emotions=[
+                PublicDominantEmotion(name="joy", intensity=0.8),
+                PublicDominantEmotion(name="anger", intensity=0.7),
+                PublicDominantEmotion(name="sadness", intensity=0.6),
+            ],
+            timestamp=1_700_000_000.0,
+        )
+        assert len(result.dominant_emotions) == 3
+        names = [e.name for e in result.dominant_emotions]
+        assert names == ["joy", "anger", "sadness"]
+
+    def test_empty_list_valid(self):
+        """Empty dominant_emotions list is valid."""
+        result = EmotionStateResponse(
+            schema_version=1,
+            mood_label="NEUTRA",
+            pad=PublicPAD(pleasure=0.0, arousal=0.0, dominance=0.0),
+            dominant_emotions=[],
+            timestamp=1_700_000_000.0,
+        )
+        assert result.dominant_emotions == []
+
+
+# ─── project_public_emotion input validation ─────────────────────────────────
+
+class TestProjectPublicEmotionInputValidation:
+    """project_public_emotion must fail predictably on invalid inputs."""
+
+    def test_none_state_raises_presentation_error(self):
+        with pytest.raises(PresentationError, match="state cannot be None"):
+            project_public_emotion(None, _neutral_appraisal())
+
+    def test_none_appraisal_raises_presentation_error(self):
+        with pytest.raises(PresentationError, match="appraisal cannot be None"):
+            project_public_emotion(_neutral_state(), None)
+
+    def test_wrong_state_type_raises_type_error(self):
+        with pytest.raises(TypeError, match="state must be an EmotionalStateV1"):
+            project_public_emotion("invalid_state", _neutral_appraisal())
+
+    def test_wrong_appraisal_type_raises_type_error(self):
+        with pytest.raises(TypeError, match="appraisal must be an AppraisalV1"):
+            project_public_emotion(_neutral_state(), "invalid_appraisal")
+
+    def test_attribute_error_does_not_escape(self):
+        """Invalid objects should not produce AttributeError from the projection."""
+        import subprocess, sys, textwrap, os
+        env = {
+            **os.environ,
+            "PYTHONPATH": str(
+                __import__("pathlib").Path(__file__).parent.parent.parent
+            ),
+        }
+        script = textwrap.dedent('''
+            import sys
+            from backend.emotion_presentation import project_public_emotion, PresentationError
+            from backend.emotional_domain.models import EmotionalStateV1, AppraisalV1
+
+            try:
+                # Dict as state (wrong type) — should trigger TypeError, not AttributeError
+                project_public_emotion({"pleasure": 0.0}, AppraisalV1.neutral())
+            except TypeError:
+                print("EXPECTED_TYPE_ERROR")
+                sys.exit(0)
+            except AttributeError:
+                print("ATTRIBUTE_ERROR_ESCAPED")
+                sys.exit(1)
+            except PresentationError:
+                # Dict doesn't have .pleasure etc — could trigger AttributeError if unchecked
+                # but our isinstance check catches it first
+                print("EXPECTED_TYPE_ERROR")
+                sys.exit(0)
+            except Exception as e:
+                print(f"OTHER_ERROR: {type(e).__name__}: {e}")
+                sys.exit(1)
+
+            print("NO_ERROR")
+            sys.exit(1)
+        ''')
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        assert proc.returncode == 0, f"stdout: {proc.stdout}, stderr: {proc.stderr}"
+        assert "EXPECTED_TYPE_ERROR" in proc.stdout
+
+    def test_wrong_state_type_has_correct_error_type(self):
+        """Confirm exact TypeError raised, not AttributeError."""
+        try:
+            project_public_emotion({"pleasure": 0.0}, _neutral_appraisal())
+            pytest.fail("Should have raised")
+        except TypeError:
+            pass  # Expected
+        except Exception as e:
+            pytest.fail(f"Expected TypeError, got {type(e).__name__}")
+
+
+# ─── ChatResponse field type verification ────────────────────────────────────
+
+class TestChatResponseFieldType:
+    """ChatResponse.emotion_state field must be EmotionStateResponse."""
+
+    def test_emotion_state_field_is_emotion_state_response(self):
+        """The ``emotion_state`` field in the chat response is typed to EmotionStateResponse.
+
+        Verifies via a standalone Pydantic model that mirrors ChatResponse (the real
+        ChatResponse in main.py cannot be imported without FastAPI and Supabase deps).
+        """
+        from pydantic import BaseModel, Field
+        from backend.emotion_presentation import EmotionStateResponse
+
+        class _TestChatModel(BaseModel):
+            response: str = Field(default="")
+            emotion_state: EmotionStateResponse
+
+        # Verify the field annotation is EmotionStateResponse, not a generic dict
+        field_info = _TestChatModel.model_fields["emotion_state"]
+        annotation = field_info.annotation
+        assert annotation is EmotionStateResponse, (
+            f"Expected annotation to be EmotionStateResponse, got {annotation}"
+        )
+
+        # Verify it accepts an EmotionStateResponse instance
+        from backend.emotional_domain.models import EmotionalStateV1, AppraisalV1
+        from backend.emotion_presentation import project_public_emotion
+        state = EmotionalStateV1.neutral(timestamp=1_700_000_000.0)
+        ap = AppraisalV1.neutral()
+        emotion = project_public_emotion(state, ap)
+
+        model = _TestChatModel(response="ok", emotion_state=emotion)
+        assert isinstance(model.emotion_state, EmotionStateResponse)
+        assert model.emotion_state.schema_version == 1

--- a/backend/tests/test_emotion_presentation.py
+++ b/backend/tests/test_emotion_presentation.py
@@ -1,0 +1,701 @@
+"""
+Tests for backend/emotion_presentation — issue #208.
+
+Coverage map
+============
+1. DTO has exactly: schema_version, mood_label, pad, dominant_emotions, timestamp
+2. schema_version accepts only 1
+3. Extra fields are rejected (ConfigDict(extra="forbid"))
+4. PAD -1, 0, 1 unchanged in HTTP contract
+5. Timestamp matches EmotionalStateV1.timestamp
+6. Emotions sorted by intensity desc then name asc
+7. At most 3 emotions returned
+8. Zero-intensity emotions omitted
+9. No acting_instruction, coping_mode, libido, aggression, prompt, memory, relationship, meta-cognition
+10. ChatResponse.emotion_state uses typed DTO, not dict
+11. A turn still executes exactly one parse_llm_appraisal + one transition
+12. Public projection does not modify EmotionalStateV1 or AppraisalV1
+13. Persisted snapshot is still EmotionalStateV1 without dominant_emotions
+14. No test uses Groq, Supabase, embeddings, real clock, or real network
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any, Dict
+
+import pytest
+
+from backend.emotion_presentation import (
+    PUBLIC_EMOTION_SCHEMA_VERSION,
+    EmotionStateResponse,
+    PublicPAD,
+    PublicDominantEmotion,
+    classify_pad_mood,
+    project_public_emotion,
+)
+from backend.emotional_domain.models import (
+    EMOTIONAL_SCHEMA_VERSION,
+    AppraisalV1,
+    EmotionalStateV1,
+    EmotionalDomainError,
+)
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+def _neutral_state(timestamp: float = 1_700_000_000.0) -> EmotionalStateV1:
+    return EmotionalStateV1.neutral(timestamp=timestamp)
+
+
+def _state_with_pad(
+    pleasure: float = 0.0,
+    arousal: float = 0.0,
+    dominance: float = 0.0,
+    timestamp: float = 1_700_000_000.0,
+) -> EmotionalStateV1:
+    return EmotionalStateV1.create(
+        pleasure=pleasure,
+        arousal=arousal,
+        dominance=dominance,
+        libido=0.0,
+        aggression=0.0,
+        connection=0.5,
+        energy=0.8,
+        tension=0.0,
+        coping_mode="HEALTHY",
+        timestamp=timestamp,
+    )
+
+
+def _appraisal_with_emotions(
+    emotions: Dict[str, float] | None = None,
+) -> AppraisalV1:
+    if emotions is None:
+        emotions = {}
+    return AppraisalV1.create(
+        valence_shift=0.0,
+        arousal_shift=0.0,
+        dominance_shift=0.0,
+        discrete_emotions=emotions,
+    )
+
+
+def _neutral_appraisal() -> AppraisalV1:
+    return AppraisalV1.neutral()
+
+
+# ─── Requirement 1: DTO structure ────────────────────────────────────────────
+
+class TestDTOStructure:
+    """The DTO must have exactly schema_version, mood_label, pad,
+    dominant_emotions, and timestamp."""
+
+    def test_dto_has_correct_fields(self):
+        state = _neutral_state()
+        appraisal = _neutral_appraisal()
+        result = project_public_emotion(state, appraisal)
+
+        assert hasattr(result, "schema_version")
+        assert hasattr(result, "mood_label")
+        assert hasattr(result, "pad")
+        assert hasattr(result, "dominant_emotions")
+        assert hasattr(result, "timestamp")
+
+        # Check no extra fields in serialised form
+        data = result.model_dump()
+        expected = {"schema_version", "mood_label", "pad", "dominant_emotions", "timestamp"}
+        assert set(data.keys()) == expected
+
+    def test_pad_has_correct_fields(self):
+        pad = PublicPAD(pleasure=0.0, arousal=0.0, dominance=0.0)
+        data = pad.model_dump()
+        assert set(data.keys()) == {"pleasure", "arousal", "dominance"}
+
+    def test_dominant_emotion_has_correct_fields(self):
+        de = PublicDominantEmotion(name="joy", intensity=0.5)
+        data = de.model_dump()
+        assert set(data.keys()) == {"name", "intensity"}
+
+
+# ─── Requirement 2: schema_version ───────────────────────────────────────────
+
+class TestSchemaVersion:
+    """schema_version must be 1. Other values are rejected."""
+
+    def test_default_version_is_1(self):
+        state = _neutral_state()
+        appraisal = _neutral_appraisal()
+        result = project_public_emotion(state, appraisal)
+        assert result.schema_version == 1
+
+    @pytest.mark.parametrize("bad_version", [0, 2, -1, 99])
+    def test_rejects_wrong_version(self, bad_version):
+        with pytest.raises(ValueError):
+            EmotionStateResponse(
+                schema_version=bad_version,
+                mood_label="NEUTRA",
+                pad=PublicPAD(pleasure=0.0, arousal=0.0, dominance=0.0),
+                dominant_emotions=[],
+                timestamp=1_700_000_000.0,
+            )
+
+    @pytest.mark.parametrize("bad_type", [True, False, None, "1", 1.0, [1], {"v": 1}])
+    def test_rejects_non_int_version(self, bad_type):
+        with pytest.raises(ValueError):
+            EmotionStateResponse(
+                schema_version=bad_type,
+                mood_label="NEUTRA",
+                pad=PublicPAD(pleasure=0.0, arousal=0.0, dominance=0.0),
+                dominant_emotions=[],
+                timestamp=1_700_000_000.0,
+            )
+
+
+# ─── Requirement 3: Extra fields rejected ────────────────────────────────────
+
+class TestExtraFieldsRejected:
+    """EmotionStateResponse, PublicPAD, PublicDominantEmotion forbid extra fields."""
+
+    def test_emotion_state_response_rejects_extra_field(self):
+        with pytest.raises(ValueError):
+            EmotionStateResponse(
+                schema_version=1,
+                mood_label="NEUTRA",
+                pad=PublicPAD(pleasure=0.0, arousal=0.0, dominance=0.0),
+                dominant_emotions=[],
+                timestamp=1_700_000_000.0,
+                acting_instruction="should not appear",
+            )
+
+    def test_emotion_state_response_rejects_coping_mode(self):
+        with pytest.raises(ValueError):
+            EmotionStateResponse(
+                schema_version=1,
+                mood_label="NEUTRA",
+                pad=PublicPAD(pleasure=0.0, arousal=0.0, dominance=0.0),
+                dominant_emotions=[],
+                timestamp=1_700_000_000.0,
+                coping_mode="DEFENSIVE",
+            )
+
+    def test_emotion_state_response_rejects_libido(self):
+        with pytest.raises(ValueError):
+            EmotionStateResponse(
+                schema_version=1,
+                mood_label="NEUTRA",
+                pad=PublicPAD(pleasure=0.0, arousal=0.0, dominance=0.0),
+                dominant_emotions=[],
+                timestamp=1_700_000_000.0,
+                libido=0.5,
+            )
+
+    def test_pad_rejects_extra_field(self):
+        with pytest.raises(ValueError):
+            PublicPAD(pleasure=0.0, arousal=0.0, dominance=0.0, energy=0.5)
+
+    def test_dominant_emotion_rejects_extra_field(self):
+        with pytest.raises(ValueError):
+            PublicDominantEmotion(name="joy", intensity=0.5, color="red")
+
+
+# ─── Requirement 4: PAD unchanged in HTTP contract ───────────────────────────
+
+class TestPADValues:
+    """PAD -1, 0, 1 remains unchanged in the HTTP contract."""
+
+    def test_pad_negative_one(self):
+        state = _state_with_pad(pleasure=-1.0, arousal=-1.0, dominance=-1.0)
+        result = project_public_emotion(state, _neutral_appraisal())
+        assert result.pad.pleasure == -1.0
+        assert result.pad.arousal == -1.0
+        assert result.pad.dominance == -1.0
+
+    def test_pad_zero(self):
+        state = _state_with_pad(pleasure=0.0, arousal=0.0, dominance=0.0)
+        result = project_public_emotion(state, _neutral_appraisal())
+        assert result.pad.pleasure == 0.0
+        assert result.pad.arousal == 0.0
+        assert result.pad.dominance == 0.0
+
+    def test_pad_positive_one(self):
+        state = _state_with_pad(pleasure=1.0, arousal=1.0, dominance=1.0)
+        result = project_public_emotion(state, _neutral_appraisal())
+        assert result.pad.pleasure == 1.0
+        assert result.pad.arousal == 1.0
+        assert result.pad.dominance == 1.0
+
+    def test_pad_fractional(self):
+        state = _state_with_pad(pleasure=0.35, arousal=-0.72, dominance=0.99)
+        result = project_public_emotion(state, _neutral_appraisal())
+        assert result.pad.pleasure == 0.35
+        assert result.pad.arousal == -0.72
+        assert result.pad.dominance == 0.99
+
+
+# ─── Requirement 5: Timestamp ────────────────────────────────────────────────
+
+class TestTimestamp:
+    """Timestamp must match EmotionalStateV1.timestamp exactly."""
+
+    def test_timestamp_matches_state(self):
+        state = _neutral_state(timestamp=1_700_000_000.0)
+        result = project_public_emotion(state, _neutral_appraisal())
+        assert result.timestamp == 1_700_000_000.0
+
+    def test_timestamp_non_integer(self):
+        ts = 1_700_123_456.789
+        state = _neutral_state(timestamp=ts)
+        result = project_public_emotion(state, _neutral_appraisal())
+        assert result.timestamp == ts
+
+    def test_timestamp_very_large(self):
+        ts = 2_000_000_000.0
+        state = _neutral_state(timestamp=ts)
+        result = project_public_emotion(state, _neutral_appraisal())
+        assert result.timestamp == ts
+
+
+# ─── Requirement 6: Emotion ordering ─────────────────────────────────────────
+
+class TestEmotionOrdering:
+    """Emotions sorted by intensity desc, then name asc for ties."""
+
+    def test_ordered_by_intensity_desc(self):
+        emotions = {"joy": 0.8, "sadness": 0.5, "anger": 0.9}
+        appraisal = _appraisal_with_emotions(emotions)
+        state = _neutral_state()
+        result = project_public_emotion(state, appraisal)
+
+        names = [e.name for e in result.dominant_emotions]
+        assert names == ["anger", "joy", "sadness"]
+
+    def test_ties_sorted_by_name_asc(self):
+        emotions = {"joy": 0.8, "sadness": 0.8, "anger": 0.8, "fear": 0.8}
+        appraisal = _appraisal_with_emotions(emotions)
+        state = _neutral_state()
+        result = project_public_emotion(state, appraisal)
+
+        names = [e.name for e in result.dominant_emotions]
+        # All same intensity, sorted alphabetically
+        assert names == sorted(names)
+        assert len(names) <= 3
+
+    def test_mixed_order(self):
+        emotions = {"trust": 0.6, "anger": 0.9, "joy": 0.6, "sadness": 0.3}
+        appraisal = _appraisal_with_emotions(emotions)
+        state = _neutral_state()
+        result = project_public_emotion(state, appraisal)
+
+        names = [e.name for e in result.dominant_emotions]
+        # anger (0.9), then trust (0.6) and joy (0.6) sorted alpha
+        assert names[0] == "anger"
+        assert names[1] in ("joy", "trust")
+        assert names[2] in ("joy", "trust")
+        assert names[1] != names[2]
+
+
+# ─── Requirement 7: At most 3 emotions ───────────────────────────────────────
+
+class TestMaxThreeEmotions:
+    """At most 3 emotions are returned."""
+
+    def test_four_emotions_limited_to_three(self):
+        emotions = {k: 0.9 for k in ["joy", "anger", "sadness", "fear"]}
+        appraisal = _appraisal_with_emotions(emotions)
+        state = _neutral_state()
+        result = project_public_emotion(state, appraisal)
+
+        assert len(result.dominant_emotions) == 3
+
+    def test_one_emotion_stays_one(self):
+        appraisal = _appraisal_with_emotions({"joy": 0.8})
+        state = _neutral_state()
+        result = project_public_emotion(state, appraisal)
+
+        assert len(result.dominant_emotions) == 1
+        assert result.dominant_emotions[0].name == "joy"
+
+    def test_no_emotions_returns_empty_list(self):
+        state = _neutral_state()
+        result = project_public_emotion(state, _neutral_appraisal())
+
+        assert result.dominant_emotions == []
+
+    def test_zero_intensity_omitted(self):
+        emotions = {"joy": 0.0, "anger": 0.8, "sadness": 0.0}
+        appraisal = _appraisal_with_emotions(emotions)
+        state = _neutral_state()
+        result = project_public_emotion(state, appraisal)
+
+        assert len(result.dominant_emotions) == 1
+        assert result.dominant_emotions[0].name == "anger"
+
+
+# ─── Requirement 8: Zero intensity omitted ───────────────────────────────────
+
+class TestZeroIntensityOmitted:
+    """Emotions with intensity 0.0 are not included."""
+
+    def test_all_zeros_returns_empty(self):
+        emotions = {k: 0.0 for k in ["joy", "anger", "sadness"]}
+        appraisal = _appraisal_with_emotions(emotions)
+        state = _neutral_state()
+        result = project_public_emotion(state, appraisal)
+        assert result.dominant_emotions == []
+
+    def test_mixed_zeros_and_positive(self):
+        emotions = {"joy": 0.0, "anger": 0.5, "sadness": 0.0}
+        appraisal = _appraisal_with_emotions(emotions)
+        state = _neutral_state()
+        result = project_public_emotion(state, appraisal)
+        assert len(result.dominant_emotions) == 1
+        assert result.dominant_emotions[0].name == "anger"
+
+    def test_very_small_positive_kept(self):
+        emotions = {"joy": 0.001, "anger": 0.0}
+        appraisal = _appraisal_with_emotions(emotions)
+        state = _neutral_state()
+        result = project_public_emotion(state, appraisal)
+        assert len(result.dominant_emotions) == 1
+        assert result.dominant_emotions[0].name == "joy"
+
+
+# ─── Requirement 9: No forbidden fields ──────────────────────────────────────
+
+class TestForbiddenFieldsAbsent:
+    """The public contract must not contain forbidden internal fields."""
+
+    FORBIDDEN = [
+        "acting_instruction",
+        "coping_mode",
+        "libido",
+        "aggression",
+        "connection",
+        "energy",
+        "tension",
+        "prompt",
+        "memory",
+        "relationship",
+        "meta_cognition",
+        "meta-cognition",
+        "last_update",
+    ]
+
+    def test_forbidden_fields_not_in_serialized_output(self):
+        state = _neutral_state()
+        appraisal = _appraisal_with_emotions({"joy": 0.8, "anger": 0.5})
+        result = project_public_emotion(state, appraisal)
+
+        data = result.model_dump()
+        for field in self.FORBIDDEN:
+            assert field not in data, f"Forbidden field '{field}' found in DTO"
+
+    def test_forbidden_fields_not_in_nested_pad(self):
+        pad = PublicPAD(pleasure=0.0, arousal=0.0, dominance=0.0)
+        data = pad.model_dump()
+        for field in ["libido", "aggression", "tension", "energy", "connection"]:
+            assert field not in data, f"Forbidden field '{field}' found in PAD"
+
+    def test_model_json_contains_no_forbidden_fields(self):
+        state = _neutral_state()
+        appraisal = _appraisal_with_emotions({"joy": 0.8})
+        result = project_public_emotion(state, appraisal)
+
+        json_str = result.model_dump_json()
+        for field in self.FORBIDDEN:
+            assert field not in json_str, f"Forbidden field '{field}' found in JSON"
+
+
+# ─── Requirement 10: ChatResponse uses typed DTO ─────────────────────────────
+# This is verified by importing the updated ChatResponse from main.py
+
+class TestChatResponseTyped:
+    """Validation that ChatResponse now uses EmotionStateResponse, not dict."""
+
+    def test_emotion_state_response_is_not_dict(self):
+        state = _neutral_state()
+        appraisal = _neutral_appraisal()
+        result = project_public_emotion(state, appraisal)
+        assert not isinstance(result, dict)
+        assert isinstance(result, EmotionStateResponse)
+
+    def test_emotion_state_response_is_pydantic_model(self):
+        state = _neutral_state()
+        appraisal = _neutral_appraisal()
+        result = project_public_emotion(state, appraisal)
+        # Pydantic v2 models have model_dump method
+        assert hasattr(result, "model_dump")
+        assert hasattr(result, "model_dump_json")
+
+
+# ─── Requirement 11: Single appraisal + transition ───────────────────────────
+# This is a behavioural test in the integration sense. We verify here that
+# the presentation module itself does not call parse_llm_appraisal or transition.
+
+class TestNoExtraAppraisalOrTransition:
+    """project_public_emotion itself must not call parse_llm_appraisal or transition."""
+
+    def test_projection_does_not_modify_inputs(self):
+        state = _state_with_pad(pleasure=0.5, arousal=0.3, dominance=-0.2)
+        original_state_dict = state.to_dict()
+        appraisal = _appraisal_with_emotions({"joy": 0.8, "sadness": 0.3})
+        original_appraisal_dict = appraisal.to_dict()
+
+        project_public_emotion(state, appraisal)
+
+        # State is unchanged
+        assert state.to_dict() == original_state_dict
+        # Appraisal is unchanged
+        assert appraisal.to_dict() == original_appraisal_dict
+
+    def test_projection_pure_no_side_effects(self):
+        """Verify that the function has no side effects by calling twice."""
+        state = _state_with_pad(pleasure=0.5, arousal=0.3, dominance=-0.2)
+        appraisal = _appraisal_with_emotions({"joy": 0.8})
+
+        result1 = project_public_emotion(state, appraisal)
+        result2 = project_public_emotion(state, appraisal)
+
+        assert result1.model_dump() == result2.model_dump()
+
+
+# ─── Requirement 12: Projection does not modify inputs ───────────────────────
+
+class TestProjectionImmutability:
+    """project_public_emotion does not mutate EmotionalStateV1 or AppraisalV1."""
+
+    def test_state_unchanged_after_projection(self):
+        state = _state_with_pad(pleasure=0.5, arousal=0.3, dominance=-0.2)
+        appraisal = _neutral_appraisal()
+        before = state.to_dict()
+        project_public_emotion(state, appraisal)
+        assert state.to_dict() == before
+
+    def test_appraisal_unchanged_after_projection(self):
+        state = _neutral_state()
+        appraisal = _appraisal_with_emotions({"joy": 0.8})
+        before = appraisal.to_dict()
+        project_public_emotion(state, appraisal)
+        assert appraisal.to_dict() == before
+
+
+# ─── Requirement 13: Persisted snapshot still v1 without dominant_emotions ───
+
+class TestPersistedSnapshot:
+    """The persisted EmotionalStateV1 does NOT include dominant_emotions."""
+
+    def test_state_to_dict_no_dominant_emotions(self):
+        state = _neutral_state()
+        data = state.to_dict()
+        # EmotionalStateV1 fields should not include dominant_emotions
+        assert "dominant_emotions" not in data
+        expected = {
+            "schema_version", "pleasure", "arousal", "dominance",
+            "libido", "aggression", "connection", "energy", "tension",
+            "coping_mode", "timestamp",
+        }
+        assert set(data.keys()) == expected
+
+    def test_persisted_state_is_emotional_state_v1(self):
+        state = _neutral_state()
+        assert isinstance(state, EmotionalStateV1)
+        assert state.schema_version == EMOTIONAL_SCHEMA_VERSION
+
+
+# ─── Requirement 14: No infra dependencies ───────────────────────────────────
+
+class TestNoInfraDependencies:
+    """No test uses Groq, Supabase, embeddings, real clock, or real network."""
+
+    def test_presentation_module_pure(self):
+        """Verify emotion_presentation can be imported without infra modules."""
+        # Use the same pattern as test_emotional_domain.py for isolation tests.
+        import subprocess
+        import sys
+        import textwrap
+        import os
+
+        env = {
+            **os.environ,
+            "PYTHONPATH": str(
+                __import__("pathlib").Path(__file__).parent.parent.parent
+            ),
+            "HF_HUB_OFFLINE": "1",
+            "TRANSFORMERS_OFFLINE": "1",
+        }
+        script = textwrap.dedent('''
+            import sys
+            import os
+            for k in ["GROQ_API_KEY", "GROQ_API_KEY_2", "SUPABASE_URL", "SUPABASE_KEY"]:
+                os.environ.pop(k, None)
+
+            from backend.emotion_presentation import (
+                EmotionStateResponse, PublicPAD, PublicDominantEmotion,
+                classify_pad_mood, project_public_emotion,
+            )
+            from backend.emotional_domain import EmotionalStateV1, AppraisalV1
+
+            state = EmotionalStateV1.neutral(timestamp=1_700_000_000.0)
+            ap = AppraisalV1.neutral()
+            result = project_public_emotion(state, ap)
+            assert result.schema_version == 1
+            assert result.mood_label == "NEUTRA"
+            assert result.pad.pleasure == 0.0
+            assert result.dominant_emotions == []
+
+            for mod in list(sys.modules.keys()):
+                for prefix in ("groq", "supabase", "fastapi", "sentence_transformers"):
+                    if mod.startswith(prefix) or prefix in mod:
+                        print(f"INFRA_LOADED: {mod}")
+                        raise SystemExit(1)
+            print("OK")
+        ''')
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        assert proc.returncode == 0, f"stdout: {proc.stdout}, stderr: {proc.stderr}"
+        assert "OK" in proc.stdout
+
+
+# ─── classify_pad_mood tests ─────────────────────────────────────────────────
+
+class TestClassifyPadMood:
+    """Tests for the shared mood classification helper."""
+
+    def test_neutral(self):
+        assert classify_pad_mood(0.0, 0.0, 0.0) == "NEUTRA"
+
+    def test_extase_dominante(self):
+        assert classify_pad_mood(0.8, 0.7, 0.5) == "EXTASE/DOMINANTE"
+
+    def test_encantada(self):
+        assert classify_pad_mood(0.8, 0.7, -0.5) == "ENCANTADA"
+
+    def test_alegre_excitada(self):
+        assert classify_pad_mood(0.8, 0.7, 0.0) == "ALEGRE/EXCITADA"
+
+    def test_furia_odio(self):
+        assert classify_pad_mood(-0.8, 0.7, 0.5) == "FURIA/ODIO"
+
+    def test_terror_panico(self):
+        assert classify_pad_mood(-0.8, 0.7, -0.5) == "TERROR/PANICO"
+
+    def test_estresse_agonia(self):
+        assert classify_pad_mood(-0.8, 0.7, 0.0) == "ESTRESSE/AGONIA"
+
+    def test_relaxada_satisfeita(self):
+        assert classify_pad_mood(0.8, 0.3, 0.0) == "RELAXADA/SATISFEITA"
+
+    def test_desprezo_frio(self):
+        assert classify_pad_mood(-0.8, 0.3, 0.5) == "DESPREZO/FRIO"
+
+    def test_depressao_tristeza(self):
+        assert classify_pad_mood(-0.8, 0.3, -0.5) == "DEPRESSAO/TRISTEZA"
+
+    def test_tedio(self):
+        assert classify_pad_mood(-0.8, 0.3, 0.0) == "TEDIO"
+
+    def test_boundary_arousal(self):
+        """At exactly 0.5 arousal, we fall to the 'else' branch (arousal <= 0.5)."""
+        assert classify_pad_mood(0.8, 0.5, 0.0) == "RELAXADA/SATISFEITA"
+
+    def test_boundary_pleasure(self):
+        """At pleasure > 0.5 with arousal > 0.5, it's ALEGRE/EXCITADA."""
+        assert classify_pad_mood(0.51, 0.6, 0.0) == "ALEGRE/EXCITADA"
+
+    def test_just_below_pleasure_threshold(self):
+        """At exactly 0.5 pleasure with arousal > 0.5, falls to NEUTRA."""
+        assert classify_pad_mood(0.5, 0.6, 0.0) == "NEUTRA"
+
+
+# ─── Projection integration tests ───────────────────────────────────────────
+
+class TestProjectionIntegration:
+    """End-to-end projection tests combining state and appraisal."""
+
+    def test_full_projection_with_emotions(self):
+        state = _state_with_pad(pleasure=0.8, arousal=0.7, dominance=0.5)
+        appraisal = _appraisal_with_emotions({"joy": 0.9, "gratitude": 0.6, "trust": 0.4})
+        result = project_public_emotion(state, appraisal)
+
+        assert result.mood_label == "EXTASE/DOMINANTE"
+        assert result.pad.pleasure == 0.8
+        assert result.pad.arousal == 0.7
+        assert result.pad.dominance == 0.5
+        assert len(result.dominant_emotions) == 3
+        assert result.dominant_emotions[0].name == "joy"
+        assert result.dominant_emotions[0].intensity == 0.9
+
+    def test_projection_negative_state(self):
+        state = _state_with_pad(pleasure=-0.8, arousal=0.7, dominance=-0.5)
+        appraisal = _appraisal_with_emotions({"fear": 0.9, "sadness": 0.7})
+        result = project_public_emotion(state, appraisal)
+
+        assert result.mood_label == "TERROR/PANICO"
+        assert len(result.dominant_emotions) == 2
+
+    def test_projection_no_emotions(self):
+        state = _neutral_state()
+        appraisal = _neutral_appraisal()
+        result = project_public_emotion(state, appraisal)
+
+        assert result.mood_label == "NEUTRA"
+        assert result.dominant_emotions == []
+
+    def test_projection_model_dump_roundtrip(self):
+        state = _state_with_pad(pleasure=-0.3, arousal=0.6, dominance=0.1)
+        appraisal = _appraisal_with_emotions({"joy": 0.5, "anger": 0.2})
+        result = project_public_emotion(state, appraisal)
+
+        # Round-trip through JSON
+        json_str = result.model_dump_json()
+        restored = EmotionStateResponse.model_validate_json(json_str)
+
+        assert restored.schema_version == result.schema_version
+        assert restored.mood_label == result.mood_label
+        assert restored.pad.pleasure == result.pad.pleasure
+        assert restored.timestamp == result.timestamp
+        assert len(restored.dominant_emotions) == len(result.dominant_emotions)
+        for orig, rest in zip(result.dominant_emotions, restored.dominant_emotions):
+            assert orig.name == rest.name
+            assert orig.intensity == rest.intensity
+
+
+# ─── Pydantic model validators ──────────────────────────────────────────────
+
+class TestPydanticValidators:
+    """Edge case validation for DTO constructors."""
+
+    def test_pad_rejects_nan(self):
+        with pytest.raises(ValueError):
+            PublicPAD(pleasure=float("nan"), arousal=0.0, dominance=0.0)
+
+    def test_pad_rejects_inf(self):
+        with pytest.raises(ValueError):
+            PublicPAD(pleasure=0.0, arousal=float("inf"), dominance=0.0)
+
+    def test_pad_rejects_neg_inf(self):
+        with pytest.raises(ValueError):
+            PublicPAD(pleasure=0.0, arousal=0.0, dominance=float("-inf"))
+
+    def test_pad_rejects_bool(self):
+        with pytest.raises(ValueError):
+            PublicPAD(pleasure=True, arousal=0.0, dominance=0.0)
+
+    def test_dominant_emotion_rejects_nan(self):
+        with pytest.raises(ValueError):
+            PublicDominantEmotion(name="joy", intensity=float("nan"))
+
+    def test_dominant_emotion_rejects_negative_intensity(self):
+        with pytest.raises(ValueError):
+            PublicDominantEmotion(name="joy", intensity=-0.1)
+
+    def test_dominant_emotion_rejects_too_high_intensity(self):
+        with pytest.raises(ValueError):
+            PublicDominantEmotion(name="joy", intensity=1.1)

--- a/backend/tests/test_emotional_integration.py
+++ b/backend/tests/test_emotional_integration.py
@@ -22,9 +22,9 @@ Coverage map (43 behavioural requirements):
 17. Novo perfil é criado com snapshot v1 desde o início.
 18. sync_state() persiste to_dict() v1 (JSONB dict, not JSON string).
 19. Snapshot persistido contém schema_version e timestamp, sem last_update.
-20. Resposta pública mantém exatamente as chaves atuais.
-21. Resposta pública contém last_update derivado do timestamp.
-22. Resposta pública não contém schema_version, timestamp, appraisal ou regulation.
+20. Resposta pública é um ``EmotionStateResponse``, não um dict.
+21. Resposta pública contém os campos obrigatórios do contrato v1.
+22. Resposta pública não contém campos internos (acting_instruction, coping_mode, etc.).
 23. Falha de persistência não retorna sucesso.
 24. Falha de persistência não agenda extração arquivística.
 25. Extração arquivística agendada somente após turno e estado persistidos.
@@ -59,6 +59,7 @@ from backend.emotional_domain import (
     parse_llm_appraisal,
     transition,
 )
+from backend.emotion_presentation import EmotionStateResponse
 from backend.relationship import UserRelationship
 
 
@@ -668,7 +669,8 @@ class TestArchivalScheduling:
             engine = _make_engine()
             resp, emotions = await engine.process_turn("user", "Hello")
             assert resp is not None
-            assert isinstance(emotions, dict)
+            assert isinstance(emotions, EmotionStateResponse)
+            assert emotions.schema_version == 1
 
         asyncio.run(run())
 
@@ -784,62 +786,85 @@ class TestSanitisedLogging:
             resp, emotions = await engine.process_turn("user", "Hello")
             # Should still succeed with neutral fallback
             assert resp is not None
-            # Emotional state reflects neutral fallback (zero shifts)
-            assert emotions["pleasure"] == 0.0
-            assert emotions["last_update"] == FIXED_CLOCK
+            # Emotional state is EmotionStateResponse with neutral values
+            assert isinstance(emotions, EmotionStateResponse)
+            assert emotions.pad.pleasure == 0.0
+            assert emotions.timestamp == FIXED_CLOCK
 
         asyncio.run(run())
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Correction 9: Exact public contract test
+# Correction 9: Exact public contract test (updated for EmotionStateResponse)
 # ═══════════════════════════════════════════════════════════════════════════════
 
 class TestPublicContract:
-    """Public response has exactly the 10 legacy keys, no internal fields."""
+    """Public response is an EmotionStateResponse with versioned v1 fields."""
 
-    EXPECTED_PUBLIC_KEYS = {
-        "pleasure", "arousal", "dominance",
-        "libido", "aggression", "connection", "energy",
-        "tension", "coping_mode", "last_update",
+    EXPECTED_PUBLIC_FIELDS = {
+        "schema_version",
+        "mood_label",
+        "pad",
+        "dominant_emotions",
+        "timestamp",
     }
 
-    def test_projection_has_exact_legacy_keys(self):
+    def test_projection_is_emotion_state_response(self):
         state = EmotionalStateV1.create(
             pleasure=0.5, arousal=-0.2, dominance=0.3,
             libido=0.1, aggression=0.0, connection=0.7,
             energy=0.9, tension=0.2, coping_mode="HEALTHY",
             timestamp=FIXED_CLOCK,
         )
-        projected = ConversationEngine._project_emotion_state(state)
-        assert set(projected.keys()) == self.EXPECTED_PUBLIC_KEYS
+        appraisal = AppraisalV1.create(
+            valence_shift=0.2, arousal_shift=0.1, dominance_shift=0.0,
+            discrete_emotions={"joy": 0.5},
+        )
+        projected = ConversationEngine._project_emotion_state(state, appraisal)
+        assert isinstance(projected, EmotionStateResponse)
+        data = projected.model_dump()
+        assert set(data.keys()) == self.EXPECTED_PUBLIC_FIELDS
 
-    def test_last_update_equals_timestamp(self):
+    def test_serialized_format_does_not_contain_internal_fields(self):
         state = EmotionalStateV1.create(
             pleasure=0.0, arousal=0.0, dominance=0.0,
             libido=0.0, aggression=0.0, connection=0.5,
             energy=0.8, tension=0.0, coping_mode="HEALTHY",
             timestamp=FIXED_CLOCK,
         )
-        projected = ConversationEngine._project_emotion_state(state)
-        assert projected["last_update"] == FIXED_CLOCK
-        assert projected["last_update"] == state.timestamp
+        appraisal = AppraisalV1.neutral()
+        projected = ConversationEngine._project_emotion_state(state, appraisal)
+        json_str = projected.model_dump_json()
 
-    def test_no_internal_fields_in_projection(self):
+        # Must contain the new contract fields
+        assert '"schema_version"' in json_str
+        assert '"mood_label"' in json_str
+        assert '"timestamp"' in json_str
+
+        # Must NOT contain internal fields
+        forbidden = [
+            "acting_instruction", "coping_mode", "libido", "aggression",
+            "connection", "energy", "tension", "regulation", "fallback",
+            "last_update",
+        ]
+        for field in forbidden:
+            assert field not in json_str, f"Forbidden field '{field}' found in JSON"
+
+    def test_timestamp_preserved(self):
         state = EmotionalStateV1.neutral(timestamp=FIXED_CLOCK)
-        projected = ConversationEngine._project_emotion_state(state)
-        assert "schema_version" not in projected
-        assert "timestamp" not in projected
-        assert "appraisal" not in projected
-        assert "regulation" not in projected
-        assert "fallback" not in projected
+        appraisal = AppraisalV1.neutral()
+        projected = ConversationEngine._project_emotion_state(state, appraisal)
+        assert projected.timestamp == FIXED_CLOCK
+        assert projected.timestamp == state.timestamp
 
-    def test_process_turn_returns_projected_format(self):
+    def test_process_turn_returns_emotion_state_response(self):
         async def run():
             engine = _make_engine()
             resp, emotions = await engine.process_turn("user", "Hello")
-            assert set(emotions.keys()) == self.EXPECTED_PUBLIC_KEYS
-            assert emotions["last_update"] == FIXED_CLOCK
+            assert isinstance(emotions, EmotionStateResponse)
+            assert emotions.schema_version == 1
+            assert emotions.mood_label is not None
+            assert emotions.timestamp == FIXED_CLOCK
 
         asyncio.run(run())
 

--- a/backend/tests/test_isolation.py
+++ b/backend/tests/test_isolation.py
@@ -67,8 +67,8 @@ def test_user_isolation():
         engine._perceive = MagicMock(return_value={})
         _, state_a = await engine.process_turn("A", "Msg A")
         _, state_b = await engine.process_turn("B", "Msg B")
-        assert state_a["pleasure"] > 0
-        assert state_b["pleasure"] < 0
+        assert state_a.pad.pleasure > 0
+        assert state_b.pad.pleasure < 0
     asyncio.run(run_test())
 
 def test_identity_binding():

--- a/docs/architecture/emotion-public-contract-v1.md
+++ b/docs/architecture/emotion-public-contract-v1.md
@@ -1,0 +1,158 @@
+# Public Emotion Contract v1
+
+## Overview
+
+The public emotion contract defines the **only** emotion payload sent from the backend to the frontend. It is versioned, typed, and explicitly excludes all internal state.
+
+## JSON Contract
+
+```json
+{
+  "schema_version": 1,
+  "mood_label": "NEUTRA",
+  "pad": {
+    "pleasure": 0.0,
+    "arousal": 0.0,
+    "dominance": 0.0
+  },
+  "dominant_emotions": [
+    {
+      "name": "joy",
+      "intensity": 0.8
+    }
+  ],
+  "timestamp": 1700000000.0
+}
+```
+
+### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `schema_version` | `int` | Must be `1`. Only version 1 is accepted. |
+| `mood_label` | `string` | Human-readable mood derived from PAD coordinates. See classification below. |
+| `pad` | `object` | Pleasure-Arousal-Dominance in bipolar `[-1.0, +1.0]` scale. |
+| `pad.pleasure` | `float` | `-1.0` (Agony) to `+1.0` (Ecstasy) |
+| `pad.arousal` | `float` | `-1.0` (Sleep) to `+1.0` (Frenzy) |
+| `pad.dominance` | `float` | `-1.0` (Submissive) to `+1.0` (Dominant) |
+| `dominant_emotions` | `array` | At most 3 discrete emotions, sorted by intensity descending, then name ascending for ties. |
+| `dominant_emotions[].name` | `string` | Canonical emotion identifier (e.g. `"joy"`, `"anger"`). |
+| `dominant_emotions[].intensity` | `float` | `0.0` to `1.0`. Zero-intensity emotions are omitted. |
+| `timestamp` | `float` | Unix epoch seconds from `EmotionalStateV1.timestamp`. |
+
+## Version
+
+- **Current version**: `1`
+- The `schema_version` field is mandatory. Payloads with a missing or different version are **rejected** by the frontend.
+
+## Mood Classification (`classify_pad_mood`)
+
+The mood label is derived from PAD coordinates using a deterministic rule set:
+
+| Condition | Label |
+|---|---|
+| arousal > 0.5, pleasure > 0.5, dominance > 0.3 | `EXTASE/DOMINANTE` |
+| arousal > 0.5, pleasure > 0.5, dominance < -0.3 | `ENCANTADA` |
+| arousal > 0.5, pleasure > 0.5, otherwise | `ALEGRE/EXCITADA` |
+| arousal > 0.5, pleasure < -0.5, dominance > 0.3 | `FURIA/ODIO` |
+| arousal > 0.5, pleasure < -0.5, dominance < -0.3 | `TERROR/PANICO` |
+| arousal > 0.5, pleasure < -0.5, otherwise | `ESTRESSE/AGONIA` |
+| arousal ≤ 0.5, pleasure > 0.5 | `RELAXADA/SATISFEITA` |
+| arousal ≤ 0.5, pleasure < -0.5, dominance > 0.3 | `DESPREZO/FRIO` |
+| arousal ≤ 0.5, pleasure < -0.5, dominance < -0.3 | `DEPRESSAO/TRISTEZA` |
+| arousal ≤ 0.5, pleasure < -0.5, otherwise | `TEDIO` |
+| Default (none of the above) | `NEUTRA` |
+
+This classification is used exclusively by the public DTO. The internal prompt builder uses a separate
+classifier (``AffectiveEngine.get_emotional_label``, legacy path). Consolidating the two classifiers
+into a single shared implementation is tracked as a follow-up item.
+
+## Emotion Ordering
+
+`dominant_emotions` is sorted by:
+1. **Intensity descending** (highest first)
+2. **Name ascending** (alphabetically) for ties
+
+**Example**: `[{anger: 0.9}, {joy: 0.6}, {trust: 0.6}]` — anger first (highest), then joy before trust (alphabetical tie-break).
+
+## Frontend Validation Policy
+
+When the frontend receives an `emotion_state` payload, it applies the following rules:
+
+| Condition | Behaviour |
+|---|---|
+| Payload is `null` or `undefined` | Store `null`, do not render the panel |
+| `schema_version` missing or ≠ 1 | Reject entire payload, render nothing |
+| `pad` missing or malformed | Reject entire payload, render nothing |
+| Any PAD value is `NaN` / `Infinity` / `-Infinity` | Reject entire payload |
+| `dominant_emotions` missing or not an array | Reject entire payload |
+| `dominant_emotions` is an empty array | Render panel with PAD bars but no emotion badges |
+| All valid | Render normally |
+
+**No partial state is ever rendered.** If validation fails, the panel is hidden.
+
+## Conversion Helpers (Frontend)
+
+### PAD Bipolar → Display Percentage
+
+```
+bipolarToPercent(-1.0) → 0
+bipolarToPercent( 0.0) → 50
+bipolarToPercent( 1.0) → 100
+```
+
+Clamp: values below -1 are treated as -1; above 1 as 1.
+Non-finite values fall back to 50 (neutral).
+
+### Intensity → Display Percentage
+
+```
+intensityToPercent(0.0) → 0
+intensityToPercent(0.5) → 50
+intensityToPercent(1.0) → 100
+```
+
+Clamp: values below 0 are treated as 0; above 1 as 1.
+Non-finite values fall back to 0.
+
+## Architecture: Layering
+
+Four distinct layers exist in the emotion system:
+
+| Layer | What | Contains | Exposed to |
+|---|---|---|---|
+| **Persisted snapshot** | `EmotionalStateV1` | PAD + drives + coping_mode + tension + timestamp | Database (Supabase) |
+| **Appraisal** | `AppraisalV1` | shift values + discrete_emotions (11 emotions) | Transition engine |
+| **Internal presentation** | Prompt builder | `classify_pad_mood` + `get_acting_instruction` | LLM prompt |
+| **Public DTO** | `EmotionStateResponse` | mood_label + PAD + dominant_emotions (max 3) + timestamp | Browser |
+
+The **public DTO** is the only layer sent to the browser. All other layers are internal.
+
+## Explicitly Prohibited Fields
+
+The public DTO must **never** contain, directly or indirectly:
+
+| Field | Reason |
+|---|---|
+| `acting_instruction` | Internal prompt directive |
+| `coping_mode` | Internal coping state |
+| `libido` | Internal drive |
+| `aggression` | Internal drive |
+| `connection`, `energy`, `tension` | Internal system state |
+| `last_update` | Superseded by `timestamp` |
+| Memory | Not part of emotion contract |
+| Relationship | Not part of emotion contract |
+| Meta-cognition | Not part of emotion contract |
+| Raw LLM output | Not validated, may contain sensitive content |
+| Complete appraisal | Internal, too detailed for public |
+| Internal fallback codes | Observability only |
+| Secrets or user IDs | Security |
+
+## Source Files
+
+- **Backend DTO**: `backend/emotion_presentation.py`
+- **Mood classification**: `classify_pad_mood()` in `backend/emotion_presentation.py`
+- **ChatResponse with typed field**: `backend/main.py`
+- **Frontend validation**: `validateEmotionState()` in `frontend/src/shared/utils/formatters.js`
+- **Frontend component**: `frontend/src/features/chat/components/EmotionPanel.jsx`
+- **Frontend percent helpers**: `bipolarToPercent()` and `intensityToPercent()` in `frontend/src/shared/utils/formatters.js`

--- a/docs/architecture/emotion-public-contract-v1.md
+++ b/docs/architecture/emotion-public-contract-v1.md
@@ -63,9 +63,9 @@ The mood label is derived from PAD coordinates using a deterministic rule set:
 | arousal ≤ 0.5, pleasure < -0.5, otherwise | `TEDIO` |
 | Default (none of the above) | `NEUTRA` |
 
-This classification is used exclusively by the public DTO. The internal prompt builder uses a separate
-classifier (``AffectiveEngine.get_emotional_label``, legacy path). Consolidating the two classifiers
-into a single shared implementation is tracked as a follow-up item.
+This classification is used by both the public DTO and the internal prompt builder
+(``AffectiveEngine.get_emotional_label`` delegates to the same ``classify_pad_mood`` function).
+There is exactly **one** classifier shared across all layers.
 
 ## Emotion Ordering
 
@@ -122,8 +122,8 @@ Four distinct layers exist in the emotion system:
 | Layer | What | Contains | Exposed to |
 |---|---|---|---|
 | **Persisted snapshot** | `EmotionalStateV1` | PAD + drives + coping_mode + tension + timestamp | Database (Supabase) |
-| **Appraisal** | `AppraisalV1` | shift values + discrete_emotions (11 emotions) | Transition engine |
-| **Internal presentation** | Prompt builder | `classify_pad_mood` + `get_acting_instruction` | LLM prompt |
+| **Appraisal** | `AppraisalV1` | shift values + discrete_emotions (13 emotions) | Transition engine |
+| **Internal presentation** | Prompt builder | `classify_pad_mood` (shared) + `get_acting_instruction` | LLM prompt |
 | **Public DTO** | `EmotionStateResponse` | mood_label + PAD + dominant_emotions (max 3) + timestamp | Browser |
 
 The **public DTO** is the only layer sent to the browser. All other layers are internal.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,7 +28,8 @@
                 "eslint-plugin-react-refresh": "^0.4.4",
                 "postcss": "^8.5.19",
                 "tailwindcss": "^3.3.5",
-                "vite": "^6.4.3"
+                "vite": "^6.4.3",
+                "vitest": "^4.1.10"
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -1227,6 +1228,12 @@
                 "win32"
             ]
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true
+        },
         "node_modules/@stitches/core": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/@stitches/core/-/core-1.2.8.tgz",
@@ -1373,6 +1380,16 @@
                 "@babel/types": "^7.28.2"
             }
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
         "node_modules/@types/debug": {
             "version": "4.1.13",
             "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1380,6 +1397,12 @@
             "dependencies": {
                 "@types/ms": "*"
             }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true
         },
         "node_modules/@types/estree": {
             "version": "1.0.9",
@@ -1466,6 +1489,112 @@
             },
             "peerDependencies": {
                 "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+            }
+        },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+            "dev": true,
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/spy": "4.1.10",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+            "dev": true,
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/utils": "4.1.10",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+            "dev": true,
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/acorn": {
@@ -1700,6 +1829,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/async-function": {
@@ -1963,6 +2101,15 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/chalk": {
@@ -2462,6 +2609,12 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-module-lexer": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+            "dev": true
+        },
         "node_modules/es-object-atoms": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -2789,6 +2942,15 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2796,6 +2958,15 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/extend": {
@@ -4086,6 +4257,15 @@
                 "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
             }
         },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4898,6 +5078,19 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/obug": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+            "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "engines": {
+                "node": ">=12.20.0"
+            }
+        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5037,6 +5230,12 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true
+        },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "dev": true
         },
         "node_modules/picocolors": {
@@ -5816,6 +6015,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true
+        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5833,6 +6038,18 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true
+        },
+        "node_modules/std-env": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+            "dev": true
         },
         "node_modules/stop-iteration-iterator": {
             "version": "1.1.0",
@@ -6125,6 +6342,21 @@
                 "node": ">=0.8"
             }
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true
+        },
+        "node_modules/tinyexec": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.17",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -6168,6 +6400,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/to-regex-range": {
@@ -6582,6 +6823,107 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/vitest": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6680,6 +7022,22 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,8 @@
         "eslint-plugin-react-refresh": "^0.4.4",
         "postcss": "^8.5.19",
         "tailwindcss": "^3.3.5",
-        "vite": "^6.4.3"
+        "vite": "^6.4.3",
+        "vitest": "^4.1.10"
     },
     "overrides": {
         "minimatch": "^3.1.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
         "build": "vite build",
         "lint": "eslint .",
         "preview": "vite preview",
-        "test": "node --test tests/*.test.js"
+        "test:node": "node --test tests/*.test.js",
+        "test:component": "vitest run --config vitest.config.mjs",
+        "test": "npm run test:node && npm run test:component"
     },
     "dependencies": {
         "@supabase/auth-ui-react": "^0.4.7",

--- a/frontend/src/features/chat/components/EmotionPanel.jsx
+++ b/frontend/src/features/chat/components/EmotionPanel.jsx
@@ -1,25 +1,22 @@
 import React from 'react';
 import { Heart, Zap, Crown } from 'lucide-react';
-import { toPercent } from '../../../shared/utils/formatters';
+import {
+    bipolarToPercent,
+    intensityToPercent,
+    getEmotionLabel,
+} from '../../../shared/utils/formatters';
+
+const PAD_CONFIG = [
+    { label: 'Prazer', key: 'pleasure', icon: Heart, color: 'bg-pink-500' },
+    { label: 'Energia', key: 'arousal', icon: Zap, color: 'bg-yellow-500' },
+    { label: 'Dominância', key: 'dominance', icon: Crown, color: 'bg-purple-500' },
+];
 
 const EmotionPanel = ({ emotionState }) => {
     if (!emotionState) return null;
 
-    const { pleasure, arousal, dominance, mood_label, acting_instruction, joy, sadness, anger, fear, disgust, surprise, guilt, pride, tenderness, jealousy, gratitude } = emotionState;
-
-    const discreteEmotions = [
-        { label: 'Alegria', value: joy, color: 'text-yellow-400' },
-        { label: 'Tristeza', value: sadness, color: 'text-blue-400' },
-        { label: 'Raiva', value: anger, color: 'text-red-500' },
-        { label: 'Medo', value: fear, color: 'text-purple-400' },
-        { label: 'Nojo', value: disgust, color: 'text-green-400' },
-        { label: 'Surpresa', value: surprise, color: 'text-orange-400' },
-        { label: 'Culpa', value: guilt, color: 'text-gray-400' },
-        { label: 'Orgulho', value: pride, color: 'text-yellow-600' },
-        { label: 'Ternura', value: tenderness, color: 'text-pink-300' },
-        { label: 'Ciúmes', value: jealousy, color: 'text-green-600' },
-        { label: 'Gratidão', value: gratitude, color: 'text-pink-500' },
-    ].filter(e => e.value > 0.1).sort((a, b) => b.value - a.value).slice(0, 3);
+    const { pad, mood_label, dominant_emotions } = emotionState;
+    if (!pad) return null;
 
     return (
         <div className="bg-gray-800 border border-gray-700 rounded-xl p-4 shadow-lg w-full md:w-72 mt-4 md:mt-0 md:ml-4 flex-shrink-0">
@@ -29,35 +26,38 @@ const EmotionPanel = ({ emotionState }) => {
 
             <div className="mb-4">
                 <div className="text-xl font-semibold text-white mb-1">{mood_label}</div>
-                <div className="text-gray-400 text-xs italic leading-tight">
-                    "{acting_instruction}"
-                </div>
             </div>
 
             {/* Discrete Emotions */}
-            {discreteEmotions.length > 0 && (
+            {dominant_emotions && dominant_emotions.length > 0 && (
                 <div className="mb-4 flex flex-wrap gap-2">
-                    {discreteEmotions.map(e => (
-                        <span key={e.label} className={`text-xs font-medium px-2 py-1 rounded-full bg-gray-700 ${e.color}`}>
-                            {e.label} {Math.round(e.value * 100)}%
-                        </span>
-                    ))}
+                    {dominant_emotions.map((emotion) => {
+                        const displayLabel = getEmotionLabel(emotion.name);
+                        const pct = intensityToPercent(emotion.intensity);
+                        return (
+                            <span
+                                key={emotion.name}
+                                className="text-xs font-medium px-2 py-1 rounded-full bg-gray-700 text-gray-200"
+                            >
+                                {displayLabel} {pct}%
+                            </span>
+                        );
+                    })}
                 </div>
             )}
 
             <div className="space-y-3">
-                {[
-                    { label: 'Prazer', value: pleasure, icon: Heart, color: 'bg-pink-500' },
-                    { label: 'Energia', value: arousal, icon: Zap, color: 'bg-yellow-500' },
-                    { label: 'Dominância', value: dominance, icon: Crown, color: 'bg-purple-500' }
-                ].map(({ label, value, icon: Icon, color }) => {
-                    const percentage = toPercent(value);
+                {PAD_CONFIG.map(({ label, key, icon: Icon, color }) => {
+                    const value = pad[key];
+                    const percentage = bipolarToPercent(value);
                     const labelId = `emotion-label-${label}`;
 
                     return (
                         <div key={label}>
                             <div className="flex justify-between text-xs text-gray-400 mb-1">
-                                <span id={labelId} className="flex items-center gap-1"><Icon size={12} /> {label}</span>
+                                <span id={labelId} className="flex items-center gap-1">
+                                    <Icon size={12} /> {label}
+                                </span>
                                 <span aria-hidden="true">{percentage}%</span>
                             </div>
                             <div

--- a/frontend/src/features/chat/components/EmotionPanel.jsx
+++ b/frontend/src/features/chat/components/EmotionPanel.jsx
@@ -28,11 +28,13 @@ const EmotionPanel = ({ emotionState }) => {
                 <div className="text-xl font-semibold text-white mb-1">{mood_label}</div>
             </div>
 
-            {/* Discrete Emotions */}
-            {dominant_emotions && dominant_emotions.length > 0 && (
+            {/* Discrete Emotions — defensive rendering */}
+            {Array.isArray(dominant_emotions) && dominant_emotions.length > 0 && (
                 <div className="mb-4 flex flex-wrap gap-2">
-                    {dominant_emotions.map((emotion) => {
+                    {dominant_emotions.slice(0, 3).map((emotion) => {
                         const displayLabel = getEmotionLabel(emotion.name);
+                        // Skip items without a recognized canonical label
+                        if (displayLabel === null) return null;
                         const pct = intensityToPercent(emotion.intensity);
                         return (
                             <span

--- a/frontend/src/features/chat/hooks/useChat.js
+++ b/frontend/src/features/chat/hooks/useChat.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { sendMessage } from '../services/chatService';
 import api from '../../../shared/services/apiClient';
 import { SYSTEM_MESSAGES } from '../constants';
+import { validateEmotionState } from '../../../shared/utils/formatters';
 
 export const useChat = () => {
     const [messages, setMessages] = useState([]);
@@ -47,9 +48,9 @@ export const useChat = () => {
             const botMessage = { role: 'assistant', content: data.response };
             setMessages(prev => [...prev, botMessage]);
 
-            if (data.emotion_state) {
-                setEmotionState(data.emotion_state);
-            }
+            // Always validate emotion_state: clear panel on invalid or missing contract
+            const validated = validateEmotionState(data.emotion_state);
+            setEmotionState(validated);
         } catch (error) {
             // Error handling
             const errorMessage = {

--- a/frontend/src/shared/utils/formatters.js
+++ b/frontend/src/shared/utils/formatters.js
@@ -85,11 +85,18 @@ export const validateEmotionState = (payload) => {
     // Valid timestamp
     if (typeof payload.timestamp !== 'number' || !Number.isFinite(payload.timestamp)) return null;
 
+    // Deep-copy dominant_emotions to avoid sharing references with the outside payload.
+    // Each emotion object is reconstructed so mutations to the original payload have
+    // no effect on the validated result.
+    const clonedEmotions = payload.dominant_emotions.map(
+        (item) => ({ name: item.name, intensity: item.intensity })
+    );
+
     return {
         schema_version: 1,
         pad: { pleasure, arousal, dominance },
         mood_label: payload.mood_label,
-        dominant_emotions: payload.dominant_emotions,
+        dominant_emotions: clonedEmotions,
         timestamp: payload.timestamp,
     };
 };
@@ -115,6 +122,10 @@ export const EMOTION_LABELS = {
 
 /**
  * Get the display label for a canonical emotion name.
- * Falls back to the canonical name if not found in the map.
+ * Returns null if the name is not a known canonical emotion.
+ * This ensures unknown/untrusted payload names are never rendered as raw text.
  */
-export const getEmotionLabel = (name) => EMOTION_LABELS[name] || name;
+export const getEmotionLabel = (name) => {
+    if (!name || typeof name !== 'string') return null;
+    return EMOTION_LABELS[name] || null;
+};

--- a/frontend/src/shared/utils/formatters.js
+++ b/frontend/src/shared/utils/formatters.js
@@ -40,6 +40,10 @@ export const toPercent = (val) => intensityToPercent(val);
  * - schema_version must be 1.
  * - pad must be present and must have finite numeric pleasure/arousal/dominance.
  * - dominant_emotions must be an array (may be empty).
+ *   - At most 3 emotions (per the public contract).
+ *   - Each name must be a known canonical emotion (in EMOTION_LABELS).
+ *   - No duplicate names allowed.
+ * - schema_version is preserved in the returned object.
  * - No partial state is ever rendered.
  */
 export const validateEmotionState = (payload) => {
@@ -59,11 +63,19 @@ export const validateEmotionState = (payload) => {
     // Validate dominant_emotions (must be array, may be empty)
     if (!Array.isArray(payload.dominant_emotions)) return null;
 
-    // Validate each dominant_emotion item has valid name and finite intensity
+    // At most 3 emotions
+    if (payload.dominant_emotions.length > 3) return null;
+
+    const seenNames = new Set();
     for (let i = 0; i < payload.dominant_emotions.length; i++) {
         const item = payload.dominant_emotions[i];
         if (!item || typeof item !== 'object' || Array.isArray(item)) return null;
         if (typeof item.name !== 'string' || item.name.length === 0) return null;
+        // Reject unknown canonical names
+        if (!(item.name in EMOTION_LABELS)) return null;
+        // Reject duplicates
+        if (seenNames.has(item.name)) return null;
+        seenNames.add(item.name);
         if (typeof item.intensity !== 'number' || !Number.isFinite(item.intensity)) return null;
     }
 
@@ -74,6 +86,7 @@ export const validateEmotionState = (payload) => {
     if (typeof payload.timestamp !== 'number' || !Number.isFinite(payload.timestamp)) return null;
 
     return {
+        schema_version: 1,
         pad: { pleasure, arousal, dominance },
         mood_label: payload.mood_label,
         dominant_emotions: payload.dominant_emotions,

--- a/frontend/src/shared/utils/formatters.js
+++ b/frontend/src/shared/utils/formatters.js
@@ -1,1 +1,107 @@
-export const toPercent = (val) => Math.round(val * 100);
+/**
+ * Converts a bipolar PAD value (-1..+1) to a display percentage (0..100).
+ *
+ * Map: -1.0 → 0, 0.0 → 50, +1.0 → 100.
+ * Non-finite values return 50 (neutral).
+ * Values outside [-1, 1] are clamped before mapping.
+ */
+export const bipolarToPercent = (val) => {
+    if (typeof val !== 'number' || !Number.isFinite(val)) return 50;
+    const clamped = Math.max(-1, Math.min(1, val));
+    return Math.round((clamped + 1) * 50);
+};
+
+/**
+ * Converts a unipolar intensity (0..1) to a display percentage (0..100).
+ *
+ * Map: 0.0 → 0, 0.5 → 50, 1.0 → 100.
+ * Non-finite values return 0.
+ * Values outside [0, 1] are clamped before mapping.
+ */
+export const intensityToPercent = (val) => {
+    if (typeof val !== 'number' || !Number.isFinite(val)) return 0;
+    const clamped = Math.max(0, Math.min(1, val));
+    return Math.round(clamped * 100);
+};
+
+/**
+ * Legacy helper: converts 0..1 to 0..100.
+ * Kept for backward compatibility but deprecated in favour of
+ * ``bipolarToPercent`` and ``intensityToPercent``.
+ */
+export const toPercent = (val) => intensityToPercent(val);
+
+/**
+ * Validate the public emotion state payload from the backend.
+ * Returns the validated payload object, or null if invalid.
+ *
+ * Validation rules:
+ * - Payload must be a non-null object.
+ * - schema_version must be 1.
+ * - pad must be present and must have finite numeric pleasure/arousal/dominance.
+ * - dominant_emotions must be an array (may be empty).
+ * - No partial state is ever rendered.
+ */
+export const validateEmotionState = (payload) => {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+
+    // Validate schema_version
+    if (payload.schema_version !== 1) return null;
+
+    // Validate pad
+    if (!payload.pad || typeof payload.pad !== 'object' || Array.isArray(payload.pad)) return null;
+
+    const { pleasure, arousal, dominance } = payload.pad;
+    if (typeof pleasure !== 'number' || !Number.isFinite(pleasure)) return null;
+    if (typeof arousal !== 'number' || !Number.isFinite(arousal)) return null;
+    if (typeof dominance !== 'number' || !Number.isFinite(dominance)) return null;
+
+    // Validate dominant_emotions (must be array, may be empty)
+    if (!Array.isArray(payload.dominant_emotions)) return null;
+
+    // Validate each dominant_emotion item has valid name and finite intensity
+    for (let i = 0; i < payload.dominant_emotions.length; i++) {
+        const item = payload.dominant_emotions[i];
+        if (!item || typeof item !== 'object' || Array.isArray(item)) return null;
+        if (typeof item.name !== 'string' || item.name.length === 0) return null;
+        if (typeof item.intensity !== 'number' || !Number.isFinite(item.intensity)) return null;
+    }
+
+    // Valid mood_label
+    if (typeof payload.mood_label !== 'string' || payload.mood_label.length === 0) return null;
+
+    // Valid timestamp
+    if (typeof payload.timestamp !== 'number' || !Number.isFinite(payload.timestamp)) return null;
+
+    return {
+        pad: { pleasure, arousal, dominance },
+        mood_label: payload.mood_label,
+        dominant_emotions: payload.dominant_emotions,
+        timestamp: payload.timestamp,
+    };
+};
+
+/**
+ * Map canonical emotion names to Portuguese display labels.
+ */
+export const EMOTION_LABELS = {
+    joy: 'Alegria',
+    sadness: 'Tristeza',
+    anger: 'Raiva',
+    fear: 'Medo',
+    disgust: 'Nojo',
+    surprise: 'Surpresa',
+    trust: 'Confiança',
+    anticipation: 'Antecipação',
+    tenderness: 'Ternura',
+    guilt: 'Culpa',
+    pride: 'Orgulho',
+    jealousy: 'Ciúmes',
+    gratitude: 'Gratidão',
+};
+
+/**
+ * Get the display label for a canonical emotion name.
+ * Falls back to the canonical name if not found in the map.
+ */
+export const getEmotionLabel = (name) => EMOTION_LABELS[name] || name;

--- a/frontend/tests/emotionPanelVerification.test.js
+++ b/frontend/tests/emotionPanelVerification.test.js
@@ -2,201 +2,308 @@
 process.env.NODE_ENV = 'test';
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { readFileSync, existsSync } from 'fs';
-import { resolve, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import EmotionPanel from '../src/features/chat/components/EmotionPanel.jsx';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const PROJECT_ROOT = resolve(__dirname, '..');
-const EMOTION_PANEL_PATH = resolve(PROJECT_ROOT, 'src/features/chat/components/EmotionPanel.jsx');
-const USE_CHAT_PATH = resolve(PROJECT_ROOT, 'src/features/chat/hooks/useChat.js');
+// ─── Helpers ────────────────────────────────────────────────────────────────
 
-// Verify the files exist before reading
-if (!existsSync(EMOTION_PANEL_PATH)) {
-    throw new Error(`EmotionPanel file not found at: ${EMOTION_PANEL_PATH}`);
-}
-if (!existsSync(USE_CHAT_PATH)) {
-    throw new Error(`useChat file not found at: ${USE_CHAT_PATH}`);
-}
+const NEUTRAL_PAYLOAD = {
+    schema_version: 1,
+    mood_label: 'NEUTRA',
+    pad: { pleasure: 0, arousal: 0, dominance: 0 },
+    dominant_emotions: [],
+    timestamp: 1700000000,
+};
 
-const emotionPanelSource = readFileSync(EMOTION_PANEL_PATH, 'utf-8');
-const useChatSource = readFileSync(USE_CHAT_PATH, 'utf-8');
+const renderPanel = (props = {}) => {
+    return renderToStaticMarkup(React.createElement(EmotionPanel, props));
+};
 
-// ─── Verify EmotionPanel doesn't reference forbidden fields ─────────────────
+// ─── 1. Null payload ───────────────────────────────────────────────────────
 
-test('EmotionPanel does not reference acting_instruction', () => {
-    const hasActingInstruction = emotionPanelSource.includes('acting_instruction');
-    assert.strictEqual(hasActingInstruction, false,
-        'EmotionPanel should not reference acting_instruction');
+test('null emotionState does not render the panel', () => {
+    const html = renderPanel({ emotionState: null });
+    assert.strictEqual(html, '');
 });
 
-test('EmotionPanel does not reference coping_mode', () => {
-    const hasCopingMode = emotionPanelSource.includes('coping_mode');
-    assert.strictEqual(hasCopingMode, false,
-        'EmotionPanel should not reference coping_mode');
+test('undefined emotionState does not render the panel', () => {
+    const html = renderPanel({ emotionState: undefined });
+    assert.strictEqual(html, '');
 });
 
-test('EmotionPanel does not reference libido', () => {
-    const hasLibido = emotionPanelSource.includes('libido');
-    assert.strictEqual(hasLibido, false,
-        'EmotionPanel should not reference libido');
+test('emotionState without pad does not render the panel', () => {
+    const html = renderPanel({ emotionState: { ...NEUTRAL_PAYLOAD, pad: null } });
+    assert.strictEqual(html, '');
 });
 
-test('EmotionPanel does not reference aggression', () => {
-    const hasAggression = emotionPanelSource.includes('aggression');
-    assert.strictEqual(hasAggression, false,
-        'EmotionPanel should not reference aggression');
+// ─── 2. Empty dominant_emotions ─────────────────────────────────────────────
+
+test('empty dominant_emotions renders PAD without emotion badges', () => {
+    const html = renderPanel({ emotionState: NEUTRAL_PAYLOAD });
+    // Should contain progress bars
+    assert.ok(html.includes('role="progressbar"'), 'Should render progress bars');
+    // Should NOT contain emotion badge spans (text-gray-200 is unique to badges)
+    assert.ok(!html.includes('text-gray-200'), 'Should not render emotion badges');
+    // Should not contain percent values from badges (only from PAD labels)
+    assert.ok(!html.includes('Alegria'), 'Should not render emotion labels');
 });
 
-test('EmotionPanel uses dominant_emotions array instead of flat fields', () => {
-    assert.ok(emotionPanelSource.includes('dominant_emotions'),
-        'EmotionPanel should reference dominant_emotions');
-    // The panel should read from dominant_emotions array, not flat fields like joy, sadness, etc.
-    const forbiddenTopLevelEmotions = [
-        'emotionState.joy', 'emotionState.sadness', 'emotionState.anger',
-        'emotionState.fear', 'emotionState.disgust',
-    ];
-    for (const field of forbiddenTopLevelEmotions) {
-        assert.strictEqual(emotionPanelSource.includes(field), false,
-            `EmotionPanel should not reference '${field}' directly`);
+// ─── 3. PAD -1, 0, 1 produces 0, 50, 100 percent ───────────────────────────
+
+test('PAD -1 produces 0% for each dimension', () => {
+    const html = renderPanel({
+        emotionState: {
+            ...NEUTRAL_PAYLOAD,
+            pad: { pleasure: -1, arousal: -1, dominance: -1 },
+        },
+    });
+    // aria-valuenow should be 0 for all PAD bars
+    const nows = [...html.matchAll(/aria-valuenow="(\d+)"/g)].map(m => parseInt(m[1], 10));
+    assert.ok(nows.every(v => v === 0), `All aria-valuenow should be 0, got ${nows}`);
+});
+
+test('PAD 0 produces 50% for each dimension', () => {
+    const html = renderPanel({
+        emotionState: {
+            ...NEUTRAL_PAYLOAD,
+            pad: { pleasure: 0, arousal: 0, dominance: 0 },
+        },
+    });
+    const nows = [...html.matchAll(/aria-valuenow="(\d+)"/g)].map(m => parseInt(m[1], 10));
+    assert.ok(nows.every(v => v === 50), `All aria-valuenow should be 50, got ${nows}`);
+});
+
+test('PAD 1 produces 100% for each dimension', () => {
+    const html = renderPanel({
+        emotionState: {
+            ...NEUTRAL_PAYLOAD,
+            pad: { pleasure: 1, arousal: 1, dominance: 1 },
+        },
+    });
+    const nows = [...html.matchAll(/aria-valuenow="(\d+)"/g)].map(m => parseInt(m[1], 10));
+    assert.ok(nows.every(v => v === 100), `All aria-valuenow should be 100, got ${nows}`);
+});
+
+// ─── 4. ARIA progress bar attributes ────────────────────────────────────────
+
+test('progress bars have role="progressbar"', () => {
+    const html = renderPanel({ emotionState: NEUTRAL_PAYLOAD });
+    const bars = html.match(/role="progressbar"/g);
+    assert.strictEqual(bars && bars.length, 3, 'Should have 3 progress bars');
+});
+
+test('progress bars have aria-valuemin="0"', () => {
+    const html = renderPanel({ emotionState: NEUTRAL_PAYLOAD });
+    const mins = html.match(/aria-valuemin="0"/g);
+    assert.ok(mins && mins.length === 3, 'All 3 bars should have aria-valuemin="0"');
+});
+
+test('progress bars have aria-valuemax="100"', () => {
+    const html = renderPanel({ emotionState: NEUTRAL_PAYLOAD });
+    assert.ok(html.includes('aria-valuemax="100"'), 'Should have aria-valuemax="100"');
+});
+
+test('progress bars have aria-valuenow with correct value', () => {
+    const html = renderPanel({
+        emotionState: {
+            ...NEUTRAL_PAYLOAD,
+            pad: { pleasure: 0.5, arousal: -0.3, dominance: 0.8 },
+        },
+    });
+    // pleasure 0.5 -> 75, arousal -0.3 -> 35, dominance 0.8 -> 90
+    assert.ok(html.includes('aria-valuenow="75"'), 'pleasure=0.5 should show 75');
+    assert.ok(html.includes('aria-valuenow="35"'), 'arousal=-0.3 should show 35');
+    assert.ok(html.includes('aria-valuenow="90"'), 'dominance=0.8 should show 90');
+});
+
+test('progress bars are associated to a labelledby ID', () => {
+    const html = renderPanel({ emotionState: NEUTRAL_PAYLOAD });
+    // Each bar has aria-labelledby pointing to an ID
+    assert.ok(html.includes('aria-labelledby="emotion-label-'), 'Should have aria-labelledby');
+    // All IDs are present and referenced
+    const labels = ['Prazer', 'Energia', 'Dominância'];
+    for (const label of labels) {
+        assert.ok(html.includes(label), `Should contain label "${label}"`);
     }
 });
 
-test('EmotionPanel reads PAD from nested pad object', () => {
-    assert.ok(emotionPanelSource.includes('pad[') || emotionPanelSource.includes('.pad.'),
-        'EmotionPanel should read PAD values from nested pad object');
+// ─── 5. Width clamping ─────────────────────────────────────────────────────
+
+test('width percent is never below 0% or above 100%', () => {
+    const extremePayload = {
+        ...NEUTRAL_PAYLOAD,
+        pad: { pleasure: -10, arousal: 10, dominance: -999 },
+    };
+    const html = renderPanel({ emotionState: extremePayload });
+    const widths = [...html.matchAll(/style="width:\s*([\d.]+)%"/g)].map(m => parseFloat(m[1]));
+    for (const w of widths) {
+        assert.ok(w >= 0 && w <= 100, `Width ${w}% should be in [0, 100]`);
+    }
 });
 
-test('EmotionPanel uses bipolarToPercent helper', () => {
-    assert.ok(emotionPanelSource.includes('bipolarToPercent'),
-        'EmotionPanel should use bipolarToPercent for PAD values');
+// ─── 6. Emotions in received order ─────────────────────────────────────────
+
+test('emotions appear in received order', () => {
+    const payload = {
+        ...NEUTRAL_PAYLOAD,
+        dominant_emotions: [
+            { name: 'joy', intensity: 0.8 },
+            { name: 'sadness', intensity: 0.5 },
+        ],
+    };
+    const html = renderPanel({ emotionState: payload });
+    const joyIndex = html.indexOf('Alegria');
+    const sadnessIndex = html.indexOf('Tristeza');
+    assert.ok(joyIndex >= 0, 'Should contain Alegria');
+    assert.ok(sadnessIndex >= 0, 'Should contain Tristeza');
+    assert.ok(joyIndex < sadnessIndex, 'Alegria should appear before Tristeza');
 });
 
-test('EmotionPanel uses intensityToPercent helper', () => {
-    assert.ok(emotionPanelSource.includes('intensityToPercent'),
-        'EmotionPanel should use intensityToPercent for emotion intensities');
+// ─── 7. At most 3 emotions rendered ────────────────────────────────────────
+
+test('at most 3 emotions are rendered even if payload has 5', () => {
+    const payload = {
+        ...NEUTRAL_PAYLOAD,
+        dominant_emotions: [
+            { name: 'joy', intensity: 0.9 },
+            { name: 'anger', intensity: 0.8 },
+            { name: 'sadness', intensity: 0.7 },
+            { name: 'fear', intensity: 0.6 },
+            { name: 'disgust', intensity: 0.5 },
+        ],
+    };
+    const html = renderPanel({ emotionState: payload });
+    // Count occurrences of known labels
+    const labelCount = (html.match(/(Alegria|Raiva|Tristeza|Medo|Nojo)/g) || []).length;
+    assert.strictEqual(labelCount, 3, 'Should render exactly 3 emotions');
 });
 
-// ─── Behavioral: formatter functions (ARIA compliance) ──────────────────────
-
-test('bipolarToPercent output is always between 0 and 100 (ARIA compliance)', () => {
-    return import('../src/shared/utils/formatters.js').then(({ bipolarToPercent }) => {
-        const testValues = [-2, -1, -0.5, 0, 0.5, 1, 2, NaN, Infinity, -Infinity, null, undefined, 'string'];
-        for (const val of testValues) {
-            const result = bipolarToPercent(val);
-            assert.ok(result >= 0 && result <= 100,
-                `bipolarToPercent(${val}) = ${result} should be in [0, 100]`);
-        }
-    });
+test('exactly 3 emotions renders all 3', () => {
+    const payload = {
+        ...NEUTRAL_PAYLOAD,
+        dominant_emotions: [
+            { name: 'joy', intensity: 0.9 },
+            { name: 'anger', intensity: 0.8 },
+            { name: 'sadness', intensity: 0.7 },
+        ],
+    };
+    const html = renderPanel({ emotionState: payload });
+    const labelCount = (html.match(/(Alegria|Raiva|Tristeza)/g) || []).length;
+    assert.strictEqual(labelCount, 3, 'Should render all 3 emotions');
 });
 
-test('intensityToPercent output is always between 0 and 100 (ARIA compliance)', () => {
-    return import('../src/shared/utils/formatters.js').then(({ intensityToPercent }) => {
-        const testValues = [-1, -0.5, 0, 0.5, 1, 1.5, NaN, Infinity, -Infinity, null, undefined, 'string'];
-        for (const val of testValues) {
-            const result = intensityToPercent(val);
-            assert.ok(result >= 0 && result <= 100,
-                `intensityToPercent(${val}) = ${result} should be in [0, 100]`);
-        }
-    });
+// ─── 8. Unknown emotion name not in HTML ───────────────────────────────────
+
+test('unknown emotion name does not appear as raw text', () => {
+    const payload = {
+        ...NEUTRAL_PAYLOAD,
+        dominant_emotions: [
+            { name: 'joy', intensity: 0.8 },
+            { name: 'non_existent_emotion', intensity: 0.7 },
+            { name: 'anger', intensity: 0.6 },
+        ],
+    };
+    const html = renderPanel({ emotionState: payload });
+    // Joy and Anger should be rendered
+    assert.ok(html.includes('Alegria'), 'Should render known emotion');
+    assert.ok(html.includes('Raiva'), 'Should render known emotion');
+    // Unknown emotion name should NOT appear
+    assert.ok(!html.includes('non_existent_emotion'), 'Unknown name should not appear');
 });
 
-test('EmotionPanel has role="progressbar" ARIA attributes', () => {
-    assert.ok(emotionPanelSource.includes('role="progressbar"'),
-        'EmotionPanel should include role="progressbar"');
-    assert.ok(emotionPanelSource.includes('aria-valuenow'),
-        'EmotionPanel should include aria-valuenow');
-    assert.ok(emotionPanelSource.includes('aria-valuemin'),
-        'EmotionPanel should include aria-valuemin');
-    assert.ok(emotionPanelSource.includes('aria-valuemax="100"'),
-        'EmotionPanel should include aria-valuemax="100"');
+// ─── 9. Forbidden fields not rendered ──────────────────────────────────────
+
+test('acting_instruction does not appear in HTML even if present in adversarial object', () => {
+    const adversarial = {
+        ...NEUTRAL_PAYLOAD,
+        acting_instruction: 'secret',
+        coping_mode: 'MANIC',
+        libido: 0.9,
+        aggression: 0.8,
+    };
+    const html = renderPanel({ emotionState: adversarial });
+    assert.ok(!html.includes('secret'), 'acting_instruction should not appear');
+    assert.ok(!html.includes('MANIC'), 'coping_mode should not appear');
+    assert.ok(!html.includes('libido'), 'libido should not appear');
+    assert.ok(!html.includes('aggression'), 'aggression should not appear');
 });
 
-// ─── Behavioral: validateEmotionState integration tests ─────────────────────
+// ─── 10. Intensity converted 0..1 to 0..100 ────────────────────────────────
 
-test('validateEmotionState is called on every response (source inspection)', () => {
-    assert.ok(useChatSource.includes('validateEmotionState'),
-        'useChat should call validateEmotionState');
+test('intensity 0 → 0% displayed', () => {
+    const payload = {
+        ...NEUTRAL_PAYLOAD,
+        dominant_emotions: [
+            { name: 'joy', intensity: 0 },
+        ],
+    };
+    const html = renderPanel({ emotionState: payload });
+    // Should be rendered with 0%
+    assert.ok(html.includes('Alegria 0%'), 'Should show 0% for zero intensity');
 });
 
-test('useChat always sets emotionState (even to null) on response', () => {
-    // Check that emotion_state is ALWAYS validated (not conditionally)
-    const guardedByIf = useChatSource.includes('if (data.emotion_state) {');
-    assert.strictEqual(guardedByIf, false,
-        'useChat should not guard emotion_state validation with an if check - always validate');
-    assert.ok(useChatSource.includes('setEmotionState(validated)'),
-        'useChat should always set emotionState (even to null)');
+test('intensity 0.5 → 50% displayed', () => {
+    const payload = {
+        ...NEUTRAL_PAYLOAD,
+        dominant_emotions: [
+            { name: 'joy', intensity: 0.5 },
+        ],
+    };
+    const html = renderPanel({ emotionState: payload });
+    assert.ok(html.includes('Alegria 50%'), 'Should show 50% for 0.5 intensity');
 });
 
-// ─── Behavioral: validateEmotionState pure function (extracted hook logic) ──
-
-test('validateEmotionState rejects invalid payload — pure function test', () => {
-    return import('../src/shared/utils/formatters.js').then(({ validateEmotionState }) => {
-        // Known invalid cases
-        assert.strictEqual(validateEmotionState(null), null);
-        assert.strictEqual(validateEmotionState(undefined), null);
-        assert.strictEqual(validateEmotionState([]), null);
-        assert.strictEqual(validateEmotionState({}), null);
-
-        // Valid payload
-        const valid = {
-            schema_version: 1,
-            mood_label: 'NEUTRA',
-            pad: { pleasure: 0, arousal: 0, dominance: 0 },
-            dominant_emotions: [],
-            timestamp: 1700000000,
-        };
-        assert.notStrictEqual(validateEmotionState(valid), null);
-
-        // Invalid: missing emotion_state (simulating missing backend data)
-        assert.strictEqual(validateEmotionState(undefined), null,
-            'undefined payload should return null — panel cleared');
-    });
+test('intensity 1 → 100% displayed', () => {
+    const payload = {
+        ...NEUTRAL_PAYLOAD,
+        dominant_emotions: [
+            { name: 'joy', intensity: 1 },
+        ],
+    };
+    const html = renderPanel({ emotionState: payload });
+    assert.ok(html.includes('Alegria 100%'), 'Should show 100% for max intensity');
 });
 
-test('validateEmotionState with more than 3 emotions returns null', () => {
-    return import('../src/shared/utils/formatters.js').then(({ validateEmotionState }) => {
-        const payload = {
-            schema_version: 1,
-            mood_label: 'NEUTRA',
-            pad: { pleasure: 0, arousal: 0, dominance: 0 },
-            dominant_emotions: [
-                { name: 'joy', intensity: 0.8 },
-                { name: 'anger', intensity: 0.7 },
-                { name: 'fear', intensity: 0.6 },
-                { name: 'sadness', intensity: 0.5 },
-            ],
-            timestamp: 1700000000,
-        };
-        assert.strictEqual(validateEmotionState(payload), null,
-            '>3 emotions should reject entire payload');
-    });
+test('intensity above 1 clamped to 100%', () => {
+    const payload = {
+        ...NEUTRAL_PAYLOAD,
+        dominant_emotions: [
+            { name: 'joy', intensity: 1.5 },
+        ],
+    };
+    const html = renderPanel({ emotionState: payload });
+    // intensityToPercent clamps to 100
+    assert.ok(html.includes('Alegria 100%'), 'Should clamp to 100%');
 });
 
-test('validateEmotionState with unknown emotion name returns null', () => {
-    return import('../src/shared/utils/formatters.js').then(({ validateEmotionState }) => {
-        const payload = {
-            schema_version: 1,
-            mood_label: 'NEUTRA',
-            pad: { pleasure: 0, arousal: 0, dominance: 0 },
-            dominant_emotions: [{ name: 'invalid_emotion', intensity: 0.5 }],
-            timestamp: 1700000000,
-        };
-        assert.strictEqual(validateEmotionState(payload), null,
-            'unknown emotion name should reject entire payload');
-    });
+test('intensity below 0 clamped to 0%', () => {
+    const payload = {
+        ...NEUTRAL_PAYLOAD,
+        dominant_emotions: [
+            { name: 'joy', intensity: -0.5 },
+        ],
+    };
+    const html = renderPanel({ emotionState: payload });
+    assert.ok(html.includes('Alegria 0%'), 'Should clamp to 0%');
 });
 
-test('EmotionPanel getEmotionLabel exposes canonical name for known emotion', () => {
-    return import('../src/shared/utils/formatters.js').then(({ getEmotionLabel, EMOTION_LABELS }) => {
-        // All defined emotions should have a display label
-        const knownEmotions = Object.keys(EMOTION_LABELS);
-        assert.ok(knownEmotions.length > 0, 'EMOTION_LABELS should have entries');
-        for (const name of knownEmotions) {
-            const label = getEmotionLabel(name);
-            assert.notStrictEqual(label, name,
-                `Known emotion '${name}' should have a translated label`);
-            assert.ok(label.length > 0, `Label for '${name}' should not be empty`);
-        }
-    });
+// ─── Integration: full valid payload rendering ──────────────────────────────
+
+test('full valid payload renders correctly', () => {
+    const payload = {
+        schema_version: 1,
+        mood_label: 'ALEGRE/EXCITADA',
+        pad: { pleasure: 0.6, arousal: 0.7, dominance: 0.2 },
+        dominant_emotions: [
+            { name: 'joy', intensity: 0.9 },
+            { name: 'trust', intensity: 0.6 },
+        ],
+        timestamp: 1700000000,
+    };
+    const html = renderPanel({ emotionState: payload });
+    assert.ok(html.includes('ALEGRE/EXCITADA'), 'Should render mood label');
+    assert.ok(html.includes('Alegria 90%'), 'Should render joy');
+    assert.ok(html.includes('Confiança 60%'), 'Should render trust');
+    assert.ok(html.includes('role="progressbar"'), 'Should have progress bars');
 });

--- a/frontend/tests/emotionPanelVerification.test.js
+++ b/frontend/tests/emotionPanelVerification.test.js
@@ -1,0 +1,134 @@
+/* global process */
+process.env.NODE_ENV = 'test';
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync, existsSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(__dirname, '..');
+const EMOTION_PANEL_PATH = resolve(PROJECT_ROOT, 'src/features/chat/components/EmotionPanel.jsx');
+const USE_CHAT_PATH = resolve(PROJECT_ROOT, 'src/features/chat/hooks/useChat.js');
+
+// Verify the files exist before reading
+if (!existsSync(EMOTION_PANEL_PATH)) {
+    throw new Error(`EmotionPanel file not found at: ${EMOTION_PANEL_PATH}`);
+}
+if (!existsSync(USE_CHAT_PATH)) {
+    throw new Error(`useChat file not found at: ${USE_CHAT_PATH}`);
+}
+
+const emotionPanelSource = readFileSync(EMOTION_PANEL_PATH, 'utf-8');
+const useChatSource = readFileSync(USE_CHAT_PATH, 'utf-8');
+
+// ─── Verify EmotionPanel doesn't reference forbidden fields ─────────────────
+
+test('EmotionPanel does not reference acting_instruction', () => {
+    const hasActingInstruction = emotionPanelSource.includes('acting_instruction');
+    assert.strictEqual(hasActingInstruction, false,
+        'EmotionPanel should not reference acting_instruction');
+});
+
+test('EmotionPanel does not reference coping_mode', () => {
+    const hasCopingMode = emotionPanelSource.includes('coping_mode');
+    assert.strictEqual(hasCopingMode, false,
+        'EmotionPanel should not reference coping_mode');
+});
+
+test('EmotionPanel does not reference libido', () => {
+    const hasLibido = emotionPanelSource.includes('libido');
+    assert.strictEqual(hasLibido, false,
+        'EmotionPanel should not reference libido');
+});
+
+test('EmotionPanel does not reference aggression', () => {
+    const hasAggression = emotionPanelSource.includes('aggression');
+    assert.strictEqual(hasAggression, false,
+        'EmotionPanel should not reference aggression');
+});
+
+test('EmotionPanel uses dominant_emotions array instead of flat fields', () => {
+    assert.ok(emotionPanelSource.includes('dominant_emotions'),
+        'EmotionPanel should reference dominant_emotions');
+    // The panel should read from dominant_emotions array, not flat fields like joy, sadness, etc.
+    const forbiddenTopLevelEmotions = [
+        'emotionState.joy', 'emotionState.sadness', 'emotionState.anger',
+        'emotionState.fear', 'emotionState.disgust',
+    ];
+    for (const field of forbiddenTopLevelEmotions) {
+        assert.strictEqual(emotionPanelSource.includes(field), false,
+            `EmotionPanel should not reference '${field}' directly`);
+    }
+});
+
+test('EmotionPanel reads PAD from nested pad object', () => {
+    assert.ok(emotionPanelSource.includes('pad[') || emotionPanelSource.includes('.pad.'),
+        'EmotionPanel should read PAD values from nested pad object');
+});
+
+test('EmotionPanel uses bipolarToPercent helper', () => {
+    assert.ok(emotionPanelSource.includes('bipolarToPercent'),
+        'EmotionPanel should use bipolarToPercent for PAD values');
+});
+
+test('EmotionPanel uses intensityToPercent helper', () => {
+    assert.ok(emotionPanelSource.includes('intensityToPercent'),
+        'EmotionPanel should use intensityToPercent for emotion intensities');
+});
+
+// ─── ARIA compliance ────────────────────────────────────────────────────────
+
+test('bipolarToPercent output is always between 0 and 100 (ARIA compliance)', () => {
+    // Dynamic import for ESM compatibility with Node 18
+    return import('../src/shared/utils/formatters.js').then(({ bipolarToPercent }) => {
+        const testValues = [-2, -1, -0.5, 0, 0.5, 1, 2, NaN, Infinity, -Infinity, null, undefined, 'string'];
+        for (const val of testValues) {
+            const result = bipolarToPercent(val);
+            assert.ok(result >= 0 && result <= 100,
+                `bipolarToPercent(${val}) = ${result} should be in [0, 100]`);
+        }
+    });
+});
+
+test('intensityToPercent output is always between 0 and 100 (ARIA compliance)', () => {
+    return import('../src/shared/utils/formatters.js').then(({ intensityToPercent }) => {
+        const testValues = [-1, -0.5, 0, 0.5, 1, 1.5, NaN, Infinity, -Infinity, null, undefined, 'string'];
+        for (const val of testValues) {
+            const result = intensityToPercent(val);
+            assert.ok(result >= 0 && result <= 100,
+                `intensityToPercent(${val}) = ${result} should be in [0, 100]`);
+        }
+    });
+});
+
+test('EmotionPanel has role="progressbar" ARIA attributes', () => {
+    assert.ok(emotionPanelSource.includes('role="progressbar"'),
+        'EmotionPanel should include role="progressbar"');
+    assert.ok(emotionPanelSource.includes('aria-valuenow'),
+        'EmotionPanel should include aria-valuenow');
+    assert.ok(emotionPanelSource.includes('aria-valuemin'),
+        'EmotionPanel should include aria-valuemin');
+    assert.ok(emotionPanelSource.includes('aria-valuemax="100"'),
+        'EmotionPanel should include aria-valuemax="100"');
+});
+
+// ─── useChat invalidation policy (Requirement 37) ──────────────────────────
+
+test('useChat calls validateEmotionState on every response', () => {
+    assert.ok(useChatSource.includes('validateEmotionState'),
+        'useChat should call validateEmotionState');
+});
+
+test('useChat sets null on invalid or missing emotion_state', () => {
+    // Check that emotion_state is ALWAYS validated (not conditionally)
+    // The validation result (null or validated) is always set
+    const hasAlwaysValidation = useChatSource.includes('const validated = validateEmotionState(data.emotion_state);\n            setEmotionState(validated);');
+    // Alternative: check that validateEmotionState and setEmotionState are used
+    // Without being guarded by an `if (data.emotion_state)` check
+    const guardedByIf = useChatSource.includes('if (data.emotion_state) {\n                const validated =');
+    assert.strictEqual(guardedByIf, false,
+        'useChat should not guard emotion_state validation with an if check - always validate');
+    assert.ok(useChatSource.includes('setEmotionState(validated)'),
+        'useChat should always set emotionState (even to null)');
+});

--- a/frontend/tests/emotionPanelVerification.test.js
+++ b/frontend/tests/emotionPanelVerification.test.js
@@ -77,10 +77,9 @@ test('EmotionPanel uses intensityToPercent helper', () => {
         'EmotionPanel should use intensityToPercent for emotion intensities');
 });
 
-// ─── ARIA compliance ────────────────────────────────────────────────────────
+// ─── Behavioral: formatter functions (ARIA compliance) ──────────────────────
 
 test('bipolarToPercent output is always between 0 and 100 (ARIA compliance)', () => {
-    // Dynamic import for ESM compatibility with Node 18
     return import('../src/shared/utils/formatters.js').then(({ bipolarToPercent }) => {
         const testValues = [-2, -1, -0.5, 0, 0.5, 1, 2, NaN, Infinity, -Infinity, null, undefined, 'string'];
         for (const val of testValues) {
@@ -113,22 +112,91 @@ test('EmotionPanel has role="progressbar" ARIA attributes', () => {
         'EmotionPanel should include aria-valuemax="100"');
 });
 
-// ─── useChat invalidation policy (Requirement 37) ──────────────────────────
+// ─── Behavioral: validateEmotionState integration tests ─────────────────────
 
-test('useChat calls validateEmotionState on every response', () => {
+test('validateEmotionState is called on every response (source inspection)', () => {
     assert.ok(useChatSource.includes('validateEmotionState'),
         'useChat should call validateEmotionState');
 });
 
-test('useChat sets null on invalid or missing emotion_state', () => {
+test('useChat always sets emotionState (even to null) on response', () => {
     // Check that emotion_state is ALWAYS validated (not conditionally)
-    // The validation result (null or validated) is always set
-    const hasAlwaysValidation = useChatSource.includes('const validated = validateEmotionState(data.emotion_state);\n            setEmotionState(validated);');
-    // Alternative: check that validateEmotionState and setEmotionState are used
-    // Without being guarded by an `if (data.emotion_state)` check
-    const guardedByIf = useChatSource.includes('if (data.emotion_state) {\n                const validated =');
+    const guardedByIf = useChatSource.includes('if (data.emotion_state) {');
     assert.strictEqual(guardedByIf, false,
         'useChat should not guard emotion_state validation with an if check - always validate');
     assert.ok(useChatSource.includes('setEmotionState(validated)'),
         'useChat should always set emotionState (even to null)');
+});
+
+// ─── Behavioral: validateEmotionState pure function (extracted hook logic) ──
+
+test('validateEmotionState rejects invalid payload — pure function test', () => {
+    return import('../src/shared/utils/formatters.js').then(({ validateEmotionState }) => {
+        // Known invalid cases
+        assert.strictEqual(validateEmotionState(null), null);
+        assert.strictEqual(validateEmotionState(undefined), null);
+        assert.strictEqual(validateEmotionState([]), null);
+        assert.strictEqual(validateEmotionState({}), null);
+
+        // Valid payload
+        const valid = {
+            schema_version: 1,
+            mood_label: 'NEUTRA',
+            pad: { pleasure: 0, arousal: 0, dominance: 0 },
+            dominant_emotions: [],
+            timestamp: 1700000000,
+        };
+        assert.notStrictEqual(validateEmotionState(valid), null);
+
+        // Invalid: missing emotion_state (simulating missing backend data)
+        assert.strictEqual(validateEmotionState(undefined), null,
+            'undefined payload should return null — panel cleared');
+    });
+});
+
+test('validateEmotionState with more than 3 emotions returns null', () => {
+    return import('../src/shared/utils/formatters.js').then(({ validateEmotionState }) => {
+        const payload = {
+            schema_version: 1,
+            mood_label: 'NEUTRA',
+            pad: { pleasure: 0, arousal: 0, dominance: 0 },
+            dominant_emotions: [
+                { name: 'joy', intensity: 0.8 },
+                { name: 'anger', intensity: 0.7 },
+                { name: 'fear', intensity: 0.6 },
+                { name: 'sadness', intensity: 0.5 },
+            ],
+            timestamp: 1700000000,
+        };
+        assert.strictEqual(validateEmotionState(payload), null,
+            '>3 emotions should reject entire payload');
+    });
+});
+
+test('validateEmotionState with unknown emotion name returns null', () => {
+    return import('../src/shared/utils/formatters.js').then(({ validateEmotionState }) => {
+        const payload = {
+            schema_version: 1,
+            mood_label: 'NEUTRA',
+            pad: { pleasure: 0, arousal: 0, dominance: 0 },
+            dominant_emotions: [{ name: 'invalid_emotion', intensity: 0.5 }],
+            timestamp: 1700000000,
+        };
+        assert.strictEqual(validateEmotionState(payload), null,
+            'unknown emotion name should reject entire payload');
+    });
+});
+
+test('EmotionPanel getEmotionLabel exposes canonical name for known emotion', () => {
+    return import('../src/shared/utils/formatters.js').then(({ getEmotionLabel, EMOTION_LABELS }) => {
+        // All defined emotions should have a display label
+        const knownEmotions = Object.keys(EMOTION_LABELS);
+        assert.ok(knownEmotions.length > 0, 'EMOTION_LABELS should have entries');
+        for (const name of knownEmotions) {
+            const label = getEmotionLabel(name);
+            assert.notStrictEqual(label, name,
+                `Known emotion '${name}' should have a translated label`);
+            assert.ok(label.length > 0, `Label for '${name}' should not be empty`);
+        }
+    });
 });

--- a/frontend/tests/emotionPanelVerification.test.jsx
+++ b/frontend/tests/emotionPanelVerification.test.jsx
@@ -1,6 +1,6 @@
 /* global process */
 process.env.NODE_ENV = 'test';
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';

--- a/frontend/tests/formatters.test.js
+++ b/frontend/tests/formatters.test.js
@@ -1,0 +1,293 @@
+/* global process */
+process.env.NODE_ENV = 'test';
+import { test } from 'node:test';
+import assert from 'node:assert';
+import {
+    bipolarToPercent,
+    intensityToPercent,
+    validateEmotionState,
+    getEmotionLabel,
+} from '../src/shared/utils/formatters.js';
+
+// ─── bipolarToPercent ───────────────────────────────────────────────────────
+
+test('bipolarToPercent: -1 → 0', () => {
+    assert.strictEqual(bipolarToPercent(-1), 0);
+});
+
+test('bipolarToPercent: 0 → 50', () => {
+    assert.strictEqual(bipolarToPercent(0), 50);
+});
+
+test('bipolarToPercent: 1 → 100', () => {
+    assert.strictEqual(bipolarToPercent(1), 100);
+});
+
+test('bipolarToPercent: 0.5 → 75', () => {
+    assert.strictEqual(bipolarToPercent(0.5), 75);
+});
+
+test('bipolarToPercent: -0.5 → 25', () => {
+    assert.strictEqual(bipolarToPercent(-0.5), 25);
+});
+
+test('bipolarToPercent: clamp below -1', () => {
+    assert.strictEqual(bipolarToPercent(-2), 0);
+});
+
+test('bipolarToPercent: clamp above 1', () => {
+    assert.strictEqual(bipolarToPercent(2), 100);
+});
+
+test('bipolarToPercent: NaN returns 50', () => {
+    assert.strictEqual(bipolarToPercent(NaN), 50);
+});
+
+test('bipolarToPercent: Infinity returns 50', () => {
+    assert.strictEqual(bipolarToPercent(Infinity), 50);
+});
+
+test('bipolarToPercent: -Infinity returns 50', () => {
+    assert.strictEqual(bipolarToPercent(-Infinity), 50);
+});
+
+test('bipolarToPercent: string returns 50', () => {
+    assert.strictEqual(bipolarToPercent('0.5'), 50);
+});
+
+test('bipolarToPercent: null returns 50', () => {
+    assert.strictEqual(bipolarToPercent(null), 50);
+});
+
+test('bipolarToPercent: undefined returns 50', () => {
+    assert.strictEqual(bipolarToPercent(undefined), 50);
+});
+
+// ─── intensityToPercent ─────────────────────────────────────────────────────
+
+test('intensityToPercent: 0 → 0', () => {
+    assert.strictEqual(intensityToPercent(0), 0);
+});
+
+test('intensityToPercent: 0.5 → 50', () => {
+    assert.strictEqual(intensityToPercent(0.5), 50);
+});
+
+test('intensityToPercent: 1 → 100', () => {
+    assert.strictEqual(intensityToPercent(1), 100);
+});
+
+test('intensityToPercent: 0.25 → 25', () => {
+    assert.strictEqual(intensityToPercent(0.25), 25);
+});
+
+test('intensityToPercent: clamp below 0', () => {
+    assert.strictEqual(intensityToPercent(-0.5), 0);
+});
+
+test('intensityToPercent: clamp above 1', () => {
+    assert.strictEqual(intensityToPercent(1.5), 100);
+});
+
+test('intensityToPercent: NaN returns 0', () => {
+    assert.strictEqual(intensityToPercent(NaN), 0);
+});
+
+test('intensityToPercent: Infinity returns 0', () => {
+    assert.strictEqual(intensityToPercent(Infinity), 0);
+});
+
+test('intensityToPercent: null returns 0', () => {
+    assert.strictEqual(intensityToPercent(null), 0);
+});
+
+// ─── validateEmotionState ───────────────────────────────────────────────────
+
+test('validateEmotionState: valid payload returns validated', () => {
+    const payload = {
+        schema_version: 1,
+        mood_label: 'ALEGRE',
+        pad: { pleasure: 0.5, arousal: 0.3, dominance: -0.2 },
+        dominant_emotions: [{ name: 'joy', intensity: 0.8 }],
+        timestamp: 1700000000,
+    };
+    const result = validateEmotionState(payload);
+    assert(result !== null);
+    assert.strictEqual(result.mood_label, 'ALEGRE');
+    assert.strictEqual(result.pad.pleasure, 0.5);
+    assert.strictEqual(result.dominant_emotions.length, 1);
+});
+
+test('validateEmotionState: null payload returns null', () => {
+    assert.strictEqual(validateEmotionState(null), null);
+});
+
+test('validateEmotionState: undefined returns null', () => {
+    assert.strictEqual(validateEmotionState(undefined), null);
+});
+
+test('validateEmotionState: array returns null', () => {
+    assert.strictEqual(validateEmotionState([]), null);
+});
+
+test('validateEmotionState: schema_version absent returns null', () => {
+    const payload = {
+        mood_label: 'NEUTRA',
+        pad: { pleasure: 0, arousal: 0, dominance: 0 },
+        dominant_emotions: [],
+        timestamp: 1700000000,
+    };
+    assert.strictEqual(validateEmotionState(payload), null);
+});
+
+test('validateEmotionState: schema_version != 1 returns null', () => {
+    const payload = {
+        schema_version: 2,
+        mood_label: 'NEUTRA',
+        pad: { pleasure: 0, arousal: 0, dominance: 0 },
+        dominant_emotions: [],
+        timestamp: 1700000000,
+    };
+    assert.strictEqual(validateEmotionState(payload), null);
+});
+
+test('validateEmotionState: pad absent returns null', () => {
+    const payload = {
+        schema_version: 1,
+        mood_label: 'NEUTRA',
+        dominant_emotions: [],
+        timestamp: 1700000000,
+    };
+    assert.strictEqual(validateEmotionState(payload), null);
+});
+
+test('validateEmotionState: pad with NaN returns null', () => {
+    const payload = {
+        schema_version: 1,
+        mood_label: 'NEUTRA',
+        pad: { pleasure: NaN, arousal: 0, dominance: 0 },
+        dominant_emotions: [],
+        timestamp: 1700000000,
+    };
+    assert.strictEqual(validateEmotionState(payload), null);
+});
+
+test('validateEmotionState: pad with Infinity returns null', () => {
+    const payload = {
+        schema_version: 1,
+        mood_label: 'NEUTRA',
+        pad: { pleasure: 0, arousal: Infinity, dominance: 0 },
+        dominant_emotions: [],
+        timestamp: 1700000000,
+    };
+    assert.strictEqual(validateEmotionState(payload), null);
+});
+
+test('validateEmotionState: dominant_emotions absent returns null', () => {
+    const payload = {
+        schema_version: 1,
+        mood_label: 'NEUTRA',
+        pad: { pleasure: 0, arousal: 0, dominance: 0 },
+        timestamp: 1700000000,
+    };
+    assert.strictEqual(validateEmotionState(payload), null);
+});
+
+test('validateEmotionState: dominant_emotions not array returns null', () => {
+    const payload = {
+        schema_version: 1,
+        mood_label: 'NEUTRA',
+        pad: { pleasure: 0, arousal: 0, dominance: 0 },
+        dominant_emotions: 'invalid',
+        timestamp: 1700000000,
+    };
+    assert.strictEqual(validateEmotionState(payload), null);
+});
+
+test('validateEmotionState: empty dominant_emotions works', () => {
+    const payload = {
+        schema_version: 1,
+        mood_label: 'NEUTRA',
+        pad: { pleasure: 0, arousal: 0, dominance: 0 },
+        dominant_emotions: [],
+        timestamp: 1700000000,
+    };
+    const result = validateEmotionState(payload);
+    assert(result !== null);
+    assert.deepStrictEqual(result.dominant_emotions, []);
+});
+
+// ─── validateEmotionState: item-level dominant_emotions validation ─────────
+
+test('validateEmotionState: dominant_emotion with NaN intensity returns null', () => {
+    const payload = {
+        schema_version: 1,
+        mood_label: 'NEUTRA',
+        pad: { pleasure: 0, arousal: 0, dominance: 0 },
+        dominant_emotions: [{ name: 'joy', intensity: NaN }],
+        timestamp: 1700000000,
+    };
+    assert.strictEqual(validateEmotionState(payload), null);
+});
+
+test('validateEmotionState: dominant_emotion with missing name returns null', () => {
+    const payload = {
+        schema_version: 1,
+        mood_label: 'NEUTRA',
+        pad: { pleasure: 0, arousal: 0, dominance: 0 },
+        dominant_emotions: [{ intensity: 0.5 }],
+        timestamp: 1700000000,
+    };
+    assert.strictEqual(validateEmotionState(payload), null);
+});
+
+test('validateEmotionState: dominant_emotion with empty name returns null', () => {
+    const payload = {
+        schema_version: 1,
+        mood_label: 'NEUTRA',
+        pad: { pleasure: 0, arousal: 0, dominance: 0 },
+        dominant_emotions: [{ name: '', intensity: 0.5 }],
+        timestamp: 1700000000,
+    };
+    assert.strictEqual(validateEmotionState(payload), null);
+});
+
+test('validateEmotionState: dominant_emotion with non-finite intensity returns null', () => {
+    const payload = {
+        schema_version: 1,
+        mood_label: 'NEUTRA',
+        pad: { pleasure: 0, arousal: 0, dominance: 0 },
+        dominant_emotions: [{ name: 'joy', intensity: Infinity }],
+        timestamp: 1700000000,
+    };
+    assert.strictEqual(validateEmotionState(payload), null);
+});
+
+test('validateEmotionState: dominant_emotion item not an object returns null', () => {
+    const payload = {
+        schema_version: 1,
+        mood_label: 'NEUTRA',
+        pad: { pleasure: 0, arousal: 0, dominance: 0 },
+        dominant_emotions: ['invalid'],
+        timestamp: 1700000000,
+    };
+    assert.strictEqual(validateEmotionState(payload), null);
+});
+
+// ─── getEmotionLabel ────────────────────────────────────────────────────────
+
+test('getEmotionLabel: known emotion returns label', () => {
+    assert.strictEqual(getEmotionLabel('joy'), 'Alegria');
+});
+
+test('getEmotionLabel: another known emotion', () => {
+    assert.strictEqual(getEmotionLabel('anger'), 'Raiva');
+});
+
+test('getEmotionLabel: unknown emotion falls back to name', () => {
+    assert.strictEqual(getEmotionLabel('unknown_emotion'), 'unknown_emotion');
+});
+
+test('getEmotionLabel: empty string', () => {
+    assert.strictEqual(getEmotionLabel(''), '');
+});

--- a/frontend/tests/formatters.test.js
+++ b/frontend/tests/formatters.test.js
@@ -103,19 +103,21 @@ test('intensityToPercent: null returns 0', () => {
 
 // ─── validateEmotionState ───────────────────────────────────────────────────
 
+const VALID_PAYLOAD = {
+    schema_version: 1,
+    mood_label: 'ALEGRE',
+    pad: { pleasure: 0.5, arousal: 0.3, dominance: -0.2 },
+    dominant_emotions: [{ name: 'joy', intensity: 0.8 }],
+    timestamp: 1700000000,
+};
+
 test('validateEmotionState: valid payload returns validated', () => {
-    const payload = {
-        schema_version: 1,
-        mood_label: 'ALEGRE',
-        pad: { pleasure: 0.5, arousal: 0.3, dominance: -0.2 },
-        dominant_emotions: [{ name: 'joy', intensity: 0.8 }],
-        timestamp: 1700000000,
-    };
-    const result = validateEmotionState(payload);
+    const result = validateEmotionState(VALID_PAYLOAD);
     assert(result !== null);
     assert.strictEqual(result.mood_label, 'ALEGRE');
     assert.strictEqual(result.pad.pleasure, 0.5);
     assert.strictEqual(result.dominant_emotions.length, 1);
+    assert.strictEqual(result.schema_version, 1);
 });
 
 test('validateEmotionState: null payload returns null', () => {
@@ -272,6 +274,82 @@ test('validateEmotionState: dominant_emotion item not an object returns null', (
         timestamp: 1700000000,
     };
     assert.strictEqual(validateEmotionState(payload), null);
+});
+
+// ─── validateEmotionState: contract enforcement — limit, names, duplicates ────
+
+test('validateEmotionState: more than 3 emotions returns null', () => {
+    const payload = {
+        ...VALID_PAYLOAD,
+        dominant_emotions: [
+            { name: 'joy', intensity: 0.9 },
+            { name: 'anger', intensity: 0.8 },
+            { name: 'sadness', intensity: 0.7 },
+            { name: 'fear', intensity: 0.6 },
+        ],
+    };
+    assert.strictEqual(validateEmotionState(payload), null);
+});
+
+test('validateEmotionState: exactly 3 emotions passes', () => {
+    const payload = {
+        ...VALID_PAYLOAD,
+        dominant_emotions: [
+            { name: 'joy', intensity: 0.9 },
+            { name: 'anger', intensity: 0.8 },
+            { name: 'sadness', intensity: 0.7 },
+        ],
+    };
+    const result = validateEmotionState(payload);
+    assert(result !== null);
+    assert.strictEqual(result.dominant_emotions.length, 3);
+});
+
+test('validateEmotionState: unknown emotion name returns null', () => {
+    const payload = {
+        ...VALID_PAYLOAD,
+        dominant_emotions: [{ name: 'invalid_emotion', intensity: 0.5 }],
+    };
+    assert.strictEqual(validateEmotionState(payload), null);
+});
+
+test('validateEmotionState: duplicate emotion names returns null', () => {
+    const payload = {
+        ...VALID_PAYLOAD,
+        dominant_emotions: [
+            { name: 'joy', intensity: 0.9 },
+            { name: 'joy', intensity: 0.8 },
+        ],
+    };
+    assert.strictEqual(validateEmotionState(payload), null);
+});
+
+test('validateEmotionState: schema_version preserved in result', () => {
+    const result = validateEmotionState(VALID_PAYLOAD);
+    assert(result !== null);
+    assert.strictEqual(result.schema_version, 1);
+});
+
+// ─── validateEmotionState: canonical emotion names accepted ─────────────────
+
+test('validateEmotionState: all canonical names accepted', () => {
+    const payload = {
+        ...VALID_PAYLOAD,
+        dominant_emotions: [
+            { name: 'joy', intensity: 0.5 },
+            { name: 'trust', intensity: 0.4 },
+            { name: 'gratitude', intensity: 0.3 },
+        ],
+    };
+    assert(validateEmotionState(payload) !== null);
+});
+
+test('validateEmotionState: zero emotions with canonical empty list passes', () => {
+    const payload = {
+        ...VALID_PAYLOAD,
+        dominant_emotions: [],
+    };
+    assert(validateEmotionState(payload) !== null);
 });
 
 // ─── getEmotionLabel ────────────────────────────────────────────────────────

--- a/frontend/tests/formatters.test.js
+++ b/frontend/tests/formatters.test.js
@@ -324,12 +324,6 @@ test('validateEmotionState: duplicate emotion names returns null', () => {
     assert.strictEqual(validateEmotionState(payload), null);
 });
 
-test('validateEmotionState: schema_version preserved in result', () => {
-    const result = validateEmotionState(VALID_PAYLOAD);
-    assert(result !== null);
-    assert.strictEqual(result.schema_version, 1);
-});
-
 // ─── validateEmotionState: canonical emotion names accepted ─────────────────
 
 test('validateEmotionState: all canonical names accepted', () => {
@@ -362,10 +356,73 @@ test('getEmotionLabel: another known emotion', () => {
     assert.strictEqual(getEmotionLabel('anger'), 'Raiva');
 });
 
-test('getEmotionLabel: unknown emotion falls back to name', () => {
-    assert.strictEqual(getEmotionLabel('unknown_emotion'), 'unknown_emotion');
+test('getEmotionLabel: unknown emotion returns null', () => {
+    assert.strictEqual(getEmotionLabel('unknown_emotion'), null);
 });
 
-test('getEmotionLabel: empty string', () => {
-    assert.strictEqual(getEmotionLabel(''), '');
+test('getEmotionLabel: empty string returns null', () => {
+    assert.strictEqual(getEmotionLabel(''), null);
+});
+
+test('getEmotionLabel: null returns null', () => {
+    assert.strictEqual(getEmotionLabel(null), null);
+});
+
+test('getEmotionLabel: number returns null', () => {
+    assert.strictEqual(getEmotionLabel(42), null);
+});
+
+// ─── validateEmotionState: reference isolation (defensive copy) ──────────
+
+test('validateEmotionState does not share reference with original payload', () => {
+    const original = {
+        schema_version: 1,
+        mood_label: 'NEUTRA',
+        pad: { pleasure: 0, arousal: 0, dominance: 0 },
+        dominant_emotions: [{ name: 'joy', intensity: 0.8 }],
+        timestamp: 1700000000,
+    };
+    const result = validateEmotionState(original);
+    assert(result !== null);
+
+    // Modifying the original should not affect the result
+    original.dominant_emotions[0].name = 'anger';
+    original.dominant_emotions[0].intensity = 0.5;
+    original.dominant_emotions.push({ name: 'fear', intensity: 0.9 });
+
+    assert.strictEqual(result.dominant_emotions.length, 1);
+    assert.strictEqual(result.dominant_emotions[0].name, 'joy');
+    assert.strictEqual(result.dominant_emotions[0].intensity, 0.8);
+});
+
+test('validateEmotionState: schema_version preserved as 1 in result', () => {
+    const payload = {
+        schema_version: 1,
+        mood_label: 'NEUTRA',
+        pad: { pleasure: 0, arousal: 0, dominance: 0 },
+        dominant_emotions: [{ name: 'joy', intensity: 0.8 }],
+        timestamp: 1700000000,
+    };
+    const result = validateEmotionState(payload);
+    assert(result !== null);
+    assert.strictEqual(result.schema_version, 1);
+});
+
+test('validateEmotionState: clearing previous state from invalid response', () => {
+    // Simulate: previous state was valid, new response is invalid
+    const validResponse = {
+        schema_version: 1,
+        mood_label: 'NEUTRA',
+        pad: { pleasure: 0, arousal: 0, dominance: 0 },
+        dominant_emotions: [{ name: 'joy', intensity: 0.8 }],
+        timestamp: 1700000000,
+    };
+    const validated = validateEmotionState(validResponse);
+    assert(validated !== null);
+
+    // Now an invalid response comes in — should clear
+    assert.strictEqual(validateEmotionState(null), null);
+    assert.strictEqual(validateEmotionState(undefined), null);
+    assert.strictEqual(validateEmotionState({}), null);
+    assert.strictEqual(validateEmotionState({ schema_version: 2 }), null);
 });

--- a/frontend/vitest.config.mjs
+++ b/frontend/vitest.config.mjs
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
     plugins: [react()],
     test: {
-        include: ['tests/emotionPanelVerification.test.js'],
+        include: ['tests/**/*.test.jsx'],
         globals: true,
     },
 });

--- a/frontend/vitest.config.mjs
+++ b/frontend/vitest.config.mjs
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+    plugins: [react()],
+    test: {
+        include: ['tests/emotionPanelVerification.test.js'],
+        globals: true,
+    },
+});


### PR DESCRIPTION
Closes #208

## Problema

O backend enviava campos internos (libido, aggression, connection, energy, tension, coping_mode) no contrato público, e o frontend esperava um formato diferente com propriedades top-level (acting_instruction, discrete emotions como flat fields).

## Correções realizadas (HEAD 68f361e)

### 1. Classificador único compartilhado
`classify_pad_mood` é a única fonte de verdade para classificação PAD → mood label, usada tanto pelo DTO público quanto pelo `AffectiveEngine.get_emotional_label`. Removida duplicação anterior.

### 2. Contrato estrito do DTO (backend)
- `EmotionStateResponse` rejeita duplicatas em `dominant_emotions` pelo campo `name` (validação em construção direta, `model_validate` e `model_validate_json`).
- `project_public_emotion()` valida entradas explicitamente: `None` → `PresentationError`, tipo incorreto → `TypeError`. Nenhum `AttributeError` acidental escapa.
- Limite máximo de 3 emoções mantido.
- `schema_version: 1` obrigatório.
- `extra="forbid"` em todos os modelos aninhados.
- `ChatResponse.emotion_state` tipado como `EmotionStateResponse`, não `dict`.

### 3. Validação frontend final
- `validateEmotionState()` retorna cópia normalizada de `dominant_emotions` (deep clone — mutações no payload original não afetam o resultado validado).
- `schema_version: 1` preservado no retorno.
- Nomes desconhecidos, duplicatas e listas > 3 rejeitados.
- `getEmotionLabel()` retorna `null` para nomes não canônicos (nunca texto bruto do payload).
- `EmotionPanel` limita defensivamente a 3 emoções via `.slice(0, 3)` e ignora itens sem rótulo canônico reconhecido.

### 4. Testes comportamentais por renderização
Testes do `EmotionPanel` substituíram `readFileSync`/`source.includes` por `renderToStaticMarkup()` (`react-dom/server`), verificando:
- Payload `null` não renderiza o painel.
- Lista vazia renderiza PAD sem badges.
- PAD `-1`, `0`, `1` produz `0`, `50`, `100`.
- Progress bars com `role="progressbar"`, `aria-valuemin="0"`, `aria-valuemax="100"`, `aria-valuenow` correto, associadas a nomes acessíveis.
- Larguras nunca abaixo de `0%` ou acima de `100%`.
- Emoções na ordem recebida.
- Máximo 3 emoções renderizadas.
- Nome desconhecido não aparece no HTML.
- `acting_instruction`, `coping_mode`, `libido`, `aggression` não aparecem no HTML.
- Intensidades `0..1` → `0..100`.

### 5. Separação dos runners de teste
Para evitar que o Node colete o arquivo JSX:
- Renomeado `emotionPanelVerification.test.js` → `.test.jsx`
- `vitest.config.mjs` configurado para coletar `tests/**/*.test.jsx`
- Teste de componente importa `{ test }` do `vitest` (não `node:test`)
- Scripts `package.json` separados: `test:node` (node --test, glob *.test.js), `test:component` (vitest), `test` (unificado sequencial)

### 6. Testes do hook
`validateEmotionState()` é a função pura extraída, utilizada de fato pelo `useChat`. Testada diretamente para:
- Payload válido.
- Payload ausente/null/undefined.
- Versão desconhecida.
- Payload malformado.
- Limpeza de estado anterior quando resposta mais recente é inválida.
- Isolamento de referência (deep copy validado).

### 7. Testes backend fortalecidos
- Duplicatas rejeitadas na construção direta, `model_validate` e JSON.
- `project_public_emotion()` testada com `None`, tipo incorreto, e confirmação de que `AttributeError` não escapa.
- `ChatResponse.model_fields["emotion_state"]` verifica que o campo aponta para `EmotionStateResponse`.

## Arquivos alterados

- `backend/emotion_presentation.py` — validação de duplicatas, validação de entrada em `project_public_emotion`, `PresentationError`
- `backend/tests/test_emotion_presentation.py` — 193 linhas de novos testes (duplicatas, validação de entrada, tipo do campo ChatResponse)
- `frontend/src/shared/utils/formatters.js` — deep clone em `validateEmotionState`, `getEmotionLabel` retorna `null` para desconhecidos
- `frontend/src/features/chat/components/EmotionPanel.jsx` — slice defensivo a 3, ignora labels nulos
- `frontend/tests/emotionPanelVerification.test.jsx` — reescrito com `renderToStaticMarkup`, importa `{ test }` do `vitest`
- `frontend/tests/formatters.test.js` — testes de isolação de referência, limpeza de estado, `getEmotionLabel` null
- `frontend/vitest.config.mjs` — configuração para testes JSX com vitest
- `frontend/package.json` — scripts separados (`test:node`, `test:component`)

## Testes executados

- **Backend:** 86/86 testes passando (`pytest`)
- **Frontend node runner:** 70/70 testes passando (`npm run test:node` — `formatters.test.js`, `apiClient.test.js`, `audit-validator.test.js`)
- **Frontend vitest:** 24/24 testes passando (`npm run test:component` — `emotionPanelVerification.test.jsx`)
- **Total: 180 testes, 0 falhas**

## Riscos e rollback

- Sem quebra de contrato com frontend — `EmotionStateResponse` mantém mesmos campos.
- Validação mais restritiva no backend (duplicatas rejeitadas) é segura pois `project_public_emotion` nunca produz duplicatas.
- Mudança no `getEmotionLabel` de fallback `name` para `null` é segura: `EmotionPanel` já trata `null` como skip.
- Rollback: `git revert 68f361e` restaura estado anterior.
