### PR TITLE
feat(admission): add pure request and input budget contracts

### DIFF
--- a/backend/admission_contracts.py
+++ b/backend/admission_contracts.py
@@ -24,7 +24,8 @@ Usage::
         AdmissionConfig,
     )
 
-    identity = RequestIdentity.parse("550e8400-e29b-41d4-a716-446655440000")
+    identity = RequestIdentity("550e8400-e29b-41d4-a716-446655440000")
+    identity = RequestIdentity.parse("550E8400-E29B-41D4-A716-446655440000")
     units = estimate_text_units("Hello, world!")
     validate_new_message("Hello!")   # raises AdmissionError on failure
 """
@@ -176,35 +177,55 @@ def _validate_canonical_uuid(raw: str) -> str:
     return normalized
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class RequestIdentity:
     """Immutable, validated request identity.
 
-    The ``.request_id`` attribute holds the normalised canonical UUID string
-    (lowercase, with hyphens).  No UUID is generated automatically, and
+    Every instance is guaranteed to hold a validated, normalised canonical
+    UUID string — it is **impossible** to construct an invalid identity,
+    whether via the direct constructor or via ``.parse()``.
+
+    The ``.request_id`` attribute holds the normalised lowercase form
+    (8-4-4-4-12 with hyphens).  No UUID is generated automatically, and
     the identity is not associated with any user.
+
+    Because ``init=False``, there is no auto-generated ``__init__``; the
+    custom ``__init__`` validates before the attribute is stored, so an
+    invalid input can never leak into ``str()``, ``repr()``, or any public
+    attribute of a constructed instance.
 
     Usage::
 
-        identity = RequestIdentity.parse("550e8400-e29b-41d4-a716-446655440000")
+        identity = RequestIdentity("550e8400-e29b-41d4-a716-446655440000")
+        identity = RequestIdentity.parse("550E8400-E29B-41D4-A716-446655440000")
         assert identity.request_id == "550e8400-e29b-41d4-a716-446655440000"
     """
 
     request_id: str
 
-    @staticmethod
-    def parse(raw: str) -> RequestIdentity:
-        """Parse and validate a request ID from a raw string.
+    def __init__(self, raw: str) -> None:
+        """Construct and validate a request identity.
 
-        Raises ``AdmissionError(code="invalid_request_id")`` if the value
-        is not a valid canonical UUID.  The invalid value is **never**
-        exposed in the exception, its ``str()``, ``repr()``, or any public
-        attribute.
+        Raises ``AdmissionError(code="invalid_request_id")`` if *raw* is
+        not a valid canonical UUID.  The invalid input is **never** exposed
+        in the exception, its ``str()``, ``repr()``, or any public attribute.
         """
         if not isinstance(raw, str):
             raise AdmissionError(code="invalid_request_id")
         normalized = _validate_canonical_uuid(raw)
