### PR TITLE
feat(admission): integrate request identity and ledger into chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Required. Admission HMAC secret with at least 32 UTF-8 bytes.
+# Generate and store the real value outside source control.
+ADMISSION_HMAC_SECRET=
+
+# Optional comma-separated IPv4/IPv6 CIDRs for trusted reverse proxies.
+# Leave empty when the application receives client connections directly.
+TRUSTED_PROXY_CIDRS=

--- a/backend/admission.py
+++ b/backend/admission.py
@@ -1,0 +1,358 @@
+"""Admission runtime primitives for the active ``/chat`` path.
+
+The module is deliberately independent from FastAPI, Supabase, Groq, embeddings,
+engine, memory, clock, randomness, filesystem, and network I/O. Environment
+variables are read only when :meth:`AdmissionRuntimeConfig.from_env` is called.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import ipaddress
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from .admission_contracts import AdmissionError, RequestIdentity, estimate_text_units
+
+MESSAGE_HMAC_DOMAIN = b"message"
+NETWORK_HMAC_DOMAIN = b"network"
+UNKNOWN_NETWORK_IDENTITY = "unknown"
+
+ADMITTED = "admitted"
+REQUEST_REPLAY_UNAVAILABLE = "request_replay_unavailable"
+REQUEST_ID_CONFLICT = "request_id_conflict"
+USER_RATE_LIMITED = "user_rate_limited"
+NETWORK_RATE_LIMITED = "network_rate_limited"
+APPLICATION_RATE_LIMITED = "application_rate_limited"
+USER_DAILY_REQUEST_QUOTA_EXCEEDED = "user_daily_request_quota_exceeded"
+USER_DAILY_UNIT_QUOTA_EXCEEDED = "user_daily_unit_quota_exceeded"
+INVALID_ADMISSION_INPUT = "invalid_admission_input"
+
+ADMISSION_DECISIONS = frozenset(
+    {
+        ADMITTED,
+        REQUEST_REPLAY_UNAVAILABLE,
+        REQUEST_ID_CONFLICT,
+        USER_RATE_LIMITED,
+        NETWORK_RATE_LIMITED,
+        APPLICATION_RATE_LIMITED,
+        USER_DAILY_REQUEST_QUOTA_EXCEEDED,
+        USER_DAILY_UNIT_QUOTA_EXCEEDED,
+        INVALID_ADMISSION_INPUT,
+    }
+)
+
+_EXPECTED_RETRY_AFTER = {
+    ADMITTED: 0,
+    REQUEST_REPLAY_UNAVAILABLE: 0,
+    REQUEST_ID_CONFLICT: 0,
+    INVALID_ADMISSION_INPUT: 0,
+    USER_RATE_LIMITED: 60,
+    NETWORK_RATE_LIMITED: 60,
+    APPLICATION_RATE_LIMITED: 60,
+    USER_DAILY_REQUEST_QUOTA_EXCEEDED: 86400,
+    USER_DAILY_UNIT_QUOTA_EXCEEDED: 86400,
+}
+
+
+class AdmissionConfigurationError(Exception):
+    """Sanitised, non-secret configuration failure."""
+
+    code = "invalid_admission_configuration"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+    def __repr__(self) -> str:
+        return "AdmissionConfigurationError()"
+
+
+class AdmissionUnavailable(Exception):
+    """Sanitised failure for an unavailable or malformed admission store."""
+
+    code = "admission_unavailable"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+    def __repr__(self) -> str:
+        return "AdmissionUnavailable()"
+
+
+IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+
+
+@dataclass(frozen=True)
+class AdmissionRuntimeConfig:
+    """Immutable process-wide admission configuration.
+
+    ``secret_bytes`` is excluded from repr and must contain at least 32 UTF-8
+    bytes. Trusted proxy CIDRs are parsed once during startup.
+    """
+
+    secret_bytes: bytes = field(repr=False)
+    trusted_proxy_networks: tuple[IPNetwork, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.secret_bytes, bytes) or len(self.secret_bytes) < 32:
+            raise AdmissionConfigurationError()
+        if not isinstance(self.trusted_proxy_networks, tuple):
+            raise AdmissionConfigurationError()
+        if any(
+            not isinstance(network, (ipaddress.IPv4Network, ipaddress.IPv6Network))
+            for network in self.trusted_proxy_networks
+        ):
+            raise AdmissionConfigurationError()
+
+    @classmethod
+    def from_values(
+        cls,
+        secret: object,
+        trusted_proxy_cidrs: object = None,
+    ) -> "AdmissionRuntimeConfig":
+        if not isinstance(secret, str) or not secret or not secret.strip():
+            raise AdmissionConfigurationError()
+        try:
+            secret_bytes = secret.encode("utf-8")
+        except Exception:
+            raise AdmissionConfigurationError() from None
+        if len(secret_bytes) < 32:
+            raise AdmissionConfigurationError()
+
+        if trusted_proxy_cidrs is None or trusted_proxy_cidrs == "":
+            networks: tuple[IPNetwork, ...] = ()
+        else:
+            if not isinstance(trusted_proxy_cidrs, str):
+                raise AdmissionConfigurationError()
+            parsed: list[IPNetwork] = []
+            for raw_token in trusted_proxy_cidrs.split(","):
+                token = raw_token.strip()
+                if not token:
+                    raise AdmissionConfigurationError()
+                try:
+                    parsed.append(ipaddress.ip_network(token, strict=False))
+                except ValueError:
+                    raise AdmissionConfigurationError() from None
+            networks = tuple(parsed)
+
+        return cls(secret_bytes=secret_bytes, trusted_proxy_networks=networks)
+
+    @classmethod
+    def from_env(
+        cls,
+        env: Mapping[str, object] | None = None,
+    ) -> "AdmissionRuntimeConfig":
+        if env is None:
+            import os
+
+            source: Mapping[str, object] = os.environ
+        else:
+            source = env
+        return cls.from_values(
+            source.get("ADMISSION_HMAC_SECRET"),
+            source.get("TRUSTED_PROXY_CIDRS"),
+        )
+
+
+def _parse_ip(value: object) -> IPAddress | None:
+    if not isinstance(value, str) or not value or value != value.strip():
+        return None
+    try:
+        return ipaddress.ip_address(value)
+    except ValueError:
+        return None
+
+
+def _is_trusted(address: IPAddress, networks: tuple[IPNetwork, ...]) -> bool:
+    return any(address.version == network.version and address in network for network in networks)
+
+
+def resolve_network_identity(
+    peer_host: object,
+    x_forwarded_for: object,
+    trusted_proxy_networks: tuple[IPNetwork, ...],
+) -> str:
+    """Resolve a canonical network identity without trusting arbitrary headers."""
+
+    peer = _parse_ip(peer_host)
+    if peer is None:
+        return UNKNOWN_NETWORK_IDENTITY
+
+    if not _is_trusted(peer, trusted_proxy_networks):
+        return str(peer)
+
+    if not isinstance(x_forwarded_for, str) or not x_forwarded_for:
+        return UNKNOWN_NETWORK_IDENTITY
+
+    parsed_chain: list[IPAddress] = []
+    for raw_token in x_forwarded_for.split(","):
+        token = raw_token.strip()
+        if not token:
+            return UNKNOWN_NETWORK_IDENTITY
+        address = _parse_ip(token)
+        if address is None:
+            return UNKNOWN_NETWORK_IDENTITY
+        parsed_chain.append(address)
+
+    if not parsed_chain:
+        return UNKNOWN_NETWORK_IDENTITY
+
+    for address in reversed(parsed_chain):
+        if not _is_trusted(address, trusted_proxy_networks):
+            return str(address)
+
+    return str(parsed_chain[0])
+
+
+def compute_hmac_sha256(secret_bytes: bytes, domain: bytes, payload: str) -> str:
+    """Compute an exact lowercase HMAC-SHA256 with domain separation."""
+
+    if not isinstance(secret_bytes, bytes) or len(secret_bytes) < 32:
+        raise AdmissionConfigurationError()
+    if domain not in (MESSAGE_HMAC_DOMAIN, NETWORK_HMAC_DOMAIN):
+        raise ValueError("unsupported admission HMAC domain")
+    if not isinstance(payload, str):
+        raise TypeError("admission HMAC payload must be a str")
+    return hmac.new(
+        secret_bytes,
+        domain + b"\x00" + payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _is_lower_hex64(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+@dataclass(frozen=True, repr=False)
+class AdmissionRequest:
+    user_id: str
+    request_id: str
+    message_hmac_sha256: str
+    network_hmac_sha256: str
+    estimated_units: int
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.user_id, str)
+            or not self.user_id
+            or not self.user_id.strip()
+            or len(self.user_id) > 128
+        ):
+            raise AdmissionUnavailable()
+        try:
+            canonical_request_id = RequestIdentity(self.request_id).request_id
+        except AdmissionError:
+            raise AdmissionUnavailable() from None
+        if not _is_lower_hex64(self.message_hmac_sha256):
+            raise AdmissionUnavailable()
+        if not _is_lower_hex64(self.network_hmac_sha256):
+            raise AdmissionUnavailable()
+        if (
+            isinstance(self.estimated_units, bool)
+            or not isinstance(self.estimated_units, int)
+            or not 1 <= self.estimated_units <= 6000
+        ):
+            raise AdmissionUnavailable()
+        object.__setattr__(self, "request_id", canonical_request_id)
+
+    def __repr__(self) -> str:
+        return "AdmissionRequest(<redacted>)"
+
+    def rpc_params(self) -> dict[str, object]:
+        return {
+            "p_user_id": self.user_id,
+            "p_request_id": self.request_id,
+            "p_message_hmac_sha256": self.message_hmac_sha256,
+            "p_network_hmac_sha256": self.network_hmac_sha256,
+            "p_estimated_units": self.estimated_units,
+        }
+
+
+@dataclass(frozen=True)
+class AdmissionResult:
+    decision: str
+    retry_after_seconds: int
+
+    def __post_init__(self) -> None:
+        if self.decision not in ADMISSION_DECISIONS:
+            raise AdmissionUnavailable()
+        if (
+            isinstance(self.retry_after_seconds, bool)
+            or not isinstance(self.retry_after_seconds, int)
+            or self.retry_after_seconds != _EXPECTED_RETRY_AFTER[self.decision]
+        ):
+            raise AdmissionUnavailable()
+
+
+def build_admission_request(
+    *,
+    user_id: object,
+    request_identity: RequestIdentity,
+    message: str,
+    network_identity: str,
+    config: AdmissionRuntimeConfig,
+) -> AdmissionRequest:
+    if not isinstance(user_id, str) or not user_id or len(user_id) > 128:
+        raise AdmissionUnavailable()
+    if not isinstance(request_identity, RequestIdentity):
+        raise AdmissionUnavailable()
+    if not isinstance(message, str) or not isinstance(network_identity, str):
+        raise AdmissionUnavailable()
+    if not network_identity or not isinstance(config, AdmissionRuntimeConfig):
+        raise AdmissionUnavailable()
+
+    return AdmissionRequest(
+        user_id=user_id,
+        request_id=request_identity.request_id,
+        message_hmac_sha256=compute_hmac_sha256(
+            config.secret_bytes, MESSAGE_HMAC_DOMAIN, message
+        ),
+        network_hmac_sha256=compute_hmac_sha256(
+            config.secret_bytes, NETWORK_HMAC_DOMAIN, network_identity
+        ),
+        estimated_units=estimate_text_units(message),
+    )
+
+
+def parse_admission_result(payload: Any) -> AdmissionResult:
+    """Validate an RPC result exactly and fail closed on any mismatch."""
+
+    if not isinstance(payload, list) or len(payload) != 1:
+        raise AdmissionUnavailable()
+    row = payload[0]
+    if not isinstance(row, dict) or set(row) != {
+        "decision",
+        "retry_after_seconds",
+    }:
+        raise AdmissionUnavailable()
+
+    decision = row.get("decision")
+    retry_after = row.get("retry_after_seconds")
+    if not isinstance(decision, str) or decision not in ADMISSION_DECISIONS:
+        raise AdmissionUnavailable()
+    if isinstance(retry_after, bool) or not isinstance(retry_after, int):
+        raise AdmissionUnavailable()
+    if retry_after < 0 or retry_after != _EXPECTED_RETRY_AFTER[decision]:
+        raise AdmissionUnavailable()
+
+    return AdmissionResult(decision=decision, retry_after_seconds=retry_after)
+
+
+def reserve_admission_sync(client: Any, request: AdmissionRequest) -> AdmissionResult:
+    """Call the admission RPC through a duck-typed Supabase client."""
+
+    if client is None or not isinstance(request, AdmissionRequest):
+        raise AdmissionUnavailable()
+    try:
+        response = client.rpc("reserve_admission", request.rpc_params()).execute()
+        payload = response.data
+    except Exception:
+        raise AdmissionUnavailable() from None
+    return parse_admission_result(payload)

--- a/backend/admission.py
+++ b/backend/admission.py
@@ -15,7 +15,7 @@ from typing import Any, Mapping
 
 from .admission_contracts import (
     AdmissionError,
-    NEW_MESSAGE_MAX_UNITS,
+    MESSAGE_MAX_ESTIMATED_UNITS,
     RequestIdentity,
     estimate_text_units,
 )
@@ -274,7 +274,7 @@ class AdmissionRequest:
         if (
             isinstance(self.estimated_units, bool)
             or not isinstance(self.estimated_units, int)
-            or not 1 <= self.estimated_units <= NEW_MESSAGE_MAX_UNITS
+            or not 1 <= self.estimated_units <= MESSAGE_MAX_ESTIMATED_UNITS
         ):
             raise AdmissionUnavailable()
         object.__setattr__(self, "request_id", canonical_request_id)

--- a/backend/admission.py
+++ b/backend/admission.py
@@ -13,7 +13,12 @@ import ipaddress
 from dataclasses import dataclass, field
 from typing import Any, Mapping
 
-from .admission_contracts import AdmissionError, RequestIdentity, estimate_text_units
+from .admission_contracts import (
+    AdmissionError,
+    NEW_MESSAGE_MAX_UNITS,
+    RequestIdentity,
+    estimate_text_units,
+)
 
 MESSAGE_HMAC_DOMAIN = b"message"
 NETWORK_HMAC_DOMAIN = b"network"
@@ -84,20 +89,31 @@ IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
 IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
 
 
+def _validate_secret_bytes(value: object) -> bytes:
+    if not isinstance(value, bytes) or len(value) < 32:
+        raise AdmissionConfigurationError()
+    try:
+        decoded = value.decode("utf-8")
+    except UnicodeDecodeError:
+        raise AdmissionConfigurationError() from None
+    if not decoded.strip():
+        raise AdmissionConfigurationError()
+    return value
+
+
 @dataclass(frozen=True)
 class AdmissionRuntimeConfig:
     """Immutable process-wide admission configuration.
 