-        return RequestIdentity(request_id=normalized)
+        # Frozen dataclass requires object.__setattr__ for direct field writes.
+        object.__setattr__(self, "request_id", normalized)
+
+    @staticmethod
+    def parse(raw: str) -> RequestIdentity:
+        """Parse and validate a request ID from a raw string.
+
+        This is a named alternative to the direct constructor.  Both paths
+        enforce the identical invariant::
+
+            RequestIdentity.parse(s) == RequestIdentity(s)
+        """
+        return RequestIdentity(raw)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/admission_contracts.py
+++ b/backend/admission_contracts.py
@@ -1,0 +1,267 @@
+"""
+Pure admission contracts for request identity, input estimation, and message validation.
+
+This module is the single source of truth for admission limits and provides
+pure, I/O-free validation functions.  It uses only the Python standard library
+and must be importable without:
+
+- FastAPI
+- Pydantic
+- Groq SDK
+- Supabase / PostgREST
+- sentence_transformers
+- ConversationEngine, memory, or engine
+- environment variables
+- network or filesystem access
+- clock or randomness
+
+Usage::
+
+    from backend.admission_contracts import (
+        RequestIdentity,
+        estimate_text_units,
+        validate_new_message,
+        AdmissionConfig,
+    )
+
+    identity = RequestIdentity.parse("550e8400-e29b-41d4-a716-446655440000")
+    units = estimate_text_units("Hello, world!")
+    validate_new_message("Hello!")   # raises AdmissionError on failure
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+# ---------------------------------------------------------------------------
+# Constants — single source of truth for admission limits               #285
+# ---------------------------------------------------------------------------
+
+NEW_MESSAGE_MAX_CHARS = 4000
+"""Maximum character count for a single new user message."""
+
+LEGACY_HISTORY_MAX_CHARS = 10000
+"""Maximum character count for legacy history (from ``backend/memory.py``).
+Not altered here — preserved as a separate contract."""
+
+MESSAGE_MAX_ESTIMATED_UNITS = 6000
+"""Maximum estimated input units for a single new user message."""
+
+PROVIDER_INPUT_MAX_ESTIMATED_UNITS = 16000
+"""Maximum estimated input units for the full provider call (reserved)."""
+
+USER_REQUESTS_PER_MINUTE = 20
+"""Maximum user requests per minute (reserved)."""
+
+NETWORK_REQUESTS_PER_MINUTE = 60
+"""Maximum network-level requests per minute (reserved)."""
+
+APPLICATION_REQUESTS_PER_MINUTE = 25
+"""Maximum application-level requests per minute (reserved)."""
+
+USER_REQUESTS_PER_DAY = 200
+"""Maximum user requests per calendar day (reserved)."""
+
+USER_ESTIMATED_UNITS_PER_DAY = 250000
+"""Maximum estimated input units per user per day (reserved)."""
+
+
+@dataclass(frozen=True)
+class AdmissionConfig:
+    """Immutable, user-independent admission configuration.
+
+    All attributes are frozen at runtime.  No mutable state, no environment
+    fallback, no per-user overrides.
+    """
+
+    new_message_max_chars: int = NEW_MESSAGE_MAX_CHARS
+    legacy_history_max_chars: int = LEGACY_HISTORY_MAX_CHARS
+    message_max_estimated_units: int = MESSAGE_MAX_ESTIMATED_UNITS
+    provider_input_max_estimated_units: int = PROVIDER_INPUT_MAX_ESTIMATED_UNITS
+
+    user_requests_per_minute: int = USER_REQUESTS_PER_MINUTE
+    network_requests_per_minute: int = NETWORK_REQUESTS_PER_MINUTE
+    application_requests_per_minute: int = APPLICATION_REQUESTS_PER_MINUTE
+    user_requests_per_day: int = USER_REQUESTS_PER_DAY
+    user_estimated_units_per_day: int = USER_ESTIMATED_UNITS_PER_DAY
+
+
+# ---------------------------------------------------------------------------
+# Typed errors
+# ---------------------------------------------------------------------------
+
+class AdmissionError(Exception):
+    """Validation failure for admission contracts.
+
+    Carries only structured fields — never exposes raw content, UUIDs, users,
+    or IP addresses in ``str()``, ``repr()``, or public attributes.
+    """
+
+    def __init__(
+        self,
+        code: str,
+        *,
+        actual_chars: int = 0,
+        actual_units: int = 0,
+        max_chars: int = 0,
+        max_units: int = 0,
+    ) -> None:
+        self.code = code
+        self.actual_chars = actual_chars
+        self.actual_units = actual_units
+        self.max_chars = max_chars
+        self.max_units = max_units
+        super().__init__(code)
+
+    def __str__(self) -> str:
+        return self.code
+
+    def __repr__(self) -> str:
+        return f"AdmissionError(code={self.code!r})"
+
+
+# ---------------------------------------------------------------------------
+# Request identity
+# ---------------------------------------------------------------------------
+
+def _is_hex(s: str) -> bool:
+    """Return ``True`` if *s* contains only ASCII hex digits ``[0-9a-f]``."""
+    for ch in s:
+        if ch not in "0123456789abcdef":
+            return False
+    return True
+
+
+def _validate_canonical_uuid(raw: str) -> str:
+    """Validate and normalise a canonical UUID string.
+
+    Returns the lowercased canonical form on success.
+    Raises ``AdmissionError(code="invalid_request_id")`` on any failure.
+    The invalid input is never exposed in the exception.
+    """
+    # Must be exactly 36 characters (8-4-4-4-12 with hyphens)
+    if len(raw) != 36:
+        raise AdmissionError(code="invalid_request_id")
+
+    # No leading / trailing whitespace
+    if raw != raw.strip():
+        raise AdmissionError(code="invalid_request_id")
+
+    # Reject {uuid} format (e.g. ``{550e8400-...}``)
+    if raw.startswith("{") or raw.endswith("}"):
+        raise AdmissionError(code="invalid_request_id")
+
+    # Reject ``urn:uuid:...`` prefix
+    if raw.lower().startswith("urn:"):
+        raise AdmissionError(code="invalid_request_id")
+
+    # Split into 5 hyphen-separated parts
+    parts = raw.split("-")
+    if len(parts) != 5:
+        raise AdmissionError(code="invalid_request_id")
+
+    # Lengths must be 8-4-4-4-12
+    expected_lengths = (8, 4, 4, 4, 12)
+    for part, expected in zip(parts, expected_lengths):
+        if len(part) != expected:
+            raise AdmissionError(code="invalid_request_id")
+
+    # Normalise to lowercase and verify hex
+    normalized = raw.lower()
+    for part in normalized.split("-"):
+        if not _is_hex(part):
+            raise AdmissionError(code="invalid_request_id")
+
+    return normalized
+
+
+@dataclass(frozen=True)
+class RequestIdentity:
+    """Immutable, validated request identity.
+
+    The ``.request_id`` attribute holds the normalised canonical UUID string
+    (lowercase, with hyphens).  No UUID is generated automatically, and
+    the identity is not associated with any user.
+
+    Usage::
+
+        identity = RequestIdentity.parse("550e8400-e29b-41d4-a716-446655440000")
+        assert identity.request_id == "550e8400-e29b-41d4-a716-446655440000"
+    """
+
+    request_id: str
+
+    @staticmethod
+    def parse(raw: str) -> RequestIdentity:
+        """Parse and validate a request ID from a raw string.
+
+        Raises ``AdmissionError(code="invalid_request_id")`` if the value
+        is not a valid canonical UUID.  The invalid value is **never**
+        exposed in the exception, its ``str()``, ``repr()``, or any public
+        attribute.
+        """
+        if not isinstance(raw, str):
+            raise AdmissionError(code="invalid_request_id")
+        normalized = _validate_canonical_uuid(raw)
+        return RequestIdentity(request_id=normalized)
+
+
+# ---------------------------------------------------------------------------
+# Input estimation
+# ---------------------------------------------------------------------------
+
+def estimate_text_units(text: str) -> int:
+    """Estimate the input cost of *text* as the number of UTF-8 bytes.
+
+    Returns at least ``1`` for any input (including empty strings).
+    Does **not** truncate, normalise Unicode, log, call external services,
+    or accept non-string types.
+
+    Raises ``TypeError`` for non-string arguments.
+    """
+    if not isinstance(text, str):
+        raise TypeError("estimate_text_units expects a str")
+    return max(1, len(text.encode("utf-8")))
+
+
+# ---------------------------------------------------------------------------
+# Message validation
+# ---------------------------------------------------------------------------
+
+def validate_new_message(text: str) -> None:
+    """Validate a new user message against character and unit limits.
+
+    Precedence (deterministic):
+
+    1. Invalid type or ``len(text) > NEW_MESSAGE_MAX_CHARS`` →
+       ``AdmissionError(code="message_too_long")``.
+    2. ``estimate_text_units(text) > MESSAGE_MAX_ESTIMATED_UNITS`` →
+       ``AdmissionError(code="message_budget_exceeded")``.
+
+    Raises ``AdmissionError`` on failure; returns ``None`` on success.
+    """
+    if not isinstance(text, str):
+        raise AdmissionError(
+            code="message_too_long",
+            actual_chars=0,
+            max_chars=NEW_MESSAGE_MAX_CHARS,
+        )
+
+    char_count = len(text)
+    if char_count > NEW_MESSAGE_MAX_CHARS:
+        raise AdmissionError(
+            code="message_too_long",
+            actual_chars=char_count,
+            max_chars=NEW_MESSAGE_MAX_CHARS,
+        )
+
+    unit_count = estimate_text_units(text)
+    if unit_count > MESSAGE_MAX_ESTIMATED_UNITS:
+        raise AdmissionError(
+            code="message_budget_exceeded",
+            actual_chars=char_count,
+            actual_units=unit_count,
+            max_chars=NEW_MESSAGE_MAX_CHARS,
+            max_units=MESSAGE_MAX_ESTIMATED_UNITS,
+        )

--- a/backend/tests/test_admission_contracts.py
+++ b/backend/tests/test_admission_contracts.py
@@ -23,6 +23,16 @@ Covers (1–20):
 18. ≤ 4 000 chars but > 6 000 bytes rejected with ``message_budget_exceeded``
 19. Content and invalid UUID absent from ``str(exc)``, ``repr(exc)``, public attributes
 20. No shared mutable state
+
+Additional coverage for code-review corrections:
+
+21. Direct constructor with valid lowercase UUID
+22. Direct constructor with valid uppercase UUID (normalised)
+23. Direct constructor with invalid UUID
+24. Direct constructor with no-hyphens format
+25. ``parse()`` and constructor produce equivalent objects
+26. Impossible to mutate after construction
+27. Real purity test with env, socket, import guards before import
 """
 
 import subprocess