-    ``secret_bytes`` is excluded from repr and must contain at least 32 UTF-8
-    bytes. Trusted proxy CIDRs are parsed once during startup.
+    ``secret_bytes`` is excluded from repr and must contain at least 32 valid,
+    non-whitespace UTF-8 bytes. Trusted proxy CIDRs are parsed once at startup.
     """
 
     secret_bytes: bytes = field(repr=False)
     trusted_proxy_networks: tuple[IPNetwork, ...] = ()
 
     def __post_init__(self) -> None:
-        if not isinstance(self.secret_bytes, bytes) or len(self.secret_bytes) < 32:
-            raise AdmissionConfigurationError()
+        _validate_secret_bytes(self.secret_bytes)
         if not isinstance(self.trusted_proxy_networks, tuple):
             raise AdmissionConfigurationError()
         if any(
@@ -118,8 +134,7 @@ class AdmissionRuntimeConfig:
             secret_bytes = secret.encode("utf-8")
         except Exception:
             raise AdmissionConfigurationError() from None
-        if len(secret_bytes) < 32:
-            raise AdmissionConfigurationError()
+        _validate_secret_bytes(secret_bytes)
 
         if trusted_proxy_cidrs is None or trusted_proxy_cidrs == "":
             networks: tuple[IPNetwork, ...] = ()
@@ -166,7 +181,10 @@ def _parse_ip(value: object) -> IPAddress | None:
 
 
 def _is_trusted(address: IPAddress, networks: tuple[IPNetwork, ...]) -> bool:
-    return any(address.version == network.version and address in network for network in networks)
+    return any(
+        address.version == network.version and address in network
+        for network in networks
+    )
 
 
 def resolve_network_identity(
@@ -209,14 +227,13 @@ def resolve_network_identity(
 def compute_hmac_sha256(secret_bytes: bytes, domain: bytes, payload: str) -> str:
     """Compute an exact lowercase HMAC-SHA256 with domain separation."""
 
-    if not isinstance(secret_bytes, bytes) or len(secret_bytes) < 32:
-        raise AdmissionConfigurationError()
+    validated_secret = _validate_secret_bytes(secret_bytes)
     if domain not in (MESSAGE_HMAC_DOMAIN, NETWORK_HMAC_DOMAIN):
         raise ValueError("unsupported admission HMAC domain")
     if not isinstance(payload, str):
         raise TypeError("admission HMAC payload must be a str")
     return hmac.new(
-        secret_bytes,
+        validated_secret,
         domain + b"\x00" + payload.encode("utf-8"),
         hashlib.sha256,
     ).hexdigest()
@@ -257,7 +274,7 @@ class AdmissionRequest:
         if (
             isinstance(self.estimated_units, bool)
             or not isinstance(self.estimated_units, int)
-            or not 1 <= self.estimated_units <= 6000
+            or not 1 <= self.estimated_units <= NEW_MESSAGE_MAX_UNITS
         ):
             raise AdmissionUnavailable()
         object.__setattr__(self, "request_id", canonical_request_id)
@@ -305,8 +322,16 @@ def build_admission_request(
         raise AdmissionUnavailable()
     if not isinstance(message, str) or not isinstance(network_identity, str):
         raise AdmissionUnavailable()
-    if not network_identity or not isinstance(config, AdmissionRuntimeConfig):
+    if not isinstance(config, AdmissionRuntimeConfig):
         raise AdmissionUnavailable()
+
+    if network_identity != UNKNOWN_NETWORK_IDENTITY:
+        parsed_network_identity = _parse_ip(network_identity)
+        if (
+            parsed_network_identity is None
+            or network_identity != str(parsed_network_identity)
+        ):
+            raise AdmissionUnavailable()
 
     return AdmissionRequest(
         user_id=user_id,

--- a/backend/chat_engine.py
+++ b/backend/chat_engine.py
@@ -1,0 +1,41 @@
+"""HTTP-facing conversation engine adapter with explicit budget injection."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import BackgroundTasks
+
+from .engine import ConversationEngine
+from .turn_execution import TurnBudget, create_budget
+
+
+class ChatConversationEngine(ConversationEngine):
+    """Conversation engine used by the active request path.
+
+    Internal callers may omit ``budget`` and retain the existing behavior.
+    The HTTP admission path supplies the already-started budget so admission,
+    lock acquisition, generation, and commit share one monotonic deadline.
+    """
+
+    async def process_turn(
+        self,
+        user_id: str,
+        user_message: str,
+        background_tasks: Optional[BackgroundTasks] = None,
+        *,
+        budget: Optional[TurnBudget] = None,
+    ):
+        active_budget = (
+            budget
+            if budget is not None
+            else create_budget(self._turn_config, now_provider=self._monotonic)
+        )
+        if not isinstance(active_budget, TurnBudget):
+            raise TypeError("budget must be a TurnBudget")
+        return await self._run_turn_locked(
+            user_id,
+            user_message,
+            background_tasks,
+            active_budget,
+        )

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,19 +1,20 @@
 import asyncio
-import logging
-import os
-from typing import Optional
-
-import uvicorn
-from dotenv import load_dotenv
-from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Depends, BackgroundTasks, Request
 from fastapi.exceptions import RequestValidationError
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+import logging
+from supabase_auth.errors import AuthApiError, AuthRetryableError
+logger = logging.getLogger(__name__)
+
+
 from pydantic import BaseModel, ConfigDict, StrictStr, field_validator
 from pydantic_core import PydanticCustomError
-from supabase_auth.errors import AuthApiError, AuthRetryableError
-
+from typing import Optional
+import uvicorn
+import os
+from dotenv import load_dotenv
 from .admission import (
     ADMITTED,
     APPLICATION_RATE_LIMITED,
@@ -33,21 +34,21 @@ from .admission import (
 )
 from .admission_contracts import AdmissionError, RequestIdentity, validate_new_message
 from .chat_engine import ChatConversationEngine
-from .emotion_presentation import EmotionStateResponse
-from .groq_manager import GroqPoolExhaustedError, GroqRequestError
 from .memory import StatePersistenceError
+from .emotion_presentation import EmotionStateResponse
 from .turn_execution import (
-    DeadlineExceeded,
-    TurnErrorCode,
     TurnExecutionConfig,
     TurnExecutionError,
+    TurnErrorCode,
+    DeadlineExceeded,
     create_budget,
     run_blocking_write,
 )
-
-logger = logging.getLogger(__name__)
+from .groq_manager import GroqPoolExhaustedError, GroqRequestError
 
 load_dotenv()
+
+from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI(title="SoulMate API", description="Backend for the Emotional Companion Bot")
 
@@ -62,8 +63,8 @@ app.add_middleware(
 # Validate runtime containment before initialising the engine.
 # This runs at module load time, so multi-worker configurations fail early.
 from .runtime_containment import (
-    parse_archival_extraction_flag,
     validate_worker_configuration,
+    parse_archival_extraction_flag,
 )
 
 validate_worker_configuration()
@@ -73,8 +74,8 @@ _archival_extraction_enabled = parse_archival_extraction_flag(
     os.environ.get("ARCHIVAL_EXTRACTION_ENABLED")
 )
 
-# Parse immutable runtime configuration. Admission has no fallback secret and
-# therefore fails closed during application initialisation.
+# Parse turn execution and admission config from environment. Admission has no
+# fallback secret and fails closed during application initialisation.
 _turn_config = TurnExecutionConfig.from_env()
 _admission_config = AdmissionRuntimeConfig.from_env()
 
@@ -84,24 +85,16 @@ engine = ChatConversationEngine(
     turn_config=_turn_config,
 )
 
+
 security = HTTPBearer(auto_error=False)
 
-
-def get_current_user(
-    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
-):
+def get_current_user(credentials: Optional[HTTPAuthorizationCredentials] = Depends(security)):
     if not credentials:
-        raise HTTPException(
-            status_code=401,
-            detail="Not authenticated",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+        raise HTTPException(status_code=401, detail="Not authenticated", headers={"WWW-Authenticate": "Bearer"})
     token = credentials.credentials
     try:
         if not engine.memory_manager.supabase:
-            raise HTTPException(
-                status_code=503, detail="Authentication service unavailable"
-            )
+            raise HTTPException(status_code=503, detail="Authentication service unavailable")
 
         auth_response = engine.memory_manager.supabase.auth.get_user(token)
         if not auth_response.user:
@@ -113,32 +106,21 @@ def get_current_user(
         return auth_response.user
     except HTTPException:
         raise
-    except AuthApiError as exc:
-        if exc.status in (400, 401, 403):
-            raise HTTPException(
-                status_code=401,
-                detail="Authentication failed",
-                headers={"WWW-Authenticate": "Bearer"},
-            )
+    except AuthApiError as e:
+        # e.status is present in AuthApiError
+        if e.status in (400, 401, 403):
+            raise HTTPException(status_code=401, detail="Authentication failed", headers={"WWW-Authenticate": "Bearer"})
         logger.error("Authentication service failure: Upstream AuthApiError")
-        raise HTTPException(
-            status_code=503, detail="Authentication service unavailable"
-        )
+        raise HTTPException(status_code=503, detail="Authentication service unavailable")
     except AuthRetryableError:
         logger.error("Authentication service failure: Transport/Fetch error")
-        raise HTTPException(
-            status_code=503, detail="Authentication service unavailable"
-        )
+        raise HTTPException(status_code=503, detail="Authentication service unavailable")
     except Exception:
         logger.error("Authentication service failure: Unexpected error")
-        raise HTTPException(
-            status_code=503, detail="Authentication service unavailable"
-        )
-
+        raise HTTPException(status_code=503, detail="Authentication service unavailable")
 
 class ChatInput(BaseModel):
     model_config = ConfigDict(extra="forbid")
-
     request_id: StrictStr
     message: StrictStr
 
@@ -158,7 +140,6 @@ class ChatInput(BaseModel):
         except AdmissionError as exc:
             raise PydanticCustomError(exc.code, exc.code)
         return value
-
 
 class ChatResponse(BaseModel):
     response: str
@@ -190,19 +171,19 @@ async def _sanitise_request_validation_error(
             break
     return JSONResponse(
         status_code=422,
-        content={
-            "detail": {
-                "code": code,
-                "message": _VALIDATION_MESSAGES[code],
-            }
-        },
+        content={"detail": {"code": code, "message": _VALIDATION_MESSAGES[code]}},
     )
 
 
 # ─── Error mapping ───────────────────────────────────────────────────────────
 
-
 def _turn_code_to_http(code: TurnErrorCode) -> int:
+    """Map a ``TurnErrorCode`` to an HTTP status code.
+
+    Centralised single-entry mapping so both ``TurnExecutionError`` and
+    ``GroqPoolExhaustedError`` produce identical status codes for the
+    same logical failure.
+    """
     mapping = {
         TurnErrorCode.turn_timeout: 504,
         TurnErrorCode.upstream_rate_limited: 429,
@@ -216,6 +197,7 @@ def _turn_code_to_http(code: TurnErrorCode) -> int:
 
 
 def _turn_code_to_message(code: TurnErrorCode) -> str:
+    """Map a ``TurnErrorCode`` to a public, sanitised message."""
     mapping = {
         TurnErrorCode.turn_timeout: "Turn deadline exceeded.",
         TurnErrorCode.upstream_rate_limited: "Upstream rate limited.",
@@ -229,6 +211,14 @@ def _turn_code_to_message(code: TurnErrorCode) -> str:
 
 
 def _map_turn_error(exc: Exception) -> HTTPException:
+    """Map domain exceptions to stable HTTP error responses.
+
+    Never exposes: model name, provider details, exception text, prompt,
+    infrastructure details, stack trace, or user content.
+    Uses ``detail.code`` for structured error responses.
+    Both ``TurnExecutionError`` and ``GroqPoolExhaustedError`` go through
+    the same ``_turn_code_to_http`` / ``_turn_code_to_message`` helpers.
+    """
     if isinstance(exc, DeadlineExceeded):
         code = TurnErrorCode.turn_timeout
         return HTTPException(
@@ -244,57 +234,39 @@ def _map_turn_error(exc: Exception) -> HTTPException:
         )
 
     if isinstance(exc, GroqPoolExhaustedError):
+        # Map the failure code if available
         from .groq_manager import provider_failure_to_turn_code
-
         turn_code = (
-            provider_failure_to_turn_code(exc.failure_code)
-            if exc.failure_code
+            provider_failure_to_turn_code(exc.failure_code) if exc.failure_code
             else TurnErrorCode.provider_unavailable
         )
         return HTTPException(
             status_code=_turn_code_to_http(turn_code),
-            detail={
-                "code": turn_code.value,
-                "message": _turn_code_to_message(turn_code),
-            },
+            detail={"code": turn_code.value, "message": _turn_code_to_message(turn_code)},
         )
 
     if isinstance(exc, GroqRequestError):
         return HTTPException(
             status_code=503,
-            detail={
-                "code": TurnErrorCode.provider_unavailable.value,
-                "message": "Provider request failed.",
-            },
+            detail={"code": TurnErrorCode.provider_unavailable.value, "message": "Provider request failed."},
         )
 
     if isinstance(exc, StatePersistenceError):
         return HTTPException(
             status_code=503,
-            detail={
-                "code": TurnErrorCode.persistence_unavailable.value,
-                "message": "Persistence service unavailable.",
-            },
+            detail={"code": TurnErrorCode.persistence_unavailable.value, "message": "Persistence service unavailable."},
         )
 
+    # Unknown/unexpected — sanitize to generic 500
     return HTTPException(
         status_code=500,
-        detail={
-            "code": TurnErrorCode.internal_error.value,
-            "message": "Internal server error.",
-        },
+        detail={"code": TurnErrorCode.internal_error.value, "message": "Internal server error."},
     )
 
 
 _ADMISSION_HTTP = {
-    REQUEST_REPLAY_UNAVAILABLE: (
-        409,
-        "Request was already received but its response is unavailable.",
-    ),
-    REQUEST_ID_CONFLICT: (
-        409,
-        "Request identifier conflicts with a different message.",
-    ),
+    REQUEST_REPLAY_UNAVAILABLE: (409, "Request was already received but its response is unavailable."),
+    REQUEST_ID_CONFLICT: (409, "Request identifier conflicts with a different message."),
     USER_RATE_LIMITED: (429, "User request rate limit exceeded."),
     NETWORK_RATE_LIMITED: (429, "Network request rate limit exceeded."),
     APPLICATION_RATE_LIMITED: (429, "Application request rate limit exceeded."),
@@ -306,9 +278,7 @@ _ADMISSION_HTTP = {
 
 def _map_admission_rejection(result: AdmissionResult) -> HTTPException:
     status_code, message = _ADMISSION_HTTP[result.decision]
-    headers = None
-    if status_code == 429:
-        headers = {"Retry-After": str(result.retry_after_seconds)}
+    headers = {"Retry-After": str(result.retry_after_seconds)} if status_code == 429 else None
     return HTTPException(
         status_code=status_code,
         detail={"code": result.decision, "message": message},
@@ -319,10 +289,7 @@ def _map_admission_rejection(result: AdmissionResult) -> HTTPException:
 def _admission_unavailable_error() -> HTTPException:
     return HTTPException(
         status_code=503,
-        detail={
-            "code": AdmissionUnavailable.code,
-            "message": "Admission service unavailable.",
-        },
+        detail={"code": AdmissionUnavailable.code, "message": "Admission service unavailable."},
     )
 
 
@@ -331,7 +298,7 @@ async def chat_endpoint(
     input_data: ChatInput,
     request: Request,
     background_tasks: BackgroundTasks,
-    current_user=Depends(get_current_user),
+    current_user = Depends(get_current_user)
 ):
     try:
         budget = create_budget(_turn_config)
@@ -343,7 +310,6 @@ async def chat_endpoint(
             request.headers.get("x-forwarded-for"),
             _admission_config.trusted_proxy_networks,
         )
-
         admission_request = build_admission_request(
             user_id=user_id,
             request_identity=identity,
@@ -351,86 +317,64 @@ async def chat_endpoint(
             network_identity=network_identity,
             config=_admission_config,
         )
-
-        try:
-            admission_result = await run_blocking_write(
-                "reserve_admission",
-                budget,
-                _turn_config.supabase_timeout,
-                reserve_admission_sync,
-                engine.memory_manager.supabase,
-                admission_request,
-                allowlist_exceptions=(AdmissionUnavailable,),
-            )
-        except AdmissionUnavailable:
-            logger.error("event=admission_unavailable")
-            raise _admission_unavailable_error()
-
+        admission_result = await run_blocking_write(
+            "reserve_admission",
+            budget,
+            _turn_config.supabase_timeout,
+            reserve_admission_sync,
+            engine.memory_manager.supabase,
+            admission_request,
+            allowlist_exceptions=(AdmissionUnavailable,),
+        )
         if admission_result.decision != ADMITTED:
-            logger.info(
-                "event=admission_rejected code=%s", admission_result.decision
-            )
+            logger.info("event=admission_rejected code=%s", admission_result.decision)
             raise _map_admission_rejection(admission_result)
 
         logger.info("event=admission_admitted")
         response_text, current_emotion = await engine.process_turn(
-            user_id,
-            input_data.message,
-            background_tasks,
-            budget=budget,
+            user_id, input_data.message, background_tasks, budget=budget
         )
         return ChatResponse(response=response_text, emotion_state=current_emotion)
     except asyncio.CancelledError:
+        # CancelledError must NOT be converted to HTTP 500 — propagate
         raise
     except HTTPException:
         raise
     except AdmissionUnavailable:
         logger.error("event=admission_unavailable")
         raise _admission_unavailable_error()
-    except (
-        DeadlineExceeded,
-        TurnExecutionError,
-        GroqPoolExhaustedError,
-        GroqRequestError,
-        StatePersistenceError,
-    ) as exc:
+    except (DeadlineExceeded, TurnExecutionError, GroqPoolExhaustedError,
+            GroqRequestError, StatePersistenceError) as exc:
         raise _map_turn_error(exc)
     except Exception:
+        # Sanitize logging: avoid logging raw exceptions that might contain secrets or tracebacks
         logger.error("Event: Chat Turn Failure")
         raise HTTPException(
             status_code=500,
-            detail={
-                "code": TurnErrorCode.internal_error.value,
-                "message": "Internal server error.",
-            },
+            detail={"code": TurnErrorCode.internal_error.value, "message": "Internal server error."},
         )
-
 
 @app.get("/health")
 def health_check():
     return {"status": "alive", "engine_status": "ready"}
 
-
 @app.get("/history")
-def get_history(current_user=Depends(get_current_user)):
+def get_history(current_user = Depends(get_current_user)):
     user_id = current_user.id
     try:
         if not engine.memory_manager.supabase:
             return []
-
-        response = (
-            engine.memory_manager.supabase.table("chat_logs")
-            .select("*")
-            .eq("user_id", user_id)
-            .order("created_at", desc=True)
-            .limit(50)
+            
+        response = engine.memory_manager.supabase.table("chat_logs")\
+            .select("*")\
+            .eq("user_id", user_id)\
+            .order("created_at", desc=True)\
+            .limit(50)\
             .execute()
-        )
-
+            
         return response.data[::-1] if response.data else []
     except Exception:
         raise HTTPException(status_code=500, detail="Internal Server Error")
-
 
 if __name__ == "__main__":
     # Development entrypoint — NOT for production use.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,31 +1,53 @@
 import asyncio
-from fastapi import FastAPI, HTTPException, Depends, BackgroundTasks
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-
 import logging
-from supabase_auth.errors import AuthApiError, AuthRetryableError
-logger = logging.getLogger(__name__)
-
-
-from pydantic import BaseModel, ConfigDict, Field
-from typing import List, Optional
-import uvicorn
 import os
+from typing import Optional
+
+import uvicorn
 from dotenv import load_dotenv
-from .engine import ConversationEngine
-from .memory import MAX_MESSAGE_LENGTH, StatePersistenceError
+from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel, ConfigDict, StrictStr, field_validator
+from pydantic_core import PydanticCustomError
+from supabase_auth.errors import AuthApiError, AuthRetryableError
+
+from .admission import (
+    ADMITTED,
+    APPLICATION_RATE_LIMITED,
+    INVALID_ADMISSION_INPUT,
+    NETWORK_RATE_LIMITED,
+    REQUEST_ID_CONFLICT,
+    REQUEST_REPLAY_UNAVAILABLE,
+    USER_DAILY_REQUEST_QUOTA_EXCEEDED,
+    USER_DAILY_UNIT_QUOTA_EXCEEDED,
+    USER_RATE_LIMITED,
+    AdmissionResult,
+    AdmissionRuntimeConfig,
+    AdmissionUnavailable,
+    build_admission_request,
+    reserve_admission_sync,
+    resolve_network_identity,
+)
+from .admission_contracts import AdmissionError, RequestIdentity, validate_new_message
 from .emotion_presentation import EmotionStateResponse
+from .engine import ConversationEngine
+from .groq_manager import GroqPoolExhaustedError, GroqRequestError
+from .memory import StatePersistenceError
 from .turn_execution import (
+    DeadlineExceeded,
+    TurnErrorCode,
     TurnExecutionConfig,
     TurnExecutionError,
-    TurnErrorCode,
-    DeadlineExceeded,
+    create_budget,
+    run_blocking_write,
 )
-from .groq_manager import GroqPoolExhaustedError, GroqRequestError
+
+logger = logging.getLogger(__name__)
 
 load_dotenv()
-
-from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI(title="SoulMate API", description="Backend for the Emotional Companion Bot")
 
@@ -40,8 +62,8 @@ app.add_middleware(
 # Validate runtime containment before initialising the engine.
 # This runs at module load time, so multi-worker configurations fail early.
 from .runtime_containment import (
-    validate_worker_configuration,
     parse_archival_extraction_flag,
+    validate_worker_configuration,
 )
 
 validate_worker_configuration()
@@ -51,8 +73,10 @@ _archival_extraction_enabled = parse_archival_extraction_flag(
     os.environ.get("ARCHIVAL_EXTRACTION_ENABLED")
 )
 
-# Parse turn execution config from environment
+# Parse immutable runtime configuration. Admission has no fallback secret and
+# therefore fails closed during application initialisation.
 _turn_config = TurnExecutionConfig.from_env()
+_admission_config = AdmissionRuntimeConfig.from_env()
 
 # Initialize Engine with containment-aware configuration
 engine = ConversationEngine(
@@ -60,16 +84,24 @@ engine = ConversationEngine(
     turn_config=_turn_config,
 )
 
-
 security = HTTPBearer(auto_error=False)
 
-def get_current_user(credentials: Optional[HTTPAuthorizationCredentials] = Depends(security)):
+
+def get_current_user(
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
     if not credentials:
-        raise HTTPException(status_code=401, detail="Not authenticated", headers={"WWW-Authenticate": "Bearer"})
+        raise HTTPException(
+            status_code=401,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
     token = credentials.credentials
     try:
         if not engine.memory_manager.supabase:
-            raise HTTPException(status_code=503, detail="Authentication service unavailable")
+            raise HTTPException(
+                status_code=503, detail="Authentication service unavailable"
+            )
 
         auth_response = engine.memory_manager.supabase.auth.get_user(token)
         if not auth_response.user:
@@ -81,37 +113,96 @@ def get_current_user(credentials: Optional[HTTPAuthorizationCredentials] = Depen
         return auth_response.user
     except HTTPException:
         raise
-    except AuthApiError as e:
-        # e.status is present in AuthApiError
-        if e.status in (400, 401, 403):
-            raise HTTPException(status_code=401, detail="Authentication failed", headers={"WWW-Authenticate": "Bearer"})
+    except AuthApiError as exc:
+        if exc.status in (400, 401, 403):
+            raise HTTPException(
+                status_code=401,
+                detail="Authentication failed",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
         logger.error("Authentication service failure: Upstream AuthApiError")
-        raise HTTPException(status_code=503, detail="Authentication service unavailable")
+        raise HTTPException(
+            status_code=503, detail="Authentication service unavailable"
+        )
     except AuthRetryableError:
         logger.error("Authentication service failure: Transport/Fetch error")
-        raise HTTPException(status_code=503, detail="Authentication service unavailable")
+        raise HTTPException(
+            status_code=503, detail="Authentication service unavailable"
+        )
     except Exception:
         logger.error("Authentication service failure: Unexpected error")
-        raise HTTPException(status_code=503, detail="Authentication service unavailable")
+        raise HTTPException(
+            status_code=503, detail="Authentication service unavailable"
+        )
+
 
 class ChatInput(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    message: str = Field(max_length=MAX_MESSAGE_LENGTH)
+
+    request_id: StrictStr
+    message: StrictStr
+
+    @field_validator("request_id")
+    @classmethod
+    def _validate_request_id(cls, value: str) -> str:
+        try:
+            return RequestIdentity(value).request_id
+        except AdmissionError:
+            raise PydanticCustomError("invalid_request_id", "invalid_request_id")
+
+    @field_validator("message")
+    @classmethod
+    def _validate_message(cls, value: str) -> str:
+        try:
+            validate_new_message(value)
+        except AdmissionError as exc:
+            raise PydanticCustomError(exc.code, exc.code)
+        return value
+
 
 class ChatResponse(BaseModel):
     response: str
     emotion_state: EmotionStateResponse
 
 
+_VALIDATION_MESSAGES = {
+    "invalid_request_id": "Invalid request identifier.",
+    "message_too_long": "Message exceeds the character limit.",
+    "message_budget_exceeded": "Message exceeds the input budget.",
+    "invalid_request": "Invalid request body.",
+}
+
+
+@app.exception_handler(RequestValidationError)
+async def _sanitise_request_validation_error(
+    _request: Request,
+    exc: RequestValidationError,
+) -> JSONResponse:
+    error_types = {item.get("type") for item in exc.errors()}
+    code = "invalid_request"
+    for candidate in (
+        "invalid_request_id",
+        "message_too_long",
+        "message_budget_exceeded",
+    ):
+        if candidate in error_types:
+            code = candidate
+            break
+    return JSONResponse(
+        status_code=422,
+        content={
+            "detail": {
+                "code": code,
+                "message": _VALIDATION_MESSAGES[code],
+            }
+        },
+    )
+
+
 # ─── Error mapping ───────────────────────────────────────────────────────────
 
-def _turn_code_to_http(code: TurnErrorCode) -> int:
-    """Map a ``TurnErrorCode`` to an HTTP status code.
 
-    Centralised single-entry mapping so both ``TurnExecutionError`` and
-    ``GroqPoolExhaustedError`` produce identical status codes for the
-    same logical failure.
-    """
+def _turn_code_to_http(code: TurnErrorCode) -> int:
     mapping = {
         TurnErrorCode.turn_timeout: 504,
         TurnErrorCode.upstream_rate_limited: 429,
@@ -125,7 +216,6 @@ def _turn_code_to_http(code: TurnErrorCode) -> int:
 
 
 def _turn_code_to_message(code: TurnErrorCode) -> str:
-    """Map a ``TurnErrorCode`` to a public, sanitised message."""
     mapping = {
         TurnErrorCode.turn_timeout: "Turn deadline exceeded.",
         TurnErrorCode.upstream_rate_limited: "Upstream rate limited.",
@@ -139,14 +229,6 @@ def _turn_code_to_message(code: TurnErrorCode) -> str:
 
 
 def _map_turn_error(exc: Exception) -> HTTPException:
-    """Map domain exceptions to stable HTTP error responses.
-
-    Never exposes: model name, provider details, exception text, prompt,
-    infrastructure details, stack trace, or user content.
-    Uses ``detail.code`` for structured error responses.
-    Both ``TurnExecutionError`` and ``GroqPoolExhaustedError`` go through
-    the same ``_turn_code_to_http`` / ``_turn_code_to_message`` helpers.
-    """
     if isinstance(exc, DeadlineExceeded):
         code = TurnErrorCode.turn_timeout
         return HTTPException(
@@ -162,83 +244,193 @@ def _map_turn_error(exc: Exception) -> HTTPException:
         )
 
     if isinstance(exc, GroqPoolExhaustedError):
-        # Map the failure code if available
         from .groq_manager import provider_failure_to_turn_code
+
         turn_code = (
-            provider_failure_to_turn_code(exc.failure_code) if exc.failure_code
+            provider_failure_to_turn_code(exc.failure_code)
+            if exc.failure_code
             else TurnErrorCode.provider_unavailable
         )
         return HTTPException(
             status_code=_turn_code_to_http(turn_code),
-            detail={"code": turn_code.value, "message": _turn_code_to_message(turn_code)},
+            detail={
+                "code": turn_code.value,
+                "message": _turn_code_to_message(turn_code),
+            },
         )
 
     if isinstance(exc, GroqRequestError):
         return HTTPException(
             status_code=503,
-            detail={"code": TurnErrorCode.provider_unavailable.value, "message": "Provider request failed."},
+            detail={
+                "code": TurnErrorCode.provider_unavailable.value,
+                "message": "Provider request failed.",
+            },
         )
 
     if isinstance(exc, StatePersistenceError):
         return HTTPException(
             status_code=503,
-            detail={"code": TurnErrorCode.persistence_unavailable.value, "message": "Persistence service unavailable."},
+            detail={
+                "code": TurnErrorCode.persistence_unavailable.value,
+                "message": "Persistence service unavailable.",
+            },
         )
 
-    # Unknown/unexpected — sanitize to generic 500
     return HTTPException(
         status_code=500,
-        detail={"code": TurnErrorCode.internal_error.value, "message": "Internal server error."},
+        detail={
+            "code": TurnErrorCode.internal_error.value,
+            "message": "Internal server error.",
+        },
+    )
+
+
+_ADMISSION_HTTP = {
+    REQUEST_REPLAY_UNAVAILABLE: (
+        409,
+        "Request was already received but its response is unavailable.",
+    ),
+    REQUEST_ID_CONFLICT: (
+        409,
+        "Request identifier conflicts with a different message.",
+    ),
+    USER_RATE_LIMITED: (429, "User request rate limit exceeded."),
+    NETWORK_RATE_LIMITED: (429, "Network request rate limit exceeded."),
+    APPLICATION_RATE_LIMITED: (429, "Application request rate limit exceeded."),
+    USER_DAILY_REQUEST_QUOTA_EXCEEDED: (429, "Daily request quota exceeded."),
+    USER_DAILY_UNIT_QUOTA_EXCEEDED: (429, "Daily input quota exceeded."),
+    INVALID_ADMISSION_INPUT: (422, "Invalid admission input."),
+}
+
+
+def _map_admission_rejection(result: AdmissionResult) -> HTTPException:
+    status_code, message = _ADMISSION_HTTP[result.decision]
+    headers = None
+    if status_code == 429:
+        headers = {"Retry-After": str(result.retry_after_seconds)}
+    return HTTPException(
+        status_code=status_code,
+        detail={"code": result.decision, "message": message},
+        headers=headers,
+    )
+
+
+def _admission_unavailable_error() -> HTTPException:
+    return HTTPException(
+        status_code=503,
+        detail={
+            "code": AdmissionUnavailable.code,
+            "message": "Admission service unavailable.",
+        },
     )
 
 
 @app.post("/chat", response_model=ChatResponse)
 async def chat_endpoint(
     input_data: ChatInput,
+    request: Request,
     background_tasks: BackgroundTasks,
-    current_user = Depends(get_current_user)
+    current_user=Depends(get_current_user),
 ):
     try:
-        user_id = current_user.id
+        budget = create_budget(_turn_config)
+        user_id = getattr(current_user, "id", None)
+        identity = RequestIdentity(input_data.request_id)
+        peer_host = request.client.host if request.client is not None else None
+        network_identity = resolve_network_identity(
+            peer_host,
+            request.headers.get("x-forwarded-for"),
+            _admission_config.trusted_proxy_networks,
+        )
+
+        admission_request = build_admission_request(
+            user_id=user_id,
+            request_identity=identity,
+            message=input_data.message,
+            network_identity=network_identity,
+            config=_admission_config,
+        )
+
+        try:
+            admission_result = await run_blocking_write(
+                "reserve_admission",
+                budget,
+                _turn_config.supabase_timeout,
+                reserve_admission_sync,
+                engine.memory_manager.supabase,
+                admission_request,
+                allowlist_exceptions=(AdmissionUnavailable,),
+            )
+        except AdmissionUnavailable:
+            logger.error("event=admission_unavailable")
+            raise _admission_unavailable_error()
+
+        if admission_result.decision != ADMITTED:
+            logger.info(
+                "event=admission_rejected code=%s", admission_result.decision
+            )
+            raise _map_admission_rejection(admission_result)
+
+        logger.info("event=admission_admitted")
         response_text, current_emotion = await engine.process_turn(
-            user_id, input_data.message, background_tasks
+            user_id,
+            input_data.message,
+            background_tasks,
+            budget=budget,
         )
         return ChatResponse(response=response_text, emotion_state=current_emotion)
     except asyncio.CancelledError:
-        # CancelledError must NOT be converted to HTTP 500 — propagate
         raise
-    except (DeadlineExceeded, TurnExecutionError, GroqPoolExhaustedError,
-            GroqRequestError, StatePersistenceError) as exc:
+    except HTTPException:
+        raise
+    except AdmissionUnavailable:
+        logger.error("event=admission_unavailable")
+        raise _admission_unavailable_error()
+    except (
+        DeadlineExceeded,
+        TurnExecutionError,
+        GroqPoolExhaustedError,
+        GroqRequestError,
+        StatePersistenceError,
+    ) as exc:
         raise _map_turn_error(exc)
     except Exception:
-        # Sanitize logging: avoid logging raw exceptions that might contain secrets or tracebacks
         logger.error("Event: Chat Turn Failure")
         raise HTTPException(
             status_code=500,
-            detail={"code": TurnErrorCode.internal_error.value, "message": "Internal server error."},
+            detail={
+                "code": TurnErrorCode.internal_error.value,
+                "message": "Internal server error.",
+            },
         )
+
 
 @app.get("/health")
 def health_check():
     return {"status": "alive", "engine_status": "ready"}
 
+
 @app.get("/history")
-def get_history(current_user = Depends(get_current_user)):
+def get_history(current_user=Depends(get_current_user)):
     user_id = current_user.id
     try:
         if not engine.memory_manager.supabase:
             return []
-            
-        response = engine.memory_manager.supabase.table("chat_logs")\
-            .select("*")\
-            .eq("user_id", user_id)\
-            .order("created_at", desc=True)\
-            .limit(50)\
+
+        response = (
+            engine.memory_manager.supabase.table("chat_logs")
+            .select("*")
+            .eq("user_id", user_id)
+            .order("created_at", desc=True)
+            .limit(50)
             .execute()
-            
+        )
+
         return response.data[::-1] if response.data else []
     except Exception:
         raise HTTPException(status_code=500, detail="Internal Server Error")
+
 
 if __name__ == "__main__":
     # Development entrypoint — NOT for production use.

--- a/backend/main.py
+++ b/backend/main.py
@@ -32,8 +32,8 @@ from .admission import (
     resolve_network_identity,
 )
 from .admission_contracts import AdmissionError, RequestIdentity, validate_new_message
+from .chat_engine import ChatConversationEngine
 from .emotion_presentation import EmotionStateResponse
-from .engine import ConversationEngine
 from .groq_manager import GroqPoolExhaustedError, GroqRequestError
 from .memory import StatePersistenceError
 from .turn_execution import (
@@ -79,7 +79,7 @@ _turn_config = TurnExecutionConfig.from_env()
 _admission_config = AdmissionRuntimeConfig.from_env()
 
 # Initialize Engine with containment-aware configuration
-engine = ConversationEngine(
+engine = ChatConversationEngine(
     archival_extraction_enabled=_archival_extraction_enabled,
     turn_config=_turn_config,
 )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,7 @@
 import os
 
-# Force mock placeholders for tests to prevent real environment keys from being used
+# Force mock placeholders for tests to prevent real environment keys from being used.
 os.environ["GROQ_API_KEY"] = "mock_groq_key_placeholder"
 os.environ["GROQ_API_KEY_2"] = "mock_groq_key_2_placeholder"
+os.environ["ADMISSION_HMAC_SECRET"] = "test-admission-secret-that-is-at-least-32-bytes"
+os.environ["TRUSTED_PROXY_CIDRS"] = ""

--- a/backend/tests/test_admission_additional_invariants.py
+++ b/backend/tests/test_admission_additional_invariants.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import pytest
+from fastapi import BackgroundTasks, Request
+
+import backend.main as main
+from backend.admission import (
+    AdmissionConfigurationError,
+    AdmissionRuntimeConfig,
+    AdmissionUnavailable,
+    build_admission_request,
+)
+from backend.admission_contracts import RequestIdentity
+
+UUID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+@pytest.mark.parametrize(
+    "secret_bytes",
+    [
+        b" " * 32,
+        b"\xff" * 32,
+    ],
+)
+def test_direct_config_constructor_rejects_invalid_utf8_or_whitespace(secret_bytes):
+    with pytest.raises(AdmissionConfigurationError):
+        AdmissionRuntimeConfig(secret_bytes=secret_bytes)
+
+
+@pytest.mark.parametrize(
+    "network_identity",
+    [
+        "",
+        "not-an-ip",
+        "2001:0db8:0000:0000:0000:0000:0000:0001",
+        " 203.0.113.1",
+    ],
+)
+def test_request_builder_rejects_noncanonical_network_identity(network_identity):
+    with pytest.raises(AdmissionUnavailable):
+        build_admission_request(
+            user_id="user-a",
+            request_identity=RequestIdentity(UUID),
+            message="hello",
+            network_identity=network_identity,
+            config=AdmissionRuntimeConfig.from_values("s" * 32),
+        )
+
+
+def test_request_builder_accepts_unknown_network_bucket():
+    request = build_admission_request(
+        user_id="user-a",
+        request_identity=RequestIdentity(UUID),
+        message="hello",
+        network_identity="unknown",
+        config=AdmissionRuntimeConfig.from_values("s" * 32),
+    )
+    assert len(request.network_hmac_sha256) == 64
+
+
+def test_endpoint_cancellation_drains_reservation_and_never_calls_engine(monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+    completed = threading.Event()
+
+    class FakeEngine:
+        def __init__(self):
+            self.memory_manager = SimpleNamespace(supabase=object())
+            self.calls = []
+
+        async def process_turn(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+            raise AssertionError("engine must not run after cancelled admission")
+
+    fake_engine = FakeEngine()
+    monkeypatch.setattr(main, "engine", fake_engine)
+    monkeypatch.setattr(
+        main,
+        "_admission_config",
+        AdmissionRuntimeConfig.from_values("s" * 32),
+    )
+
+    def blocking_reservation(_client, _request):
+        started.set()
+        release.wait(timeout=5)
+        completed.set()
+        return None
+
+    monkeypatch.setattr(main, "reserve_admission_sync", blocking_reservation)
+
+    async def scenario():
+        request = Request(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/chat",
+                "headers": [],
+                "client": ("203.0.113.8", 12345),
+            }
+        )
+        task = asyncio.create_task(
+            main.chat_endpoint(
+                main.ChatInput(request_id=UUID, message="hello"),
+                request,
+                BackgroundTasks(),
+                current_user=SimpleNamespace(id="user-a"),
+            )
+        )
+        started_ok = await asyncio.to_thread(started.wait, 2)
+        assert started_ok
+
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(scenario())
+    assert completed.is_set()
+    assert fake_engine.calls == []

--- a/backend/tests/test_admission_runtime.py
+++ b/backend/tests/test_admission_runtime.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import os
+import subprocess
+import sys
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from backend.admission import (
+    ADMISSION_DECISIONS,
+    ADMITTED,
+    APPLICATION_RATE_LIMITED,
+    INVALID_ADMISSION_INPUT,
+    MESSAGE_HMAC_DOMAIN,
+    NETWORK_HMAC_DOMAIN,
+    NETWORK_RATE_LIMITED,
+    REQUEST_ID_CONFLICT,
+    REQUEST_REPLAY_UNAVAILABLE,
+    UNKNOWN_NETWORK_IDENTITY,
+    USER_DAILY_REQUEST_QUOTA_EXCEEDED,
+    USER_DAILY_UNIT_QUOTA_EXCEEDED,
+    USER_RATE_LIMITED,
+    AdmissionConfigurationError,
+    AdmissionRequest,
+    AdmissionResult,
+    AdmissionRuntimeConfig,
+    AdmissionUnavailable,
+    build_admission_request,
+    compute_hmac_sha256,
+    parse_admission_result,
+    reserve_admission_sync,
+    resolve_network_identity,
+)
+from backend.admission_contracts import RequestIdentity
+from backend.turn_execution import (
+    DeadlineExceeded,
+    TurnBudget,
+    TurnExecutionConfig,
+    create_budget,
+    run_blocking_write,
+)
+
+SECRET = "s" * 32
+UUID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+@pytest.mark.parametrize("secret", [None, "", "   ", "short", 123, b"x" * 32])
+def test_invalid_secret_fails_closed_without_exposure(secret):
+    marker = "sensitive-secret-marker"
+    with pytest.raises(AdmissionConfigurationError) as exc_info:
+        AdmissionRuntimeConfig.from_values(secret)
+    assert str(exc_info.value) == "invalid_admission_configuration"
+    assert marker not in str(exc_info.value)
+    assert marker not in repr(exc_info.value)
+
+
+def test_valid_config_is_frozen_and_redacts_secret():
+    config = AdmissionRuntimeConfig.from_values(
+        SECRET,
+        "10.0.0.0/8, 2001:db8::/32",
+    )
+    assert len(config.secret_bytes) == 32
+    assert len(config.trusted_proxy_networks) == 2
+    assert SECRET not in repr(config)
+    with pytest.raises(Exception):
+        config.secret_bytes = b"changed"
+
+
+@pytest.mark.parametrize("cidrs", ["invalid", "10.0.0.0/8,", ",10.0.0.0/8", 42])
+def test_invalid_proxy_config_fails_closed(cidrs):
+    with pytest.raises(AdmissionConfigurationError):
+        AdmissionRuntimeConfig.from_values(SECRET, cidrs)
+
+
+def test_hmac_is_exact_utf8_and_domain_separated():
+    secret = SECRET.encode("utf-8")
+    text = "Olá, Katherine 🌙"
+    expected = hmac.new(
+        secret,
+        b"message\x00" + text.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    message_digest = compute_hmac_sha256(secret, MESSAGE_HMAC_DOMAIN, text)
+    network_digest = compute_hmac_sha256(secret, NETWORK_HMAC_DOMAIN, text)
+    assert message_digest == expected
+    assert message_digest != network_digest
+    assert len(message_digest) == 64
+    assert message_digest == message_digest.lower()
+
+
+def test_untrusted_peer_ignores_forwarded_header():
+    config = AdmissionRuntimeConfig.from_values(SECRET, "10.0.0.0/8")
+    assert resolve_network_identity(
+        "203.0.113.8",
+        "198.51.100.7",
+        config.trusted_proxy_networks,
+    ) == "203.0.113.8"
+
+
+def test_trusted_proxy_chain_is_walked_from_right_to_left():
+    config = AdmissionRuntimeConfig.from_values(
+        SECRET,
+        "10.0.0.0/8,192.168.0.0/16",
+    )
+    assert resolve_network_identity(
+        "10.0.0.5",
+        "198.51.100.9, 192.168.1.4, 10.0.0.4",
+        config.trusted_proxy_networks,
+    ) == "198.51.100.9"
+
+
+def test_all_trusted_proxy_chain_uses_leftmost_address():
+    config = AdmissionRuntimeConfig.from_values(SECRET, "10.0.0.0/8")
+    assert resolve_network_identity(
+        "10.0.0.5",
+        "10.1.1.1, 10.2.2.2",
+        config.trusted_proxy_networks,
+    ) == "10.1.1.1"
+
+
+@pytest.mark.parametrize(
+    ("peer", "header"),
+    [
+        (None, None),
+        ("invalid", "198.51.100.1"),
+        ("10.0.0.5", None),
+        ("10.0.0.5", ""),
+        ("10.0.0.5", "198.51.100.1,,10.0.0.4"),
+        ("10.0.0.5", "not-an-ip"),
+    ],
+)
+def test_invalid_or_ambiguous_network_input_uses_unknown(peer, header):
+    config = AdmissionRuntimeConfig.from_values(SECRET, "10.0.0.0/8")
+    assert (
+        resolve_network_identity(peer, header, config.trusted_proxy_networks)
+        == UNKNOWN_NETWORK_IDENTITY
+    )
+
+
+def test_ipv6_is_canonicalised():
+    config = AdmissionRuntimeConfig.from_values(SECRET)
+    assert resolve_network_identity(
+        "2001:0db8:0000:0000:0000:0000:0000:0001",
+        None,
+        config.trusted_proxy_networks,
+    ) == "2001:db8::1"
+
+
+def test_build_request_contains_only_rpc_contract_and_no_raw_payload():
+    config = AdmissionRuntimeConfig.from_values(SECRET)
+    request = build_admission_request(
+        user_id="user-a",
+        request_identity=RequestIdentity(UUID.upper()),
+        message="raw-sensitive-message",
+        network_identity="203.0.113.5",
+        config=config,
+    )
+    assert request.request_id == UUID
+    assert request.estimated_units == len("raw-sensitive-message".encode("utf-8"))
+    assert set(request.rpc_params()) == {
+        "p_user_id",
+        "p_request_id",
+        "p_message_hmac_sha256",
+        "p_network_hmac_sha256",
+        "p_estimated_units",
+    }
+    assert "raw-sensitive-message" not in repr(request)
+    assert "203.0.113.5" not in repr(request)
+    assert SECRET not in repr(request)
+
+
+@pytest.mark.parametrize(
+    ("decision", "retry"),
+    [
+        (ADMITTED, 0),
+        (REQUEST_REPLAY_UNAVAILABLE, 0),
+        (REQUEST_ID_CONFLICT, 0),
+        (INVALID_ADMISSION_INPUT, 0),
+        (USER_RATE_LIMITED, 60),
+        (NETWORK_RATE_LIMITED, 60),
+        (APPLICATION_RATE_LIMITED, 60),
+        (USER_DAILY_REQUEST_QUOTA_EXCEEDED, 86400),
+        (USER_DAILY_UNIT_QUOTA_EXCEEDED, 86400),
+    ],
+)
+def test_parse_admission_result_accepts_only_exact_contract(decision, retry):
+    result = parse_admission_result(
+        [{"decision": decision, "retry_after_seconds": retry}]
+    )
+    assert result.decision == decision
+    assert result.retry_after_seconds == retry
+    assert decision in ADMISSION_DECISIONS
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        [],
+        [{"decision": ADMITTED, "retry_after_seconds": 0}, {}],
+        {},
+        [{"decision": ADMITTED}],
+        [{"decision": ADMITTED, "retry_after_seconds": 0, "extra": True}],
+        [{"decision": "unknown", "retry_after_seconds": 0}],
+        [{"decision": ADMITTED, "retry_after_seconds": True}],
+        [{"decision": ADMITTED, "retry_after_seconds": -1}],
+        [{"decision": ADMITTED, "retry_after_seconds": 60}],
+        [{"decision": USER_RATE_LIMITED, "retry_after_seconds": 1}],
+    ],
+)
+def test_parse_admission_result_rejects_malformed_payload(payload):
+    with pytest.raises(AdmissionUnavailable):
+        parse_admission_result(payload)
+
+
+class FakeRpcBuilder:
+    def __init__(self, data):
+        self._data = data
+
+    def execute(self):
+        return SimpleNamespace(data=self._data)
+
+
+class FakeClient:
+    def __init__(self, data):
+        self.data = data
+        self.calls = []
+
+    def rpc(self, name, params):
+        self.calls.append((name, params))
+        return FakeRpcBuilder(self.data)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"user_id": "   "},
+        {"request_id": "not-a-uuid"},
+        {"message_hmac_sha256": "A" * 64},
+        {"network_hmac_sha256": "z" * 64},
+        {"estimated_units": 0},
+        {"estimated_units": True},
+    ],
+)
+def test_direct_admission_request_construction_fails_closed(kwargs):
+    values = {
+        "user_id": "user-a",
+        "request_id": UUID,
+        "message_hmac_sha256": "a" * 64,
+        "network_hmac_sha256": "b" * 64,
+        "estimated_units": 7,
+    }
+    values.update(kwargs)
+    with pytest.raises(AdmissionUnavailable):
+        AdmissionRequest(**values)
+
+
+@pytest.mark.parametrize(
+    ("decision", "retry"),
+    [("unknown", 0), (ADMITTED, 60), (USER_RATE_LIMITED, True)],
+)
+def test_direct_admission_result_construction_fails_closed(decision, retry):
+    with pytest.raises(AdmissionUnavailable):
+        AdmissionResult(decision, retry)
+
+
+def test_sync_adapter_calls_exact_rpc_and_params():
+    request = AdmissionRequest(
+        user_id="user-a",
+        request_id=UUID,
+        message_hmac_sha256="a" * 64,
+        network_hmac_sha256="b" * 64,
+        estimated_units=7,
+    )
+    client = FakeClient([{"decision": ADMITTED, "retry_after_seconds": 0}])
+    result = reserve_admission_sync(client, request)
+    assert result.decision == ADMITTED
+    assert client.calls == [("reserve_admission", request.rpc_params())]
+
+
+def test_sync_adapter_sanitises_upstream_exception():
+    marker = "upstream-sensitive-marker"
+
+    class FailingClient:
+        def rpc(self, _name, _params):
+            raise RuntimeError(marker)
+
+    with pytest.raises(AdmissionUnavailable) as exc_info:
+        reserve_admission_sync(
+            FailingClient(),
+            AdmissionRequest("user", UUID, "a" * 64, "b" * 64, 1),
+        )
+    assert marker not in str(exc_info.value)
+    assert marker not in repr(exc_info.value)
+
+
+def test_write_cancellation_drains_reservation_worker():
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def blocking_reservation():
+        started.set()
+        release.wait(timeout=5)
+        finished.set()
+        return "done"
+
+    async def scenario():
+        budget = create_budget(TurnExecutionConfig.defaults())
+        task = asyncio.create_task(
+            run_blocking_write(
+                "reserve_admission",
+                budget,
+                5.0,
+                blocking_reservation,
+            )
+        )
+        await asyncio.to_thread(started.wait, 2)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert finished.is_set()
+
+    asyncio.run(scenario())
+
+
+def test_expired_budget_does_not_start_reservation_worker():
+    called = False
+
+    def worker():
+        nonlocal called
+        called = True
+
+    async def scenario():
+        budget = TurnBudget(deadline=0.0, reserve=0.0, now_provider=lambda: 1.0)
+        with pytest.raises(DeadlineExceeded):
+            await run_blocking_write("reserve_admission", budget, 5.0, worker)
+
+    asyncio.run(scenario())
+    assert called is False
+
+
+def test_module_import_has_no_env_network_or_heavy_import_side_effects():
+    script = r'''
+import builtins
+import os
+import socket
+import sys
+
+class BombEnvironment(dict):
+    def __getitem__(self, key):
+        raise AssertionError("environment read")
+    def get(self, key, default=None):
+        raise AssertionError("environment read")
+
+os.environ = BombEnvironment()
+os.getenv = lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("getenv"))
+socket.socket = lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("socket"))
+socket.create_connection = lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("network"))
+
+blocked = {
+    "fastapi", "pydantic", "supabase", "postgrest", "groq",
+    "sentence_transformers", "backend.engine", "backend.memory",
+}
+real_import = builtins.__import__
+def guarded_import(name, *args, **kwargs):
+    if name in blocked or any(name.startswith(item + ".") for item in blocked):
+        raise AssertionError("heavy import: " + name)
+    return real_import(name, *args, **kwargs)
+builtins.__import__ = guarded_import
+
+import backend.admission
+print("ok")
+'''
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.getcwd()
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"

--- a/backend/tests/test_archival_memory_integration.py
+++ b/backend/tests/test_archival_memory_integration.py
@@ -13,6 +13,9 @@ from unittest.mock import patch, AsyncMock
 from fastapi import BackgroundTasks
 from fastapi.testclient import TestClient
 
+REQUEST_ID = "550e8400-e29b-41d4-a716-446655440000"
+
+
 @pytest.fixture(autouse=True, scope="module")
 def mock_external_dependencies():
     # Capture states at setup phase
@@ -28,6 +31,8 @@ def mock_external_dependencies():
     os.environ['GROQ_API_KEY'] = 'mock_key'
     os.environ['SUPABASE_URL'] = 'http://mock'
     os.environ['SUPABASE_SERVICE_ROLE_KEY'] = 'mock_key'
+    os.environ['ADMISSION_HMAC_SECRET'] = 'test-admission-secret-that-is-at-least-32-bytes'
+    os.environ['TRUSTED_PROXY_CIDRS'] = ''
 
     yield
 
@@ -72,6 +77,9 @@ def client_app(mock_external_dependencies):
 def mock_supabase():
     from backend.main import engine
     with patch.object(engine.memory_manager, 'supabase', MagicMock()) as mock_sb:
+        mock_sb.rpc.return_value.execute.return_value.data = [
+            {"decision": "admitted", "retry_after_seconds": 0}
+        ]
         yield mock_sb
 
 
@@ -371,7 +379,7 @@ def test_chat_response_format(client_app, mock_supabase):
     
     response = client_app.post(
         "/chat",
-        json={"message": "hello"},
+        json={"request_id": REQUEST_ID, "message": "hello"},
         headers={"Authorization": "Bearer valid_token"}
     )
     

--- a/backend/tests/test_archival_memory_integration.py
+++ b/backend/tests/test_archival_memory_integration.py
@@ -350,7 +350,7 @@ async def test_run_archival_extraction_disabled_returns_early(backend):
     engine.groq_manager.chat_completion.assert_not_called()
 
 
-def test_chat_response_format(client_app, mock_supabase):
+def test_chat_response_format(client_app, mock_supabase, monkeypatch):
     from backend.main import engine
     from backend.relationship import RelationshipStateV1
     
@@ -365,7 +365,7 @@ def test_chat_response_format(client_app, mock_supabase):
     
     from backend.emotion_presentation import EmotionStateResponse, PublicPAD, PublicDominantEmotion
     
-    # Mock process_turn to return valid EmotionStateResponse
+    # Mock process_turn to return valid EmotionStateResponse and restore it after the test.
     mock_emotion = EmotionStateResponse(
         schema_version=1,
         mood_label="NEUTRA",
@@ -375,7 +375,11 @@ def test_chat_response_format(client_app, mock_supabase):
         ],
         timestamp=1700000000.0,
     )
-    engine.process_turn = AsyncMock(return_value=("My response text", mock_emotion))
+    monkeypatch.setattr(
+        engine,
+        "process_turn",
+        AsyncMock(return_value=("My response text", mock_emotion)),
+    )
     
     response = client_app.post(
         "/chat",

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -4,6 +4,13 @@ import logging
 import pytest
 from unittest.mock import patch, MagicMock, ANY
 
+REQUEST_ID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def _chat_payload(message, **extra):
+    return {"request_id": REQUEST_ID, "message": message, **extra}
+
+
 @pytest.fixture(autouse=True, scope="module")
 def mock_external_dependencies():
     _original_modules = dict(sys.modules)
@@ -12,7 +19,9 @@ def mock_external_dependencies():
     mock_env = {
         'GROQ_API_KEY': 'mock_key',
         'SUPABASE_URL': 'http://mock',
-        'SUPABASE_SERVICE_ROLE_KEY': 'mock_key'
+        'SUPABASE_SERVICE_ROLE_KEY': 'mock_key',
+        'ADMISSION_HMAC_SECRET': 'test-admission-secret-that-is-at-least-32-bytes',
+        'TRUSTED_PROXY_CIDRS': '',
     }
     os.environ.update(mock_env)
 
@@ -51,11 +60,16 @@ def client_app(mock_external_dependencies):
     from backend.main import app
     return TestClient(app)
 
+
 @pytest.fixture
 def mock_supabase():
     from backend.main import engine
     with patch.object(engine.memory_manager, 'supabase', MagicMock()) as mock_sb:
+        mock_sb.rpc.return_value.execute.return_value.data = [
+            {"decision": "admitted", "retry_after_seconds": 0}
+        ]
         yield mock_sb
+
 
 @pytest.fixture
 def mock_engine_process():
@@ -71,18 +85,22 @@ def mock_engine_process():
     with patch.object(engine, 'process_turn', return_value=("Mock response", fake_emotion)) as mock_process:
         yield mock_process
 
+
 class MockUser:
     def __init__(self, id):
         self.id = id
+
 
 class MockAuthResponse:
     def __init__(self, user):
         self.user = user
 
+
 from supabase_auth.errors import AuthApiError, AuthRetryableError
 
+
 def test_missing_token(client_app, mock_supabase, mock_engine_process):
-    response = client_app.post("/chat", json={"message": "Hello"})
+    response = client_app.post("/chat", json=_chat_payload("Hello"))
     assert response.status_code == 401
     assert "Not authenticated" in response.json()["detail"]
     assert response.headers.get("WWW-Authenticate") == "Bearer"
@@ -94,10 +112,11 @@ def test_missing_token(client_app, mock_supabase, mock_engine_process):
     mock_engine_process.assert_not_called()
     mock_supabase.table.assert_not_called()
 
+
 def test_invalid_scheme(client_app, mock_supabase, mock_engine_process):
     response = client_app.post(
         "/chat",
-        json={"message": "Hello"},
+        json=_chat_payload("Hello"),
         headers={"Authorization": "Basic x"}
     )
     assert response.status_code == 401
@@ -105,12 +124,13 @@ def test_invalid_scheme(client_app, mock_supabase, mock_engine_process):
     mock_engine_process.assert_not_called()
     mock_supabase.table.assert_not_called()
 
+
 def test_invalid_token(client_app, mock_supabase, mock_engine_process):
     mock_supabase.auth.get_user.side_effect = AuthApiError("Internal Mock JWT SDK Error", 400, "")
 
     response = client_app.post(
         "/chat",
-        json={"message": "Hello"},
+        json=_chat_payload("Hello"),
         headers={"Authorization": "Bearer invalid_token"}
     )
     assert response.status_code == 401
@@ -121,6 +141,7 @@ def test_invalid_token(client_app, mock_supabase, mock_engine_process):
     mock_engine_process.assert_not_called()
     mock_supabase.table.assert_not_called()
 
+
 def test_user_is_none(client_app, mock_supabase, mock_engine_process):
     mock_supabase.auth.get_user.return_value = MockAuthResponse(user=None)
     response = client_app.get("/history", headers={"Authorization": "Bearer token"})
@@ -130,14 +151,20 @@ def test_user_is_none(client_app, mock_supabase, mock_engine_process):
     mock_engine_process.assert_not_called()
     mock_supabase.table.assert_not_called()
 
+
 def test_service_unavailable(client_app, mock_supabase, mock_engine_process):
     from backend.main import engine
     with patch.object(engine.memory_manager, 'supabase', None):
-        response = client_app.post("/chat", json={"message": "Hi"}, headers={"Authorization": "Bearer t"})
+        response = client_app.post(
+            "/chat",
+            json=_chat_payload("Hi"),
+            headers={"Authorization": "Bearer t"},
+        )
         assert response.status_code == 503
         assert response.json()["detail"] == "Authentication service unavailable"
         mock_engine_process.assert_not_called()
     mock_supabase.table.assert_not_called()
+
 
 def test_valid_token(client_app, mock_supabase, mock_engine_process):
     mock_user = MockUser(id="user123")
@@ -145,13 +172,14 @@ def test_valid_token(client_app, mock_supabase, mock_engine_process):
 
     response = client_app.post(
         "/chat",
-        json={"message": "Hello"},
+        json=_chat_payload("Hello"),
         headers={"Authorization": "Bearer valid_token"}
     )
 
     assert response.status_code == 200
     assert response.json()["response"] == "Mock response"
-    mock_engine_process.assert_called_once_with("user123", "Hello", ANY)
+    mock_engine_process.assert_called_once_with("user123", "Hello", ANY, budget=ANY)
+
 
 def test_spoofing_user_id_in_chat(client_app, mock_supabase, mock_engine_process):
     mock_user = MockUser(id="user123")
@@ -159,13 +187,15 @@ def test_spoofing_user_id_in_chat(client_app, mock_supabase, mock_engine_process
 
     response = client_app.post(
         "/chat",
-        json={"user_id": "other_user", "message": "Hello"},
+        json=_chat_payload("Hello", user_id="other_user"),
         headers={"Authorization": "Bearer valid_token"}
     )
 
     assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "invalid_request"
     mock_engine_process.assert_not_called()
     mock_supabase.table.assert_not_called()
+
 
 def test_history_valid_token(client_app, mock_supabase):
     mock_user = MockUser(id="user123")
@@ -200,6 +230,7 @@ def test_history_valid_token(client_app, mock_supabase):
     # Verify that it strictly uses current_user.id
     mock_select.eq.assert_called_once_with("user_id", "user123")
 
+
 def test_history_legacy_route_removed(client_app, mock_supabase, mock_engine_process):
     mock_user = MockUser(id="user123")
     mock_supabase.auth.get_user.return_value = MockAuthResponse(user=mock_user)
@@ -211,6 +242,7 @@ def test_history_legacy_route_removed(client_app, mock_supabase, mock_engine_pro
 
     assert response.status_code == 404
 
+
 def test_credential_rejection_401(client_app, mock_supabase, mock_engine_process, caplog):
     error = AuthApiError("SENSITIVE_AUTH_MARKER", 400, "error_code")
     mock_supabase.auth.get_user.side_effect = error
@@ -218,7 +250,7 @@ def test_credential_rejection_401(client_app, mock_supabase, mock_engine_process
     with caplog.at_level(logging.ERROR):
         response = client_app.post(
             "/chat",
-            json={"message": "Hello"},
+            json=_chat_payload("Hello"),
             headers={"Authorization": "Bearer invalid_token"}
         )
 
@@ -229,6 +261,7 @@ def test_credential_rejection_401(client_app, mock_supabase, mock_engine_process
     mock_engine_process.assert_not_called()
     mock_supabase.table.assert_not_called()
 
+
 def test_transport_timeout_503(client_app, mock_supabase, mock_engine_process, caplog):
     error = AuthRetryableError("SENSITIVE_AUTH_MARKER_TIMEOUT", 503)
     mock_supabase.auth.get_user.side_effect = error
@@ -236,7 +269,7 @@ def test_transport_timeout_503(client_app, mock_supabase, mock_engine_process, c
     with caplog.at_level(logging.ERROR):
         response = client_app.post(
             "/chat",
-            json={"message": "Hello"},
+            json=_chat_payload("Hello"),
             headers={"Authorization": "Bearer some_token"}
         )
 
@@ -246,6 +279,7 @@ def test_transport_timeout_503(client_app, mock_supabase, mock_engine_process, c
     assert "SENSITIVE_AUTH_MARKER" not in response.text
     mock_engine_process.assert_not_called()
     mock_supabase.table.assert_not_called()
+
 
 def test_service_error_5xx(client_app, mock_supabase, mock_engine_process, caplog):
     error = AuthApiError("SENSITIVE_AUTH_MARKER_500", 500, "error_code")
@@ -254,7 +288,7 @@ def test_service_error_5xx(client_app, mock_supabase, mock_engine_process, caplo
     with caplog.at_level(logging.ERROR):
         response = client_app.post(
             "/chat",
-            json={"message": "Hello"},
+            json=_chat_payload("Hello"),
             headers={"Authorization": "Bearer some_token"}
         )
 
@@ -265,6 +299,7 @@ def test_service_error_5xx(client_app, mock_supabase, mock_engine_process, caplo
     mock_engine_process.assert_not_called()
     mock_supabase.table.assert_not_called()
 
+
 def test_unexpected_error_503(client_app, mock_supabase, mock_engine_process, caplog):
     error = Exception("SENSITIVE_AUTH_MARKER_UNKNOWN")
     mock_supabase.auth.get_user.side_effect = error
@@ -272,7 +307,7 @@ def test_unexpected_error_503(client_app, mock_supabase, mock_engine_process, ca
     with caplog.at_level(logging.ERROR):
         response = client_app.post(
             "/chat",
-            json={"message": "Hello"},
+            json=_chat_payload("Hello"),
             headers={"Authorization": "Bearer some_token"}
         )
 
@@ -302,7 +337,7 @@ def test_http_chat_load_failure_sanitization(client_app, mock_supabase, caplog):
     with caplog.at_level(logging.ERROR):
         response = client_app.post(
             "/chat",
-            json={"message": "Hello"},
+            json=_chat_payload("Hello"),
             headers={"Authorization": "Bearer some_token"}
         )
 
@@ -340,7 +375,7 @@ def test_http_chat_persistence_failure_sanitization(client_app, mock_supabase, c
     with caplog.at_level(logging.ERROR):
         response = client_app.post(
             "/chat",
-            json={"message": "Hello"},
+            json=_chat_payload("Hello"),
             headers={"Authorization": "Bearer some_token"}
         )
 
@@ -351,33 +386,37 @@ def test_http_chat_persistence_failure_sanitization(client_app, mock_supabase, c
     assert "user123" not in response.text
     assert "user123" not in caplog.text
 
+
 def test_chat_message_exactly_at_limit(client_app, mock_supabase, mock_engine_process):
-    from backend.memory import MAX_MESSAGE_LENGTH
+    from backend.admission_contracts import NEW_MESSAGE_MAX_CHARS
     mock_user = MockUser(id="user123")
     mock_supabase.auth.get_user.return_value = MockAuthResponse(user=mock_user)
+    message = "a" * NEW_MESSAGE_MAX_CHARS
 
     response = client_app.post(
         "/chat",
-        json={"message": "a" * MAX_MESSAGE_LENGTH},
+        json=_chat_payload(message),
         headers={"Authorization": "Bearer valid_token"}
     )
 
     assert response.status_code == 200
     assert response.json()["response"] == "Mock response"
-    mock_engine_process.assert_called_once_with("user123", "a" * MAX_MESSAGE_LENGTH, ANY)
+    mock_engine_process.assert_called_once_with("user123", message, ANY, budget=ANY)
+
 
 def test_chat_message_exceeds_limit(client_app, mock_supabase, mock_engine_process):
-    from backend.memory import MAX_MESSAGE_LENGTH
+    from backend.admission_contracts import NEW_MESSAGE_MAX_CHARS
     mock_user = MockUser(id="user123")
     mock_supabase.auth.get_user.return_value = MockAuthResponse(user=mock_user)
 
     response = client_app.post(
         "/chat",
-        json={"message": "a" * (MAX_MESSAGE_LENGTH + 1)},
+        json=_chat_payload("a" * (NEW_MESSAGE_MAX_CHARS + 1)),
         headers={"Authorization": "Bearer valid_token"}
     )
 
     assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "message_too_long"
     mock_engine_process.assert_not_called()
 
 

--- a/backend/tests/test_chat_admission.py
+++ b/backend/tests/test_chat_admission.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+import backend.main as main
+from backend.admission import (
+    ADMITTED,
+    APPLICATION_RATE_LIMITED,
+    INVALID_ADMISSION_INPUT,
+    NETWORK_RATE_LIMITED,
+    REQUEST_ID_CONFLICT,
+    REQUEST_REPLAY_UNAVAILABLE,
+    USER_DAILY_REQUEST_QUOTA_EXCEEDED,
+    USER_DAILY_UNIT_QUOTA_EXCEEDED,
+    USER_RATE_LIMITED,
+    AdmissionResult,
+    AdmissionRuntimeConfig,
+    AdmissionUnavailable,
+)
+from backend.emotion_presentation import EmotionStateResponse
+from backend.turn_execution import TurnBudget
+
+UUID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def emotion_response() -> EmotionStateResponse:
+    return EmotionStateResponse(
+        schema_version=1,
+        mood_label="NEUTRA",
+        pad={"pleasure": 0.0, "arousal": 0.0, "dominance": 0.0},
+        dominant_emotions=[],
+        timestamp=1000.0,
+    )
+
+
+class FakeEngine:
+    def __init__(self):
+        self.memory_manager = SimpleNamespace(supabase=object())
+        self.calls = []
+
+    async def process_turn(
+        self,
+        user_id,
+        message,
+        background_tasks=None,
+        *,
+        budget=None,
+    ):
+        self.calls.append(
+            {
+                "user_id": user_id,
+                "message": message,
+                "background_tasks": background_tasks,
+                "budget": budget,
+            }
+        )
+        return "response", emotion_response()
+
+
+@pytest.fixture
+def endpoint(monkeypatch):
+    fake_engine = FakeEngine()
+    captured = {}
+
+    monkeypatch.setattr(main, "engine", fake_engine)
+    monkeypatch.setattr(
+        main,
+        "_admission_config",
+        AdmissionRuntimeConfig.from_values("s" * 32),
+    )
+
+    async def fake_run_blocking_write(
+        stage_label,
+        budget,
+        supabase_timeout,
+        func,
+        *args,
+        allowlist_exceptions=(),
+        **kwargs,
+    ):
+        captured["stage_label"] = stage_label
+        captured["budget"] = budget
+        captured["supabase_timeout"] = supabase_timeout
+        captured["allowlist_exceptions"] = allowlist_exceptions
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(main, "run_blocking_write", fake_run_blocking_write)
+    main.app.dependency_overrides[main.get_current_user] = lambda: SimpleNamespace(
+        id="user-a"
+    )
+    client = TestClient(main.app)
+    try:
+        yield client, fake_engine, captured
+    finally:
+        main.app.dependency_overrides.clear()
+
+
+def test_admitted_normalises_uuid_and_shares_one_budget(endpoint, monkeypatch):
+    client, fake_engine, captured = endpoint
+    rpc_calls = []
+
+    def admitted(_client, request):
+        rpc_calls.append(request)
+        return AdmissionResult(ADMITTED, 0)
+
+    monkeypatch.setattr(main, "reserve_admission_sync", admitted)
+
+    response = client.post(
+        "/chat",
+        json={"request_id": UUID.upper(), "message": "Olá"},
+    )
+
+    assert response.status_code == 200
+    assert set(response.json()) == {"response", "emotion_state"}
+    assert len(rpc_calls) == 1
+    request = rpc_calls[0]
+    assert request.user_id == "user-a"
+    assert request.request_id == UUID
+    assert request.estimated_units == len("Olá".encode("utf-8"))
+    assert len(fake_engine.calls) == 1
+    assert fake_engine.calls[0]["budget"] is captured["budget"]
+    assert captured["stage_label"] == "reserve_admission"
+    assert captured["allowlist_exceptions"] == (AdmissionUnavailable,)
+
+
+@pytest.mark.parametrize(
+    ("decision", "retry", "status", "header"),
+    [
+        (REQUEST_REPLAY_UNAVAILABLE, 0, 409, None),
+        (REQUEST_ID_CONFLICT, 0, 409, None),
+        (USER_RATE_LIMITED, 60, 429, "60"),
+        (NETWORK_RATE_LIMITED, 60, 429, "60"),
+        (APPLICATION_RATE_LIMITED, 60, 429, "60"),
+        (USER_DAILY_REQUEST_QUOTA_EXCEEDED, 86400, 429, "86400"),
+        (USER_DAILY_UNIT_QUOTA_EXCEEDED, 86400, 429, "86400"),
+        (INVALID_ADMISSION_INPUT, 0, 422, None),
+    ],
+)
+def test_rejections_map_exactly_without_calling_engine(
+    endpoint,
+    monkeypatch,
+    decision,
+    retry,
+    status,
+    header,
+):
+    client, fake_engine, _captured = endpoint
+    monkeypatch.setattr(
+        main,
+        "reserve_admission_sync",
+        lambda _client, _request: AdmissionResult(decision, retry),
+    )
+
+    response = client.post(
+        "/chat",
+        json={"request_id": UUID, "message": "hello"},
+    )
+
+    assert response.status_code == status
+    assert response.json()["detail"]["code"] == decision
+    assert response.headers.get("Retry-After") == header
+    assert fake_engine.calls == []
+
+
+def test_store_unavailable_fails_closed_without_engine(endpoint, monkeypatch):
+    client, fake_engine, _captured = endpoint
+    marker = "sensitive-upstream-marker"
+
+    def unavailable(_client, _request):
+        raise AdmissionUnavailable() from RuntimeError(marker)
+
+    monkeypatch.setattr(main, "reserve_admission_sync", unavailable)
+    response = client.post(
+        "/chat",
+        json={"request_id": UUID, "message": marker},
+    )
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["detail"]["code"] == "admission_unavailable"
+    assert marker not in response.text
+    assert fake_engine.calls == []
+
+
+def test_invalid_uuid_is_sanitised_and_never_reserves(endpoint, monkeypatch):
+    client, fake_engine, _captured = endpoint
+    marker = "not-a-uuid-sensitive-marker"
+    called = False
+
+    def reserve(_client, _request):
+        nonlocal called
+        called = True
+        return AdmissionResult(ADMITTED, 0)
+
+    monkeypatch.setattr(main, "reserve_admission_sync", reserve)
+    response = client.post(
+        "/chat",
+        json={"request_id": marker, "message": "hello"},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "invalid_request_id"
+    assert marker not in response.text
+    assert called is False
+    assert fake_engine.calls == []
+
+
+def test_character_limit_error_does_not_echo_message(endpoint):
+    client, fake_engine, _captured = endpoint
+    message = "x" * 4001
+    response = client.post(
+        "/chat",
+        json={"request_id": UUID, "message": message},
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "message_too_long"
+    assert message not in response.text
+    assert fake_engine.calls == []
+
+
+def test_utf8_budget_error_does_not_echo_message(endpoint):
+    client, fake_engine, _captured = endpoint
+    message = "🌙" * 1501
+    assert len(message) <= 4000
+    assert len(message.encode("utf-8")) > 6000
+    response = client.post(
+        "/chat",
+        json={"request_id": UUID, "message": message},
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "message_budget_exceeded"
+    assert message not in response.text
+    assert fake_engine.calls == []
+
+
+def test_extra_field_and_wrong_types_use_generic_sanitised_validation(endpoint):
+    client, fake_engine, _captured = endpoint
+    marker = "raw-body-marker"
+    response = client.post(
+        "/chat",
+        json={
+            "request_id": UUID,
+            "message": 123,
+            "extra": marker,
+        },
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "invalid_request"
+    assert marker not in response.text
+    assert "123" not in response.text
+    assert fake_engine.calls == []
+
+
+def test_missing_authentication_does_not_reserve(monkeypatch):
+    fake_engine = FakeEngine()
+    monkeypatch.setattr(main, "engine", fake_engine)
+    main.app.dependency_overrides.clear()
+    called = False
+
+    def reserve(_client, _request):
+        nonlocal called
+        called = True
+        return AdmissionResult(ADMITTED, 0)
+
+    monkeypatch.setattr(main, "reserve_admission_sync", reserve)
+    client = TestClient(main.app)
+    response = client.post(
+        "/chat",
+        json={"request_id": UUID, "message": "hello"},
+    )
+    assert response.status_code == 401
+    assert called is False
+    assert fake_engine.calls == []
+
+
+def test_expired_budget_returns_timeout_before_rpc(endpoint, monkeypatch):
+    client, fake_engine, _captured = endpoint
+    called = False
+
+    def reserve(_client, _request):
+        nonlocal called
+        called = True
+        return AdmissionResult(ADMITTED, 0)
+
+    monkeypatch.setattr(main, "reserve_admission_sync", reserve)
+    monkeypatch.setattr(
+        main,
+        "create_budget",
+        lambda _config: TurnBudget(
+            deadline=0.0,
+            reserve=0.0,
+            now_provider=lambda: 1.0,
+        ),
+    )
+    from backend.turn_execution import run_blocking_write
+
+    monkeypatch.setattr(main, "run_blocking_write", run_blocking_write)
+    response = client.post(
+        "/chat",
+        json={"request_id": UUID, "message": "hello"},
+    )
+    assert response.status_code == 504
+    assert response.json()["detail"]["code"] == "turn_timeout"
+    assert called is False
+    assert fake_engine.calls == []

--- a/backend/tests/test_engine_budget_passthrough.py
+++ b/backend/tests/test_engine_budget_passthrough.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+
+from backend.chat_engine import ChatConversationEngine
+from backend.turn_execution import TurnBudget, TurnExecutionConfig
+
+
+def test_process_turn_uses_explicit_budget_object():
+    engine = object.__new__(ChatConversationEngine)
+    provided = TurnBudget(deadline=100.0, reserve=10.0, now_provider=lambda: 0.0)
+    captured = {}
+
+    async def fake_run(user_id, message, background_tasks, budget):
+        captured.update(
+            user_id=user_id,
+            message=message,
+            background_tasks=background_tasks,
+            budget=budget,
+        )
+        return "ok"
+
+    engine._run_turn_locked = fake_run
+    result = asyncio.run(
+        engine.process_turn("user-a", "hello", None, budget=provided)
+    )
+    assert result == "ok"
+    assert captured["budget"] is provided
+
+
+def test_process_turn_still_creates_budget_for_internal_callers():
+    engine = object.__new__(ChatConversationEngine)
+    engine._turn_config = TurnExecutionConfig.defaults()
+    engine._monotonic = lambda: 10.0
+    captured = {}
+
+    async def fake_run(_user_id, _message, _background_tasks, budget):
+        captured["budget"] = budget
+        return "ok"
+
+    engine._run_turn_locked = fake_run
+    assert asyncio.run(engine.process_turn("user-a", "hello")) == "ok"
+    budget = captured["budget"]
+    assert isinstance(budget, TurnBudget)
+    assert budget.deadline == 55.0
+    assert budget.reserve == 10.0

--- a/frontend/src/features/chat/constants.js
+++ b/frontend/src/features/chat/constants.js
@@ -5,4 +5,5 @@ export const STORAGE_KEYS = {
 
 export const SYSTEM_MESSAGES = {
     ERROR_SENDING: 'Erro ao falar com a Katherine. Tente novamente.',
+    REQUEST_ID_UNAVAILABLE: 'Não foi possível iniciar um envio seguro neste navegador.',
 };

--- a/frontend/src/features/chat/hooks/useChat.js
+++ b/frontend/src/features/chat/hooks/useChat.js
@@ -110,6 +110,7 @@ export const useChat = () => {
         const userMessageText = input.trim();
         const randomUUID = globalThis.crypto?.randomUUID;
         if (typeof randomUUID !== 'function') {
+            localMessagesVersionRef.current += 1;
             setMessages(prev => [...prev, {
                 role: 'system',
                 content: SYSTEM_MESSAGES.REQUEST_ID_UNAVAILABLE,
@@ -121,6 +122,7 @@ export const useChat = () => {
         try {
             requestId = randomUUID.call(globalThis.crypto);
         } catch {
+            localMessagesVersionRef.current += 1;
             setMessages(prev => [...prev, {
                 role: 'system',
                 content: SYSTEM_MESSAGES.REQUEST_ID_UNAVAILABLE,

--- a/frontend/src/features/chat/hooks/useChat.js
+++ b/frontend/src/features/chat/hooks/useChat.js
@@ -7,21 +7,9 @@ import { validateEmotionState } from '../../../shared/utils/formatters';
 /**
  * Hook for managing chat state with AbortController-based timeout.
  *
- * Each send creates a fresh AbortController. The timer is cleaned up on
- * success, error, cancellation, and unmount.
- *
- * Ownership model: single-flight — at most one active request per hook
- * instance. A second handleSend() call while one is in-flight is silently
- * rejected.
- *
- * A monotonically increasing request token invalidates ownership on
- * unmount, ensuring stale callbacks never update state.
- *
- * Lifecycle:
- * 1. mountedRef guards all state updates after await.
- * 2. requestTokenRef guards ownership against stale requests on unmount.
- * 3. inFlightRef synchronously blocks double submission before rerender.
- * 4. focusTimerRef tracks the deferred focus timer for explicit cleanup.
+ * Each accepted logical send creates exactly one Web Crypto UUID and one
+ * request. Single-flight, ownership, history, timeout, and unmount guards are
+ * preserved.
  */
 export const useChat = () => {
     const [messages, setMessages] = useState([]);
@@ -35,14 +23,7 @@ export const useChat = () => {
     const requestTokenRef = useRef(0);
     const mountedRef = useRef(true);
     const focusTimerRef = useRef(null);
-    // Synchronous in-flight guard: prevents double submission before rerender.
-    // isLoading depends on rerender, but the ref is synchronous, so a second
-    // handleSend() call in the same microtask is rejected immediately.
     const inFlightRef = useRef(false);
-
-    // Monotonically increasing version counter for local message mutations.
-    // Guards the deferred /history response from overwriting messages that
-    // were added or cleared after the history read started.
     const localMessagesVersionRef = useRef(0);
 
     const cleanupRequest = useCallback(() => {
@@ -63,29 +44,18 @@ export const useChat = () => {
         }
     }, []);
 
-    // Lifecycle effect: set mountedRef on mount, teardown on unmount
     useEffect(() => {
         mountedRef.current = true;
 
         return () => {
             mountedRef.current = false;
-
-            // Invalidate current request ownership before aborting, so the
-            // rejection caused by abort() is treated as stale continuation.
             requestTokenRef.current += 1;
             inFlightRef.current = false;
-
             cleanupRequest();
             cleanupFocusTimer();
         };
     }, [cleanupRequest, cleanupFocusTimer]);
 
-    // Auto-spin fetchHistory (EFH) with guarded lifecycle.
-    // Uses a local active flag, an AbortController, and a version snapshot
-    // to prevent stale /history responses from updating state after:
-    //   - unmount (active flag + abort)
-    //   - a local mutation (version mismatch: send or clearHistory)
-    //   - the read was superseded by a newer fetch (the effect runs once)
     useEffect(() => {
         let active = true;
         const controller = new AbortController();
@@ -109,12 +79,10 @@ export const useChat = () => {
                     setMessages(response.data);
                 }
             } catch (error) {
-                // Silent return on expected lifecycle termination
                 if (!active || controller.signal.aborted) {
                     return;
                 }
 
-                // History fetch failure is not critical — log sanitised
                 if (
                     typeof import.meta !== 'undefined' &&
                     import.meta.env?.MODE !== 'test'
@@ -132,38 +100,49 @@ export const useChat = () => {
         };
     }, []);
 
-    // Auto-scroll to bottom
     useEffect(() => {
         messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
     }, [messages, isLoading]);
 
     const handleSend = useCallback(async () => {
-        // Synchronous guard: reject second call before any optimistic effects.
         if (!input.trim() || isLoading || inFlightRef.current) return;
 
         const userMessageText = input.trim();
+        const randomUUID = globalThis.crypto?.randomUUID;
+        if (typeof randomUUID !== 'function') {
+            setMessages(prev => [...prev, {
+                role: 'system',
+                content: SYSTEM_MESSAGES.REQUEST_ID_UNAVAILABLE,
+            }]);
+            return;
+        }
+
+        let requestId;
+        try {
+            requestId = randomUUID.call(globalThis.crypto);
+        } catch {
+            setMessages(prev => [...prev, {
+                role: 'system',
+                content: SYSTEM_MESSAGES.REQUEST_ID_UNAVAILABLE,
+            }]);
+            return;
+        }
+
         const newUserMessage = { role: 'user', content: userMessageText };
 
-        // Mark in-flight synchronously BEFORE any side effects.
         inFlightRef.current = true;
         localMessagesVersionRef.current += 1;
 
-        // Optimistic update
         setMessages(prev => [...prev, newUserMessage]);
         setInput('');
         setIsLoading(true);
 
-        // Clear any stale controller/timer from previous request
         cleanupRequest();
 
-        // Claim ownership of this request with a monotonically increasing token
         const token = ++requestTokenRef.current;
-
-        // Create fresh AbortController for this request
         const controller = new AbortController();
         abortControllerRef.current = controller;
 
-        // Create timeout timer
         const timeoutMs = 50000;
         const timerId = setTimeout(() => {
             controller.abort();
@@ -174,26 +153,21 @@ export const useChat = () => {
             const data = await sendMessage(userMessageText, {
                 signal: controller.signal,
                 timeout: timeoutMs,
-            });
+            }, requestId);
 
-            // Guard: only mounted and owning request may update state
             if (!mountedRef.current || token !== requestTokenRef.current) return;
 
-            // Clear timer on success
             clearTimeout(timerId);
             timerIdRef.current = null;
 
             const botMessage = { role: 'assistant', content: data.response };
             setMessages(prev => [...prev, botMessage]);
 
-            // Always validate emotion_state: clear panel on invalid or missing contract
             const validated = validateEmotionState(data.emotion_state);
             setEmotionState(validated);
         } catch (error) {
-            // Guard: only mounted and owning request may show error state
             if (!mountedRef.current || token !== requestTokenRef.current) return;
 
-            // Clear timer on error/cancel
             clearTimeout(timerId);
             timerIdRef.current = null;
 
@@ -204,7 +178,6 @@ export const useChat = () => {
                 };
                 setMessages(prev => [...prev, errorMessage]);
             } else {
-                // Unknown error — use safe default
                 const errorMessage = {
                     role: 'system',
                     content: SYSTEM_MESSAGES.ERROR_SENDING,
@@ -212,13 +185,11 @@ export const useChat = () => {
                 setMessages(prev => [...prev, errorMessage]);
             }
         } finally {
-            // Guard: only mounted and owning request may clear refs, inFlight, and loading state
             if (mountedRef.current && token === requestTokenRef.current) {
                 setIsLoading(false);
                 inFlightRef.current = false;
                 abortControllerRef.current = null;
                 timerIdRef.current = null;
-                // Focus back on input — tracked by focusTimerRef for explicit cleanup
                 cleanupFocusTimer();
                 focusTimerRef.current = setTimeout(() => inputRef.current?.focus(), 100);
             }

--- a/frontend/src/features/chat/services/chatService.js
+++ b/frontend/src/features/chat/services/chatService.js
@@ -3,11 +3,12 @@ import api from '../../../shared/services/apiClient.js';
 /**
  * Sanitised error classification for chat API responses.
  *
- * Never contains: raw Axios error objects, headers, tokens, config, or request data.
+ * Never contains: raw Axios error objects, headers, tokens, config, request IDs,
+ * or request data.
  */
 export class ChatError extends Error {
     /**
-     * @param {'timeout'|'rate_limited'|'service_unavailable'|'validation'|'unknown'} type
+     * @param {'timeout'|'rate_limited'|'service_unavailable'|'validation'|'request_replay'|'request_conflict'|'unknown'} type
      * @param {string} message
      */
     constructor(type, message) {
@@ -18,43 +19,48 @@ export class ChatError extends Error {
 }
 
 /**
- * Classify an HTTP error code into a stable ChatError type.
- *
- * @param {number} status - HTTP status code
- * @returns {'timeout'|'rate_limited'|'service_unavailable'|'validation'|'unknown'}
+ * Classify an HTTP status and allowlisted public code into a stable ChatError type.
  */
-export function classifyHttpError(status) {
+export function classifyHttpError(status, code = null) {
     if (status === 504 || status === 0) return 'timeout';
+    if (status === 409 && code === 'request_replay_unavailable') return 'request_replay';
+    if (status === 409 && code === 'request_id_conflict') return 'request_conflict';
     if (status === 429) return 'rate_limited';
     if (status === 503) return 'service_unavailable';
     if (status === 422) return 'validation';
     return 'unknown';
 }
 
+function extractPublicCode(error) {
+    const detail = error?.response?.data?.detail;
+    if (!detail || typeof detail !== 'object' || Array.isArray(detail)) return null;
+    const code = detail.code;
+    if (code === 'request_replay_unavailable' || code === 'request_id_conflict') {
+        return code;
+    }
+    return null;
+}
+
 /**
- * Create a ChatError from an Axios error, safely extracting only the status code.
- *
- * Axios errors may contain config, headers, and tokens — never log the raw object.
- *
- * @param {import('axios').AxiosError} error
- * @returns {ChatError}
+ * Create a ChatError from an Axios error while extracting only status and an
+ * allowlisted public reconciliation code.
  */
 export function createChatError(error) {
-    // Timeout / abort
-    if (error.code === 'ECONNABORTED' || error.code === 'ERR_CANCELED') {
+    if (error?.code === 'ECONNABORTED' || error?.code === 'ERR_CANCELED') {
         return new ChatError('timeout', 'A requisição excedeu o tempo limite.');
     }
 
-    // No response (network error)
-    if (!error.response) {
+    if (!error?.response) {
         return new ChatError('timeout', 'Sem resposta do servidor.');
     }
 
     const status = error.response.status;
-    const type = classifyHttpError(status);
+    const type = classifyHttpError(status, extractPublicCode(error));
 
     const messages = {
         timeout: 'A requisição excedeu o tempo limite.',
+        request_replay: 'Este envio já foi recebido, mas a resposta não pode ser recuperada.',
+        request_conflict: 'Este envio não pôde ser reconciliado. Envie a mensagem novamente.',
         rate_limited: 'Muitas requisições. Aguarde um momento e tente novamente.',
         service_unavailable: 'Serviço temporariamente indisponível. Tente novamente mais tarde.',
         validation: 'Dados inválidos enviados.',
@@ -65,27 +71,32 @@ export function createChatError(error) {
 }
 
 /**
- * Send a message to the chat API with AbortController support.
+ * Send a message to the chat API with an explicit logical request ID.
  *
- * @param {string} message - User message text
+ * @param {string} message
  * @param {object} [options]
- * @param {AbortSignal} [options.signal] - AbortSignal from AbortController
- * @param {number} [options.timeout=50000] - Timeout in milliseconds
- * @returns {Promise<{response: string, emotion_state: object}>}
- * @throws {ChatError}
+ * @param {string} requestId
+ * @param {AbortSignal} [options.signal]
+ * @param {number} [options.timeout=50000]
  */
-export const sendMessage = async (message, options = {}) => {
+export const sendMessage = async (message, options = {}, requestId) => {
     const { signal, timeout = 50000 } = options;
+
+    if (typeof requestId !== 'string' || requestId.length === 0) {
+        throw new ChatError('validation', 'Não foi possível identificar este envio.');
+    }
 
     try {
         const response = await api.post('/chat', {
-            message: message,
+            request_id: requestId,
+            message,
         }, {
             signal,
             timeout,
         });
         return response.data;
     } catch (error) {
+        if (error instanceof ChatError) throw error;
         throw createChatError(error);
     }
 };

--- a/frontend/tests/chatServiceAdmission.test.jsx
+++ b/frontend/tests/chatServiceAdmission.test.jsx
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPost = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/shared/services/apiClient.js', () => ({
+    default: {
+        post: mockPost,
+    },
+}));
+
+import {
+    ChatError,
+    classifyHttpError,
+    createChatError,
+    sendMessage,
+} from '../src/features/chat/services/chatService.js';
+
+const REQUEST_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+describe('chat admission service contract', () => {
+    beforeEach(() => {
+        mockPost.mockReset();
+    });
+
+    it('sends the exact request_id and message payload', async () => {
+        mockPost.mockResolvedValue({ data: { response: 'ok', emotion_state: {} } });
+        const signal = new AbortController().signal;
+
+        await sendMessage('hello', { signal, timeout: 1234 }, REQUEST_ID);
+
+        expect(mockPost).toHaveBeenCalledTimes(1);
+        expect(mockPost).toHaveBeenCalledWith(
+            '/chat',
+            { request_id: REQUEST_ID, message: 'hello' },
+            { signal, timeout: 1234 },
+        );
+    });
+
+    it('fails locally when request ID is absent', async () => {
+        await expect(sendMessage('hello', {}, undefined)).rejects.toMatchObject({
+            name: 'ChatError',
+            type: 'validation',
+        });
+        expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it('classifies replay and conflict as distinct safe errors', () => {
+        expect(classifyHttpError(409, 'request_replay_unavailable')).toBe('request_replay');
+        expect(classifyHttpError(409, 'request_id_conflict')).toBe('request_conflict');
+
+        const replay = createChatError({
+            response: {
+                status: 409,
+                data: { detail: { code: 'request_replay_unavailable' } },
+            },
+        });
+        const conflict = createChatError({
+            response: {
+                status: 409,
+                data: { detail: { code: 'request_id_conflict' } },
+            },
+        });
+
+        expect(replay).toBeInstanceOf(ChatError);
+        expect(replay.type).toBe('request_replay');
+        expect(conflict.type).toBe('request_conflict');
+        expect(replay.message).not.toBe(conflict.message);
+    });
+
+    it('does not expose raw request identifiers or response fields', () => {
+        const marker = 'sensitive-request-id-marker';
+        const error = createChatError({
+            response: {
+                status: 409,
+                data: {
+                    detail: {
+                        code: 'request_id_conflict',
+                        request_id: marker,
+                        message: marker,
+                    },
+                },
+            },
+            config: { data: marker },
+        });
+
+        expect(error.message).not.toContain(marker);
+        expect(error.message).not.toContain('request_id');
+    });
+
+    it('preserves the existing 429 classification', () => {
+        const error = createChatError({ response: { status: 429, data: {} } });
+        expect(error.type).toBe('rate_limited');
+    });
+});

--- a/frontend/tests/chatServiceAdmission.test.jsx
+++ b/frontend/tests/chatServiceAdmission.test.jsx
@@ -44,6 +44,20 @@ describe('chat admission service contract', () => {
         expect(mockPost).not.toHaveBeenCalled();
     });
 
+    it('rethrows an existing ChatError without wrapping it', async () => {
+        const existing = new ChatError('validation', 'safe existing error');
+        mockPost.mockRejectedValue(existing);
+
+        let received;
+        try {
+            await sendMessage('hello', {}, REQUEST_ID);
+        } catch (error) {
+            received = error;
+        }
+
+        expect(received).toBe(existing);
+    });
+
     it('classifies replay and conflict as distinct safe errors', () => {
         expect(classifyHttpError(409, 'request_replay_unavailable')).toBe('request_replay');
         expect(classifyHttpError(409, 'request_id_conflict')).toBe('request_conflict');

--- a/frontend/tests/setup.js
+++ b/frontend/tests/setup.js
@@ -1,0 +1,15 @@
+const TEST_REQUEST_ID = '00000000-0000-0000-0000-000000000001';
+
+if (!globalThis.crypto) {
+    Object.defineProperty(globalThis, 'crypto', {
+        configurable: true,
+        value: {},
+    });
+}
+
+if (typeof globalThis.crypto.randomUUID !== 'function') {
+    Object.defineProperty(globalThis.crypto, 'randomUUID', {
+        configurable: true,
+        value: () => TEST_REQUEST_ID,
+    });
+}

--- a/frontend/tests/useChatAdmission.test.jsx
+++ b/frontend/tests/useChatAdmission.test.jsx
@@ -24,6 +24,7 @@ vi.mock('../src/shared/services/apiClient', () => ({
 }));
 
 import { useChat } from '../src/features/chat/hooks/useChat';
+import { SYSTEM_MESSAGES } from '../src/features/chat/constants';
 
 const UUID_A = '550e8400-e29b-41d4-a716-446655440000';
 const UUID_B = '550e8400-e29b-41d4-a716-446655440001';
@@ -108,7 +109,33 @@ describe('useChat admission identity', () => {
 
         expect(mockSendMessage).not.toHaveBeenCalled();
         expect(result.current.messages).toEqual([
-            expect.objectContaining({ role: 'system' }),
+            {
+                role: 'system',
+                content: SYSTEM_MESSAGES.REQUEST_ID_UNAVAILABLE,
+            },
+        ]);
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.input).toBe('hello');
+    });
+
+    it('does not call the API when Web Crypto randomUUID throws', async () => {
+        const failingRandomUUID = vi.fn(() => {
+            throw new Error('randomUUID failure');
+        });
+        vi.stubGlobal('crypto', { randomUUID: failingRandomUUID });
+        const { result } = renderHook(() => useChat());
+
+        await act(async () => { result.current.setInput('hello'); });
+        await waitFor(() => expect(result.current.input).toBe('hello'));
+        await act(async () => { await result.current.handleSend(); });
+
+        expect(failingRandomUUID).toHaveBeenCalledTimes(1);
+        expect(mockSendMessage).not.toHaveBeenCalled();
+        expect(result.current.messages).toEqual([
+            {
+                role: 'system',
+                content: SYSTEM_MESSAGES.REQUEST_ID_UNAVAILABLE,
+            },
         ]);
         expect(result.current.isLoading).toBe(false);
         expect(result.current.input).toBe('hello');

--- a/frontend/tests/useChatAdmission.test.jsx
+++ b/frontend/tests/useChatAdmission.test.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSendMessage = vi.hoisted(() => vi.fn());
+const mockApiGet = vi.hoisted(() => vi.fn().mockResolvedValue({ data: [] }));
+
+vi.mock('../src/features/chat/services/chatService', () => ({
+    sendMessage: (...args) => mockSendMessage(...args),
+    ChatError: class ChatError extends Error {
+        constructor(type, message) {
+            super(message);
+            this.name = 'ChatError';
+            this.type = type;
+        }
+    },
+}));
+
+vi.mock('../src/shared/services/apiClient', () => ({
+    default: {
+        get: (...args) => mockApiGet(...args),
+        post: vi.fn(),
+    },
+}));
+
+import { useChat } from '../src/features/chat/hooks/useChat';
+
+const UUID_A = '550e8400-e29b-41d4-a716-446655440000';
+const UUID_B = '550e8400-e29b-41d4-a716-446655440001';
+
+function response(text = 'ok') {
+    return {
+        response: text,
+        emotion_state: {
+            schema_version: 1,
+            pad: { pleasure: 0, arousal: 0, dominance: 0 },
+            dominant_emotions: [],
+            mood_label: 'NEUTRA',
+            timestamp: 1000,
+        },
+    };
+}
+
+describe('useChat admission identity', () => {
+    let randomUUID;
+
+    beforeEach(() => {
+        mockSendMessage.mockReset();
+        mockApiGet.mockReset();
+        mockApiGet.mockResolvedValue({ data: [] });
+        randomUUID = vi.fn(() => UUID_A);
+        vi.stubGlobal('crypto', { randomUUID });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+    });
+
+    it('generates exactly one UUID for one accepted logical send', async () => {
+        let resolveSend;
+        mockSendMessage.mockReturnValue(new Promise(resolve => { resolveSend = resolve; }));
+        const { result } = renderHook(() => useChat());
+
+        await act(async () => { result.current.setInput('hello'); });
+        await waitFor(() => expect(result.current.input).toBe('hello'));
+
+        let first;
+        await act(async () => {
+            first = result.current.handleSend();
+            result.current.handleSend();
+        });
+
+        expect(randomUUID).toHaveBeenCalledTimes(1);
+        expect(mockSendMessage).toHaveBeenCalledTimes(1);
+        expect(mockSendMessage.mock.calls[0][0]).toBe('hello');
+        expect(mockSendMessage.mock.calls[0][2]).toBe(UUID_A);
+
+        await act(async () => {
+            resolveSend(response());
+            await first;
+        });
+    });
+
+    it('uses a new UUID for a new manual send', async () => {
+        randomUUID.mockReturnValueOnce(UUID_A).mockReturnValueOnce(UUID_B);
+        mockSendMessage.mockResolvedValue(response());
+        const { result } = renderHook(() => useChat());
+
+        await act(async () => { result.current.setInput('first'); });
+        await act(async () => { await result.current.handleSend(); });
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        await act(async () => { result.current.setInput('second'); });
+        await act(async () => { await result.current.handleSend(); });
+
+        expect(randomUUID).toHaveBeenCalledTimes(2);
+        expect(mockSendMessage.mock.calls[0][2]).toBe(UUID_A);
+        expect(mockSendMessage.mock.calls[1][2]).toBe(UUID_B);
+    });
+
+    it('does not call the API when Web Crypto randomUUID is unavailable', async () => {
+        vi.stubGlobal('crypto', {});
+        const { result } = renderHook(() => useChat());
+
+        await act(async () => { result.current.setInput('hello'); });
+        await act(async () => { await result.current.handleSend(); });
+
+        expect(mockSendMessage).not.toHaveBeenCalled();
+        expect(result.current.messages).toEqual([
+            expect.objectContaining({ role: 'system' }),
+        ]);
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.input).toBe('hello');
+    });
+});

--- a/frontend/tests/useChatAdmission.test.jsx
+++ b/frontend/tests/useChatAdmission.test.jsx
@@ -140,4 +140,28 @@ describe('useChat admission identity', () => {
         expect(result.current.isLoading).toBe(false);
         expect(result.current.input).toBe('hello');
     });
+
+    it('does not let late history overwrite a local Web Crypto failure', async () => {
+        let resolveHistory;
+        mockApiGet.mockReturnValue(new Promise(resolve => { resolveHistory = resolve; }));
+        vi.stubGlobal('crypto', {});
+        const { result } = renderHook(() => useChat());
+
+        await waitFor(() => expect(mockApiGet).toHaveBeenCalledTimes(1));
+        await act(async () => { result.current.setInput('hello'); });
+        await act(async () => { await result.current.handleSend(); });
+
+        await act(async () => {
+            resolveHistory({ data: [{ role: 'user', content: 'stale history' }] });
+        });
+        await act(async () => {});
+
+        expect(result.current.messages).toEqual([
+            {
+                role: 'system',
+                content: SYSTEM_MESSAGES.REQUEST_ID_UNAVAILABLE,
+            },
+        ]);
+        expect(result.current.input).toBe('hello');
+    });
 });

--- a/frontend/vitest.config.mjs
+++ b/frontend/vitest.config.mjs
@@ -7,6 +7,6 @@ export default defineConfig({
         include: ['tests/**/*.test.jsx'],
         globals: true,
         environment: 'jsdom',
-        setupFiles: [],
+        setupFiles: ['./tests/setup.js'],
     },
 });


### PR DESCRIPTION
Closes #292

## Causa raiz

O ledger PostgreSQL e os contratos puros já existiam, mas o caminho ativo do `/chat` ainda aceitava somente `message`, não possuía identidade lógica fornecida pelo cliente e executava estado, histórico, embeddings e provider sem uma reserva compartilhada anterior.

## Implementação final

### Backend

- adiciona `backend/admission.py`, independente de FastAPI, Supabase, Groq, engine, memória e rede no import;
- exige `ADMISSION_HMAC_SECRET` com no mínimo 32 bytes UTF-8 válidos e não compostos apenas por whitespace, sem fallback;
- valida `TRUSTED_PROXY_CIDRS` e resolve peer/XFF da direita para a esquerda;
- ignora XFF quando o peer não é confiável e usa `unknown` em entrada ausente, inválida ou ambígua;
- usa HMAC-SHA256 com separação de domínio para mensagem e identidade de rede;
- valida integralmente construção, request e response da RPC `reserve_admission`;
- exige `request_id` e `message` como strings estritas;
- aplica 4.000 caracteres e 6.000 unidades UTF-8 antes da admissão;
- sanitiza todo erro 422 sem ecoar body, UUID ou mensagem;
- executa a reserva com `run_blocking_write`, drenando a escrita em cancelamento;
- cria um único `TurnBudget` antes da admissão;
- usa `ChatConversationEngine` para passar o mesmo budget ao turno sem alterar `ConversationEngine`;
- impede engine, memória e provider em replay, conflito, quota ou store indisponível;
- mapeia decisões para 409, 429, 422 ou 503 e adiciona `Retry-After` somente às quotas.

### Frontend

- gera `crypto.randomUUID()` exatamente uma vez por envio aceito;
- envia `{ request_id, message }`;
- preserva single-flight, timeout, ownership, unmount e history guards;
- não envia quando Web Crypto está ausente ou lança;
- preserva a mensagem local de falha contra resposta tardia de `/history`;
- distingue replay e conflito com mensagens públicas sanitizadas;
- preserva a identidade de `ChatError` já classificado;
- não implementa retry automático.

## Segurança e privacidade

Não são registrados ou persistidos no caminho ativo:

- mensagem;
- UUID;
- user ID;
- IP ou `X-Forwarded-For`;
- HMAC;
- segredo;
- payload ou exceção upstream bruta.

O banco recebe somente UUID canônico, user ID autenticado, dois HMACs e unidades estimadas, conforme a RPC integrada na #290.

## Testes e correções de isolamento

A suíte cobre:

- configuração, HMAC, Unicode e separação de domínio;
- IPv4/IPv6, proxies confiáveis, peer direto e bucket `unknown`;
- invariantes de construção, payload RPC exato e respostas malformadas;
- exceções upstream sanitizadas;
- cancelamento real do endpoint com drain da reserva e engine não chamado;
- deadline expirado antes da RPC;
- endpoint: auth, UUID normalizado, limites, todas as decisões, headers e fail-closed;
- mesmo objeto `TurnBudget` entre admissão e turno;
- frontend: UUID único, novo UUID por envio, Web Crypto ausente ou lançando, payload exato e histórico tardio;
- replay/conflito distintos e preservação de `ChatError`;
- testes legados de `/chat` migrados para o contrato com UUID;
- correção de mock antigo de `engine.process_turn` que vazava entre módulos por atribuição direta.

As duas sugestões da revisão automática foram implementadas e as threads foram resolvidas.

## CI final

HEAD auditado:

`d463f1d1d3edc3d78a48ccf8748cb8e8b591ad86`

CI #134 (`30484442900`) completamente verde:

- backend: **1.549 passed**;
- integração real do ledger: **11 passed**;
- upgrade legado: **2 passed**;
- matriz real de autorização: **8 passed**;
- pgTAP: aprovado;
- frontend: audit, testes, lint e build aprovados;
- database: todos os resets e testes aprovados.

## Arquivos alterados

18 arquivos, limitados a configuração de ambiente, domínio/adapter de admissão, caminho HTTP, testes correspondentes e contrato do frontend. Não há alteração em migration, `backend/engine.py`, memória, relacionamento, sistema emocional ou prompts.

## Riscos residuais

- a reserva aceita a solicitação antes do processamento, mas replay da resposta final permanece para `turn_requests` / #272;
- o orçamento de 16.000 unidades do envelope do provider permanece deliberadamente fora desta PR;
- `ADMISSION_HMAC_SECRET` precisa ser provisionado no ambiente de execução antes do deploy;
- `TRUSTED_PROXY_CIDRS` precisa refletir somente proxies realmente administrados;
- nenhuma migration ou alteração desta PR foi aplicada ao Supabase hospedado.

## Fora de escopo

- orçamento de 16.000 unidades do envelope do provider;
- replay da resposta final e `turn_requests`;
- retry automático;
- migrations ou alteração do ledger;
- retenção/cleanup;
- sistema emocional, memória, relacionamento ou prompts;
- `.Jules/palette.md`;
- aplicação de migration no Supabase hospedado.