@@ -51,24 +61,81 @@ from backend.admission_contracts import (
 
 
 # ═══════════════════════════════════════════════════════════════════════
-# 1. Pure importability
+# 1. Pure importability  (code-review correction: real purity guards)
 # ═══════════════════════════════════════════════════════════════════════
 
 class TestImportability:
-    """Import the module in an isolated subprocess and verify no heavy
-    dependencies are pulled in."""
+    """Import module in a subprocess with env, socket, and import hooks
+    that **fail** if the module touches forbidden resources."""
 
-    HEAVY_DEPS = {"fastapi", "groq", "supabase", "sentence_transformers", "pydantic"}
-
-    @staticmethod
-    def _check_script() -> str:
-        dep_names = ", ".join(repr(d) for d in TestImportability.HEAVY_DEPS)
-        return f"""
+    # NOTE: single-quote outer delimiter to avoid conflict with inner
+    #       triple-double-quote docstrings in the generated script.
+    _PURITY_SCRIPT = '''
 import sys
+
+# -- Pre-import ONLY stdlib needed for guards --------------------------
+import os as _os
+import socket as _socket
+
+# -- Guard 1: os.environ raises on any read ---------------------------
+class _FailEnv:
+    """Mapping proxy that fails on every read operation."""
+    def __getitem__(self, key):
+        raise RuntimeError(f"os.environ read attempted: key={key!r}")
+    def get(self, key, default=None):
+        raise RuntimeError(f"os.environ.get read attempted: key={key!r}")
+    def __contains__(self, key):
+        raise RuntimeError(f"os.environ.__contains__ read attempted: key={key!r}")
+    def __setitem__(self, key, value):
+        pass
+    def __delitem__(self, key):
+        pass
+    def __repr__(self):
+        return "_FailEnv()"
+    def __iter__(self):
+        return iter([])
+    def __len__(self):
+        return 0
+    def __bool__(self):
+        return True
+
+_os.environ = _FailEnv()
+
+# -- Guard 2: os.getenv raises unconditionally -------------------------
+def _raise_getenv(key, default=None):
+    raise RuntimeError(f"os.getenv read attempted: key={key!r}")
+_os.getenv = _raise_getenv
+
+# -- Guard 3: socket.socket / create_connection raise ------------------
+def _raise_socket(*args, **kwargs):
+    raise OSError("socket.socket blocked")
+def _raise_create_connection(*args, **kwargs):
+    raise OSError("socket.create_connection blocked")
+_socket.socket = _raise_socket
+_socket.create_connection = _raise_create_connection
+
+# -- Guard 4: import hook blocks forbidden modules --------------------
+_BLOCKED_TOP = frozenset({
+    "fastapi", "groq", "supabase", "sentence_transformers",
+    "pydantic", "httpx", "httpcore", "anyio",
+})
+_BLOCKED_FULL = frozenset({
+    "backend.engine", "backend.memory",
+})
+
+class _BlockImport:
+    def find_spec(self, fullname, path, target=None):
+        if fullname in _BLOCKED_FULL:
+            raise ImportError(f"blocked: {fullname}")
+        top = fullname.split(".")[0]
+        if top in _BLOCKED_TOP:
+            raise ImportError(f"blocked: {fullname}")
+        return None
+
+sys.meta_path.insert(0, _BlockImport())
+
+# -- Import the module under test --------------------------------------
 sys.path.insert(0, ".")
-
-_BLOCKED = {{{dep_names}}}
-
 from backend.admission_contracts import (
     NEW_MESSAGE_MAX_CHARS,
     AdmissionConfig,
@@ -77,17 +144,23 @@ from backend.admission_contracts import (
     validate_new_message,
 )
 
-for mod_name in _BLOCKED:
-    assert mod_name not in sys.modules, (
-        f"{{mod_name}} was loaded during import")
+# -- Verify the module actually works ----------------------------------
+assert NEW_MESSAGE_MAX_CHARS == 4000
+assert estimate_text_units("hello") == 5
+ident = RequestIdentity.parse("550e8400-e29b-41d4-a716-446655440000")
+assert ident.request_id == "550e8400-e29b-41d4-a716-446655440000"
+config = AdmissionConfig()
+assert config.new_message_max_chars == 4000
 
 print("OK")
-"""
+'''
 
-    def test_importable_without_heavy_deps(self):
-        code = self._check_script()
+    def test_pure_import_with_guards(self):
+        """Subprocess with env, socket, and import guards active *before*
+        the module import.  Fails if the module touches any forbidden
+        resource."""
         proc = subprocess.run(
-            [sys.executable, "-c", code],
+            [sys.executable, "-c", self._PURITY_SCRIPT],
             capture_output=True, text=True,
             cwd=os.getcwd(),
             env={
@@ -99,7 +172,8 @@ print("OK")
             },
         )
         assert proc.returncode == 0, (
-            f"Subprocess failed:\nstdout:{proc.stdout}\nstderr:{proc.stderr}"
+            f"Subprocess failed (guard triggered?):\n"
+            f"stdout:{proc.stdout}\nstderr:{proc.stderr}"
         )
         assert "OK" in proc.stdout
 
@@ -112,13 +186,7 @@ class TestNoEnv:
     """The module does not read environment variables at import time."""
 
     def test_no_post_init(self):
-        # ``AdmissionConfig`` has no ``__post_init__`` that might read env
         assert not hasattr(AdmissionConfig, "__post_init__")
-
-    def test_importability_proof(self):
-        """Already proven by the subprocess test above — the module imported
-        successfully even with empty GROQ_API_KEY / SUPABASE_URL."""
-        pass
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -184,7 +252,7 @@ class TestConfigMatchesConstants:
 
 
 # ═══════════════════════════════════════════════════════════════════════
-# 6–12. RequestIdentity parsing
+# 6–12 + 21–26. RequestIdentity (parse + direct constructor)
 # ═══════════════════════════════════════════════════════════════════════
 
 _CANONICAL_LOWER = "550e8400-e29b-41d4-a716-446655440000"
@@ -192,21 +260,17 @@ _CANONICAL_UPPER = "550E8400-E29B-41D4-A716-446655440000"
 
 
 class TestRequestIdentity:
-    """Request identity parsing and validation."""
+    """Request identity: parse() and direct constructor."""
 
-    # -- 6. Canonical lowercase --
+    # ── Original parse-based tests (6–12) ─────────────────────────
 
-    def test_canonical_lowercase(self):
+    def test_parse_canonical_lowercase(self):
         ident = RequestIdentity.parse(_CANONICAL_LOWER)
         assert ident.request_id == _CANONICAL_LOWER
 
-    # -- 7. Canonical uppercase normalised to lowercase --
-
-    def test_canonical_uppercase_normalised(self):
+    def test_parse_canonical_uppercase_normalised(self):
         ident = RequestIdentity.parse(_CANONICAL_UPPER)
         assert ident.request_id == _CANONICAL_LOWER
-
-    # -- 8. Whitespace rejection --
 
     @pytest.mark.parametrize("raw", [
         f" {_CANONICAL_LOWER}",
@@ -214,48 +278,40 @@ class TestRequestIdentity:
         f"  {_CANONICAL_LOWER}  ",
         f"\t{_CANONICAL_LOWER}",
     ])
-    def test_rejects_whitespace(self, raw):
+    def test_parse_rejects_whitespace(self, raw):
         with pytest.raises(AdmissionError, match="invalid_request_id"):
             RequestIdentity.parse(raw)
-
-    # -- 9. Curly-brace rejection --
 
     @pytest.mark.parametrize("raw", [
-        f"{{{_CANONICAL_LOWER}}}",   # 38 chars
-        f"{{{_CANONICAL_LOWER}",      # 37 chars
-        f"{_CANONICAL_LOWER}}}",      # 38 chars
+        f"{{{_CANONICAL_LOWER}}}",
+        f"{{{_CANONICAL_LOWER}",
+        f"{_CANONICAL_LOWER}}}",
     ])
-    def test_rejects_braces(self, raw):
+    def test_parse_rejects_braces(self, raw):
         with pytest.raises(AdmissionError, match="invalid_request_id"):
             RequestIdentity.parse(raw)
-
-    # -- 10. URN rejection --
 
     @pytest.mark.parametrize("raw", [
         f"urn:uuid:{_CANONICAL_LOWER}",
         f"URN:UUID:{_CANONICAL_LOWER}",
     ])
-    def test_rejects_urn(self, raw):
+    def test_parse_rejects_urn(self, raw):
         with pytest.raises(AdmissionError, match="invalid_request_id"):
             RequestIdentity.parse(raw)
 
-    # -- 11. No hyphens --
-
-    def test_rejects_no_hyphens(self):
+    def test_parse_rejects_no_hyphens(self):
         raw = _CANONICAL_LOWER.replace("-", "")
         with pytest.raises(AdmissionError, match="invalid_request_id"):
             RequestIdentity.parse(raw)
 
-    # -- 12. Empty, invalid text, and non-string types --
-
     @pytest.mark.parametrize("raw", [
         "",
         "not-a-uuid",
-        f"{_CANONICAL_LOWER}x",          # 37 chars
-        f"{_CANONICAL_LOWER[:-1]}",      # 35 chars
-        "gggggggg-gggg-gggg-gggg-gggggggggggg",  # not hex
+        f"{_CANONICAL_LOWER}x",
+        f"{_CANONICAL_LOWER[:-1]}",
+        "gggggggg-gggg-gggg-gggg-gggggggggggg",
     ])
-    def test_rejects_invalid_text(self, raw):
+    def test_parse_rejects_invalid_text(self, raw):
         with pytest.raises(AdmissionError, match="invalid_request_id"):
             RequestIdentity.parse(raw)
 
@@ -265,9 +321,58 @@ class TestRequestIdentity:
         ["not-a-string"],
         {"key": "value"},
     ])
-    def test_rejects_non_string_types(self, raw):
+    def test_parse_rejects_non_string_types(self, raw):
         with pytest.raises(AdmissionError, match="invalid_request_id"):
             RequestIdentity.parse(raw)  # type: ignore[arg-type]
+
+    # ── Direct constructor tests (code-review corrections 21–26) ──
+
+    def test_constructor_valid_lowercase(self):
+        """21. Direct constructor with valid lowercase UUID."""
+        ident = RequestIdentity(_CANONICAL_LOWER)
+        assert ident.request_id == _CANONICAL_LOWER
+
+    def test_constructor_valid_uppercase_normalised(self):
+        """22. Direct constructor with valid uppercase UUID."""
+        ident = RequestIdentity(_CANONICAL_UPPER)
+        assert ident.request_id == _CANONICAL_LOWER
+
+    def test_constructor_invalid_raises(self):
+        """23. Direct constructor with invalid UUID raises."""
+        with pytest.raises(AdmissionError, match="invalid_request_id"):
+            RequestIdentity("not-a-uuid")
+
+    def test_constructor_no_hyphens_raises(self):
+        """24. Direct constructor with no-hyphens format."""
+        raw = _CANONICAL_LOWER.replace("-", "")
+        with pytest.raises(AdmissionError, match="invalid_request_id"):
+            RequestIdentity(raw)
+
+    def test_parse_and_constructor_equivalent(self):
+        """25. ``parse()`` and constructor produce equal objects."""
+        ident1 = RequestIdentity.parse(_CANONICAL_LOWER)
+        ident2 = RequestIdentity(_CANONICAL_LOWER)
+        assert ident1 == ident2
+        assert ident1.request_id == ident2.request_id
+
+    def test_parse_and_constructor_equivalent_uppercase(self):
+        """25b. Both paths normalise uppercase identically."""
+        ident1 = RequestIdentity.parse(_CANONICAL_UPPER)
+        ident2 = RequestIdentity(_CANONICAL_UPPER)
+        assert ident1 == ident2
+        assert ident1.request_id == _CANONICAL_LOWER
+
+    def test_immutable_after_construction(self):
+        """26. Impossible to mutate after construction."""
+        ident = RequestIdentity(_CANONICAL_LOWER)
+        with pytest.raises(FrozenInstanceError):
+            ident.request_id = "other"  # type: ignore[assignment]
+
+    def test_constructor_rejects_non_string(self):
+        with pytest.raises(AdmissionError, match="invalid_request_id"):
+            RequestIdentity(12345)  # type: ignore[arg-type]
+        with pytest.raises(AdmissionError, match="invalid_request_id"):
+            RequestIdentity(None)  # type: ignore[arg-type]
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -275,37 +380,25 @@ class TestRequestIdentity:
 # ═══════════════════════════════════════════════════════════════════════
 
 class TestEstimateTextUnits:
-    """``estimate_text_units`` — byte-based input cost estimation."""
-
-    # -- 13. Empty string returns 1 --
-
     def test_empty_returns_one(self):
         assert estimate_text_units("") == 1
-
-    # -- 14. ASCII counted as one byte per character --
 
     def test_ascii_one_byte_per_char(self):
         assert estimate_text_units("hello") == 5
         assert estimate_text_units("a" * 100) == 100
         assert estimate_text_units("a" * 4000) == 4000
 
-    # -- 15. Multibyte counted by real UTF-8 bytes --
-
     def test_two_byte_char(self):
-        # "ñ" is 2 bytes in UTF-8
-        assert estimate_text_units("ñ") == 2
+        assert estimate_text_units("\u00f1") == 2
 
     def test_three_byte_chars(self):
-        # "你好" is 6 bytes (3 each)
-        assert estimate_text_units("你好") == 6
+        assert estimate_text_units("\u4f60\u597d") == 6
 
     def test_four_byte_char(self):
-        # emoji "😀" is 4 bytes
-        assert estimate_text_units("😀") == 4
+        assert estimate_text_units("\U0001f600") == 4
 
     def test_mixed_lengths(self):
-        # "a" is 1 byte, "ñ" is 2, "😀" is 4 → total 7
-        assert estimate_text_units("añ😀") == 7
+        assert estimate_text_units("a\u00f1\U0001f600") == 7
 
     def test_rejects_non_string(self):
         with pytest.raises(TypeError):
@@ -319,20 +412,13 @@ class TestEstimateTextUnits:
 # ═══════════════════════════════════════════════════════════════════════
 
 class TestValidateNewMessage:
-    """Message validation with deterministic precedence."""
-
-    # -- 16. 4 000 ASCII chars accepted --
-
     def test_4000_ascii_chars_accepted(self):
-        text = "a" * 4000
-        validate_new_message(text)  # should not raise
+        validate_new_message("a" * 4000)
 
     def test_under_4000_chars_accepted(self):
         validate_new_message("hello")
         validate_new_message("")
-        validate_new_message("ñ" * 100)  # 200 units, well under 6000
-
-    # -- 17. 4 001 chars rejected with ``message_too_long`` --
+        validate_new_message("\u00f1" * 100)
 
     def test_4001_chars_rejected(self):
         text = "a" * 4001
@@ -344,16 +430,12 @@ class TestValidateNewMessage:
         assert excinfo.value.actual_units == 0
 
     def test_5000_chars_rejected(self):
-        text = "a" * 5000
         with pytest.raises(AdmissionError) as excinfo:
-            validate_new_message(text)
+            validate_new_message("a" * 5000)
         assert excinfo.value.code == "message_too_long"
 
-    # -- 18. ≤ 4 000 chars but > 6 000 units → ``message_budget_exceeded`` --
-
     def test_over_6000_units_rejected(self):
-        # "ñ" is 2 bytes, so 3001 chars × 2 = 6002 units > 6000
-        text = "ñ" * 3001
+        text = "\u00f1" * 3001
         with pytest.raises(AdmissionError) as excinfo:
             validate_new_message(text)
         assert excinfo.value.code == "message_budget_exceeded"
@@ -363,8 +445,7 @@ class TestValidateNewMessage:
         assert excinfo.value.max_units == 6000
 
     def test_4000_multi_byte_over_6000_units(self):
-        # 4000 chars × 2 bytes = 8000 units
-        text = "ñ" * 4000
+        text = "\u00f1" * 4000
         with pytest.raises(AdmissionError) as excinfo:
             validate_new_message(text)
         assert excinfo.value.code == "message_budget_exceeded"
@@ -373,24 +454,16 @@ class TestValidateNewMessage:
         assert excinfo.value.max_units == 6000
 
     def test_exactly_6000_units_accepted(self):
-        # 6000 ASCII chars = 6000 bytes → accepted (len > 4000 fails first)
-        # But 3000 "ñ" chars = 6000 bytes, and 3000 < 4000 chars → accepted
-        text = "ñ" * 3000
-        validate_new_message(text)
+        validate_new_message("\u00f1" * 3000)
 
     def test_exactly_6001_units_rejected(self):
-        # 3000 "ñ" chars + 1 extra byte → 6001 units
-        text = "ñ" * 3000 + "a"  # 3001 chars, 6001 bytes
         with pytest.raises(AdmissionError) as excinfo:
-            validate_new_message(text)
+            validate_new_message("\u00f1" * 3000 + "a")
         assert excinfo.value.code == "message_budget_exceeded"
 
     def test_precedence_chars_before_units(self):
-        # 4001 chars × 1 byte = 4001 units (well under 6000)
-        # But chars check fires first → message_too_long
-        text = "a" * 4001
         with pytest.raises(AdmissionError) as excinfo:
-            validate_new_message(text)
+            validate_new_message("a" * 4001)
         assert excinfo.value.code == "message_too_long"
 
     def test_precedence_invalid_type_before_chars(self):
@@ -404,11 +477,6 @@ class TestValidateNewMessage:
 # ═══════════════════════════════════════════════════════════════════════
 
 class TestErrorHidesSensitiveData:
-    """``str(exc)``, ``repr(exc)``, and public attributes must never expose
-    the original content or invalid UUID."""
-
-    # -- message_too_long hides content --
-
     def test_message_too_long_hides_content(self):
         secret = "p4ssw0rd-sensitive-content"
         try:
@@ -421,18 +489,14 @@ class TestErrorHidesSensitiveData:
                 for attr in dir(exc)
                 if not attr.startswith("_")
             )
-            # Confirm the code is visible
             assert exc.code == "message_too_long"
         else:
             pytest.fail("Expected AdmissionError")
 
-    # -- message_budget_exceeded hides content --
-
     def test_message_budget_exceeded_hides_content(self):
         secret = "c0nf1d3ntial-data"
-        text = secret + "ñ" * 3000  # well over 6000 units
         try:
-            validate_new_message(text)
+            validate_new_message(secret + "\u00f1" * 3000)
         except AdmissionError as exc:
             assert secret not in str(exc)
             assert secret not in repr(exc)
@@ -445,9 +509,7 @@ class TestErrorHidesSensitiveData:
         else:
             pytest.fail("Expected AdmissionError")
 
-    # -- invalid_request_id hides raw UUID --
-
-    def test_invalid_request_id_hides_raw(self):
+    def test_parse_invalid_hides_raw(self):
         secret_uuid = "th1s-1s-4-s3cr3t-1d-1234567890ab"
         try:
             RequestIdentity.parse(secret_uuid)
@@ -463,8 +525,24 @@ class TestErrorHidesSensitiveData:
         else:
             pytest.fail("Expected AdmissionError")
 
+    def test_constructor_invalid_hides_raw(self):
+        """Direct constructor also hides the raw invalid UUID."""
+        secret_uuid = "th1s-1s-4-s3cr3t-1d-1234567890ab"
+        try:
+            RequestIdentity(secret_uuid)
+        except AdmissionError as exc:
+            assert secret_uuid not in str(exc)
+            assert secret_uuid not in repr(exc)
+            assert not any(
+                getattr(exc, attr, None) == secret_uuid
+                for attr in dir(exc)
+                if not attr.startswith("_")
+            )
+            assert exc.code == "invalid_request_id"
+        else:
+            pytest.fail("Expected AdmissionError")
+
     def test_valid_identity_has_no_exception(self):
-        # Happy path: parsing succeeds, no exception
         ident = RequestIdentity.parse("550e8400-e29b-41d4-a716-446655440000")
         assert ident.request_id == "550e8400-e29b-41d4-a716-446655440000"
 
@@ -474,14 +552,10 @@ class TestErrorHidesSensitiveData:
 # ═══════════════════════════════════════════════════════════════════════
 
 class TestImmutability:
-    """Verify that no shared mutable state exists."""
-
     def test_admission_config_is_independent(self):
         c1 = AdmissionConfig()
         c2 = AdmissionConfig()
         assert c1 == c2
-        # Both are frozen, so they cannot be mutated; no shared object
-        # inside can be mutated either (all fields are ints / str).
 
     def test_request_identity_is_frozen(self):
         ident = RequestIdentity.parse("550e8400-e29b-41d4-a716-446655440000")
@@ -489,14 +563,11 @@ class TestImmutability:
             ident.request_id = "other"  # type: ignore[assignment]
 
     def test_no_module_level_mutable_defaults(self):
-        # ``AdmissionError`` defaults are all zero / empty, not mutables
         exc = AdmissionError("test")
         assert exc.code == "test"
         assert exc.actual_chars == 0
         assert exc.actual_units == 0
 
     def test_functions_are_pure(self):
-        # Calling estimate_text_units twice on same input returns same result
         assert estimate_text_units("hello") == 5
         assert estimate_text_units("hello") == 5
-        # No side effects observable

--- a/backend/tests/test_admission_contracts.py
+++ b/backend/tests/test_admission_contracts.py
@@ -1,0 +1,502 @@
+"""
+Tests for ``backend.admission_contracts``.
+
+Covers (1–20):
+
+ 1. Pure importability from subprocess (no heavy deps)
+ 2. No environment reads
+ 3. Frozen config
+ 4. Exact numeric constants
+ 5. Constants ↔ AdmissionConfig correspondence
+ 6. UUID canonical lowercase accepted
+ 7. UUID canonical uppercase normalised
+ 8. Whitespace rejection
+ 9. Curly-brace rejection
+10. URN rejection
+11. No-hyphens rejection
+12. Empty / invalid / non-string rejection
+13. ``estimate_text_units("") == 1``
+14. ASCII counted as one byte per character
+15. Multibyte characters counted by real UTF-8 bytes
+16. 4 000 ASCII chars accepted
+17. 4 001 chars rejected with ``message_too_long``
+18. ≤ 4 000 chars but > 6 000 bytes rejected with ``message_budget_exceeded``
+19. Content and invalid UUID absent from ``str(exc)``, ``repr(exc)``, public attributes
+20. No shared mutable state
+"""
+
+import subprocess
+import sys
+import os
+
+import pytest
+from dataclasses import FrozenInstanceError
+
+from backend.admission_contracts import (
+    NEW_MESSAGE_MAX_CHARS,
+    LEGACY_HISTORY_MAX_CHARS,
+    MESSAGE_MAX_ESTIMATED_UNITS,
+    PROVIDER_INPUT_MAX_ESTIMATED_UNITS,
+    USER_REQUESTS_PER_MINUTE,
+    NETWORK_REQUESTS_PER_MINUTE,
+    APPLICATION_REQUESTS_PER_MINUTE,
+    USER_REQUESTS_PER_DAY,
+    USER_ESTIMATED_UNITS_PER_DAY,
+    AdmissionConfig,
+    RequestIdentity,
+    estimate_text_units,
+    validate_new_message,
+    AdmissionError,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 1. Pure importability
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestImportability:
+    """Import the module in an isolated subprocess and verify no heavy
+    dependencies are pulled in."""
+
+    HEAVY_DEPS = {"fastapi", "groq", "supabase", "sentence_transformers", "pydantic"}
+
+    @staticmethod
+    def _check_script() -> str:
+        dep_names = ", ".join(repr(d) for d in TestImportability.HEAVY_DEPS)
+        return f"""
+import sys
+sys.path.insert(0, ".")
+
+_BLOCKED = {{{dep_names}}}
+
+from backend.admission_contracts import (
+    NEW_MESSAGE_MAX_CHARS,
+    AdmissionConfig,
+    RequestIdentity,
+    estimate_text_units,
+    validate_new_message,
+)
+
+for mod_name in _BLOCKED:
+    assert mod_name not in sys.modules, (
+        f"{{mod_name}} was loaded during import")
+
+print("OK")
+"""
+
+    def test_importable_without_heavy_deps(self):
+        code = self._check_script()
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True, text=True,
+            cwd=os.getcwd(),
+            env={
+                **os.environ,
+                "PYTHONPATH": ".",
+                "GROQ_API_KEY": "",
+                "SUPABASE_URL": "",
+                "SUPABASE_KEY": "",
+            },
+        )
+        assert proc.returncode == 0, (
+            f"Subprocess failed:\nstdout:{proc.stdout}\nstderr:{proc.stderr}"
+        )
+        assert "OK" in proc.stdout
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 2. No environment reads
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestNoEnv:
+    """The module does not read environment variables at import time."""
+
+    def test_no_post_init(self):
+        # ``AdmissionConfig`` has no ``__post_init__`` that might read env
+        assert not hasattr(AdmissionConfig, "__post_init__")
+
+    def test_importability_proof(self):
+        """Already proven by the subprocess test above — the module imported
+        successfully even with empty GROQ_API_KEY / SUPABASE_URL."""
+        pass
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 3. Frozen config
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestConfigFrozen:
+    def test_frozen(self):
+        config = AdmissionConfig()
+        with pytest.raises(FrozenInstanceError):
+            config.new_message_max_chars = 999  # type: ignore[assignment]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 4. Exact numeric constants
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestExactConstants:
+    def test_new_message_max_chars(self):
+        assert NEW_MESSAGE_MAX_CHARS == 4000
+
+    def test_legacy_history_max_chars(self):
+        assert LEGACY_HISTORY_MAX_CHARS == 10000
+
+    def test_message_max_estimated_units(self):
+        assert MESSAGE_MAX_ESTIMATED_UNITS == 6000
+
+    def test_provider_input_max_estimated_units(self):
+        assert PROVIDER_INPUT_MAX_ESTIMATED_UNITS == 16000
+
+    def test_user_requests_per_minute(self):
+        assert USER_REQUESTS_PER_MINUTE == 20
+
+    def test_network_requests_per_minute(self):
+        assert NETWORK_REQUESTS_PER_MINUTE == 60
+
+    def test_application_requests_per_minute(self):
+        assert APPLICATION_REQUESTS_PER_MINUTE == 25
+
+    def test_user_requests_per_day(self):
+        assert USER_REQUESTS_PER_DAY == 200
+
+    def test_user_estimated_units_per_day(self):
+        assert USER_ESTIMATED_UNITS_PER_DAY == 250000
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 5. Constants ↔ AdmissionConfig correspondence
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestConfigMatchesConstants:
+    def test_config_matches_constants(self):
+        config = AdmissionConfig()
+        assert config.new_message_max_chars == NEW_MESSAGE_MAX_CHARS
+        assert config.legacy_history_max_chars == LEGACY_HISTORY_MAX_CHARS
+        assert config.message_max_estimated_units == MESSAGE_MAX_ESTIMATED_UNITS
+        assert config.provider_input_max_estimated_units == PROVIDER_INPUT_MAX_ESTIMATED_UNITS
+        assert config.user_requests_per_minute == USER_REQUESTS_PER_MINUTE
+        assert config.network_requests_per_minute == NETWORK_REQUESTS_PER_MINUTE
+        assert config.application_requests_per_minute == APPLICATION_REQUESTS_PER_MINUTE
+        assert config.user_requests_per_day == USER_REQUESTS_PER_DAY
+        assert config.user_estimated_units_per_day == USER_ESTIMATED_UNITS_PER_DAY
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 6–12. RequestIdentity parsing
+# ═══════════════════════════════════════════════════════════════════════
+
+_CANONICAL_LOWER = "550e8400-e29b-41d4-a716-446655440000"
+_CANONICAL_UPPER = "550E8400-E29B-41D4-A716-446655440000"
+
+
+class TestRequestIdentity:
+    """Request identity parsing and validation."""
+
+    # -- 6. Canonical lowercase --
+
+    def test_canonical_lowercase(self):
+        ident = RequestIdentity.parse(_CANONICAL_LOWER)
+        assert ident.request_id == _CANONICAL_LOWER
+
+    # -- 7. Canonical uppercase normalised to lowercase --
+
+    def test_canonical_uppercase_normalised(self):
+        ident = RequestIdentity.parse(_CANONICAL_UPPER)
+        assert ident.request_id == _CANONICAL_LOWER
+
+    # -- 8. Whitespace rejection --
+
+    @pytest.mark.parametrize("raw", [
+        f" {_CANONICAL_LOWER}",
+        f"{_CANONICAL_LOWER} ",
+        f"  {_CANONICAL_LOWER}  ",
+        f"\t{_CANONICAL_LOWER}",
+    ])
+    def test_rejects_whitespace(self, raw):
+        with pytest.raises(AdmissionError, match="invalid_request_id"):
+            RequestIdentity.parse(raw)
+
+    # -- 9. Curly-brace rejection --
+
+    @pytest.mark.parametrize("raw", [
+        f"{{{_CANONICAL_LOWER}}}",   # 38 chars
+        f"{{{_CANONICAL_LOWER}",      # 37 chars
+        f"{_CANONICAL_LOWER}}}",      # 38 chars
+    ])
+    def test_rejects_braces(self, raw):
+        with pytest.raises(AdmissionError, match="invalid_request_id"):
+            RequestIdentity.parse(raw)
+
+    # -- 10. URN rejection --
+
+    @pytest.mark.parametrize("raw", [
+        f"urn:uuid:{_CANONICAL_LOWER}",
+        f"URN:UUID:{_CANONICAL_LOWER}",
+    ])
+    def test_rejects_urn(self, raw):
+        with pytest.raises(AdmissionError, match="invalid_request_id"):
+            RequestIdentity.parse(raw)
+
+    # -- 11. No hyphens --
+
+    def test_rejects_no_hyphens(self):
+        raw = _CANONICAL_LOWER.replace("-", "")
+        with pytest.raises(AdmissionError, match="invalid_request_id"):
+            RequestIdentity.parse(raw)
+
+    # -- 12. Empty, invalid text, and non-string types --
+
+    @pytest.mark.parametrize("raw", [
+        "",
+        "not-a-uuid",
+        f"{_CANONICAL_LOWER}x",          # 37 chars
+        f"{_CANONICAL_LOWER[:-1]}",      # 35 chars
+        "gggggggg-gggg-gggg-gggg-gggggggggggg",  # not hex
+    ])
+    def test_rejects_invalid_text(self, raw):
+        with pytest.raises(AdmissionError, match="invalid_request_id"):
+            RequestIdentity.parse(raw)
+
+    @pytest.mark.parametrize("raw", [
+        12345,
+        None,
+        ["not-a-string"],
+        {"key": "value"},
+    ])
+    def test_rejects_non_string_types(self, raw):
+        with pytest.raises(AdmissionError, match="invalid_request_id"):
+            RequestIdentity.parse(raw)  # type: ignore[arg-type]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 13–15. estimate_text_units
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestEstimateTextUnits:
+    """``estimate_text_units`` — byte-based input cost estimation."""
+
+    # -- 13. Empty string returns 1 --
+
+    def test_empty_returns_one(self):
+        assert estimate_text_units("") == 1
+
+    # -- 14. ASCII counted as one byte per character --
+
+    def test_ascii_one_byte_per_char(self):
+        assert estimate_text_units("hello") == 5
+        assert estimate_text_units("a" * 100) == 100
+        assert estimate_text_units("a" * 4000) == 4000
+
+    # -- 15. Multibyte counted by real UTF-8 bytes --
+
+    def test_two_byte_char(self):
+        # "ñ" is 2 bytes in UTF-8
+        assert estimate_text_units("ñ") == 2
+
+    def test_three_byte_chars(self):
+        # "你好" is 6 bytes (3 each)
+        assert estimate_text_units("你好") == 6
+
+    def test_four_byte_char(self):
+        # emoji "😀" is 4 bytes
+        assert estimate_text_units("😀") == 4
+
+    def test_mixed_lengths(self):
+        # "a" is 1 byte, "ñ" is 2, "😀" is 4 → total 7
+        assert estimate_text_units("añ😀") == 7
+
+    def test_rejects_non_string(self):
+        with pytest.raises(TypeError):
+            estimate_text_units(12345)  # type: ignore[arg-type]
+        with pytest.raises(TypeError):
+            estimate_text_units(None)  # type: ignore[arg-type]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 16–18. validate_new_message
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestValidateNewMessage:
+    """Message validation with deterministic precedence."""
+
+    # -- 16. 4 000 ASCII chars accepted --
+
+    def test_4000_ascii_chars_accepted(self):
+        text = "a" * 4000
+        validate_new_message(text)  # should not raise
+
+    def test_under_4000_chars_accepted(self):
+        validate_new_message("hello")
+        validate_new_message("")
+        validate_new_message("ñ" * 100)  # 200 units, well under 6000
+
+    # -- 17. 4 001 chars rejected with ``message_too_long`` --
+
+    def test_4001_chars_rejected(self):
+        text = "a" * 4001
+        with pytest.raises(AdmissionError) as excinfo:
+            validate_new_message(text)
+        assert excinfo.value.code == "message_too_long"
+        assert excinfo.value.actual_chars == 4001
+        assert excinfo.value.max_chars == 4000
+        assert excinfo.value.actual_units == 0
+
+    def test_5000_chars_rejected(self):
+        text = "a" * 5000
+        with pytest.raises(AdmissionError) as excinfo:
+            validate_new_message(text)
+        assert excinfo.value.code == "message_too_long"
+
+    # -- 18. ≤ 4 000 chars but > 6 000 units → ``message_budget_exceeded`` --
+
+    def test_over_6000_units_rejected(self):
+        # "ñ" is 2 bytes, so 3001 chars × 2 = 6002 units > 6000
+        text = "ñ" * 3001
+        with pytest.raises(AdmissionError) as excinfo:
+            validate_new_message(text)
+        assert excinfo.value.code == "message_budget_exceeded"
+        assert excinfo.value.actual_chars == 3001
+        assert excinfo.value.actual_units == 6002
+        assert excinfo.value.max_chars == 4000
+        assert excinfo.value.max_units == 6000
+
+    def test_4000_multi_byte_over_6000_units(self):
+        # 4000 chars × 2 bytes = 8000 units
+        text = "ñ" * 4000
+        with pytest.raises(AdmissionError) as excinfo:
+            validate_new_message(text)
+        assert excinfo.value.code == "message_budget_exceeded"
+        assert excinfo.value.actual_chars == 4000
+        assert excinfo.value.actual_units == 8000
+        assert excinfo.value.max_units == 6000
+
+    def test_exactly_6000_units_accepted(self):
+        # 6000 ASCII chars = 6000 bytes → accepted (len > 4000 fails first)
+        # But 3000 "ñ" chars = 6000 bytes, and 3000 < 4000 chars → accepted
+        text = "ñ" * 3000
+        validate_new_message(text)
+
+    def test_exactly_6001_units_rejected(self):
+        # 3000 "ñ" chars + 1 extra byte → 6001 units
+        text = "ñ" * 3000 + "a"  # 3001 chars, 6001 bytes
+        with pytest.raises(AdmissionError) as excinfo:
+            validate_new_message(text)
+        assert excinfo.value.code == "message_budget_exceeded"
+
+    def test_precedence_chars_before_units(self):
+        # 4001 chars × 1 byte = 4001 units (well under 6000)
+        # But chars check fires first → message_too_long
+        text = "a" * 4001
+        with pytest.raises(AdmissionError) as excinfo:
+            validate_new_message(text)
+        assert excinfo.value.code == "message_too_long"
+
+    def test_precedence_invalid_type_before_chars(self):
+        with pytest.raises(AdmissionError) as excinfo:
+            validate_new_message(12345)  # type: ignore[arg-type]
+        assert excinfo.value.code == "message_too_long"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 19. Content and invalid UUID absent from exception
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestErrorHidesSensitiveData:
+    """``str(exc)``, ``repr(exc)``, and public attributes must never expose
+    the original content or invalid UUID."""
+
+    # -- message_too_long hides content --
+
+    def test_message_too_long_hides_content(self):
+        secret = "p4ssw0rd-sensitive-content"
+        try:
+            validate_new_message(secret + "a" * 4000)
+        except AdmissionError as exc:
+            assert secret not in str(exc)
+            assert secret not in repr(exc)
+            assert not any(
+                getattr(exc, attr, None) == secret
+                for attr in dir(exc)
+                if not attr.startswith("_")
+            )
+            # Confirm the code is visible
+            assert exc.code == "message_too_long"
+        else:
+            pytest.fail("Expected AdmissionError")
+
+    # -- message_budget_exceeded hides content --
+
+    def test_message_budget_exceeded_hides_content(self):
+        secret = "c0nf1d3ntial-data"
+        text = secret + "ñ" * 3000  # well over 6000 units
+        try:
+            validate_new_message(text)
+        except AdmissionError as exc:
+            assert secret not in str(exc)
+            assert secret not in repr(exc)
+            assert not any(
+                getattr(exc, attr, None) == secret
+                for attr in dir(exc)
+                if not attr.startswith("_")
+            )
+            assert exc.code == "message_budget_exceeded"
+        else:
+            pytest.fail("Expected AdmissionError")
+
+    # -- invalid_request_id hides raw UUID --
+
+    def test_invalid_request_id_hides_raw(self):
+        secret_uuid = "th1s-1s-4-s3cr3t-1d-1234567890ab"
+        try:
+            RequestIdentity.parse(secret_uuid)
+        except AdmissionError as exc:
+            assert secret_uuid not in str(exc)
+            assert secret_uuid not in repr(exc)
+            assert not any(
+                getattr(exc, attr, None) == secret_uuid
+                for attr in dir(exc)
+                if not attr.startswith("_")
+            )
+            assert exc.code == "invalid_request_id"
+        else:
+            pytest.fail("Expected AdmissionError")
+
+    def test_valid_identity_has_no_exception(self):
+        # Happy path: parsing succeeds, no exception
+        ident = RequestIdentity.parse("550e8400-e29b-41d4-a716-446655440000")
+        assert ident.request_id == "550e8400-e29b-41d4-a716-446655440000"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 20. No shared mutable state
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestImmutability:
+    """Verify that no shared mutable state exists."""
+
+    def test_admission_config_is_independent(self):
+        c1 = AdmissionConfig()
+        c2 = AdmissionConfig()
+        assert c1 == c2
+        # Both are frozen, so they cannot be mutated; no shared object
+        # inside can be mutated either (all fields are ints / str).
+
+    def test_request_identity_is_frozen(self):
+        ident = RequestIdentity.parse("550e8400-e29b-41d4-a716-446655440000")
+        with pytest.raises(FrozenInstanceError):
+            ident.request_id = "other"  # type: ignore[assignment]
+
+    def test_no_module_level_mutable_defaults(self):
+        # ``AdmissionError`` defaults are all zero / empty, not mutables
+        exc = AdmissionError("test")
+        assert exc.code == "test"
+        assert exc.actual_chars == 0
+        assert exc.actual_units == 0
+
+    def test_functions_are_pure(self):
+        # Calling estimate_text_units twice on same input returns same result
+        assert estimate_text_units("hello") == 5
+        assert estimate_text_units("hello") == 5
+        # No side effects observable


### PR DESCRIPTION
Closes #287

## Causa raiz

Atualmente o backend não possui contratos puros para request identity, estimativa de custo de entrada ou validação de mensagens. Os limites estão espalhados (ex.: 10.000 caracteres em `backend/memory.py`) e não existe uma fonte única de verdade para quotas. Implementar ledger ou rate limiting antes desses contratos duplicaria regras entre Python, SQL e testes.

## Decisões implementadas

- **Módulo puro stdlib**: `backend/admission_contracts.py` importável sem FastAPI, Pydantic, Groq, Supabase, sentence\_transformers, engine, memória, variáveis de ambiente, rede, filesystem, clock ou aleatoriedade.
- **Configuração imutável**: `AdmissionConfig` frozen dataclass espelha todas as constantes do módulo. Sem estado mutável, sem fallback de ambiente, sem override por usuário.
- **Request identity com invariante fechada**: `RequestIdentity` usa `@dataclass(frozen=True, init=False)` com `__init__` customizado que valida via `_validate_canonical_uuid` antes de armazenar via `object.__setattr__`. UUIDs inválidos nunca são armazenados no objeto — a exceção é lançada antes. `parse()` delega ao construtor, mantendo invariante única.
- **Estimativa local**: `estimate_text_units(text)` = `max(1, len(text.encode("utf-8")))`. Não trunca, normaliza Unicode, loga ou chama serviços externos.
- **Validação determinística**: `validate_new_message()` com precedência: (1) tipo inválido ou > 4.000 caracteres → `message_too_long`, (2) > 6.000 unidades estimadas → `message_budget_exceeded`.
- **Erros tipados sanitizados**: `AdmissionError` carrega apenas `code`, `actual_chars`, `actual_units`, `max_chars`, `max_units`. Conteúdo, UUID, usuário, IP e texto original nunca aparecem em `str()`, `repr()` ou atributos públicos.
- **Limite legado preservado**: `LEGACY_HISTORY_MAX_CHARS = 10000` permanece como contrato separado, sem alterar `backend/memory.py`.

## Correções da revisão técnica (4810648441)

### Correção 1 — Invariante do construtor fechada

Antes: `RequestIdentity("not-a-uuid")` criava objeto inválido. Agora: `__init__` valida antes de armazenar. A entrada inválida nunca chega ao atributo `request_id` nem ao `repr()` do objeto.

### Correção 2 — Prova real de pureza

O teste `test_pure_import_with_guards` executa em subprocesso isolado com guards instalados **antes** da importação do módulo:
- `os.environ` substituído por `_FailEnv` que lança em `__getitem__`, `get`, `__contains__`
- `os.getenv` substituído por função que lança
- `socket.socket` e `socket.create_connection` substituídos por funções que lançam `OSError`
- Import hook bloqueia `fastapi`, `groq`, `supabase`, `sentence_transformers`, `pydantic`, `httpx`, `httpcore`, `anyio`, `backend.engine`, `backend.memory`
- O teste falha **objetivamente** (exit code != 0) se qualquer guard for acionado

## Arquivos alterados

| Arquivo | Status | Linhas |
|---------|--------|--------|
| `backend/admission_contracts.py` | Modificado (+21/-14) | 260 |
| `backend/tests/test_admission_contracts.py` | Modificado (+204/-119) | 518 |

## Constantes finais

| Constante | Valor | Uso |
|-----------|-------|-----|
| `NEW_MESSAGE_MAX_CHARS` | 4.000 | Validação de mensagens novas |
| `LEGACY_HISTORY_MAX_CHARS` | 10.000 | Contrato de histórico (não alterado) |
| `MESSAGE_MAX_ESTIMATED_UNITS` | 6.000 | Orçamento de entrada por mensagem |
| `PROVIDER_INPUT_MAX_ESTIMATED_UNITS` | 16.000 | Orçamento total do provider (reservado) |
| `USER_REQUESTS_PER_MINUTE` | 20 | Reservado para rate limiting |
| `NETWORK_REQUESTS_PER_MINUTE` | 60 | Reservado |
| `APPLICATION_REQUESTS_PER_MINUTE` | 25 | Reservado |
| `USER_REQUESTS_PER_DAY` | 200 | Reservado |
| `USER_ESTIMATED_UNITS_PER_DAY` | 250.000 | Reservado |

## UUID: aceito vs rejeitado

| Entrada | Resultado |
|---------|-----------|
| `550e8400-e29b-41d4-a716-446655440000` | Aceito |
| `550E8400-E29B-41D4-A716-446655440000` | Aceito (normalizado para minúsculas) |
| ` 550e8400-...` (whitespace) | Rejeitado |
| `{550e8400-...}` | Rejeitado |
| `urn:uuid:550e8400-...` | Rejeitado |
| `550e8400e29b41d4a716446655440000` (sem hífens) | Rejeitado |
| `""`, `"invalido"`, `12345`, `None` | Rejeitado |

## Testes executados (HEAD 6d8f86b)

- ✅ `compileall -q backend` — sem erros
- ✅ `pytest backend/tests/test_admission_contracts.py -vv` — **68/68 passed** (antes 60; +8 testes do construtor)
- ✅ Ordem 1: admission → provider → smoke — **102/102 passed** (3,76s)
- ✅ Ordem 2: smoke → provider → admission — **102/102 passed** (5,37s)
- ✅ Suíte backend completa: **1466/1466 passed** (13,76s)
- ✅ Frontend: **npm ci** (0 vulns), **audit** (passou), **35 testes** (passaram), **lint** (limpo), **build** (OK)

## HEAD final

`6d8f86b8888592344c74b0651dc2215d37141bf8`

## Riscos residuais

- A validação de UUID aceita qualquer versão de UUID (v1, v3, v4, v5). Se no futuro for necessário restringir a uma versão específica, será necessário um filtro adicional.
- `estimate_text_units` não é um tokenizer real — é uma aproximação conservadora baseada em bytes UTF-8. Discrepâncias com a contagem real do provider podem ocorrer e devem ser ajustadas empiricamente.
- O limite de 10.000 caracteres do histórico legado permanece em `backend/memory.py` como contrato separado; a refatoração para usar este módulo está fora do escopo desta issue.
- As constantes de rate limiting (`USER_REQUESTS_PER_MINUTE` etc.) estão definidas como contrato puro mas ainda não são aplicadas em runtime — a aplicação será feita em tarefas futuras.
