### PR TITLE
feat(db): add transactional turn persistence schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,29 @@ jobs:
           trap 'mv "$hidden" "$migration"' EXIT
           python -m pytest -q -ra backend/tests/test_legacy_upgrade.py
 
+      - name: Reset database for transactional schema legacy tests
+        run: |
+          set -euo pipefail
+          supabase db reset
+
+      - name: Run Transactional Schema Legacy Test
+        env:
+          SUPABASE_URL: "http://127.0.0.1:54321"
+          PYTHONPATH: "."
+        run: |
+          python -m pytest -q -ra backend/tests/test_transactional_schema_legacy.py
+
+      - name: Reset database for transactional schema integration tests
+        run: |
+          supabase db reset
+
+      - name: Run Transactional Schema Integration Tests
+        env:
+          SUPABASE_URL: "http://127.0.0.1:54321"
+          PYTHONPATH: "."
+        run: |
+          python -m pytest -q -ra backend/tests/test_transactional_schema_integration.py
+
       - name: Reset database for authorization tests
         run: |
           supabase db reset
@@ -179,6 +202,8 @@ jobs:
               --ignore=backend/tests/test_database_authorization_integration.py \
               --ignore=backend/tests/test_admission_ledger_integration.py \
               --ignore=backend/tests/test_legacy_upgrade.py \
+              --ignore=backend/tests/test_transactional_schema_legacy.py \
+              --ignore=backend/tests/test_transactional_schema_integration.py \
               -ra
 
   frontend:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,10 +114,28 @@ jobs:
           PYTHONPATH: "."
         run: |
           set -euo pipefail
-          migration="supabase/migrations/20240101000003_admission_ledger.sql"
-          hidden="${migration}.legacy-test-hidden"
-          mv "$migration" "$hidden"
-          trap 'mv "$hidden" "$migration"' EXIT
+          # Hide every migration AFTER the hardening target (02) — now 03 and
+          # 04 — so the legacy upgrade scenario starts from a true
+          # baseline-only database. Restored in a trap, including on failure.
+          migrations=(
+            "supabase/migrations/20240101000003_admission_ledger.sql"
+            "supabase/migrations/20240101000004_transactional_turn_schema.sql"
+          )
+          hidden=()
+          restore_migrations() {
+            for f in "${hidden[@]:-}"; do
+              if [[ -f "$f.legacy-test-hidden" ]]; then
+                mv "$f.legacy-test-hidden" "$f"
+              fi
+            done
+          }
+          trap restore_migrations EXIT
+          for migration in "${migrations[@]}"; do
+            if [[ -f "$migration" ]]; then
+              mv "$migration" "$migration.legacy-test-hidden"
+              hidden+=("$migration")
+            fi
+          done
           python -m pytest -q -ra backend/tests/test_legacy_upgrade.py
 
       - name: Reset database for transactional schema legacy tests

--- a/backend/tests/test_legacy_upgrade.py
+++ b/backend/tests/test_legacy_upgrade.py
@@ -343,7 +343,7 @@ def test_valid_legacy_upgrade(supabase_service_client):
         # until the migrated tables are visible through PostgREST (a stale
         # cache would otherwise surface as PGRST205).
         _reload_postgrest_schema()
-        _wait_for_postgrest_table(supabase_service_client)
+        _wait_for_postgrest_table(supabase_service_client, "profiles")
 
         # ---- Verify migration timestamp ----
         assert _query_scalar_bool(_MIGRATION_VERSION_SQL, "result"), (

--- a/backend/tests/test_legacy_upgrade.py
+++ b/backend/tests/test_legacy_upgrade.py
@@ -13,6 +13,7 @@ import json
 import os
 import logging
 import subprocess
+import time
 import pytest
 
 from backend.supabase_cli import run_supabase_op
@@ -79,6 +80,100 @@ def _run_fixture_file(filepath: str):
         raise AssertionError(
             f"Fixture execution failed: {filepath} (exited {result.returncode})"
         )
+
+
+# ---------------------------------------------------------------------------
+# PostgREST schema cache helpers
+# ---------------------------------------------------------------------------
+
+
+def _reload_postgrest_schema():
+    """Force PostgREST to refresh its schema cache.
+
+    ``supabase migration up --local`` applies migrations directly and does
+    not reliably refresh PostgREST's cached schema, so queries against the
+    migrated tables can fail with PGRST205 ("Could not find the table in the
+    schema cache").  PostgREST reloads its schema cache when it receives
+    ``NOTIFY pgrst, 'reload schema'``; the reload is processed
+    asynchronously, so callers must also wait for the tables to become
+    visible again (see ``_wait_for_postgrest_table``).
+    """
+    _run_supabase(
+        "legacy_state_query",
+        [
+            "db", "query", "--agent=no", "--output", "json",
+            "select pg_notify('pgrst', 'reload schema')",
+        ],
+    )
+
+
+def _restart_postgrest_container():
+    """Restart the local PostgREST container to force a fresh schema cache.
+
+    The notification-based reload (``NOTIFY pgrst, 'reload schema'``)
+    requires PostgREST to be listening on its reload channel; if it is not
+    available, restarting the container guarantees the schema cache is
+    rebuilt from the current database state.
+    """
+    result = subprocess.run(
+        ["docker", "ps", "--format", "{{.Names}}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    candidates = [
+        name
+        for name in result.stdout.splitlines()
+        if "supabase" in name and "rest" in name
+    ]
+    if not candidates:
+        raise AssertionError(
+            "PostgREST container not found for schema cache restart"
+        )
+    restarted = subprocess.run(
+        ["docker", "restart", candidates[0]],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if restarted.returncode != 0:
+        raise AssertionError(
+            "Failed to restart PostgREST container for schema cache"
+        )
+
+
+def _wait_for_postgrest_table(client, table: str, timeout: float = 30.0):
+    """Wait until PostgREST exposes *table* in its schema cache.
+
+    PostgREST serves the refreshed schema cache asynchronously after a
+    reload; immediately after a raw migration apply the cache can still be
+    stale (PGRST205).  Poll a trivial query until it succeeds or *timeout*
+    seconds elapse, then fall back to restarting the PostgREST container
+    once and poll again.
+
+    Raises:
+        AssertionError: If *table* is still not visible after the retries.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            client.table(table).select("user_id").limit(1).execute()
+            return
+        except Exception:
+            time.sleep(1)
+
+    _restart_postgrest_container()
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            client.table(table).select("user_id").limit(1).execute()
+            return
+        except Exception:
+            time.sleep(1)
+    raise AssertionError(
+        f"PostgREST schema cache did not expose table '{table}' after reload"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -242,6 +337,13 @@ def test_valid_legacy_upgrade(supabase_service_client):
 
         _restore_hardening()
         _run_supabase("legacy_hardening_apply", ["migration", "up", "--local"])
+
+        # PostgREST caches the schema and a raw `supabase migration up
+        # --local` does not reliably refresh it, so force a reload and wait
+        # until the migrated tables are visible through PostgREST (a stale
+        # cache would otherwise surface as PGRST205).
+        _reload_postgrest_schema()
+        _wait_for_postgrest_table(supabase_service_client)
 
         # ---- Verify migration timestamp ----
         assert _query_scalar_bool(_MIGRATION_VERSION_SQL, "result"), (

--- a/backend/tests/test_transactional_schema.py
+++ b/backend/tests/test_transactional_schema.py
@@ -1,0 +1,321 @@
+"""
+Tests for ``backend.transactional_schema``.
+
+Covers:
+
+ 1. Pure importability from subprocess (no heavy deps, no env/socket)
+ 2. Canonical hash: deterministic
+ 3. Canonical hash: key-order independent
+ 4. Canonical hash: 64 lowercase hex digits
+ 5. Canonical hash: differs for different payloads
+ 6. Canonical hash: rejects non-mapping input
+ 7. Canonical hash: rejects non-serializable values without leaking them
+ 8. TurnRequestRecord: to_db_row omits None server-owned columns
+ 9. TurnRequestRecord: to_insert_row drops server-owned None columns
+10. TurnRequestRecord: from_db_row round-trips
+11. TurnRequestRecord: immutable after construction
+12. OutboxEventRecord: to_db_row omits None
+13. OutboxEventRecord: to_insert_row drops server-owned None columns
+14. OutboxEventRecord: from_db_row round-trips
+15. OutboxEventRecord: immutable after construction
+16. No shared mutable state / no module-level user state
+"""
+
+import subprocess
+import sys
+import os
+
+import pytest
+from dataclasses import FrozenInstanceError
+
+from backend.transactional_schema import (
+    FORBIDDEN_PAYLOAD_KEYS,
+    TurnRequestRecord,
+    OutboxEventRecord,
+    canonical_payload_hash,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 1. Pure importability
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestImportability:
+    """Import the module in a subprocess with env, socket, and import
+    hooks that fail if the module touches forbidden resources."""
+
+    _PURITY_SCRIPT = '''
+import sys
+
+# -- Pre-import ONLY stdlib needed for guards --------------------------
+import os as _os
+import socket as _socket
+
+class _FailEnv:
+    """Mapping proxy that fails on every read operation."""
+    def __getitem__(self, key):
+        raise RuntimeError(f"os.environ read attempted: key={key!r}")
+    def get(self, key, default=None):
+        raise RuntimeError(f"os.environ.get read attempted: key={key!r}")
+    def __contains__(self, key):
+        raise RuntimeError(f"os.environ.__contains__ read attempted: key={key!r}")
+    def __setitem__(self, key, value):
+        pass
+    def __delitem__(self, key):
+        pass
+    def __repr__(self):
+        return "_FailEnv()"
+    def __iter__(self):
+        return iter([])
+    def __len__(self):
+        return 0
+    def __bool__(self):
+        return True
+
+_os.environ = _FailEnv()
+
+def _raise_getenv(key, default=None):
+    raise RuntimeError(f"os.getenv read attempted: key={key!r}")
+_os.getenv = _raise_getenv
+
+def _raise_socket(*args, **kwargs):
+    raise OSError("socket.socket blocked")
+def _raise_create_connection(*args, **kwargs):
+    raise OSError("socket.create_connection blocked")
+_socket.socket = _raise_socket
+_socket.create_connection = _raise_create_connection
+
+_BLOCKED_TOP = frozenset({
+    "fastapi", "groq", "supabase", "sentence_transformers",
+    "pydantic", "httpx", "httpcore", "anyio",
+})
+_BLOCKED_FULL = frozenset({
+    "backend.engine", "backend.memory", "backend.trusted_context",
+})
+
+class _BlockImport:
+    def find_spec(self, fullname, path, target=None):
+        if fullname in _BLOCKED_FULL:
+            raise ImportError(f"blocked: {fullname}")
+        top = fullname.split(".")[0]
+        if top in _BLOCKED_TOP:
+            raise ImportError(f"blocked: {fullname}")
+        return None
+
+sys.meta_path.insert(0, _BlockImport())
+
+sys.path.insert(0, ".")
+from backend.transactional_schema import (
+    FORBIDDEN_PAYLOAD_KEYS,
+    TurnRequestRecord,
+    OutboxEventRecord,
+    canonical_payload_hash,
+)
+
+assert canonical_payload_hash({"a": 1}) == canonical_payload_hash({"a": 1})
+assert len(canonical_payload_hash({"b": 2})) == 64
+assert FORBIDDEN_PAYLOAD_KEYS == {"prompt", "system_prompt", "meta_cognition", "internal_instructions"}
+rec = TurnRequestRecord(user_id="u", request_id="r", payload_hash_sha256="a" * 64, status="pending")
+assert rec.to_db_row()["user_id"] == "u"
+outbox = OutboxEventRecord(event_type="memory_indexed", user_id="u", payload={}, status="pending", idempotency_key="k")
+assert outbox.to_db_row()["status"] == "pending"
+print("OK")
+'''
+
+    def test_pure_import_with_guards(self):
+        proc = subprocess.run(
+            [sys.executable, "-c", self._PURITY_SCRIPT],
+            capture_output=True, text=True,
+            cwd=os.getcwd(),
+            env={
+                **os.environ,
+                "PYTHONPATH": ".",
+                "GROQ_API_KEY": "",
+                "SUPABASE_URL": "",
+                "SUPABASE_KEY": "",
+            },
+        )
+        assert proc.returncode == 0, (
+            f"Subprocess failed (guard triggered?):\n"
+            f"stdout:{proc.stdout}\nstderr:{proc.stderr}"
+        )
+        assert "OK" in proc.stdout
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 2–7. canonical_payload_hash
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestCanonicalPayloadHash:
+    def test_deterministic(self):
+        payload = {"request_id": "r-1", "user_id": "u-1", "message": "hello"}
+        assert canonical_payload_hash(payload) == canonical_payload_hash(payload)
+
+    def test_key_order_independent(self):
+        a = {"z": 1, "a": 2, "m": [1, 2]}
+        b = {"m": [1, 2], "a": 2, "z": 1}
+        assert canonical_payload_hash(a) == canonical_payload_hash(b)
+
+    def test_nested_order_independent(self):
+        a = {"outer": {"z": 1, "a": 2}}
+        b = {"outer": {"a": 2, "z": 1}}
+        assert canonical_payload_hash(a) == canonical_payload_hash(b)
+
+    def test_hex64_lowercase(self):
+        import re
+        digest = canonical_payload_hash({"x": 1})
+        assert re.fullmatch(r"[0-9a-f]{64}", digest) is not None
+
+    def test_differs_for_different_payloads(self):
+        assert canonical_payload_hash({"a": 1}) != canonical_payload_hash({"a": 2})
+        assert canonical_payload_hash({"a": 1}) != canonical_payload_hash({"b": 1})
+
+    def test_rejects_non_mapping(self):
+        with pytest.raises(TypeError):
+            canonical_payload_hash("not-a-mapping")
+        with pytest.raises(TypeError):
+            canonical_payload_hash([1, 2])
+
+    def test_rejects_non_serializable_without_leak(self):
+        class Unserializable:
+            def __repr__(self):
+                return "SECRET_INTERNAL_MARKER"
+
+        with pytest.raises(TypeError) as excinfo:
+            canonical_payload_hash({"bad": Unserializable()})
+        assert "SECRET_INTERNAL_MARKER" not in str(excinfo.value)
+        assert "SECRET_INTERNAL_MARKER" not in repr(excinfo.value)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 8–11. TurnRequestRecord
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestTurnRequestRecord:
+    def _base(self):
+        return TurnRequestRecord(
+            user_id="u-1",
+            request_id="11111111-1111-4111-8111-111111111111",
+            payload_hash_sha256="a" * 64,
+            status="pending",
+            expected_revision=0,
+            lease_owner="worker-a",
+            lease_expires_at="2099-01-01T00:00:00Z",
+        )
+
+    def test_to_db_row_omits_none_fields(self):
+        row = self._base().to_db_row()
+        assert row["user_id"] == "u-1"
+        assert row["status"] == "pending"
+        assert row["lease_owner"] == "worker-a"
+        assert row["committed_revision"] is None
+        assert row["replay_payload"] is None
+
+    def test_to_insert_row_drops_server_owned_none(self):
+        insert = self._base().to_insert_row()
+        assert "id" not in insert
+        assert "created_at" not in insert
+        assert "updated_at" not in insert
+        assert "completed_at" not in insert
+        assert insert["user_id"] == "u-1"
+
+    def test_from_db_row_round_trip(self):
+        """from_db_row must reproduce every field present in the row."""
+        row = self._base().to_db_row()
+        row["id"] = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+        row["created_at"] = "2026-07-29T10:00:00Z"
+        row["completed_at"] = "2026-07-29T10:00:00Z"
+        record = TurnRequestRecord.from_db_row(row)
+        assert record.user_id == "u-1"
+        assert record.status == "pending"
+        assert record.id == "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+        assert record.created_at == "2026-07-29T10:00:00Z"
+        assert record.completed_at == "2026-07-29T10:00:00Z"
+        # Reserializing the parsed record reproduces the input row exactly.
+        assert record.to_db_row() == row
+
+    def test_immutable_after_construction(self):
+        record = self._base()
+        with pytest.raises(FrozenInstanceError):
+            record.status = "completed"  # type: ignore[assignment]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 12–15. OutboxEventRecord
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestOutboxEventRecord:
+    def _base(self):
+        return OutboxEventRecord(
+            event_type="memory_indexed",
+            user_id="u-1",
+            payload={"ref": "turn-1"},
+            status="pending",
+            idempotency_key="idem-1",
+            next_attempt_at="2099-01-01T00:00:00Z",
+        )
+
+    def test_to_db_row_omits_none_fields(self):
+        row = self._base().to_db_row()
+        assert row["event_type"] == "memory_indexed"
+        assert row["payload"] == {"ref": "turn-1"}
+        assert row["lease_owner"] is None
+        assert row["attempts"] == 0
+
+    def test_to_insert_row_drops_server_owned_none(self):
+        insert = self._base().to_insert_row()
+        assert "id" not in insert
+        assert "created_at" not in insert
+        assert "processed_at" not in insert
+        assert "dead_lettered_at" not in insert
+        assert "retention_until" not in insert
+        assert insert["idempotency_key"] == "idem-1"
+
+    def test_from_db_row_round_trip(self):
+        """from_db_row must reproduce every field present in the row."""
+        row = self._base().to_db_row()
+        row["id"] = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+        row["processed_at"] = "2026-07-29T10:00:00Z"
+        record = OutboxEventRecord.from_db_row(row)
+        assert record.event_type == "memory_indexed"
+        assert record.status == "pending"
+        assert record.id == "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+        assert record.processed_at == "2026-07-29T10:00:00Z"
+        # Reserializing the parsed record reproduces the input row exactly.
+        assert record.to_db_row() == row
+
+    def test_immutable_after_construction(self):
+        record = self._base()
+        with pytest.raises(FrozenInstanceError):
+            record.status = "completed"  # type: ignore[assignment]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 16. No shared mutable state
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestNoSharedState:
+    def test_forbidden_keys_frozen_set(self):
+        assert FORBIDDEN_PAYLOAD_KEYS == {
+            "prompt",
+            "system_prompt",
+            "meta_cognition",
+            "internal_instructions",
+        }
+
+    def test_records_are_independent(self):
+        r1 = TurnRequestRecord(user_id="u", request_id="r", payload_hash_sha256="a" * 64, status="pending")
+        r2 = TurnRequestRecord(user_id="u", request_id="r", payload_hash_sha256="a" * 64, status="pending")
+        assert r1 == r2
+
+    def test_no_module_level_user_state(self):
+        """Module-level state must be constants only — never user-keyed state."""
+        import backend.transactional_schema as module
+        # ``__builtins__`` is injected by the interpreter; everything else
+        # must be an immutable constant or a class/function.
+        mutable = [
+            (k, v)
+            for k, v in vars(module).items()
+            if k != "__builtins__" and isinstance(v, (dict, list, set))
+        ]
+        assert mutable == []

--- a/backend/tests/test_transactional_schema.py
+++ b/backend/tests/test_transactional_schema.py
@@ -10,15 +10,17 @@ Covers:
  5. Canonical hash: differs for different payloads
  6. Canonical hash: rejects non-mapping input
  7. Canonical hash: rejects non-serializable values without leaking them
+ 7b. Canonical hash: rejects NaN / Infinity / -Infinity (non-JSON values)
  8. TurnRequestRecord: to_db_row omits None server-owned columns
  9. TurnRequestRecord: to_insert_row drops server-owned None columns
 10. TurnRequestRecord: from_db_row round-trips
-11. TurnRequestRecord: immutable after construction
+11. TurnRequestRecord: immutable after construction (incl. deep payload)
 12. OutboxEventRecord: to_db_row omits None
 13. OutboxEventRecord: to_insert_row drops server-owned None columns
 14. OutboxEventRecord: from_db_row round-trips
-15. OutboxEventRecord: immutable after construction
+15. OutboxEventRecord: immutable after construction (incl. deep payload)
 16. No shared mutable state / no module-level user state
+17. Allowlist constants mirror the SQL allowlists (no overlap with forbidden)
 """
 
 import subprocess
@@ -30,6 +32,8 @@ from dataclasses import FrozenInstanceError
 
 from backend.transactional_schema import (
     FORBIDDEN_PAYLOAD_KEYS,
+    REPLAY_PAYLOAD_ALLOWED_KEYS,
+    OUTBOX_PAYLOAD_ALLOWED_KEYS,
     TurnRequestRecord,
     OutboxEventRecord,
     canonical_payload_hash,
@@ -107,6 +111,8 @@ sys.meta_path.insert(0, _BlockImport())
 sys.path.insert(0, ".")
 from backend.transactional_schema import (
     FORBIDDEN_PAYLOAD_KEYS,
+    REPLAY_PAYLOAD_ALLOWED_KEYS,
+    OUTBOX_PAYLOAD_ALLOWED_KEYS,
     TurnRequestRecord,
     OutboxEventRecord,
     canonical_payload_hash,
@@ -114,7 +120,12 @@ from backend.transactional_schema import (
 
 assert canonical_payload_hash({"a": 1}) == canonical_payload_hash({"a": 1})
 assert len(canonical_payload_hash({"b": 2})) == 64
-assert FORBIDDEN_PAYLOAD_KEYS == {"prompt", "system_prompt", "meta_cognition", "internal_instructions"}
+assert FORBIDDEN_PAYLOAD_KEYS == {
+    "prompt", "system_prompt", "meta_cognition", "internal_instructions",
+    "message", "user_message", "assistant_message", "content",
+}
+assert REPLAY_PAYLOAD_ALLOWED_KEYS.isdisjoint(FORBIDDEN_PAYLOAD_KEYS)
+assert OUTBOX_PAYLOAD_ALLOWED_KEYS.isdisjoint(FORBIDDEN_PAYLOAD_KEYS)
 rec = TurnRequestRecord(user_id="u", request_id="r", payload_hash_sha256="a" * 64, status="pending")
 assert rec.to_db_row()["user_id"] == "u"
 outbox = OutboxEventRecord(event_type="memory_indexed", user_id="u", payload={}, status="pending", idempotency_key="k")
@@ -186,6 +197,17 @@ class TestCanonicalPayloadHash:
         assert "SECRET_INTERNAL_MARKER" not in str(excinfo.value)
         assert "SECRET_INTERNAL_MARKER" not in repr(excinfo.value)
 
+    def test_rejects_non_finite_floats(self):
+        """NaN / Infinity / -Infinity are not interoperable JSON and must
+        never be hashed (the database jsonb type refuses them too)."""
+        for value in (float("nan"), float("inf"), float("-inf")):
+            with pytest.raises(TypeError):
+                canonical_payload_hash({"x": value})
+
+    def test_rejects_nested_non_finite_floats(self):
+        with pytest.raises(TypeError):
+            canonical_payload_hash({"outer": {"x": float("nan")}})
+
 
 # ═══════════════════════════════════════════════════════════════════════
 # 8–11. TurnRequestRecord
@@ -239,6 +261,33 @@ class TestTurnRequestRecord:
         with pytest.raises(FrozenInstanceError):
             record.status = "completed"  # type: ignore[assignment]
 
+    def test_replay_payload_deeply_immutable(self):
+        """The stored replay_payload is a frozen copy: mutating the source
+        dict after construction must not affect the record, and mutating
+        the stored payload must raise."""
+        source = {"response": "ok", "emotion_state": {"name": "calm"}}
+        record = TurnRequestRecord(
+            user_id="u-1",
+            request_id="11111111-1111-4111-8111-111111111111",
+            payload_hash_sha256="a" * 64,
+            status="completed",
+            committed_revision=1,
+            replay_payload=source,
+        )
+        # Mutating the caller's dict afterwards must not leak into the record.
+        source["response"] = "mutated"
+        source["emotion_state"]["name"] = "mutated"
+        assert record.replay_payload["response"] == "ok"
+        assert record.replay_payload["emotion_state"]["name"] == "calm"
+        # The stored payload itself is immutable.
+        with pytest.raises(TypeError):
+            record.replay_payload["response"] = "x"  # type: ignore[index]
+        with pytest.raises(TypeError):
+            record.replay_payload["emotion_state"]["name"] = "x"  # type: ignore[index]
+        # Serialization yields plain, JSON-serializable structures.
+        import json
+        json.dumps(record.to_db_row()["replay_payload"])
+
 
 # ═══════════════════════════════════════════════════════════════════════
 # 12–15. OutboxEventRecord
@@ -289,6 +338,29 @@ class TestOutboxEventRecord:
         with pytest.raises(FrozenInstanceError):
             record.status = "completed"  # type: ignore[assignment]
 
+    def test_payload_deeply_immutable(self):
+        """The stored outbox payload is a frozen copy: mutating the source
+        dict after construction must not affect the record, and mutating
+        the stored payload must raise."""
+        source = {"ref": "turn-1", "meta": {"n": 1}}
+        record = OutboxEventRecord(
+            event_type="memory_indexed",
+            user_id="u-1",
+            payload=source,
+            status="pending",
+            idempotency_key="idem-1",
+        )
+        source["ref"] = "mutated"
+        source["meta"]["n"] = 2
+        assert record.payload["ref"] == "turn-1"
+        assert record.payload["meta"]["n"] == 1
+        with pytest.raises(TypeError):
+            record.payload["ref"] = "x"  # type: ignore[index]
+        with pytest.raises(TypeError):
+            record.payload["meta"]["n"] = 3  # type: ignore[index]
+        import json
+        json.dumps(record.to_db_row()["payload"])
+
 
 # ═══════════════════════════════════════════════════════════════════════
 # 16. No shared mutable state
@@ -296,12 +368,38 @@ class TestOutboxEventRecord:
 
 class TestNoSharedState:
     def test_forbidden_keys_frozen_set(self):
-        assert FORBIDDEN_PAYLOAD_KEYS == {
+        assert FORBIDDEN_PAYLOAD_KEYS == frozenset({
             "prompt",
             "system_prompt",
             "meta_cognition",
             "internal_instructions",
-        }
+            "message",
+            "user_message",
+            "assistant_message",
+            "content",
+        })
+
+    def test_allowlists_are_disjoint_from_forbidden(self):
+        """Allowlist constants must mirror the SQL allowlists and never
+        overlap with the forbidden keys."""
+        assert REPLAY_PAYLOAD_ALLOWED_KEYS == frozenset({
+            "response",
+            "emotion_state",
+            "message_id",
+            "request_id",
+            "duration_ms",
+        })
+        assert OUTBOX_PAYLOAD_ALLOWED_KEYS == frozenset({
+            "ref",
+            "request_id",
+            "turn_id",
+            "message_id",
+            "entity_id",
+            "kind",
+            "version",
+        })
+        assert REPLAY_PAYLOAD_ALLOWED_KEYS.isdisjoint(FORBIDDEN_PAYLOAD_KEYS)
+        assert OUTBOX_PAYLOAD_ALLOWED_KEYS.isdisjoint(FORBIDDEN_PAYLOAD_KEYS)
 
     def test_records_are_independent(self):
         r1 = TurnRequestRecord(user_id="u", request_id="r", payload_hash_sha256="a" * 64, status="pending")

--- a/backend/tests/test_transactional_schema.py
+++ b/backend/tests/test_transactional_schema.py
@@ -288,6 +288,55 @@ class TestTurnRequestRecord:
         import json
         json.dumps(record.to_db_row()["replay_payload"])
 
+    def test_replay_payload_immutable_for_mapping_proxy(self):
+        """A MappingProxyType source must be copied, not referenced: mutating
+        the backing dict after construction must not affect the record."""
+        from types import MappingProxyType
+
+        backing = {"response": "ok", "emotion_state": {"name": "calm"}}
+        source = MappingProxyType(backing)
+        record = TurnRequestRecord(
+            user_id="u-1",
+            request_id="11111111-1111-4111-8111-111111111111",
+            payload_hash_sha256="a" * 64,
+            status="completed",
+            committed_revision=1,
+            replay_payload=source,
+        )
+        backing["response"] = "mutated"
+        backing["emotion_state"]["name"] = "mutated"
+        assert record.replay_payload["response"] == "ok"
+        assert record.replay_payload["emotion_state"]["name"] == "calm"
+        # The stored payload is still deeply immutable.
+        with pytest.raises(TypeError):
+            record.replay_payload["response"] = "x"  # type: ignore[index]
+        with pytest.raises(TypeError):
+            record.replay_payload["emotion_state"]["name"] = "x"  # type: ignore[index]
+
+    def test_replay_payload_immutable_for_user_dict(self):
+        """A UserDict source must be copied, not referenced: the mutable
+        underlying dict must not be shared with the record."""
+        from collections import UserDict
+
+        source = UserDict({"response": "ok", "meta": {"n": 1}})
+        record = TurnRequestRecord(
+            user_id="u-1",
+            request_id="11111111-1111-4111-8111-111111111111",
+            payload_hash_sha256="a" * 64,
+            status="completed",
+            committed_revision=1,
+            replay_payload=source,
+        )
+        source.data["response"] = "mutated"
+        source.data["meta"]["n"] = 2
+        assert record.replay_payload["response"] == "ok"
+        assert record.replay_payload["meta"]["n"] == 1
+        with pytest.raises(TypeError):
+            record.replay_payload["meta"]["n"] = 9  # type: ignore[index]
+        # Serialization still yields plain JSON structures.
+        import json
+        json.dumps(record.to_db_row()["replay_payload"])
+
 
 # ═══════════════════════════════════════════════════════════════════════
 # 12–15. OutboxEventRecord
@@ -360,6 +409,49 @@ class TestOutboxEventRecord:
             record.payload["meta"]["n"] = 3  # type: ignore[index]
         import json
         json.dumps(record.to_db_row()["payload"])
+
+    def test_payload_immutable_for_mapping_proxy(self):
+        """Outbox payload frozen from a MappingProxyType must not be tied to
+        the mutable backing dict."""
+        from types import MappingProxyType
+
+        backing = {"ref": "turn-1", "meta": {"n": 1}}
+        source = MappingProxyType(backing)
+        record = OutboxEventRecord(
+            event_type="memory_indexed",
+            user_id="u-1",
+            payload=source,
+            status="pending",
+            idempotency_key="idem-1",
+        )
+        backing["ref"] = "mutated"
+        backing["meta"]["n"] = 2
+        assert record.payload["ref"] == "turn-1"
+        assert record.payload["meta"]["n"] == 1
+        with pytest.raises(TypeError):
+            record.payload["ref"] = "x"  # type: ignore[index]
+        with pytest.raises(TypeError):
+            record.payload["meta"]["n"] = 5  # type: ignore[index]
+
+    def test_payload_immutable_for_user_dict(self):
+        """Outbox payload frozen from a UserDict must not share the mutable
+        underlying dict."""
+        from collections import UserDict
+
+        source = UserDict({"ref": "turn-1", "meta": {"n": 1}})
+        record = OutboxEventRecord(
+            event_type="memory_indexed",
+            user_id="u-1",
+            payload=source,
+            status="pending",
+            idempotency_key="idem-1",
+        )
+        source.data["ref"] = "mutated"
+        source.data["meta"]["n"] = 2
+        assert record.payload["ref"] == "turn-1"
+        assert record.payload["meta"]["n"] == 1
+        with pytest.raises(TypeError):
+            record.payload["meta"]["n"] = 7  # type: ignore[index]
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/backend/tests/test_transactional_schema_integration.py
+++ b/backend/tests/test_transactional_schema_integration.py
@@ -384,6 +384,112 @@ def test_outbox_payload_forbids_prompt(service_client):
         service_client.table("profiles").delete().eq("user_id", user_id).execute()
 
 
+def test_outbox_payload_forbids_nested_internal(service_client):
+    """Forbidden keys must be rejected at any depth, not only top level."""
+    user_id = _uid("on")
+    service_client.table("profiles").upsert({"user_id": user_id}).execute()
+    try:
+        payload = _valid_outbox_payload(user_id, f"idem_{user_id}")
+        payload["payload"] = {"ref": {"system_prompt": "hidden"}}
+        with pytest.raises(APIError) as exc:
+            service_client.table("outbox_events").insert(payload).execute()
+        assert getattr(exc.value, "code", None) == "23514"
+    finally:
+        service_client.table("outbox_events").delete().eq("user_id", user_id).execute()
+        service_client.table("profiles").delete().eq("user_id", user_id).execute()
+
+
+def test_outbox_payload_forbids_message_content(service_client):
+    """The outbox must never store message content, even under an allowed key."""
+    user_id = _uid("om")
+    service_client.table("profiles").upsert({"user_id": user_id}).execute()
+    try:
+        payload = _valid_outbox_payload(user_id, f"idem_{user_id}")
+        payload["payload"] = {"ref": "turn-1", "message": "conteudo sensivel"}
+        with pytest.raises(APIError) as exc:
+            service_client.table("outbox_events").insert(payload).execute()
+        assert getattr(exc.value, "code", None) == "23514"
+    finally:
+        service_client.table("outbox_events").delete().eq("user_id", user_id).execute()
+        service_client.table("profiles").delete().eq("user_id", user_id).execute()
+
+
+def test_outbox_payload_forbids_unknown_top_level_key(service_client):
+    """The explicit allowlist rejects unknown top-level keys."""
+    user_id = _uid("ou")
+    service_client.table("profiles").upsert({"user_id": user_id}).execute()
+    try:
+        payload = _valid_outbox_payload(user_id, f"idem_{user_id}")
+        payload["payload"] = {"ref": "turn-1", "unknown_key": 1}
+        with pytest.raises(APIError) as exc:
+            service_client.table("outbox_events").insert(payload).execute()
+        assert getattr(exc.value, "code", None) == "23514"
+    finally:
+        service_client.table("outbox_events").delete().eq("user_id", user_id).execute()
+        service_client.table("profiles").delete().eq("user_id", user_id).execute()
+
+
+# ---------------------------------------------------------------------------
+# Cross-user isolation (composite FKs)
+# ---------------------------------------------------------------------------
+
+
+def test_cross_user_message_reference_rejected(service_client):
+    """A request for user A must not be able to reference a chat_logs
+    message owned by user B (composite FK on (user_id, message_id))."""
+    user_a = _uid("msg_a")
+    user_b = _uid("msg_b")
+    service_client.table("profiles").upsert([
+        {"user_id": user_a},
+        {"user_id": user_b},
+    ]).execute()
+    try:
+        chat = service_client.table("chat_logs").insert({
+            "user_id": user_a,
+            "role": "user",
+            "content": "message owned by user A",
+        }).execute()
+        message_id = chat.data[0]["id"]
+
+        payload = _valid_turn_request_payload(user_b, str(uuid.uuid4()))
+        payload["user_message_chat_log_id"] = message_id
+        with pytest.raises(APIError) as exc:
+            service_client.table("turn_requests").insert(payload).execute()
+        assert getattr(exc.value, "code", None) == "23503"
+    finally:
+        service_client.table("chat_logs").delete().eq("user_id", user_a).execute()
+        for uid in (user_a, user_b):
+            service_client.table("turn_requests").delete().eq("user_id", uid).execute()
+            service_client.table("profiles").delete().eq("user_id", uid).execute()
+
+
+def test_cross_user_turn_request_reference_rejected(service_client):
+    """An outbox event for user B must not be able to reference a
+    turn_request owned by user A (composite FK on (user_id, turn_request_id))."""
+    user_a = _uid("req_a")
+    user_b = _uid("req_b")
+    service_client.table("profiles").upsert([
+        {"user_id": user_a},
+        {"user_id": user_b},
+    ]).execute()
+    try:
+        req = service_client.table("turn_requests").insert(
+            _valid_turn_request_payload(user_a, str(uuid.uuid4()))
+        ).execute()
+        request_id = req.data[0]["id"]
+
+        payload = _valid_outbox_payload(user_b, f"idem_{user_b}")
+        payload["turn_request_id"] = request_id
+        with pytest.raises(APIError) as exc:
+            service_client.table("outbox_events").insert(payload).execute()
+        assert getattr(exc.value, "code", None) == "23503"
+    finally:
+        for uid in (user_a, user_b):
+            service_client.table("turn_requests").delete().eq("user_id", uid).execute()
+            service_client.table("outbox_events").delete().eq("user_id", uid).execute()
+            service_client.table("profiles").delete().eq("user_id", uid).execute()
+
+
 # ---------------------------------------------------------------------------
 # Cascade: user deletion leaves no orphans
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_transactional_schema_integration.py
+++ b/backend/tests/test_transactional_schema_integration.py
@@ -1,0 +1,420 @@
+"""Real Supabase integration tests for the transactional schema (#270).
+
+Requires a running local Supabase instance with SUPABASE_URL,
+SUPABASE_ANON_KEY and SUPABASE_SERVICE_ROLE_KEY set (database CI job only).
+
+Covers the authorization and behavioral contract of the new server-owned
+tables:
+
+- anon / authenticated cannot reach ``turn_requests`` or ``outbox_events``
+- service_role can execute the planned operations
+- ``(user_id, request_id)`` uniqueness with cross-user reuse
+- outbox idempotency key uniqueness with cross-user reuse
+- user deletion cascades leave no orphans
+- forbidden payload keys (prompt / internal fields) are rejected
+- schema drift (missing migration) fails
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from postgrest.exceptions import APIError
+from supabase import create_client
+
+INTERNAL_TABLES = ["turn_requests", "outbox_events"]
+
+
+# ---------------------------------------------------------------------------
+# Environment and clients
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def supabase_url():
+    url = os.environ.get("SUPABASE_URL")
+    assert url, "SUPABASE_URL is required for transactional schema tests"
+    return url
+
+
+@pytest.fixture(scope="module")
+def service_role_key():
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    assert key, "SUPABASE_SERVICE_ROLE_KEY is required"
+    return key
+
+
+@pytest.fixture(scope="module")
+def anon_key():
+    key = os.environ.get("SUPABASE_ANON_KEY")
+    assert key, "SUPABASE_ANON_KEY is required"
+    return key
+
+
+@pytest.fixture(scope="module")
+def service_client(supabase_url, service_role_key):
+    return create_client(supabase_url, service_role_key)
+
+
+@pytest.fixture(scope="module")
+def anon_client(supabase_url, anon_key):
+    return create_client(supabase_url, anon_key)
+
+
+@pytest.fixture(scope="module")
+def auth_client(supabase_url, anon_key, service_client):
+    """Create a real authenticated user and return (client, user_id)."""
+    email = "transactional_schema_auth@test.com"
+    password = "password123"
+    client = create_client(supabase_url, anon_key)
+
+    for user in service_client.auth.admin.list_users():
+        if user.email == email:
+            service_client.auth.admin.delete_user(user.id)
+
+    client.auth.sign_up({"email": email, "password": password})
+    res = client.auth.sign_in_with_password({"email": email, "password": password})
+    assert res is not None and res.user is not None
+    assert res.session is not None and res.session.access_token is not None
+    yield client, res.user.id
+
+    client.auth.sign_out()
+    for user in service_client.auth.admin.list_users():
+        if user.email == email:
+            service_client.auth.admin.delete_user(user.id)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def assert_denied(op, *args, **kwargs):
+    """Assert an operation raises APIError with code 42501 (insufficient_privilege)."""
+    with pytest.raises(APIError) as exc:
+        op(*args, **kwargs).execute()
+    code = getattr(exc.value, "code", None)
+    assert code == "42501", (
+        f"Expected 42501 (insufficient_privilege) but got code={code!r}"
+    )
+
+
+def _uid(label: str) -> str:
+    return f"tx_{label}_{uuid.uuid4().hex[:12]}"
+
+
+def _valid_turn_request_payload(user_id: str, request_id: str) -> dict:
+    return {
+        "user_id": user_id,
+        "request_id": request_id,
+        "payload_hash_sha256": "a" * 64,
+        "status": "pending",
+        "lease_owner": "worker-integration",
+        "lease_expires_at": "2099-01-01T00:00:00Z",
+        "expected_revision": 0,
+    }
+
+
+def _valid_outbox_payload(user_id: str, idempotency_key: str) -> dict:
+    return {
+        "event_type": "memory_indexed",
+        "contract_version": 1,
+        "user_id": user_id,
+        "payload": {"ref": "turn-ref"},
+        "status": "pending",
+        "attempts": 0,
+        "next_attempt_at": "2099-01-01T00:00:00Z",
+        "idempotency_key": idempotency_key,
+    }
+
+
+# ---------------------------------------------------------------------------
+# anon matrix
+# ---------------------------------------------------------------------------
+
+
+def test_anon_cannot_access_internal_tables(anon_client):
+    for table in INTERNAL_TABLES:
+        assert_denied(anon_client.table(table).select, "*")
+        if table == "turn_requests":
+            payload = _valid_turn_request_payload("anon", str(uuid.uuid4()))
+        else:
+            payload = _valid_outbox_payload("anon", f"idem_anon_{uuid.uuid4().hex[:12]}")
+        assert_denied(anon_client.table(table).insert, payload)
+        assert_denied(anon_client.table(table).update({"status": "x"}).eq, "user_id", "anon")
+        assert_denied(anon_client.table(table).delete().eq, "user_id", "anon")
+
+
+# ---------------------------------------------------------------------------
+# authenticated matrix
+# ---------------------------------------------------------------------------
+
+
+def test_authenticated_cannot_access_internal_tables(auth_client, service_client):
+    client, uid = auth_client
+    service_client.table("profiles").upsert({"user_id": uid}).execute()
+    try:
+        for table in INTERNAL_TABLES:
+            assert_denied(client.table(table).select, "*")
+            if table == "turn_requests":
+                payload = _valid_turn_request_payload(uid, str(uuid.uuid4()))
+            else:
+                payload = _valid_outbox_payload(uid, f"idem_{uid}")
+            assert_denied(client.table(table).insert, payload)
+            assert_denied(client.table(table).update({"status": "x"}).eq, "user_id", uid)
+            assert_denied(client.table(table).delete().eq, "user_id", uid)
+    finally:
+        service_client.table("profiles").delete().eq("user_id", uid).execute()
+
+
+# ---------------------------------------------------------------------------
+# service_role CRUD on turn_requests
+# ---------------------------------------------------------------------------
+
+
+def test_service_role_turn_requests_crud(service_client):
+    user_id = _uid("tr")
+    service_client.table("profiles").upsert({"user_id": user_id}).execute()
+    request_id = str(uuid.uuid4())
+    try:
+        insert_res = service_client.table("turn_requests").insert(
+            _valid_turn_request_payload(user_id, request_id)
+        ).execute()
+        assert len(insert_res.data) == 1
+        row = insert_res.data[0]
+        assert row["status"] == "pending"
+        internal_id = row["id"]
+
+        select_res = service_client.table("turn_requests").select("*").eq(
+            "user_id", user_id
+        ).execute()
+        assert len(select_res.data) == 1
+        assert select_res.data[0]["request_id"] == request_id
+
+        # Complete the request (coherent completed shape).
+        update_res = service_client.table("turn_requests").update({
+            "status": "completed",
+            "completed_at": "2026-07-31T00:00:00Z",
+            "committed_revision": 1,
+            "replay_payload": {"response": "ok", "emotion_state": {"schema_version": 1}},
+            "lease_owner": None,
+            "lease_expires_at": None,
+        }).eq("id", internal_id).execute()
+        assert len(update_res.data) == 1
+        assert update_res.data[0]["status"] == "completed"
+        assert update_res.data[0]["committed_revision"] == 1
+
+        delete_res = service_client.table("turn_requests").delete().eq(
+            "user_id", user_id
+        ).execute()
+        assert len(delete_res.data) >= 1
+    finally:
+        service_client.table("turn_requests").delete().eq("user_id", user_id).execute()
+        service_client.table("profiles").delete().eq("user_id", user_id).execute()
+
+
+# ---------------------------------------------------------------------------
+# service_role CRUD on outbox_events
+# ---------------------------------------------------------------------------
+
+
+def test_service_role_outbox_crud(service_client):
+    user_id = _uid("obx")
+    service_client.table("profiles").upsert({"user_id": user_id}).execute()
+    try:
+        insert_res = service_client.table("outbox_events").insert(
+            _valid_outbox_payload(user_id, f"idem_{user_id}_1")
+        ).execute()
+        assert len(insert_res.data) == 1
+        internal_id = insert_res.data[0]["id"]
+
+        select_res = service_client.table("outbox_events").select("*").eq(
+            "user_id", user_id
+        ).execute()
+        assert len(select_res.data) == 1
+        assert select_res.data[0]["event_type"] == "memory_indexed"
+
+        # Claim → processing (coherent processing shape).
+        update_res = service_client.table("outbox_events").update({
+            "status": "processing",
+            "lease_owner": "worker-integration",
+            "lease_expires_at": "2099-01-01T00:00:00Z",
+            "attempts": 1,
+        }).eq("id", internal_id).execute()
+        assert len(update_res.data) == 1
+        assert update_res.data[0]["status"] == "processing"
+
+        delete_res = service_client.table("outbox_events").delete().eq(
+            "user_id", user_id
+        ).execute()
+        assert len(delete_res.data) >= 1
+    finally:
+        service_client.table("outbox_events").delete().eq("user_id", user_id).execute()
+        service_client.table("profiles").delete().eq("user_id", user_id).execute()
+
+
+# ---------------------------------------------------------------------------
+# Uniqueness and cross-user reuse
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_user_request_rejected(service_client):
+    user_id = _uid("dup")
+    service_client.table("profiles").upsert({"user_id": user_id}).execute()
+    request_id = str(uuid.uuid4())
+    try:
+        service_client.table("turn_requests").insert(
+            _valid_turn_request_payload(user_id, request_id)
+        ).execute()
+        with pytest.raises(APIError) as exc:
+            service_client.table("turn_requests").insert(
+                _valid_turn_request_payload(user_id, request_id)
+            ).execute()
+        assert getattr(exc.value, "code", None) == "23505"
+    finally:
+        service_client.table("turn_requests").delete().eq("user_id", user_id).execute()
+        service_client.table("profiles").delete().eq("user_id", user_id).execute()
+
+
+def test_same_request_id_allowed_for_different_users(service_client):
+    user_a = _uid("ra")
+    user_b = _uid("rb")
+    service_client.table("profiles").upsert([
+        {"user_id": user_a},
+        {"user_id": user_b},
+    ]).execute()
+    request_id = str(uuid.uuid4())
+    try:
+        service_client.table("turn_requests").insert(
+            _valid_turn_request_payload(user_a, request_id)
+        ).execute()
+        service_client.table("turn_requests").insert(
+            _valid_turn_request_payload(user_b, request_id)
+        ).execute()
+        res = service_client.table("turn_requests").select("user_id").eq(
+            "request_id", request_id
+        ).execute()
+        assert len(res.data) == 2
+    finally:
+        for uid in (user_a, user_b):
+            service_client.table("turn_requests").delete().eq("user_id", uid).execute()
+            service_client.table("profiles").delete().eq("user_id", uid).execute()
+
+
+def test_duplicate_outbox_idempotency_rejected(service_client):
+    user_id = _uid("idem")
+    service_client.table("profiles").upsert({"user_id": user_id}).execute()
+    try:
+        service_client.table("outbox_events").insert(
+            _valid_outbox_payload(user_id, "idem-key-1")
+        ).execute()
+        with pytest.raises(APIError) as exc:
+            service_client.table("outbox_events").insert(
+                _valid_outbox_payload(user_id, "idem-key-1")
+            ).execute()
+        assert getattr(exc.value, "code", None) == "23505"
+    finally:
+        service_client.table("outbox_events").delete().eq("user_id", user_id).execute()
+        service_client.table("profiles").delete().eq("user_id", user_id).execute()
+
+
+def test_same_outbox_idempotency_allowed_across_users(service_client):
+    user_a = _uid("ia")
+    user_b = _uid("ib")
+    service_client.table("profiles").upsert([
+        {"user_id": user_a},
+        {"user_id": user_b},
+    ]).execute()
+    try:
+        service_client.table("outbox_events").insert(
+            _valid_outbox_payload(user_a, "shared-key")
+        ).execute()
+        service_client.table("outbox_events").insert(
+            _valid_outbox_payload(user_b, "shared-key")
+        ).execute()
+        res = service_client.table("outbox_events").select("user_id").eq(
+            "idempotency_key", "shared-key"
+        ).execute()
+        assert len(res.data) == 2
+    finally:
+        for uid in (user_a, user_b):
+            service_client.table("outbox_events").delete().eq("user_id", uid).execute()
+            service_client.table("profiles").delete().eq("user_id", uid).execute()
+
+
+# ---------------------------------------------------------------------------
+# Forbidden payload keys (prompt / internal fields)
+# ---------------------------------------------------------------------------
+
+
+def test_turn_request_replay_payload_forbids_prompt(service_client):
+    user_id = _uid("rp")
+    service_client.table("profiles").upsert({"user_id": user_id}).execute()
+    try:
+        payload = {
+            "user_id": user_id,
+            "request_id": str(uuid.uuid4()),
+            "payload_hash_sha256": "b" * 64,
+            "status": "completed",
+            "completed_at": "2026-07-31T00:00:00Z",
+            "committed_revision": 1,
+            "replay_payload": {"prompt": "hidden", "response": "x"},
+        }
+        with pytest.raises(APIError) as exc:
+            service_client.table("turn_requests").insert(payload).execute()
+        assert getattr(exc.value, "code", None) == "23514"
+    finally:
+        service_client.table("turn_requests").delete().eq("user_id", user_id).execute()
+        service_client.table("profiles").delete().eq("user_id", user_id).execute()
+
+
+def test_outbox_payload_forbids_prompt(service_client):
+    user_id = _uid("op")
+    service_client.table("profiles").upsert({"user_id": user_id}).execute()
+    try:
+        payload = _valid_outbox_payload(user_id, f"idem_{user_id}")
+        payload["payload"] = {"prompt": "hidden"}
+        with pytest.raises(APIError) as exc:
+            service_client.table("outbox_events").insert(payload).execute()
+        assert getattr(exc.value, "code", None) == "23514"
+    finally:
+        service_client.table("outbox_events").delete().eq("user_id", user_id).execute()
+        service_client.table("profiles").delete().eq("user_id", user_id).execute()
+
+
+# ---------------------------------------------------------------------------
+# Cascade: user deletion leaves no orphans
+# ---------------------------------------------------------------------------
+
+
+def test_user_delete_cascades_internal_rows(service_client):
+    user_id = _uid("cascade")
+    service_client.table("profiles").upsert({"user_id": user_id}).execute()
+    try:
+        service_client.table("turn_requests").insert(
+            _valid_turn_request_payload(user_id, str(uuid.uuid4()))
+        ).execute()
+        service_client.table("outbox_events").insert(
+            _valid_outbox_payload(user_id, f"idem_{user_id}")
+        ).execute()
+
+        # Delete the user's profile; internal rows must cascade away.
+        service_client.table("profiles").delete().eq("user_id", user_id).execute()
+
+        res = service_client.table("turn_requests").select("user_id").eq(
+            "user_id", user_id
+        ).execute()
+        assert len(res.data) == 0
+        res = service_client.table("outbox_events").select("user_id").eq(
+            "user_id", user_id
+        ).execute()
+        assert len(res.data) == 0
+    finally:
+        service_client.table("turn_requests").delete().eq("user_id", user_id).execute()
+        service_client.table("outbox_events").delete().eq("user_id", user_id).execute()
+        service_client.table("profiles").delete().eq("user_id", user_id).execute()
+
+
+

--- a/backend/tests/test_transactional_schema_integration.py
+++ b/backend/tests/test_transactional_schema_integration.py
@@ -236,12 +236,14 @@ def test_service_role_outbox_crud(service_client):
         assert len(select_res.data) == 1
         assert select_res.data[0]["event_type"] == "memory_indexed"
 
-        # Claim → processing (coherent processing shape).
+        # Claim → processing (coherent processing shape: no scheduling field
+        # may remain — processing requires next_attempt_at IS NULL).
         update_res = service_client.table("outbox_events").update({
             "status": "processing",
             "lease_owner": "worker-integration",
             "lease_expires_at": "2099-01-01T00:00:00Z",
             "attempts": 1,
+            "next_attempt_at": None,
         }).eq("id", internal_id).execute()
         assert len(update_res.data) == 1
         assert update_res.data[0]["status"] == "processing"
@@ -423,6 +425,107 @@ def test_outbox_payload_forbids_unknown_top_level_key(service_client):
         payload["payload"] = {"ref": "turn-1", "unknown_key": 1}
         with pytest.raises(APIError) as exc:
             service_client.table("outbox_events").insert(payload).execute()
+        assert getattr(exc.value, "code", None) == "23514"
+    finally:
+        service_client.table("outbox_events").delete().eq("user_id", user_id).execute()
+        service_client.table("profiles").delete().eq("user_id", user_id).execute()
+
+
+def test_outbox_payload_rejects_long_ref(service_client):
+    """A reference field must be bounded: raw/long content under `ref` is
+    rejected by the value contract even without any forbidden key."""
+    user_id = _uid("ol")
+    service_client.table("profiles").upsert({"user_id": user_id}).execute()
+    try:
+        payload = _valid_outbox_payload(user_id, f"idem_{user_id}")
+        payload["payload"] = {"ref": "x" * 129}
+        with pytest.raises(APIError) as exc:
+            service_client.table("outbox_events").insert(payload).execute()
+        assert getattr(exc.value, "code", None) == "23514"
+    finally:
+        service_client.table("outbox_events").delete().eq("user_id", user_id).execute()
+        service_client.table("profiles").delete().eq("user_id", user_id).execute()
+
+
+def test_outbox_payload_rejects_nested_object_under_ref(service_client):
+    """Arbitrary objects must not fit under an allowed key, even when no
+    denylist key is present at any depth."""
+    user_id = _uid("oo")
+    service_client.table("profiles").upsert({"user_id": user_id}).execute()
+    try:
+        payload = _valid_outbox_payload(user_id, f"idem_{user_id}")
+        payload["payload"] = {"ref": {"text": "conteudo sem chave proibida"}}
+        with pytest.raises(APIError) as exc:
+            service_client.table("outbox_events").insert(payload).execute()
+        assert getattr(exc.value, "code", None) == "23514"
+    finally:
+        service_client.table("outbox_events").delete().eq("user_id", user_id).execute()
+        service_client.table("profiles").delete().eq("user_id", user_id).execute()
+
+
+def test_outbox_payload_rejects_invalid_version(service_client):
+    """`version` must be an integer in the documented range."""
+    user_id = _uid("ov")
+    service_client.table("profiles").upsert({"user_id": user_id}).execute()
+    try:
+        for bad in ({"version": "abc"}, {"version": 0}, {"version": 1001}):
+            payload = _valid_outbox_payload(user_id, f"idem_{user_id}_{len(str(bad))}")
+            payload["payload"] = bad
+            with pytest.raises(APIError) as exc:
+                service_client.table("outbox_events").insert(payload).execute()
+            assert getattr(exc.value, "code", None) == "23514"
+    finally:
+        service_client.table("outbox_events").delete().eq("user_id", user_id).execute()
+        service_client.table("profiles").delete().eq("user_id", user_id).execute()
+
+
+def test_outbox_payload_rejects_json_null_values(service_client):
+    """JSON null is not a valid contract value for any allowed field."""
+    user_id = _uid("onul")
+    service_client.table("profiles").upsert({"user_id": user_id}).execute()
+    try:
+        for bad in ({"ref": None}, {"version": None}):
+            payload = _valid_outbox_payload(user_id, f"idem_{user_id}_{len(str(bad))}")
+            payload["payload"] = bad
+            with pytest.raises(APIError) as exc:
+                service_client.table("outbox_events").insert(payload).execute()
+            assert getattr(exc.value, "code", None) == "23514"
+    finally:
+        service_client.table("outbox_events").delete().eq("user_id", user_id).execute()
+        service_client.table("profiles").delete().eq("user_id", user_id).execute()
+
+
+def test_outbox_payload_accepts_conforming_values(service_client):
+    """Scalar, sanitized and bounded values under the allowed keys pass."""
+    user_id = _uid("ok")
+    service_client.table("profiles").upsert({"user_id": user_id}).execute()
+    try:
+        payload = _valid_outbox_payload(user_id, f"idem_{user_id}")
+        payload["payload"] = {"ref": "turn-1", "kind": "memory_indexed", "version": 1}
+        res = service_client.table("outbox_events").insert(payload).execute()
+        assert len(res.data) == 1
+    finally:
+        service_client.table("outbox_events").delete().eq("user_id", user_id).execute()
+        service_client.table("profiles").delete().eq("user_id", user_id).execute()
+
+
+def test_processing_with_next_attempt_at_rejected(service_client):
+    """processing must not carry the pending/failed scheduling field."""
+    user_id = _uid("pn")
+    service_client.table("profiles").upsert({"user_id": user_id}).execute()
+    try:
+        insert_res = service_client.table("outbox_events").insert(
+            _valid_outbox_payload(user_id, f"idem_{user_id}")
+        ).execute()
+        internal_id = insert_res.data[0]["id"]
+        with pytest.raises(APIError) as exc:
+            service_client.table("outbox_events").update({
+                "status": "processing",
+                "lease_owner": "worker-integration",
+                "lease_expires_at": "2099-01-01T00:00:00Z",
+                "attempts": 1,
+                "next_attempt_at": "2099-01-01T00:00:00Z",
+            }).eq("id", internal_id).execute()
         assert getattr(exc.value, "code", None) == "23514"
     finally:
         service_client.table("outbox_events").delete().eq("user_id", user_id).execute()

--- a/backend/tests/test_transactional_schema_legacy.py
+++ b/backend/tests/test_transactional_schema_legacy.py
@@ -275,10 +275,18 @@ def test_operational_rollback(supabase_service_client):
     ), "profiles.revision missing before rollback"
 
     # Execute the documented operational rollback (additive-only migration).
+    # Trigger and helpers are dropped in dependency order: the trigger first
+    # (it references the function), then the tables (their CHECK constraints
+    # reference the payload helpers), then the helpers and the column.
     _run_psql(
+        "DROP TRIGGER IF EXISTS turn_requests_message_refs_null_trigger "
+        "ON public.chat_logs;\n"
+        "DROP FUNCTION IF EXISTS public.turn_requests_null_message_refs();\n"
         "DROP TABLE IF EXISTS public.outbox_events;\n"
         "DROP TABLE IF EXISTS public.turn_requests;\n"
         "ALTER TABLE public.profiles DROP COLUMN IF EXISTS revision;\n"
+        "DROP FUNCTION IF EXISTS public.jsonb_has_forbidden_key(jsonb, text[]);\n"
+        "DROP FUNCTION IF EXISTS public.jsonb_keys_subset_of(jsonb, text[]);\n"
     )
 
     # Objects are gone after rollback.
@@ -296,6 +304,22 @@ def test_operational_rollback(supabase_service_client):
         ") AS result",
         "result",
     ), "profiles.revision still exists after rollback"
+    assert not _query_scalar_bool(
+        "SELECT EXISTS("
+        "SELECT 1 FROM pg_trigger WHERE tgname = 'turn_requests_message_refs_null_trigger'"
+        ") AS result",
+        "result",
+    ), "chat_logs trigger still exists after rollback"
+    assert not _query_scalar_bool(
+        "SELECT EXISTS("
+        "SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace "
+        "WHERE n.nspname = 'public' "
+        "AND p.proname IN ("
+        "  'jsonb_has_forbidden_key', 'jsonb_keys_subset_of', "
+        "  'turn_requests_null_message_refs')"
+        ") AS result",
+        "result",
+    ), "payload helper functions still exist after rollback"
 
     # Pre-existing data survived the rollback.
     svc = supabase_service_client

--- a/backend/tests/test_transactional_schema_legacy.py
+++ b/backend/tests/test_transactional_schema_legacy.py
@@ -287,6 +287,7 @@ def test_operational_rollback(supabase_service_client):
         "ALTER TABLE public.profiles DROP COLUMN IF EXISTS revision;\n"
         "DROP FUNCTION IF EXISTS public.jsonb_has_forbidden_key(jsonb, text[]);\n"
         "DROP FUNCTION IF EXISTS public.jsonb_keys_subset_of(jsonb, text[]);\n"
+        "DROP FUNCTION IF EXISTS public.jsonb_outbox_payload_value_contract(jsonb);\n"
     )
 
     # Objects are gone after rollback.
@@ -316,6 +317,7 @@ def test_operational_rollback(supabase_service_client):
         "WHERE n.nspname = 'public' "
         "AND p.proname IN ("
         "  'jsonb_has_forbidden_key', 'jsonb_keys_subset_of', "
+        "  'jsonb_outbox_payload_value_contract', "
         "  'turn_requests_null_message_refs')"
         ") AS result",
         "result",

--- a/backend/tests/test_transactional_schema_legacy.py
+++ b/backend/tests/test_transactional_schema_legacy.py
@@ -1,0 +1,309 @@
+"""Real Supabase integration tests for the transactional schema migration (#270).
+
+This file is executed only by the database CI job against a freshly reset
+local Supabase instance. It must never be collected by the ordinary backend
+job (see the ignore list in ``.github/workflows/ci.yml``).
+
+Covers:
+
+1. Applying the transactional schema migration over the legacy fixture
+   (baseline + hardening + admission) preserves legacy data and backfills
+   ``profiles.revision`` to 0.
+2. The migration registers its version in ``schema_migrations``.
+3. The new server-owned tables exist with RLS/FORCE RLS and the documented
+   service_role grants.
+4. The documented operational rollback (additive-only migration) can be
+   exercised without losing pre-existing data.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+
+import pytest
+
+MIGRATION = "supabase/migrations/20240101000004_transactional_turn_schema.sql"
+MIGRATION_TMP = "supabase/migrations/20240101000004_transactional_turn_schema.sql.tmp"
+
+_MIGRATION_VERSION_SQL = (
+    "SELECT EXISTS("
+    "SELECT 1 FROM supabase_migrations.schema_migrations "
+    "WHERE version = '20240101000004'"
+    ") AS result"
+)
+
+
+# ---------------------------------------------------------------------------
+# CLI helpers (sanitized; never echo secrets or raw output)
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(args: list[str], check: bool = True) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        ["supabase", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError("Supabase operation failed")
+    return result
+
+
+def _run_psql(sql: str) -> None:
+    """Execute a SQL script through the local Supabase DB container."""
+    result = subprocess.run(
+        [
+            "docker", "exec", "-i", "supabase_db_app",
+            "psql", "-U", "postgres",
+            "-v", "ON_ERROR_STOP=1", "-q", "-f", "-",
+        ],
+        input=sql,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError("psql execution failed")
+
+
+def _query_scalar_bool(query: str, expected_key: str) -> bool:
+    res = _run_cli(["db", "query", "--agent=no", "--output", "json", query])
+    data = json.loads(res.stdout)
+    assert isinstance(data, list) and len(data) == 1, "expected one row"
+    assert expected_key in data[0], "missing expected key"
+    value = data[0][expected_key]
+    assert isinstance(value, bool), "expected boolean"
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Migration file manipulation (always restored in finally)
+# ---------------------------------------------------------------------------
+
+
+def _move_migration_aside() -> None:
+    if os.path.exists(MIGRATION) and not os.path.exists(MIGRATION_TMP):
+        os.rename(MIGRATION, MIGRATION_TMP)
+
+
+def _restore_migration() -> None:
+    if os.path.exists(MIGRATION_TMP) and not os.path.exists(MIGRATION):
+        os.rename(MIGRATION_TMP, MIGRATION)
+
+
+def _ensure_migration_present() -> None:
+    if os.path.exists(MIGRATION_TMP):
+        if os.path.exists(MIGRATION):
+            os.remove(MIGRATION_TMP)
+        else:
+            os.rename(MIGRATION_TMP, MIGRATION)
+
+
+# ---------------------------------------------------------------------------
+# Fixture and client helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_legacy_fixture() -> None:
+    with open("supabase/fixtures/legacy_upgrade_valid.sql", encoding="utf-8") as f:
+        _run_psql(f.read())
+
+
+@pytest.fixture(scope="module")
+def supabase_service_client():
+    """Service-role client for querying state after migration."""
+    from supabase import create_client
+
+    url = os.environ.get("SUPABASE_URL", "http://127.0.0.1:54321")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    if not key:
+        result = _run_cli(["status", "-o", "env"], check=False)
+        if result.returncode != 0:
+            pytest.skip("Could not extract service role key")
+        for line in result.stdout.splitlines():
+            if line.startswith("SERVICE_ROLE_KEY="):
+                key = line.split("=", 1)[1].strip('"')
+                break
+        if not key:
+            pytest.skip("SERVICE_ROLE_KEY not found")
+    return create_client(url, key)
+
+
+# ---------------------------------------------------------------------------
+# SCENARIO 1: valid legacy upgrade (migration applied over existing data)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.database_integration
+def test_valid_legacy_upgrade(supabase_service_client):
+    _move_migration_aside()
+    try:
+        # Reset applies baseline + hardening + admission only (04 hidden).
+        _run_cli(["db", "reset"])
+
+        # Seed legacy data before the transactional schema exists.
+        _run_legacy_fixture()
+
+        # Restore and apply the transactional schema migration.
+        _restore_migration()
+        _run_cli(["migration", "up", "--local"])
+
+        # ---- Migration version registered ----
+        assert _query_scalar_bool(_MIGRATION_VERSION_SQL, "result"), (
+            "Transactional schema migration timestamp not registered"
+        )
+
+        # ---- Legacy data preserved with revision backfilled to 0 ----
+        svc = supabase_service_client
+        profiles_res = svc.table("profiles").select("*").eq(
+            "user_id", "legacy_user_valid"
+        ).execute()
+        assert len(profiles_res.data) == 1
+        assert profiles_res.data[0]["user_id"] == "legacy_user_valid"
+        assert profiles_res.data[0]["revision"] == 0, (
+            "existing profile revision must backfill to 0"
+        )
+
+        chat_res = svc.table("chat_logs").select("*").eq(
+            "user_id", "legacy_user_valid"
+        ).execute()
+        assert len(chat_res.data) == 1
+        assert chat_res.data[0]["content"] == "legacy message"
+        assert chat_res.data[0]["role"] == "user"
+
+        # ---- New tables exist with RLS + FORCE RLS ----
+        for tbl in ("turn_requests", "outbox_events"):
+            assert _query_scalar_bool(
+                "SELECT EXISTS("
+                "SELECT 1 FROM pg_class WHERE oid = '{tbl}'::regclass "
+                "AND relrowsecurity = true"
+                ") AS result".format(tbl=tbl),
+                "result",
+            ), f"RLS not enabled for {tbl}"
+            assert _query_scalar_bool(
+                "SELECT EXISTS("
+                "SELECT 1 FROM pg_class WHERE oid = '{tbl}'::regclass "
+                "AND relforcerowsecurity = true"
+                ") AS result".format(tbl=tbl),
+                "result",
+            ), f"FORCE RLS not enabled for {tbl}"
+
+        # ---- service_role grants on both tables ----
+        for tbl in ("turn_requests", "outbox_events"):
+            for priv in ("SELECT", "INSERT", "UPDATE", "DELETE"):
+                assert _query_scalar_bool(
+                    "SELECT EXISTS("
+                    "SELECT 1 FROM information_schema.role_table_grants "
+                    "WHERE grantee = 'service_role' "
+                    "AND table_name = '{tbl}' "
+                    "AND privilege_type = '{priv}'"
+                    ") AS result".format(tbl=tbl, priv=priv),
+                    "result",
+                ), f"Missing {priv} for service_role on {tbl}"
+
+        # ---- anon / authenticated have no privileges ----
+        for role in ("anon", "authenticated"):
+            for tbl in ("turn_requests", "outbox_events"):
+                assert not _query_scalar_bool(
+                    "SELECT has_table_privilege("
+                    f"'{role}', 'public.{tbl}', "
+                    "'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'"
+                    ") AS result",
+                    "result",
+                ), f"{role} should have no privileges on {tbl}"
+
+        # ---- New profile insert starts at revision 0 (upsert compatible) ----
+        svc.table("profiles").upsert({"user_id": "tx_new_user"}).execute()
+        new_res = svc.table("profiles").select("revision").eq(
+            "user_id", "tx_new_user"
+        ).execute()
+        assert len(new_res.data) == 1
+        assert new_res.data[0]["revision"] == 0
+
+        # ---- service_role can operate the new tables ----
+        req_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+        insert_res = svc.table("turn_requests").insert({
+            "user_id": "tx_new_user",
+            "request_id": req_id,
+            "payload_hash_sha256": "a" * 64,
+            "status": "pending",
+            "lease_owner": "worker-x",
+            "lease_expires_at": "2099-01-01T00:00:00Z",
+            "expected_revision": 0,
+        }).execute()
+        assert len(insert_res.data) == 1
+        select_res = svc.table("turn_requests").select("status").eq(
+            "user_id", "tx_new_user"
+        ).execute()
+        assert len(select_res.data) == 1
+        assert select_res.data[0]["status"] == "pending"
+        svc.table("turn_requests").delete().eq("user_id", "tx_new_user").execute()
+
+    finally:
+        _ensure_migration_present()
+
+
+# ---------------------------------------------------------------------------
+# SCENARIO 2: operational rollback is exercised (additive-only migration)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.database_integration
+def test_operational_rollback(supabase_service_client):
+    # Fresh reset with the full migration stack (including 04) applied.
+    _run_cli(["db", "reset"])
+
+    # Seed legacy data that must survive the rollback untouched.
+    _run_legacy_fixture()
+
+    # Objects exist before rollback.
+    for tbl in ("turn_requests", "outbox_events"):
+        assert _query_scalar_bool(
+            "SELECT EXISTS("
+            "SELECT 1 FROM pg_class WHERE oid = '{tbl}'::regclass"
+            ") AS result".format(tbl=tbl),
+            "result",
+        ), f"{tbl} missing before rollback"
+    assert _query_scalar_bool(
+        "SELECT EXISTS("
+        "SELECT 1 FROM pg_attribute "
+        "WHERE attrelid = 'profiles'::regclass AND attname = 'revision'"
+        ") AS result",
+        "result",
+    ), "profiles.revision missing before rollback"
+
+    # Execute the documented operational rollback (additive-only migration).
+    _run_psql(
+        "DROP TABLE IF EXISTS public.outbox_events;\n"
+        "DROP TABLE IF EXISTS public.turn_requests;\n"
+        "ALTER TABLE public.profiles DROP COLUMN IF EXISTS revision;\n"
+    )
+
+    # Objects are gone after rollback.
+    for tbl in ("turn_requests", "outbox_events"):
+        assert not _query_scalar_bool(
+            "SELECT EXISTS("
+            "SELECT 1 FROM pg_class WHERE oid = '{tbl}'::regclass"
+            ") AS result".format(tbl=tbl),
+            "result",
+        ), f"{tbl} still exists after rollback"
+    assert not _query_scalar_bool(
+        "SELECT EXISTS("
+        "SELECT 1 FROM pg_attribute "
+        "WHERE attrelid = 'profiles'::regclass AND attname = 'revision'"
+        ") AS result",
+        "result",
+    ), "profiles.revision still exists after rollback"
+
+    # Pre-existing data survived the rollback.
+    svc = supabase_service_client
+    profiles_res = svc.table("profiles").select("*").eq(
+        "user_id", "legacy_user_valid"
+    ).execute()
+    assert len(profiles_res.data) == 1
+    chat_res = svc.table("chat_logs").select("*").eq(
+        "user_id", "legacy_user_valid"
+    ).execute()
+    assert len(chat_res.data) == 1

--- a/backend/tests/test_transactional_schema_legacy.py
+++ b/backend/tests/test_transactional_schema_legacy.py
@@ -177,14 +177,14 @@ def test_valid_legacy_upgrade(supabase_service_client):
         for tbl in ("turn_requests", "outbox_events"):
             assert _query_scalar_bool(
                 "SELECT EXISTS("
-                "SELECT 1 FROM pg_class WHERE oid = '{tbl}'::regclass "
+                "SELECT 1 FROM pg_class WHERE oid = to_regclass('{tbl}') "
                 "AND relrowsecurity = true"
                 ") AS result".format(tbl=tbl),
                 "result",
             ), f"RLS not enabled for {tbl}"
             assert _query_scalar_bool(
                 "SELECT EXISTS("
-                "SELECT 1 FROM pg_class WHERE oid = '{tbl}'::regclass "
+                "SELECT 1 FROM pg_class WHERE oid = to_regclass('{tbl}') "
                 "AND relforcerowsecurity = true"
                 ") AS result".format(tbl=tbl),
                 "result",
@@ -262,14 +262,14 @@ def test_operational_rollback(supabase_service_client):
     for tbl in ("turn_requests", "outbox_events"):
         assert _query_scalar_bool(
             "SELECT EXISTS("
-            "SELECT 1 FROM pg_class WHERE oid = '{tbl}'::regclass"
+            "SELECT 1 FROM pg_class WHERE oid = to_regclass('{tbl}')"
             ") AS result".format(tbl=tbl),
             "result",
         ), f"{tbl} missing before rollback"
     assert _query_scalar_bool(
         "SELECT EXISTS("
         "SELECT 1 FROM pg_attribute "
-        "WHERE attrelid = 'profiles'::regclass AND attname = 'revision'"
+        "WHERE attrelid = to_regclass('profiles') AND attname = 'revision'"
         ") AS result",
         "result",
     ), "profiles.revision missing before rollback"
@@ -294,14 +294,14 @@ def test_operational_rollback(supabase_service_client):
     for tbl in ("turn_requests", "outbox_events"):
         assert not _query_scalar_bool(
             "SELECT EXISTS("
-            "SELECT 1 FROM pg_class WHERE oid = '{tbl}'::regclass"
+            "SELECT 1 FROM pg_class WHERE oid = to_regclass('{tbl}')"
             ") AS result".format(tbl=tbl),
             "result",
         ), f"{tbl} still exists after rollback"
     assert not _query_scalar_bool(
         "SELECT EXISTS("
         "SELECT 1 FROM pg_attribute "
-        "WHERE attrelid = 'profiles'::regclass AND attname = 'revision'"
+        "WHERE attrelid = to_regclass('profiles') AND attname = 'revision'"
         ") AS result",
         "result",
     ), "profiles.revision still exists after rollback"

--- a/backend/transactional_schema.py
+++ b/backend/transactional_schema.py
@@ -117,7 +117,12 @@ def canonical_payload_hash(payload: Mapping[str, Any]) -> str:
 
 
 def _deep_freeze(value: Any) -> Any:
-    if isinstance(value, dict):
+    # Any Mapping accepted by the contract (dict, MappingProxyType, UserDict,
+    # OrderedDict, ...) is copied into a brand-new plain dict first, so the
+    # frozen view can never stay connected to external mutable storage. The
+    # copy happens BEFORE freezing, so a MappingProxyType backed by a mutable
+    # dict is detached at construction time.
+    if isinstance(value, Mapping):
         return MappingProxyType({k: _deep_freeze(v) for k, v in value.items()})
     if isinstance(value, (list, tuple)):
         return tuple(_deep_freeze(v) for v in value)

--- a/backend/transactional_schema.py
+++ b/backend/transactional_schema.py
@@ -1,0 +1,261 @@
+"""
+Minimal serialization contracts for the transactional turn schema (#270).
+
+This module is the only place where the canonical payload hash and the
+typed record shapes for the new server-owned tables are defined. It is
+pure Python (standard library only) and must be importable without:
+
+- FastAPI / Pydantic
+- Groq SDK
+- Supabase / PostgREST
+- sentence_transformers
+- ``ConversationEngine``, ``memory``, ``engine`` or any other backend module
+- environment variables
+- network or filesystem access
+- clock or randomness
+- any global user-specific state
+
+The database is the source of truth for *validation*: statuses, leases,
+attempts and payload size bounds are enforced by CHECK constraints in
+``supabase/migrations/20240101000004_transactional_turn_schema.sql``.
+These models never re-implement those rules; they only serialize and
+deserialize records so the persistence contract can be tested.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+# ---------------------------------------------------------------------------
+# Canonical payload hash
+# ---------------------------------------------------------------------------
+
+#: Columns that may never be serialized into a stored payload. Mirrors the
+#: forbidden-key CHECK constraints in the migration; kept here so the
+#: serialization contract is testable without a database.
+FORBIDDEN_PAYLOAD_KEYS = frozenset(
+    {"prompt", "system_prompt", "meta_cognition", "internal_instructions"}
+)
+
+
+def canonical_payload_hash(payload: Mapping[str, Any]) -> str:
+    """Compute the canonical SHA-256 hash of a request payload.
+
+    The digest is computed over the canonical JSON serialization of
+    *payload*: keys sorted, compact separators (``,`` / ``:``), and
+    ``ensure_ascii=False`` — the same canonical JSON convention used by
+    ``backend/trusted_context.py`` and ``backend/memory.py``.
+
+    Returns a lowercase 64-character hexadecimal digest that satisfies the
+    database CHECK ``payload_hash_sha256 ~ '^[0-9a-f]{64}$'``.
+
+    Raises:
+        TypeError: If *payload* is not a mapping or contains values that
+            cannot be JSON-serialized. The offending value is never included
+            in the exception message.
+    """
+    if not isinstance(payload, Mapping):
+        raise TypeError("payload must be a mapping")
+    try:
+        canonical = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise TypeError("payload is not JSON-serializable") from exc
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Turn request record
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TurnRequestRecord:
+    """Typed view of a ``public.turn_requests`` row.
+
+    Fields mirror the database columns. Server-owned columns (``id``,
+    ``created_at``, ``updated_at``, ``completed_at``) are optional: when
+    serializing an insert, ``None`` fields are omitted so the database
+    defaults apply.
+    """
+
+    user_id: str
+    request_id: str
+    payload_hash_sha256: str
+    status: str
+    expected_revision: int = 0
+    lease_owner: Optional[str] = None
+    lease_expires_at: Optional[str] = None
+    committed_revision: Optional[int] = None
+    user_message_chat_log_id: Optional[int] = None
+    assistant_message_chat_log_id: Optional[int] = None
+    replay_payload: Optional[Mapping[str, Any]] = None
+    error_code: Optional[str] = None
+    id: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    completed_at: Optional[str] = None
+
+    def to_db_row(self) -> dict[str, Any]:
+        """Serialize to a database row, omitting ``None`` fields.
+
+        Omitting ``None`` lets the database apply its defaults for
+        server-owned columns and keeps nullable columns nullable without
+        explicit NULL payloads.
+        """
+        return {
+            "user_id": self.user_id,
+            "request_id": self.request_id,
+            "payload_hash_sha256": self.payload_hash_sha256,
+            "status": self.status,
+            "expected_revision": self.expected_revision,
+            "lease_owner": self.lease_owner,
+            "lease_expires_at": self.lease_expires_at,
+            "committed_revision": self.committed_revision,
+            "user_message_chat_log_id": self.user_message_chat_log_id,
+            "assistant_message_chat_log_id": self.assistant_message_chat_log_id,
+            "replay_payload": self.replay_payload,
+            "error_code": self.error_code,
+            "id": self.id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "completed_at": self.completed_at,
+        }
+
+    @classmethod
+    def from_db_row(cls, row: Mapping[str, Any]) -> "TurnRequestRecord":
+        """Build a record from a database row (missing keys default to None)."""
+        return cls(
+            user_id=row["user_id"],
+            request_id=row["request_id"],
+            payload_hash_sha256=row["payload_hash_sha256"],
+            status=row["status"],
+            expected_revision=row.get("expected_revision", 0),
+            lease_owner=row.get("lease_owner"),
+            lease_expires_at=row.get("lease_expires_at"),
+            committed_revision=row.get("committed_revision"),
+            user_message_chat_log_id=row.get("user_message_chat_log_id"),
+            assistant_message_chat_log_id=row.get("assistant_message_chat_log_id"),
+            replay_payload=row.get("replay_payload"),
+            error_code=row.get("error_code"),
+            id=row.get("id"),
+            created_at=row.get("created_at"),
+            updated_at=row.get("updated_at"),
+            completed_at=row.get("completed_at"),
+        )
+
+    def to_insert_row(self) -> dict[str, Any]:
+        """Serialize for INSERT, dropping server-owned ``None`` columns.
+
+        Only the columns a server client is allowed to set are emitted;
+        ``id``, ``created_at``, ``updated_at`` and ``completed_at`` are
+        omitted when ``None`` so the database defaults and triggers own
+        them.
+        """
+        row = self.to_db_row()
+        for server_owned in ("id", "created_at", "updated_at", "completed_at"):
+            if row[server_owned] is None:
+                del row[server_owned]
+        return row
+
+
+# ---------------------------------------------------------------------------
+# Outbox event record
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OutboxEventRecord:
+    """Typed view of a ``public.outbox_events`` row.
+
+    Mirrors the database columns. Server-owned columns are optional and
+    omitted from INSERT serialization when ``None``.
+    """
+
+    event_type: str
+    user_id: str
+    payload: Mapping[str, Any]
+    status: str
+    idempotency_key: str
+    contract_version: int = 1
+    attempts: int = 0
+    turn_request_id: Optional[str] = None
+    next_attempt_at: Optional[str] = None
+    lease_owner: Optional[str] = None
+    lease_expires_at: Optional[str] = None
+    error_code: Optional[str] = None
+    id: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    processed_at: Optional[str] = None
+    dead_lettered_at: Optional[str] = None
+    retention_until: Optional[str] = None
+
+    def to_db_row(self) -> dict[str, Any]:
+        """Serialize to a database row, omitting ``None`` fields."""
+        return {
+            "event_type": self.event_type,
+            "user_id": self.user_id,
+            "payload": self.payload,
+            "status": self.status,
+            "idempotency_key": self.idempotency_key,
+            "contract_version": self.contract_version,
+            "attempts": self.attempts,
+            "turn_request_id": self.turn_request_id,
+            "next_attempt_at": self.next_attempt_at,
+            "lease_owner": self.lease_owner,
+            "lease_expires_at": self.lease_expires_at,
+            "error_code": self.error_code,
+            "id": self.id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "processed_at": self.processed_at,
+            "dead_lettered_at": self.dead_lettered_at,
+            "retention_until": self.retention_until,
+        }
+
+    @classmethod
+    def from_db_row(cls, row: Mapping[str, Any]) -> "OutboxEventRecord":
+        """Build a record from a database row (missing keys default)."""
+        return cls(
+            event_type=row["event_type"],
+            user_id=row["user_id"],
+            payload=row["payload"],
+            status=row["status"],
+            idempotency_key=row["idempotency_key"],
+            contract_version=row.get("contract_version", 1),
+            attempts=row.get("attempts", 0),
+            turn_request_id=row.get("turn_request_id"),
+            next_attempt_at=row.get("next_attempt_at"),
+            lease_owner=row.get("lease_owner"),
+            lease_expires_at=row.get("lease_expires_at"),
+            error_code=row.get("error_code"),
+            id=row.get("id"),
+            created_at=row.get("created_at"),
+            updated_at=row.get("updated_at"),
+            processed_at=row.get("processed_at"),
+            dead_lettered_at=row.get("dead_lettered_at"),
+            retention_until=row.get("retention_until"),
+        )
+
+    def to_insert_row(self) -> dict[str, Any]:
+        """Serialize for INSERT, dropping server-owned ``None`` columns."""
+        row = self.to_db_row()
+        for server_owned in (
+            "id",
+            "created_at",
+            "updated_at",
+            "processed_at",
+            "dead_lettered_at",
+            "retention_until",
+        ):
+            if row[server_owned] is None:
+                del row[server_owned]
+        return row

--- a/backend/transactional_schema.py
+++ b/backend/transactional_schema.py
@@ -27,17 +27,44 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any, Mapping, Optional
 
 # ---------------------------------------------------------------------------
 # Canonical payload hash
 # ---------------------------------------------------------------------------
 
-#: Columns that may never be serialized into a stored payload. Mirrors the
-#: forbidden-key CHECK constraints in the migration; kept here so the
-#: serialization contract is testable without a database.
+#: Keys that may never appear inside a stored payload document. Mirrors the
+#: forbidden-key lists enforced recursively by the migration CHECK
+#: constraints; kept here so the serialization contract is testable without
+#: a database. ``message`` / ``user_message`` / ``assistant_message`` /
+#: ``content`` are forbidden because the outbox must never duplicate
+#: messages or prompts.
 FORBIDDEN_PAYLOAD_KEYS = frozenset(
-    {"prompt", "system_prompt", "meta_cognition", "internal_instructions"}
+    {
+        "prompt",
+        "system_prompt",
+        "meta_cognition",
+        "internal_instructions",
+        "message",
+        "user_message",
+        "assistant_message",
+        "content",
+    }
+)
+
+#: Explicit allowlist of top-level keys for ``turn_requests.replay_payload``.
+#: Mirrors the SQL CHECK ``jsonb_keys_subset_of`` allowlist. Only public
+#: result fields are permitted — never prompts or internal state.
+REPLAY_PAYLOAD_ALLOWED_KEYS = frozenset(
+    {"response", "emotion_state", "message_id", "request_id", "duration_ms"}
+)
+
+#: Explicit allowlist of top-level keys for ``outbox_events.payload``.
+#: Mirrors the SQL CHECK ``jsonb_keys_subset_of`` allowlist. Event payloads
+#: carry only stable references and public event metadata.
+OUTBOX_PAYLOAD_ALLOWED_KEYS = frozenset(
+    {"ref", "request_id", "turn_id", "message_id", "entity_id", "kind", "version"}
 )
 
 
@@ -49,26 +76,60 @@ def canonical_payload_hash(payload: Mapping[str, Any]) -> str:
     ``ensure_ascii=False`` — the same canonical JSON convention used by
     ``backend/trusted_context.py`` and ``backend/memory.py``.
 
+    ``allow_nan=False``: ``NaN``/``Infinity``/``-Infinity`` are rejected
+    because they are not interoperable JSON and ``jsonb`` refuses them;
+    hashing them would break idempotency for values the database would
+    reject.
+
     Returns a lowercase 64-character hexadecimal digest that satisfies the
     database CHECK ``payload_hash_sha256 ~ '^[0-9a-f]{64}$'``.
 
     Raises:
         TypeError: If *payload* is not a mapping or contains values that
-            cannot be JSON-serialized. The offending value is never included
-            in the exception message.
+            cannot be JSON-serialized (including non-finite floats). The
+            offending value is never included in the exception message.
     """
     if not isinstance(payload, Mapping):
         raise TypeError("payload must be a mapping")
     try:
         canonical = json.dumps(
-            payload,
+            dict(payload),
             sort_keys=True,
             separators=(",", ":"),
             ensure_ascii=False,
+            allow_nan=False,
         )
     except (TypeError, ValueError) as exc:
         raise TypeError("payload is not JSON-serializable") from exc
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Deep immutability helpers
+# ---------------------------------------------------------------------------
+# The dataclasses are frozen, but a frozen dataclass only prevents attribute
+# reassignment. To make ``payload`` / ``replay_payload`` truly immutable we
+# deep-freeze them on construction (MappingProxyType for mappings, tuples
+# for sequences) and deep-unfreeze them back to JSON-serializable plain
+# structures in ``to_db_row``. Two records built from the same source dict
+# therefore never share mutable state, and callers can never mutate a
+# record's payload after the fact.
+
+
+def _deep_freeze(value: Any) -> Any:
+    if isinstance(value, dict):
+        return MappingProxyType({k: _deep_freeze(v) for k, v in value.items()})
+    if isinstance(value, (list, tuple)):
+        return tuple(_deep_freeze(v) for v in value)
+    return value
+
+
+def _deep_unfreeze(value: Any) -> Any:
+    if isinstance(value, MappingProxyType):
+        return {k: _deep_unfreeze(v) for k, v in value.items()}
+    if isinstance(value, tuple):
+        return [_deep_unfreeze(v) for v in value]
+    return value
 
 
 # ---------------------------------------------------------------------------
@@ -103,6 +164,10 @@ class TurnRequestRecord:
     updated_at: Optional[str] = None
     completed_at: Optional[str] = None
 
+    def __post_init__(self) -> None:
+        if self.replay_payload is not None:
+            object.__setattr__(self, "replay_payload", _deep_freeze(self.replay_payload))
+
     def to_db_row(self) -> dict[str, Any]:
         """Serialize to a database row, omitting ``None`` fields.
 
@@ -121,7 +186,11 @@ class TurnRequestRecord:
             "committed_revision": self.committed_revision,
             "user_message_chat_log_id": self.user_message_chat_log_id,
             "assistant_message_chat_log_id": self.assistant_message_chat_log_id,
-            "replay_payload": self.replay_payload,
+            "replay_payload": (
+                _deep_unfreeze(self.replay_payload)
+                if self.replay_payload is not None
+                else None
+            ),
             "error_code": self.error_code,
             "id": self.id,
             "created_at": self.created_at,
@@ -198,12 +267,15 @@ class OutboxEventRecord:
     dead_lettered_at: Optional[str] = None
     retention_until: Optional[str] = None
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "payload", _deep_freeze(self.payload))
+
     def to_db_row(self) -> dict[str, Any]:
         """Serialize to a database row, omitting ``None`` fields."""
         return {
             "event_type": self.event_type,
             "user_id": self.user_id,
-            "payload": self.payload,
+            "payload": _deep_unfreeze(self.payload),
             "status": self.status,
             "idempotency_key": self.idempotency_key,
             "contract_version": self.contract_version,

--- a/docs/architecture/transactional-turn-schema.md
+++ b/docs/architecture/transactional-turn-schema.md
@@ -80,7 +80,8 @@ fail-closed guarantee that prevents "stuck" requests.
 ## 3. Lease semantics and expiration
 
 - A `pending` request carries `lease_owner` (sanitized worker identifier,
-  max 64 chars) and `lease_expires_at`.
+  max 64 chars, `^[A-Za-z0-9_.:-]+$` — enforced by CHECK on both
+  `turn_requests` and `outbox_events`) and `lease_expires_at`.
 - The **lease pair check** enforces both-or-neither: a lease can never be
   half-written.
 - Expiration is **time-based only** — no background timer. The future worker
@@ -100,9 +101,12 @@ to detect duplicate/conflicting requests.
 
 - Computed by the application as SHA-256 over the **canonical JSON
   serialization** of the payload: `json.dumps(payload, sort_keys=True,
-  separators=(",", ":"), ensure_ascii=False)` — same canonical JSON
-  convention already used by `backend/trusted_context.py` and
-  `backend/memory.py`.
+  separators=(",", ":"), ensure_ascii=False, allow_nan=False)` — same
+  canonical JSON convention already used by `backend/trusted_context.py`
+  and `backend/memory.py`.
+- `allow_nan=False` is mandatory: `NaN`/`Infinity`/`-Infinity` are not
+  interoperable JSON and `jsonb` rejects them. Hashing them would produce
+  digests for values the database refuses, silently breaking idempotency.
 - The database validates **format only** (`~ '^[0-9a-f]{64}$'`); it never
   recomputes the hash, keeping SQL and Python from diverging on semantics.
 - `backend/transactional_schema.py::canonical_payload_hash()` is the single
@@ -118,41 +122,51 @@ to detect duplicate/conflicting requests.
 `turn_requests.replay_payload` stores **only the minimal public result**
 needed to reproduce a response after connection loss:
 
-- Public response contract fields (response text + public emotion state)
-- Hard size cap (8 KB serialized)
-- **Forbidden keys enforced by CHECK**: `prompt`, `system_prompt`,
-  `meta_cognition`, `internal_instructions` can never be stored.
+- **Explicit top-level allowlist** (public contract): `response`,
+  `emotion_state`, `message_id`, `request_id`, `duration_ms`. Any other
+  top-level key is rejected by the `jsonb_keys_subset_of` CHECK.
+- **Recursive forbidden-key validation**: `prompt`, `system_prompt`,
+  `meta_cognition`, `internal_instructions`, `message`, `user_message`,
+  `assistant_message`, `content` are rejected at **any depth** (objects and
+  arrays) by the `jsonb_has_forbidden_key` CHECK — a forbidden key can
+  never hide inside a nested structure.
+- Hard size cap (8 KB serialized).
 
 Message IDs (`user_message_chat_log_id`, `assistant_message_chat_log_id`)
-are stable references to `chat_logs` rows; they are `SET NULL` on message
-deletion, and replay must never depend on their presence — the
-`replay_payload` is authoritative for replay.
+are stable references to `chat_logs` rows. The message FKs are **composite
+`(user_id, message_id)`** (baseline `chat_logs` already has
+`UNIQUE (user_id, id)`) so a request can never reference another user's
+messages; they are nulled on message deletion and replay must never depend
+on their presence — the `replay_payload` is authoritative for replay.
 
 ---
 
 ## 6. Outbox states
 
-| Status | Meaning | Required shape |
+| Status | Meaning | Required shape (exact, mutually exclusive) |
 |---|---|---|
-| `pending` | Available for claim | no lease; `next_attempt_at` set; `attempts = 0`; no error |
-| `processing` | Leased by a worker | lease set; `attempts >= 1`; not processed |
-| `completed` | Delivered successfully | `processed_at` set; no lease; `attempts >= 1`; no error |
-| `failed` | Retryable failure | no lease; `next_attempt_at` set; `attempts` 1..9; error set |
-| `dead_letter` | Exhausted retries | `dead_lettered_at` set; `attempts = 10`; no lease |
+| `pending` | Available for claim | `processed_at`/`dead_lettered_at`/`retention_until` NULL; no lease; `next_attempt_at` set; `attempts = 0`; no error |
+| `processing` | Leased by a worker | `processed_at`/`dead_lettered_at`/`retention_until` NULL; lease set; `attempts` 1..10; no error |
+| `completed` | Delivered successfully | `processed_at` set; `dead_lettered_at` NULL; `next_attempt_at` NULL; no lease; `attempts` 1..10; no error; `retention_until` set |
+| `failed` | Retryable failure | `processed_at`/`dead_lettered_at`/`retention_until` NULL; no lease; `next_attempt_at` set; `attempts` 1..9; error set |
+| `dead_letter` | Exhausted retries | `dead_lettered_at` set; `retention_until` set; `next_attempt_at` NULL; no lease; `attempts = 10`; error set |
 
-The `outbox_events_status_coherence_check` gives every status an exact shape,
-fail-closed.
+The `outbox_events_status_coherence_check` gives every status an exact,
+mutually exclusive shape — no field of another state can leak in
+(`completed` cannot carry `next_attempt_at` or dead-letter fields;
+`dead_letter` requires error + retention; `processing` cannot carry failure
+fields), fail-closed.
 
 ---
 
 ## 7. Outbox idempotency key
 
-- `idempotency_key` is `NOT NULL` and unique per **`(user_id,
-  idempotency_key)`**.
+- `idempotency_key` is `NOT NULL`, bounded (1..128 chars,
+  `^[A-Za-z0-9_.:-]+$`), and unique per **`(user_id, idempotency_key)`**.
 - The same key for different users is allowed (user-scoped idempotency).
 - A duplicate key within the same user is rejected by the unique constraint,
   making repeated publication attempts idempotent without a worker-side
-  lock.
+  lock. The bound prevents unbounded index/storage growth.
 
 ---
 
@@ -195,10 +209,15 @@ fail-closed.
 | FK | Target | ON DELETE | Rationale |
 |---|---|---|---|
 | `turn_requests.user_id` | `profiles(user_id)` | `CASCADE` | User deletion removes their request ledger; no orphans |
-| `turn_requests.user_message_chat_log_id` | `chat_logs(id)` | `SET NULL` | Message pruning must not block; replay uses `replay_payload` |
-| `turn_requests.assistant_message_chat_log_id` | `chat_logs(id)` | `SET NULL` | Same as above |
+| `turn_requests.(user_id, user_message_chat_log_id)` | `chat_logs(user_id, id)` | `SET NULL` | **Composite FK** — a request can only reference messages of the same user; message pruning must not block; replay uses `replay_payload` |
+| `turn_requests.(user_id, assistant_message_chat_log_id)` | `chat_logs(user_id, id)` | `SET NULL` | Same as above |
 | `outbox_events.user_id` | `profiles(user_id)` | `CASCADE` | User deletion removes their events |
-| `outbox_events.turn_request_id` | `turn_requests(id)` | `CASCADE` | Event belongs to a request; deleting the request deletes its events |
+| `outbox_events.(user_id, turn_request_id)` | `turn_requests(user_id, id)` | `CASCADE` | **Composite FK** — an event can only reference a request of the same user (candidate key `turn_requests_user_id_id_key`); deleting the request deletes its events |
+
+Because a composite `ON DELETE SET NULL` would also NULL the `NOT NULL`
+`user_id`, a `BEFORE DELETE` trigger on `chat_logs`
+(`turn_requests_message_refs_null_trigger`, SECURITY DEFINER) nulls **only**
+the message references first; the FK action then has nothing left to null.
 
 Note: `chat_logs.user_id → profiles(user_id)` remains **NO ACTION** (from
 baseline). Operational user deletion therefore follows the existing order:
@@ -214,6 +233,8 @@ tested by the pgTAP orphan tests.
 
 - `turn_requests_user_id_request_id_key` — UNIQUE, covers replay lookup by
   `(user_id, request_id)`.
+- `turn_requests_user_id_id_key` — UNIQUE candidate key `(user_id, id)`,
+  referenced by the outbox composite FK.
 - `turn_requests_user_id_created_at_idx` — recent requests per user.
 - `turn_requests_status_lease_expiry_idx` — claim of expired leases.
 - `turn_requests_user_committed_revision_idx` — per-user revision queries.
@@ -240,9 +261,15 @@ makes a real, non-destructive rollback possible today:
 
 ```sql
 -- Operational rollback (only valid while nothing has written real data):
+-- Dependency order: trigger first, then tables (their CHECKs reference the
+-- payload helpers), then the helpers and the column.
+DROP TRIGGER IF EXISTS turn_requests_message_refs_null_trigger ON public.chat_logs;
+DROP FUNCTION IF EXISTS public.turn_requests_null_message_refs();
 DROP TABLE IF EXISTS public.outbox_events;
 DROP TABLE IF EXISTS public.turn_requests;
 ALTER TABLE public.profiles DROP COLUMN IF EXISTS revision;
+DROP FUNCTION IF EXISTS public.jsonb_has_forbidden_key(jsonb, text[]);
+DROP FUNCTION IF EXISTS public.jsonb_keys_subset_of(jsonb, text[]);
 ```
 
 This is exercised by `test_transactional_schema_legacy.py` and is safe only
@@ -267,6 +294,11 @@ Both new tables are **server-owned internal infrastructure**:
 No client-authenticated role can reach `turn_requests` or `outbox_events`,
 directly or through the PostgREST API. The pgTAP suite asserts the exact
 grant matrix.
+
+The payload validation helpers (`jsonb_has_forbidden_key`,
+`jsonb_keys_subset_of`) are server-only too: EXECUTE is revoked from
+`PUBLIC`, `anon` and `authenticated`, and granted only to `service_role`
+(asserted by pgTAP).
 
 ---
 

--- a/docs/architecture/transactional-turn-schema.md
+++ b/docs/architecture/transactional-turn-schema.md
@@ -1,0 +1,303 @@
+# Transactional Turn Schema — Foundation
+
+## Status
+
+Approved for issue #270 (recovery #264, tracking #269). This document is the
+architectural record for the persistence foundation that the future atomic
+commit flow (issue #271) and the outbox worker will build on.
+
+## Problem
+
+Today a turn writes messages and snapshots in separate, uncoordinated
+operations:
+
+- No persisted revision allows lost-update detection between concurrent
+  writes to a user's state.
+- No durable structure exists to claim a `request_id`, distinguish pending /
+  completed / expired requests, replay a response after connection loss, or
+  prevent persistent duplication of requests and outbox events.
+- No outbox table can host events published atomically with a future turn
+  commit.
+
+Bad schema decisions here would propagate concurrency, privacy and
+idempotency risk through the whole chain (#271, #272). This task therefore
+creates **only** schema, constraints, minimal serialization contracts,
+documentation, and real database tests. No active `ConversationEngine` flow
+is wired to the new objects.
+
+## Scope boundaries
+
+| Deliberately NOT done | Where it lands |
+|---|---|
+| `commit_turn` / full claim-reclaim | #271 |
+| `ConversationEngine` integration | #271 |
+| Outbox worker | #272 |
+| `save_turn()` / `sync_state()` changes | out of scope |
+| `backend/trusted_context.py`, prompts, emotional/relationship domains | out of scope |
+| Redis or any external coordinator | rejected — PostgreSQL-only |
+
+---
+
+## 1. Revision strategy
+
+`profiles.revision` is a `bigint NOT NULL DEFAULT 0` optimistic-concurrency
+counter.
+
+- **Monotonic per user.** Each committed turn bumps the user's revision by 1.
+- **Default 0 and deterministic backfill.** `ADD COLUMN ... NOT NULL DEFAULT 0`
+  backfills every existing profile with 0 in a single metadata-only
+  operation (no table rewrite for existing rows in modern PostgreSQL), so
+  the backfill is deterministic and lossless.
+- **Upsert compatible.** Future `ON CONFLICT` upserts that omit the column
+  start at 0 because of the default.
+- **Fail-closed.** `CHECK (revision >= 0)` rejects negative values; the
+  migration preflight fails loudly if the column already exists (drift).
+
+### `updated_at` policy
+
+`profiles.updated_at` is **application-maintained**: the backend refreshes it
+explicitly when it writes state. No trigger is introduced here — adding one
+would change the active write path, which is out of scope. The future atomic
+commit flow must refresh `updated_at` in the same statement that bumps
+`revision`.
+
+---
+
+## 2. `turn_requests` states
+
+| Status | Meaning | Required shape |
+|---|---|---|
+| `pending` | Claimed by a worker, work in progress | `lease_owner` + `lease_expires_at` set; `completed_at`/`committed_revision`/`replay_payload`/`error_code` NULL |
+| `completed` | Turn committed durably | `completed_at`, `committed_revision`, `replay_payload` set; lease and error cleared |
+| `expired` | Lease expired or abandoned | error_code set; no completion data; no lease |
+
+The `turn_requests_status_coherence_check` constraint makes every state fully
+determined — a row cannot be half-pending, half-completed. This is the
+fail-closed guarantee that prevents "stuck" requests.
+
+---
+
+## 3. Lease semantics and expiration
+
+- A `pending` request carries `lease_owner` (sanitized worker identifier,
+  max 64 chars) and `lease_expires_at`.
+- The **lease pair check** enforces both-or-neither: a lease can never be
+  half-written.
+- Expiration is **time-based only** — no background timer. The future worker
+  reclaims rows where `status = 'pending' AND lease_expires_at < now()` by
+  atomically transitioning them to `expired` with a sanitized
+  `error_code` (e.g. `lease_expired`).
+- Reclaim must be done with an atomic conditional update (compare-and-swap
+  on `lease_expires_at`), serialized by the future per-user transaction
+  lock; this task does not implement it.
+
+---
+
+## 4. Canonical payload hash
+
+`payload_hash_sha256` is the **canonical hash of the request payload** used
+to detect duplicate/conflicting requests.
+
+- Computed by the application as SHA-256 over the **canonical JSON
+  serialization** of the payload: `json.dumps(payload, sort_keys=True,
+  separators=(",", ":"), ensure_ascii=False)` — same canonical JSON
+  convention already used by `backend/trusted_context.py` and
+  `backend/memory.py`.
+- The database validates **format only** (`~ '^[0-9a-f]{64}$'`); it never
+  recomputes the hash, keeping SQL and Python from diverging on semantics.
+- `backend/transactional_schema.py::canonical_payload_hash()` is the single
+  implementation of the digest; the DB CHECK is the guardrail.
+- Idempotency semantics (replay vs. conflict) follow the same model already
+  proven by `admission_reservations`: same `(user_id, request_id)` + same
+  hash → replay; same IDs + different hash → conflict.
+
+---
+
+## 5. Data needed for replay
+
+`turn_requests.replay_payload` stores **only the minimal public result**
+needed to reproduce a response after connection loss:
+
+- Public response contract fields (response text + public emotion state)
+- Hard size cap (8 KB serialized)
+- **Forbidden keys enforced by CHECK**: `prompt`, `system_prompt`,
+  `meta_cognition`, `internal_instructions` can never be stored.
+
+Message IDs (`user_message_chat_log_id`, `assistant_message_chat_log_id`)
+are stable references to `chat_logs` rows; they are `SET NULL` on message
+deletion, and replay must never depend on their presence — the
+`replay_payload` is authoritative for replay.
+
+---
+
+## 6. Outbox states
+
+| Status | Meaning | Required shape |
+|---|---|---|
+| `pending` | Available for claim | no lease; `next_attempt_at` set; `attempts = 0`; no error |
+| `processing` | Leased by a worker | lease set; `attempts >= 1`; not processed |
+| `completed` | Delivered successfully | `processed_at` set; no lease; `attempts >= 1`; no error |
+| `failed` | Retryable failure | no lease; `next_attempt_at` set; `attempts` 1..9; error set |
+| `dead_letter` | Exhausted retries | `dead_lettered_at` set; `attempts = 10`; no lease |
+
+The `outbox_events_status_coherence_check` gives every status an exact shape,
+fail-closed.
+
+---
+
+## 7. Outbox idempotency key
+
+- `idempotency_key` is `NOT NULL` and unique per **`(user_id,
+  idempotency_key)`**.
+- The same key for different users is allowed (user-scoped idempotency).
+- A duplicate key within the same user is rejected by the unique constraint,
+  making repeated publication attempts idempotent without a worker-side
+  lock.
+
+---
+
+## 8. Retry policy
+
+- `attempts` counts delivery attempts: `0` on enqueue, incremented on each
+  claim.
+- Cap: **10 attempts** (`CHECK attempts >= 0 AND attempts <= 10`).
+- `failed` rows are eligible for retry in the 1..9 range with a future
+  `next_attempt_at`; at 10 the row transitions to `dead_letter`.
+- The exact backoff schedule (exponential with jitter, retry-after) is
+  decided by the worker task (#272); the schema fixes only the bounds.
+
+---
+
+## 9. Outbox lease
+
+- `processing` events are leased with `lease_owner` + `lease_expires_at`
+  (same both-or-neither pair check as `turn_requests`).
+- Lease expiry recovery is the worker's job (claim rows where
+  `status = 'processing' AND lease_expires_at < now()`), serialized by the
+  per-user transaction lock. Not implemented here.
+
+---
+
+## 10. Retention and dead-letter
+
+- `dead_lettered_at` records when an event exhausted its retries.
+- `retention_until` is the operational purge horizon; the worker (or a
+  maintenance job) purges `dead_letter` rows after retention and `completed`
+  rows after their (shorter) retention.
+- No automatic purge is implemented in this task; the columns exist so the
+  policy has a durable home. Retention durations are operational constants
+  to be set in #272.
+
+---
+
+## 11. Foreign keys and ON DELETE
+
+| FK | Target | ON DELETE | Rationale |
+|---|---|---|---|
+| `turn_requests.user_id` | `profiles(user_id)` | `CASCADE` | User deletion removes their request ledger; no orphans |
+| `turn_requests.user_message_chat_log_id` | `chat_logs(id)` | `SET NULL` | Message pruning must not block; replay uses `replay_payload` |
+| `turn_requests.assistant_message_chat_log_id` | `chat_logs(id)` | `SET NULL` | Same as above |
+| `outbox_events.user_id` | `profiles(user_id)` | `CASCADE` | User deletion removes their events |
+| `outbox_events.turn_request_id` | `turn_requests(id)` | `CASCADE` | Event belongs to a request; deleting the request deletes its events |
+
+Note: `chat_logs.user_id → profiles(user_id)` remains **NO ACTION** (from
+baseline). Operational user deletion therefore follows the existing order:
+extractions → memories → chat_logs → profiles, with the new server-owned
+tables cascading automatically at the profile step. This is the policy
+tested by the pgTAP orphan tests.
+
+---
+
+## 12. Indexes
+
+`turn_requests`:
+
+- `turn_requests_user_id_request_id_key` — UNIQUE, covers replay lookup by
+  `(user_id, request_id)`.
+- `turn_requests_user_id_created_at_idx` — recent requests per user.
+- `turn_requests_status_lease_expiry_idx` — claim of expired leases.
+- `turn_requests_user_committed_revision_idx` — per-user revision queries.
+
+`outbox_events`:
+
+- `outbox_events_user_id_idempotency_key_key` — UNIQUE idempotency scope.
+- `outbox_events_status_next_attempt_idx` — claim of available events
+  (`status` + `next_attempt_at`), independent of timestamp-only ordering.
+- `outbox_events_status_lease_expiry_idx` — reclaim of expired leases.
+- `outbox_events_turn_request_id_idx` — FK lookups.
+
+No ordering depends on timestamps alone: every critical query has a
+purpose-built index, verified by exact `pg_get_indexdef` assertions in the
+pgTAP suite.
+
+---
+
+## 13. Operational rollback
+
+The migration is **purely additive** (new column with default, two new
+empty tables, new grants) and does not touch the active write path. That
+makes a real, non-destructive rollback possible today:
+
+```sql
+-- Operational rollback (only valid while nothing has written real data):
+DROP TABLE IF EXISTS public.outbox_events;
+DROP TABLE IF EXISTS public.turn_requests;
+ALTER TABLE public.profiles DROP COLUMN IF EXISTS revision;
+```
+
+This is exercised by `test_transactional_schema_legacy.py` and is safe only
+before production writes exist. We deliberately do **not** ship a destructive
+downgrade migration for the sake of "reversibility"; after any real data
+lands, recovery is forward-only (new migration), consistent with
+`docs/operations/supabase-security-upgrade.md`.
+
+---
+
+## 14. RLS and grants boundaries
+
+Both new tables are **server-owned internal infrastructure**:
+
+- `ENABLE ROW LEVEL SECURITY` + `FORCE ROW LEVEL SECURITY`, **no policies**.
+- `anon`, `authenticated`, `PUBLIC`: zero privileges (explicit REVOKE +
+  verified by pgTAP).
+- `service_role`: full `SELECT, INSERT, UPDATE, DELETE` (it bypasses RLS via
+  `BYPASSRLS` in Supabase), mirroring the #265 guarantees on the
+  user-facing tables.
+
+No client-authenticated role can reach `turn_requests` or `outbox_events`,
+directly or through the PostgREST API. The pgTAP suite asserts the exact
+grant matrix.
+
+---
+
+## 15. Compatibility with the future commit flow
+
+The design is intentionally compatible with the #271 combination of a
+**per-user transactional lock** plus **revision validation**:
+
+1. Claim: `INSERT ... ON CONFLICT (user_id, request_id) DO NOTHING` inside
+   the per-user lock; read `profiles.revision` as `expected_revision`.
+2. Execute + persist messages, then update `profiles.revision = revision + 1`
+   and `updated_at` in the same transaction.
+3. Commit: `UPDATE turn_requests SET status='completed', committed_revision
+   = :new_revision, replay_payload = :minimal_public_result, completed_at =
+   now()` guarded by `WHERE status='pending' AND expected_revision = :read`.
+4. Enqueue `outbox_events` rows in the same transaction.
+
+No Redis. All coordination is PostgreSQL transactions + advisory locks +
+constraints.
+
+## File layout
+
+```
+supabase/
+  migrations/20240101000004_transactional_turn_schema.sql
+  tests/database/03_transactional_turn_schema.test.sql
+backend/
+  transactional_schema.py              # minimal serialization contracts
+  tests/test_transactional_schema.py   # pure unit tests
+  tests/test_transactional_schema_legacy.py      # real-DB legacy upgrade
+  tests/test_transactional_schema_integration.py # real-DB authz matrix
+docs/
+  architecture/transactional-turn-schema.md      # this document
+```

--- a/docs/architecture/transactional-turn-schema.md
+++ b/docs/architecture/transactional-turn-schema.md
@@ -146,7 +146,7 @@ on their presence — the `replay_payload` is authoritative for replay.
 | Status | Meaning | Required shape (exact, mutually exclusive) |
 |---|---|---|
 | `pending` | Available for claim | `processed_at`/`dead_lettered_at`/`retention_until` NULL; no lease; `next_attempt_at` set; `attempts = 0`; no error |
-| `processing` | Leased by a worker | `processed_at`/`dead_lettered_at`/`retention_until` NULL; lease set; `attempts` 1..10; no error |
+| `processing` | Leased by a worker | `processed_at`/`dead_lettered_at`/`retention_until` NULL; **`next_attempt_at` NULL**; lease set; `attempts` 1..10; no error |
 | `completed` | Delivered successfully | `processed_at` set; `dead_lettered_at` NULL; `next_attempt_at` NULL; no lease; `attempts` 1..10; no error; `retention_until` set |
 | `failed` | Retryable failure | `processed_at`/`dead_lettered_at`/`retention_until` NULL; no lease; `next_attempt_at` set; `attempts` 1..9; error set |
 | `dead_letter` | Exhausted retries | `dead_lettered_at` set; `retention_until` set; `next_attempt_at` NULL; no lease; `attempts = 10`; error set |
@@ -154,8 +154,9 @@ on their presence — the `replay_payload` is authoritative for replay.
 The `outbox_events_status_coherence_check` gives every status an exact,
 mutually exclusive shape — no field of another state can leak in
 (`completed` cannot carry `next_attempt_at` or dead-letter fields;
-`dead_letter` requires error + retention; `processing` cannot carry failure
-fields), fail-closed.
+`processing` requires `next_attempt_at IS NULL` so a claimed event cannot
+keep the pending/failed scheduling field; `dead_letter` requires error +
+retention; `processing` cannot carry failure fields), fail-closed.
 
 ---
 
@@ -167,6 +168,27 @@ fields), fail-closed.
 - A duplicate key within the same user is rejected by the unique constraint,
   making repeated publication attempts idempotent without a worker-side
   lock. The bound prevents unbounded index/storage growth.
+
+## 7b. Outbox payload value contract
+
+The outbox payload document must be **minimal, non-duplicating, and
+structured**. Key-name allowlists alone are not enough: raw content must
+never fit under an allowed key. The `jsonb_outbox_payload_value_contract`
+helper therefore validates **types and formats**, not just names:
+
+| Field | Type | Format / bound |
+|---|---|---|
+| `ref`, `request_id`, `turn_id`, `message_id`, `entity_id`, `kind` | string (scalar) | `^[A-Za-z0-9_.:-]{1,128}$` — sanitized, bounded, no arbitrary objects/arrays |
+| `version` | JSON number (integer) | `1..1000` |
+
+- Objects/arrays under `ref` or any identifier key are rejected even when
+  they contain no forbidden key — a nested `{"text": "..."}` can never be
+  smuggled in as "metadata".
+- `version` must be an integer in range; strings, floats and out-of-range
+  values are rejected.
+- Combined with the top-level allowlist and the recursive forbidden-key
+  check, the value contract guarantees the outbox never stores prompts,
+  messages, metacognition or arbitrary nested content.
 
 ---
 
@@ -270,6 +292,7 @@ DROP TABLE IF EXISTS public.turn_requests;
 ALTER TABLE public.profiles DROP COLUMN IF EXISTS revision;
 DROP FUNCTION IF EXISTS public.jsonb_has_forbidden_key(jsonb, text[]);
 DROP FUNCTION IF EXISTS public.jsonb_keys_subset_of(jsonb, text[]);
+DROP FUNCTION IF EXISTS public.jsonb_outbox_payload_value_contract(jsonb);
 ```
 
 This is exercised by `test_transactional_schema_legacy.py` and is safe only
@@ -295,10 +318,14 @@ No client-authenticated role can reach `turn_requests` or `outbox_events`,
 directly or through the PostgREST API. The pgTAP suite asserts the exact
 grant matrix.
 
-The payload validation helpers (`jsonb_has_forbidden_key`,
-`jsonb_keys_subset_of`) are server-only too: EXECUTE is revoked from
-`PUBLIC`, `anon` and `authenticated`, and granted only to `service_role`
-(asserted by pgTAP).
+The payload helpers (`jsonb_has_forbidden_key`, `jsonb_keys_subset_of`,
+`jsonb_outbox_payload_value_contract`) and the SECURITY DEFINER trigger
+function (`turn_requests_null_message_refs`) are server-only: PostgreSQL
+grants EXECUTE to PUBLIC by default, so the migration explicitly revokes
+EXECUTE from `PUBLIC`, `anon` and `authenticated` and grants it **only** to
+`service_role`. The trigger function runs exclusively through the trigger;
+the service_role grant is for operational use. The exact EXECUTE matrix for
+al four functions is asserted by pgTAP.
 
 ---
 

--- a/supabase/migrations/20240101000004_transactional_turn_schema.sql
+++ b/supabase/migrations/20240101000004_transactional_turn_schema.sql
@@ -12,8 +12,15 @@
 --    request/event can never reference rows of another user.
 --  * Recursive payload validation with an explicit allowlist, so prompts,
 --    messages and internal fields are rejected even when nested.
---  * Exact, mutually exclusive outbox states.
+--  * Exact, mutually exclusive outbox states (including next_attempt_at
+--    being NULL while processing).
+--  * Value contract for the outbox payload: reference/identifier fields are
+--    scalar, sanitized and bounded; version is an integer in a defined
+--    range. Arbitrary objects/arrays can never hide raw content under an
+--    allowed key.
 --  * Sanitized identifier bounds for lease_owner / idempotency_key.
+--  * SECURITY DEFINER trigger function has EXECUTE revoked from
+--    PUBLIC/anon/authenticated (fail-closed, granted to service_role only).
 
 -- =================================================================
 -- 0. PREFLIGHT: fail closed on unexpected schema drift
@@ -49,6 +56,7 @@ BEGIN
           AND p.proname IN (
               'jsonb_has_forbidden_key',
               'jsonb_keys_subset_of',
+              'jsonb_outbox_payload_value_contract',
               'turn_requests_null_message_refs'
           )
     ) THEN
@@ -152,12 +160,71 @@ BEGIN
 END;
 $$;
 
+-- Value contract for the outbox payload document. Key-name allowlists are
+-- not enough: a value like {"ref": "<conteúdo bruto>"} or
+-- {"ref": {"text": "..."}} would pass a pure key check. This helper
+-- validates the TYPES and FORMATS of every allowed field:
+--  * ref / request_id / turn_id / message_id / entity_id / kind: scalar
+--    string, sanitized charset, bounded length (1..128). Arbitrary
+--    objects/arrays can never be stored under these keys.
+--  * version: JSON number that is an integer in [1, 1000].
+CREATE FUNCTION public.jsonb_outbox_payload_value_contract(
+    payload jsonb
+) RETURNS boolean
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+    v_key text;
+    v_value jsonb;
+    v_text text;
+BEGIN
+    IF payload IS NULL OR jsonb_typeof(payload) <> 'object' THEN
+        RETURN FALSE;
+    END IF;
+
+    FOR v_key, v_value IN SELECT * FROM jsonb_each(payload) LOOP
+        -- jsonb_each yields SQL NULL for a JSON null value; NULL guards are
+        -- explicit because NULL comparisons never satisfy the checks below
+        -- (fail-closed: null values are not valid contract values).
+        IF v_value IS NULL THEN
+            RETURN FALSE;
+        END IF;
+        IF v_key = 'version' THEN
+            -- version must be an integer within the documented range.
+            IF jsonb_typeof(v_value) <> 'number' THEN
+                RETURN FALSE;
+            END IF;
+            v_text := v_value::text;
+            IF NOT (v_text ~ '^[0-9]{1,4}$') THEN
+                RETURN FALSE;
+            END IF;
+            IF v_text::integer < 1 OR v_text::integer > 1000 THEN
+                RETURN FALSE;
+            END IF;
+        ELSE
+            -- Reference/identifier fields are scalar, sanitized, bounded.
+            IF jsonb_typeof(v_value) <> 'string' THEN
+                RETURN FALSE;
+            END IF;
+            v_text := v_value #>> '{}';
+            IF NOT (v_text ~ '^[A-Za-z0-9_.:-]{1,128}$') THEN
+                RETURN FALSE;
+            END IF;
+        END IF;
+    END LOOP;
+    RETURN TRUE;
+END;
+$$;
+
 -- Fail-closed grant posture for the helpers (they expose no data, but
 -- clients must not be able to call server-owned internals).
 REVOKE ALL ON FUNCTION public.jsonb_has_forbidden_key(jsonb, text[]) FROM PUBLIC, anon, authenticated;
 REVOKE ALL ON FUNCTION public.jsonb_keys_subset_of(jsonb, text[]) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.jsonb_outbox_payload_value_contract(jsonb) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.jsonb_has_forbidden_key(jsonb, text[]) TO service_role;
 GRANT EXECUTE ON FUNCTION public.jsonb_keys_subset_of(jsonb, text[]) TO service_role;
+GRANT EXECUTE ON FUNCTION public.jsonb_outbox_payload_value_contract(jsonb) TO service_role;
 
 -- =================================================================
 -- 3. turn_requests
@@ -289,6 +356,13 @@ BEGIN
 END;
 $$;
 
+-- SECURITY DEFINER functions keep EXECUTE for PUBLIC by default. This
+-- function runs exclusively through the trigger below (no runtime caller),
+-- so EXECUTE is revoked from PUBLIC/anon/authenticated and granted only to
+-- service_role for operational use — fail-closed privilege boundary.
+REVOKE ALL ON FUNCTION public.turn_requests_null_message_refs() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.turn_requests_null_message_refs() TO service_role;
+
 DROP TRIGGER IF EXISTS turn_requests_message_refs_null_trigger ON public.chat_logs;
 CREATE TRIGGER turn_requests_message_refs_null_trigger
     BEFORE DELETE ON public.chat_logs
@@ -370,6 +444,7 @@ CREATE TABLE public.outbox_events (
             OR
             (status = 'processing' AND processed_at IS NULL
                 AND dead_lettered_at IS NULL AND retention_until IS NULL
+                AND next_attempt_at IS NULL
                 AND lease_owner IS NOT NULL AND lease_expires_at IS NOT NULL
                 AND attempts BETWEEN 1 AND 10
                 AND error_code IS NULL)
@@ -415,6 +490,7 @@ CREATE TABLE public.outbox_events (
                       'internal_instructions', 'message',
                       'user_message', 'assistant_message', 'content']
             )
+            AND public.jsonb_outbox_payload_value_contract(payload)
         )
 );
 

--- a/supabase/migrations/20240101000004_transactional_turn_schema.sql
+++ b/supabase/migrations/20240101000004_transactional_turn_schema.sql
@@ -1,0 +1,276 @@
+-- 20240101000004_transactional_turn_schema.sql
+-- Transactional turn persistence foundation (#270).
+--
+-- Purely additive migration: introduces profiles.revision, the internal
+-- turn_requests ledger and the durable outbox_events table. No active flow
+-- of the ConversationEngine is wired to these objects yet.
+--
+-- Design and rationale: docs/architecture/transactional-turn-schema.md
+
+-- =================================================================
+-- 0. PREFLIGHT: fail closed on unexpected schema drift
+-- =================================================================
+-- If any of the objects already exist, the database has drifted from the
+-- expected migration sequence. Fail loudly instead of silently re-creating
+-- or altering objects that a later migration owns.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_attribute a
+        WHERE a.attrelid = 'public.profiles'::regclass
+          AND a.attname = 'revision'
+    ) THEN
+        RAISE EXCEPTION 'Cannot apply transactional schema: profiles.revision already exists (unexpected drift)'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname IN ('turn_requests', 'outbox_events')
+    ) THEN
+        RAISE EXCEPTION 'Cannot apply transactional schema: internal tables already exist (unexpected drift)'
+            USING ERRCODE = '23514';
+    END IF;
+END $$;
+
+-- =================================================================
+-- 1. profiles.revision
+-- =================================================================
+-- Monotonic, per-user optimistic-concurrency counter. NOT NULL, default 0
+-- backfills every existing profile deterministically with 0 and makes new
+-- profiles (including future upserts that omit the column) start at 0.
+--
+-- updated_at policy: profiles.updated_at is maintained by the application
+-- (server-side writes refresh it). No DB trigger is added here; the future
+-- atomic commit flow must refresh updated_at whenever revision changes.
+ALTER TABLE public.profiles
+    ADD COLUMN revision bigint NOT NULL DEFAULT 0;
+
+ALTER TABLE public.profiles
+    ADD CONSTRAINT profiles_revision_non_negative_check
+    CHECK (revision >= 0);
+
+-- =================================================================
+-- 2. turn_requests
+-- =================================================================
+-- Server-owned request ledger. One row per (user, request_id) claim that
+-- the future atomic commit flow (issue #271) will use for idempotent,
+-- revision-guarded execution and replay after connection loss.
+CREATE TABLE public.turn_requests (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id text NOT NULL,
+    request_id uuid NOT NULL,
+    payload_hash_sha256 text NOT NULL,
+    status text NOT NULL,
+    lease_owner text,
+    lease_expires_at timestamptz,
+    expected_revision bigint NOT NULL DEFAULT 0,
+    committed_revision bigint,
+    user_message_chat_log_id bigint,
+    assistant_message_chat_log_id bigint,
+    replay_payload jsonb,
+    error_code text,
+    created_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+    updated_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+    completed_at timestamptz,
+
+    CONSTRAINT turn_requests_user_id_request_id_key
+        UNIQUE (user_id, request_id),
+    CONSTRAINT turn_requests_user_id_fkey
+        FOREIGN KEY (user_id) REFERENCES public.profiles(user_id)
+        ON DELETE CASCADE,
+    CONSTRAINT turn_requests_user_message_chat_log_id_fkey
+        FOREIGN KEY (user_message_chat_log_id) REFERENCES public.chat_logs(id)
+        ON DELETE SET NULL,
+    CONSTRAINT turn_requests_assistant_message_chat_log_id_fkey
+        FOREIGN KEY (assistant_message_chat_log_id) REFERENCES public.chat_logs(id)
+        ON DELETE SET NULL,
+
+    CONSTRAINT turn_requests_payload_hash_sha256_check
+        CHECK (payload_hash_sha256 ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT turn_requests_status_check
+        CHECK (status IN ('pending', 'completed', 'expired')),
+    CONSTRAINT turn_requests_expected_revision_check
+        CHECK (expected_revision >= 0),
+    CONSTRAINT turn_requests_committed_revision_check
+        CHECK (committed_revision IS NULL OR committed_revision >= 0),
+    CONSTRAINT turn_requests_error_code_check
+        CHECK (error_code IS NULL OR error_code ~ '^[a-z0-9_]{1,64}$'),
+    CONSTRAINT turn_requests_lease_pair_check
+        CHECK (
+            (lease_owner IS NULL AND lease_expires_at IS NULL)
+            OR (lease_owner IS NOT NULL AND lease_expires_at IS NOT NULL)
+        ),
+    -- Status / lease / completion coherence. Fail-closed: a request can only
+    -- exist in one fully determined shape.
+    CONSTRAINT turn_requests_status_coherence_check
+        CHECK (
+            (status = 'pending' AND lease_owner IS NOT NULL
+                AND lease_expires_at IS NOT NULL AND completed_at IS NULL
+                AND committed_revision IS NULL AND replay_payload IS NULL
+                AND error_code IS NULL)
+            OR
+            (status = 'completed' AND completed_at IS NOT NULL
+                AND committed_revision IS NOT NULL AND replay_payload IS NOT NULL
+                AND lease_owner IS NULL AND lease_expires_at IS NULL
+                AND error_code IS NULL)
+            OR
+            (status = 'expired' AND completed_at IS NULL
+                AND committed_revision IS NULL AND replay_payload IS NULL
+                AND lease_owner IS NULL AND lease_expires_at IS NULL
+                AND error_code IS NOT NULL)
+        ),
+    -- Replay payload stores ONLY the minimal public result needed to replay
+    -- a response after connection loss. Prompts, system instructions and
+    -- metacognition are forbidden inside the stored document.
+    CONSTRAINT turn_requests_replay_payload_check
+        CHECK (
+            replay_payload IS NULL
+            OR (
+                jsonb_typeof(replay_payload) = 'object'
+                AND octet_length(replay_payload::text) <= 8192
+                AND NOT (replay_payload ? 'prompt')
+                AND NOT (replay_payload ? 'system_prompt')
+                AND NOT (replay_payload ? 'meta_cognition')
+                AND NOT (replay_payload ? 'internal_instructions')
+            )
+        )
+);
+
+-- =================================================================
+-- 3. outbox_events
+-- =================================================================
+-- Durable outbox for future atomic publication. Events are enqueued in the
+-- same transaction as the turn commit; a future worker claims and delivers
+-- them. No worker exists yet in this task.
+CREATE TABLE public.outbox_events (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_type text NOT NULL,
+    contract_version integer NOT NULL DEFAULT 1,
+    user_id text NOT NULL,
+    turn_request_id uuid,
+    payload jsonb NOT NULL,
+    status text NOT NULL,
+    attempts integer NOT NULL DEFAULT 0,
+    next_attempt_at timestamptz,
+    lease_owner text,
+    lease_expires_at timestamptz,
+    idempotency_key text NOT NULL,
+    error_code text,
+    created_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+    updated_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+    processed_at timestamptz,
+    dead_lettered_at timestamptz,
+    retention_until timestamptz,
+
+    -- Idempotency key is unique per user: the same key for different users
+    -- is allowed, and replaying a delivery within the same user is rejected.
+    CONSTRAINT outbox_events_user_id_idempotency_key_key
+        UNIQUE (user_id, idempotency_key),
+    CONSTRAINT outbox_events_user_id_fkey
+        FOREIGN KEY (user_id) REFERENCES public.profiles(user_id)
+        ON DELETE CASCADE,
+    CONSTRAINT outbox_events_turn_request_id_fkey
+        FOREIGN KEY (turn_request_id) REFERENCES public.turn_requests(id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT outbox_events_event_type_check
+        CHECK (event_type ~ '^[a-z0-9_]{1,64}$'),
+    CONSTRAINT outbox_events_contract_version_check
+        CHECK (contract_version > 0),
+    CONSTRAINT outbox_events_status_check
+        CHECK (status IN ('pending', 'processing', 'completed', 'failed', 'dead_letter')),
+    CONSTRAINT outbox_events_attempts_check
+        CHECK (attempts >= 0 AND attempts <= 10),
+    CONSTRAINT outbox_events_error_code_check
+        CHECK (error_code IS NULL OR error_code ~ '^[a-z0-9_]{1,64}$'),
+    CONSTRAINT outbox_events_lease_pair_check
+        CHECK (
+            (lease_owner IS NULL AND lease_expires_at IS NULL)
+            OR (lease_owner IS NOT NULL AND lease_expires_at IS NOT NULL)
+        ),
+    -- Status / lease / attempts / completion coherence. Fail-closed: each
+    -- status has an exact, fully determined shape.
+    CONSTRAINT outbox_events_status_coherence_check
+        CHECK (
+            (status = 'pending' AND processed_at IS NULL
+                AND lease_owner IS NULL AND lease_expires_at IS NULL
+                AND next_attempt_at IS NOT NULL AND attempts = 0
+                AND error_code IS NULL)
+            OR
+            (status = 'processing' AND processed_at IS NULL
+                AND lease_owner IS NOT NULL AND lease_expires_at IS NOT NULL
+                AND attempts >= 1)
+            OR
+            (status = 'completed' AND processed_at IS NOT NULL
+                AND lease_owner IS NULL AND lease_expires_at IS NULL
+                AND attempts >= 1 AND error_code IS NULL)
+            OR
+            (status = 'failed' AND processed_at IS NULL
+                AND lease_owner IS NULL AND lease_expires_at IS NULL
+                AND next_attempt_at IS NOT NULL
+                AND attempts BETWEEN 1 AND 9 AND error_code IS NOT NULL)
+            OR
+            (status = 'dead_letter' AND processed_at IS NULL
+                AND lease_owner IS NULL AND lease_expires_at IS NULL
+                AND dead_lettered_at IS NOT NULL AND attempts = 10)
+        ),
+    -- Outbox payload is a minimal, non-duplicating event document. Messages,
+    -- prompts, system instructions and metacognition must never be persisted.
+    CONSTRAINT outbox_events_payload_check
+        CHECK (
+            jsonb_typeof(payload) = 'object'
+            AND octet_length(payload::text) <= 8192
+            AND NOT (payload ? 'prompt')
+            AND NOT (payload ? 'system_prompt')
+            AND NOT (payload ? 'meta_cognition')
+            AND NOT (payload ? 'internal_instructions')
+        )
+);
+
+-- =================================================================
+-- 4. Indexes
+-- =================================================================
+-- turn_requests: uniqueness + replay + claim of expired leases + revision
+CREATE INDEX turn_requests_user_id_created_at_idx
+    ON public.turn_requests (user_id, created_at DESC);
+CREATE INDEX turn_requests_status_lease_expiry_idx
+    ON public.turn_requests (status, lease_expires_at);
+CREATE INDEX turn_requests_user_committed_revision_idx
+    ON public.turn_requests (user_id, committed_revision);
+
+-- outbox_events: claim of available events + reclaim of expired leases
+CREATE INDEX outbox_events_status_next_attempt_idx
+    ON public.outbox_events (status, next_attempt_at);
+CREATE INDEX outbox_events_status_lease_expiry_idx
+    ON public.outbox_events (status, lease_expires_at);
+CREATE INDEX outbox_events_turn_request_id_idx
+    ON public.outbox_events (turn_request_id);
+
+-- =================================================================
+-- 5. RLS and grants (server-owned internal tables)
+-- =================================================================
+-- Both tables are internal, server-owned infrastructure. Authenticated
+-- clients must never reach them. RLS + FORCE RLS with no policies, and no
+-- grants to anon/authenticated/PUBLIC, mirror the guarantees delivered by
+-- the #265 hardening. service_role keeps full CRUD (it bypasses RLS via
+-- BYPASSRLS in Supabase), matching the pattern of the user-facing tables.
+ALTER TABLE public.turn_requests ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.turn_requests FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.outbox_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.outbox_events FORCE ROW LEVEL SECURITY;
+
+REVOKE ALL PRIVILEGES ON TABLE public.turn_requests FROM PUBLIC;
+REVOKE ALL PRIVILEGES ON TABLE public.turn_requests FROM anon, authenticated;
+REVOKE ALL PRIVILEGES ON TABLE public.outbox_events FROM PUBLIC;
+REVOKE ALL PRIVILEGES ON TABLE public.outbox_events FROM anon, authenticated;
+
+REVOKE ALL PRIVILEGES ON TABLE public.turn_requests FROM service_role;
+REVOKE ALL PRIVILEGES ON TABLE public.outbox_events FROM service_role;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.turn_requests TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.outbox_events TO service_role;

--- a/supabase/migrations/20240101000004_transactional_turn_schema.sql
+++ b/supabase/migrations/20240101000004_transactional_turn_schema.sql
@@ -6,13 +6,18 @@
 -- of the ConversationEngine is wired to these objects yet.
 --
 -- Design and rationale: docs/architecture/transactional-turn-schema.md
+--
+-- Audit revisions (PR review #305):
+--  * Composite FKs (user_id, message_id) / (user_id, turn_request_id) so a
+--    request/event can never reference rows of another user.
+--  * Recursive payload validation with an explicit allowlist, so prompts,
+--    messages and internal fields are rejected even when nested.
+--  * Exact, mutually exclusive outbox states.
+--  * Sanitized identifier bounds for lease_owner / idempotency_key.
 
 -- =================================================================
 -- 0. PREFLIGHT: fail closed on unexpected schema drift
 -- =================================================================
--- If any of the objects already exist, the database has drifted from the
--- expected migration sequence. Fail loudly instead of silently re-creating
--- or altering objects that a later migration owns.
 DO $$
 BEGIN
     IF EXISTS (
@@ -35,6 +40,32 @@ BEGIN
         RAISE EXCEPTION 'Cannot apply transactional schema: internal tables already exist (unexpected drift)'
             USING ERRCODE = '23514';
     END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public'
+          AND p.proname IN (
+              'jsonb_has_forbidden_key',
+              'jsonb_keys_subset_of',
+              'turn_requests_null_message_refs'
+          )
+    ) THEN
+        RAISE EXCEPTION 'Cannot apply transactional schema: helper functions already exist (unexpected drift)'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_trigger t
+        JOIN pg_class c ON c.oid = t.tgrelid
+        WHERE c.relname = 'chat_logs'
+          AND t.tgname = 'turn_requests_message_refs_null_trigger'
+    ) THEN
+        RAISE EXCEPTION 'Cannot apply transactional schema: chat_logs trigger already exists (unexpected drift)'
+            USING ERRCODE = '23514';
+    END IF;
 END $$;
 
 -- =================================================================
@@ -55,7 +86,81 @@ ALTER TABLE public.profiles
     CHECK (revision >= 0);
 
 -- =================================================================
--- 2. turn_requests
+-- 2. Payload validation helpers (pure, immutable, no data access)
+-- =================================================================
+-- Used by the payload CHECK constraints below. Validation is fail-closed:
+--  * jsonb_keys_subset_of()  — top-level keys must be within an explicit
+--    allowlist (the minimal public contract for the stored document).
+--  * jsonb_has_forbidden_key() — forbidden keys are rejected at ANY depth
+--    (objects and arrays), so prompts / messages / internal fields can
+--    never hide inside nested structures.
+CREATE FUNCTION public.jsonb_has_forbidden_key(
+    payload jsonb,
+    forbidden text[]
+) RETURNS boolean
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+    v_key text;
+    v_value jsonb;
+    v_elem jsonb;
+BEGIN
+    IF payload IS NULL OR jsonb_typeof(payload) NOT IN ('object', 'array') THEN
+        RETURN FALSE;
+    END IF;
+
+    IF jsonb_typeof(payload) = 'array' THEN
+        FOR v_elem IN SELECT * FROM jsonb_array_elements(payload) LOOP
+            IF public.jsonb_has_forbidden_key(v_elem, forbidden) THEN
+                RETURN TRUE;
+            END IF;
+        END LOOP;
+        RETURN FALSE;
+    END IF;
+
+    FOR v_key, v_value IN SELECT * FROM jsonb_each(payload) LOOP
+        IF v_key = ANY(forbidden)
+           OR public.jsonb_has_forbidden_key(v_value, forbidden) THEN
+            RETURN TRUE;
+        END IF;
+    END LOOP;
+    RETURN FALSE;
+END;
+$$;
+
+CREATE FUNCTION public.jsonb_keys_subset_of(
+    payload jsonb,
+    allowed text[]
+) RETURNS boolean
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+    v_key text;
+BEGIN
+    IF payload IS NULL OR jsonb_typeof(payload) <> 'object' THEN
+        RETURN FALSE;
+    END IF;
+
+    FOR v_key IN SELECT * FROM jsonb_object_keys(payload) LOOP
+        IF NOT (v_key = ANY(allowed)) THEN
+            RETURN FALSE;
+        END IF;
+    END LOOP;
+    RETURN TRUE;
+END;
+$$;
+
+-- Fail-closed grant posture for the helpers (they expose no data, but
+-- clients must not be able to call server-owned internals).
+REVOKE ALL ON FUNCTION public.jsonb_has_forbidden_key(jsonb, text[]) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.jsonb_keys_subset_of(jsonb, text[]) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.jsonb_has_forbidden_key(jsonb, text[]) TO service_role;
+GRANT EXECUTE ON FUNCTION public.jsonb_keys_subset_of(jsonb, text[]) TO service_role;
+
+-- =================================================================
+-- 3. turn_requests
 -- =================================================================
 -- Server-owned request ledger. One row per (user, request_id) claim that
 -- the future atomic commit flow (issue #271) will use for idempotent,
@@ -80,14 +185,26 @@ CREATE TABLE public.turn_requests (
 
     CONSTRAINT turn_requests_user_id_request_id_key
         UNIQUE (user_id, request_id),
+    -- Candidate key (user_id, id): enables the outbox composite FK so an
+    -- event can only reference a request of the SAME user.
+    CONSTRAINT turn_requests_user_id_id_key
+        UNIQUE (user_id, id),
     CONSTRAINT turn_requests_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES public.profiles(user_id)
         ON DELETE CASCADE,
+    -- Composite FKs enforce per-user isolation: a request can only point
+    -- at messages of the same user. The baseline chat_logs already has
+    -- UNIQUE (user_id, id) — see migration 20240101000000.
+    -- ON DELETE SET NULL on a composite key would NULL user_id (NOT NULL),
+    -- so a BEFORE DELETE trigger nulls ONLY the message references first;
+    -- the SET NULL action then has nothing left to null.
     CONSTRAINT turn_requests_user_message_chat_log_id_fkey
-        FOREIGN KEY (user_message_chat_log_id) REFERENCES public.chat_logs(id)
+        FOREIGN KEY (user_id, user_message_chat_log_id)
+        REFERENCES public.chat_logs(user_id, id)
         ON DELETE SET NULL,
     CONSTRAINT turn_requests_assistant_message_chat_log_id_fkey
-        FOREIGN KEY (assistant_message_chat_log_id) REFERENCES public.chat_logs(id)
+        FOREIGN KEY (user_id, assistant_message_chat_log_id)
+        REFERENCES public.chat_logs(user_id, id)
         ON DELETE SET NULL,
 
     CONSTRAINT turn_requests_payload_hash_sha256_check
@@ -100,6 +217,9 @@ CREATE TABLE public.turn_requests (
         CHECK (committed_revision IS NULL OR committed_revision >= 0),
     CONSTRAINT turn_requests_error_code_check
         CHECK (error_code IS NULL OR error_code ~ '^[a-z0-9_]{1,64}$'),
+    -- Sanitized worker identifier, max 64 chars (ADR section 3).
+    CONSTRAINT turn_requests_lease_owner_check
+        CHECK (lease_owner IS NULL OR lease_owner ~ '^[A-Za-z0-9_.:-]{1,64}$'),
     CONSTRAINT turn_requests_lease_pair_check
         CHECK (
             (lease_owner IS NULL AND lease_expires_at IS NULL)
@@ -124,25 +244,59 @@ CREATE TABLE public.turn_requests (
                 AND lease_owner IS NULL AND lease_expires_at IS NULL
                 AND error_code IS NOT NULL)
         ),
-    -- Replay payload stores ONLY the minimal public result needed to replay
-    -- a response after connection loss. Prompts, system instructions and
-    -- metacognition are forbidden inside the stored document.
+    -- Replay payload: minimal PUBLIC result only. Explicit allowlist of
+    -- top-level keys (public contract) plus a recursive forbidden-key check,
+    -- so prompts / messages / internal instructions can never be stored,
+    -- not even nested.
     CONSTRAINT turn_requests_replay_payload_check
         CHECK (
             replay_payload IS NULL
             OR (
                 jsonb_typeof(replay_payload) = 'object'
                 AND octet_length(replay_payload::text) <= 8192
-                AND NOT (replay_payload ? 'prompt')
-                AND NOT (replay_payload ? 'system_prompt')
-                AND NOT (replay_payload ? 'meta_cognition')
-                AND NOT (replay_payload ? 'internal_instructions')
+                AND public.jsonb_keys_subset_of(
+                    replay_payload,
+                    ARRAY['response', 'emotion_state', 'message_id',
+                          'request_id', 'duration_ms']
+                )
+                AND NOT public.jsonb_has_forbidden_key(
+                    replay_payload,
+                    ARRAY['prompt', 'system_prompt', 'meta_cognition',
+                          'internal_instructions', 'message',
+                          'user_message', 'assistant_message', 'content']
+                )
             )
         )
 );
 
+-- BEFORE DELETE trigger on chat_logs: preserves the documented SET NULL
+-- semantics for the composite message FKs. Runs as SECURITY DEFINER so it
+-- can null references on the FORCE-RLS server-owned table even when the
+-- deletion is performed by service_role.
+CREATE FUNCTION public.turn_requests_null_message_refs() RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    UPDATE public.turn_requests
+       SET user_message_chat_log_id = NULL
+     WHERE user_message_chat_log_id = OLD.id;
+    UPDATE public.turn_requests
+       SET assistant_message_chat_log_id = NULL
+     WHERE assistant_message_chat_log_id = OLD.id;
+    RETURN OLD;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS turn_requests_message_refs_null_trigger ON public.chat_logs;
+CREATE TRIGGER turn_requests_message_refs_null_trigger
+    BEFORE DELETE ON public.chat_logs
+    FOR EACH ROW
+    EXECUTE FUNCTION public.turn_requests_null_message_refs();
+
 -- =================================================================
--- 3. outbox_events
+-- 4. outbox_events
 -- =================================================================
 -- Durable outbox for future atomic publication. Events are enqueued in the
 -- same transaction as the turn commit; a future worker claims and delivers
@@ -174,8 +328,11 @@ CREATE TABLE public.outbox_events (
     CONSTRAINT outbox_events_user_id_fkey
         FOREIGN KEY (user_id) REFERENCES public.profiles(user_id)
         ON DELETE CASCADE,
+    -- Composite FK: an event can only reference a request of the SAME user
+    -- (candidate key turn_requests.user_id_id_key above).
     CONSTRAINT outbox_events_turn_request_id_fkey
-        FOREIGN KEY (turn_request_id) REFERENCES public.turn_requests(id)
+        FOREIGN KEY (user_id, turn_request_id)
+        REFERENCES public.turn_requests(user_id, id)
         ON DELETE CASCADE,
 
     CONSTRAINT outbox_events_event_type_check
@@ -188,52 +345,81 @@ CREATE TABLE public.outbox_events (
         CHECK (attempts >= 0 AND attempts <= 10),
     CONSTRAINT outbox_events_error_code_check
         CHECK (error_code IS NULL OR error_code ~ '^[a-z0-9_]{1,64}$'),
+    CONSTRAINT outbox_events_lease_owner_check
+        CHECK (lease_owner IS NULL OR lease_owner ~ '^[A-Za-z0-9_.:-]{1,64}$'),
+    -- Bounded idempotency key: prevents unbounded index/storage growth.
+    CONSTRAINT outbox_events_idempotency_key_check
+        CHECK (idempotency_key ~ '^[A-Za-z0-9_.:-]{1,128}$'),
     CONSTRAINT outbox_events_lease_pair_check
         CHECK (
             (lease_owner IS NULL AND lease_expires_at IS NULL)
             OR (lease_owner IS NOT NULL AND lease_expires_at IS NOT NULL)
         ),
     -- Status / lease / attempts / completion coherence. Fail-closed: each
-    -- status has an exact, fully determined shape.
+    -- status has an exact, mutually exclusive shape — no field of another
+    -- state can leak in (no next_attempt_at/dead_letter fields on
+    -- completed, no missing error/retention on dead_letter, no failure
+    -- fields on processing).
     CONSTRAINT outbox_events_status_coherence_check
         CHECK (
             (status = 'pending' AND processed_at IS NULL
+                AND dead_lettered_at IS NULL AND retention_until IS NULL
                 AND lease_owner IS NULL AND lease_expires_at IS NULL
                 AND next_attempt_at IS NOT NULL AND attempts = 0
                 AND error_code IS NULL)
             OR
             (status = 'processing' AND processed_at IS NULL
+                AND dead_lettered_at IS NULL AND retention_until IS NULL
                 AND lease_owner IS NOT NULL AND lease_expires_at IS NOT NULL
-                AND attempts >= 1)
+                AND attempts BETWEEN 1 AND 10
+                AND error_code IS NULL)
             OR
             (status = 'completed' AND processed_at IS NOT NULL
+                AND dead_lettered_at IS NULL
                 AND lease_owner IS NULL AND lease_expires_at IS NULL
-                AND attempts >= 1 AND error_code IS NULL)
+                AND next_attempt_at IS NULL
+                AND attempts BETWEEN 1 AND 10
+                AND error_code IS NULL
+                AND retention_until IS NOT NULL)
             OR
             (status = 'failed' AND processed_at IS NULL
+                AND dead_lettered_at IS NULL AND retention_until IS NULL
                 AND lease_owner IS NULL AND lease_expires_at IS NULL
                 AND next_attempt_at IS NOT NULL
-                AND attempts BETWEEN 1 AND 9 AND error_code IS NOT NULL)
+                AND attempts BETWEEN 1 AND 9
+                AND error_code IS NOT NULL)
             OR
             (status = 'dead_letter' AND processed_at IS NULL
                 AND lease_owner IS NULL AND lease_expires_at IS NULL
-                AND dead_lettered_at IS NOT NULL AND attempts = 10)
+                AND next_attempt_at IS NULL
+                AND attempts = 10 AND error_code IS NOT NULL
+                AND dead_lettered_at IS NOT NULL
+                AND retention_until IS NOT NULL)
         ),
-    -- Outbox payload is a minimal, non-duplicating event document. Messages,
-    -- prompts, system instructions and metacognition must never be persisted.
+    -- Outbox payload is a minimal, non-duplicating event document with an
+    -- explicit allowlist and recursive forbidden-key validation. Messages,
+    -- prompts, system instructions and metacognition can never be stored,
+    -- not even nested.
     CONSTRAINT outbox_events_payload_check
         CHECK (
             jsonb_typeof(payload) = 'object'
             AND octet_length(payload::text) <= 8192
-            AND NOT (payload ? 'prompt')
-            AND NOT (payload ? 'system_prompt')
-            AND NOT (payload ? 'meta_cognition')
-            AND NOT (payload ? 'internal_instructions')
+            AND public.jsonb_keys_subset_of(
+                payload,
+                ARRAY['ref', 'request_id', 'turn_id', 'message_id',
+                      'entity_id', 'kind', 'version']
+            )
+            AND NOT public.jsonb_has_forbidden_key(
+                payload,
+                ARRAY['prompt', 'system_prompt', 'meta_cognition',
+                      'internal_instructions', 'message',
+                      'user_message', 'assistant_message', 'content']
+            )
         )
 );
 
 -- =================================================================
--- 4. Indexes
+-- 5. Indexes
 -- =================================================================
 -- turn_requests: uniqueness + replay + claim of expired leases + revision
 CREATE INDEX turn_requests_user_id_created_at_idx
@@ -252,7 +438,7 @@ CREATE INDEX outbox_events_turn_request_id_idx
     ON public.outbox_events (turn_request_id);
 
 -- =================================================================
--- 5. RLS and grants (server-owned internal tables)
+-- 6. RLS and grants (server-owned internal tables)
 -- =================================================================
 -- Both tables are internal, server-owned infrastructure. Authenticated
 -- clients must never reach them. RLS + FORCE RLS with no policies, and no

--- a/supabase/tests/database/03_transactional_turn_schema.test.sql
+++ b/supabase/tests/database/03_transactional_turn_schema.test.sql
@@ -1,0 +1,637 @@
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgtap;
+SELECT no_plan();
+
+-- =================================================================
+-- 0. Migration registration and empty-database application
+-- =================================================================
+-- The migration must be registered by supabase db reset (fresh apply) and
+-- the pgTAP suite is the drift detector: any unexpected schema change makes
+-- the exact-definition assertions below fail.
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM supabase_migrations.schema_migrations
+    WHERE version = '20240101000004'
+  ),
+  'transactional schema migration is registered'
+);
+
+-- =================================================================
+-- 1. profiles.revision
+-- =================================================================
+SELECT has_column('public', 'profiles', 'revision', 'profiles has revision column');
+SELECT col_not_null('public', 'profiles', 'revision', 'revision is NOT NULL');
+SELECT col_type_is('public', 'profiles', 'revision', 'bigint', 'revision is bigint');
+SELECT col_default_is('public', 'profiles', 'revision', '0', 'revision defaults to 0');
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'profiles_revision_non_negative_check'
+      AND conrelid = 'profiles'::regclass
+  ),
+  'profiles has non-negative revision check'
+);
+SELECT ok(
+  (SELECT pg_get_expr(conbin, conrelid)::text LIKE '%revision%>=%0%'
+   FROM pg_constraint WHERE conname = 'profiles_revision_non_negative_check'),
+  'revision check enforces non-negative values'
+);
+
+-- Behavior: new profile starts at revision 0
+INSERT INTO public.profiles (user_id) VALUES ('pgtap_tr_user');
+SELECT is(
+  (SELECT revision FROM public.profiles WHERE user_id = 'pgtap_tr_user'),
+  0,
+  'new profile starts at revision 0'
+);
+
+-- Behavior: negative revision is rejected
+SELECT throws_ok(
+  $$INSERT INTO public.profiles (user_id, revision) VALUES ('pgtap_neg_rev', -1)$$,
+  '23514', NULL, 'negative revision is rejected'
+);
+
+-- =================================================================
+-- 2. turn_requests structure
+-- =================================================================
+SELECT has_table('public', 'turn_requests', 'turn_requests table exists');
+SELECT has_column('public', 'turn_requests', 'id', 'turn_requests has id');
+SELECT has_column('public', 'turn_requests', 'user_id', 'turn_requests has user_id');
+SELECT has_column('public', 'turn_requests', 'request_id', 'turn_requests has request_id');
+SELECT has_column('public', 'turn_requests', 'payload_hash_sha256', 'turn_requests has payload_hash_sha256');
+SELECT has_column('public', 'turn_requests', 'status', 'turn_requests has status');
+SELECT has_column('public', 'turn_requests', 'lease_owner', 'turn_requests has lease_owner');
+SELECT has_column('public', 'turn_requests', 'lease_expires_at', 'turn_requests has lease_expires_at');
+SELECT has_column('public', 'turn_requests', 'expected_revision', 'turn_requests has expected_revision');
+SELECT has_column('public', 'turn_requests', 'committed_revision', 'turn_requests has committed_revision');
+SELECT has_column('public', 'turn_requests', 'user_message_chat_log_id', 'turn_requests has user_message_chat_log_id');
+SELECT has_column('public', 'turn_requests', 'assistant_message_chat_log_id', 'turn_requests has assistant_message_chat_log_id');
+SELECT has_column('public', 'turn_requests', 'replay_payload', 'turn_requests has replay_payload');
+SELECT has_column('public', 'turn_requests', 'error_code', 'turn_requests has error_code');
+SELECT has_column('public', 'turn_requests', 'created_at', 'turn_requests has created_at');
+SELECT has_column('public', 'turn_requests', 'updated_at', 'turn_requests has updated_at');
+SELECT has_column('public', 'turn_requests', 'completed_at', 'turn_requests has completed_at');
+
+SELECT col_not_null('public', 'turn_requests', 'user_id', 'user_id NOT NULL');
+SELECT col_not_null('public', 'turn_requests', 'request_id', 'request_id NOT NULL');
+SELECT col_not_null('public', 'turn_requests', 'payload_hash_sha256', 'payload_hash_sha256 NOT NULL');
+SELECT col_not_null('public', 'turn_requests', 'status', 'status NOT NULL');
+SELECT col_not_null('public', 'turn_requests', 'expected_revision', 'expected_revision NOT NULL');
+SELECT col_type_is('public', 'turn_requests', 'request_id', 'uuid', 'request_id is uuid');
+SELECT col_type_is('public', 'turn_requests', 'payload_hash_sha256', 'text', 'payload_hash_sha256 is text');
+SELECT col_type_is('public', 'turn_requests', 'status', 'text', 'status is text');
+SELECT col_type_is('public', 'turn_requests', 'expected_revision', 'bigint', 'expected_revision is bigint');
+SELECT col_type_is('public', 'turn_requests', 'user_message_chat_log_id', 'bigint', 'user_message_chat_log_id is bigint');
+SELECT col_type_is('public', 'turn_requests', 'replay_payload', 'jsonb', 'replay_payload is jsonb');
+
+-- =================================================================
+-- 3. turn_requests constraints
+-- =================================================================
+SELECT is(
+  (SELECT pg_get_constraintdef(oid) FROM pg_constraint
+   WHERE conname = 'turn_requests_user_id_request_id_key'),
+  'UNIQUE (user_id, request_id)',
+  'turn_requests unique constraint is (user_id, request_id)'
+);
+SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'turn_requests_status_check'), 'turn_requests has status check');
+SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'turn_requests_status_coherence_check'), 'turn_requests has status coherence check');
+SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'turn_requests_lease_pair_check'), 'turn_requests has lease pair check');
+SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'turn_requests_payload_hash_sha256_check'), 'turn_requests has payload hash check');
+SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'turn_requests_expected_revision_check'), 'turn_requests has expected revision check');
+SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'turn_requests_committed_revision_check'), 'turn_requests has committed revision check');
+SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'turn_requests_replay_payload_check'), 'turn_requests has replay payload check');
+SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'turn_requests_error_code_check'), 'turn_requests has error code check');
+
+-- =================================================================
+-- 4. turn_requests behavior
+-- =================================================================
+-- Valid pending request with lease
+INSERT INTO public.turn_requests (
+  user_id, request_id, payload_hash_sha256, status,
+  lease_owner, lease_expires_at, expected_revision
+) VALUES (
+  'pgtap_tr_user', '11111111-1111-4111-8111-111111111111', repeat('a', 64), 'pending',
+  'worker-a', now() + interval '5 minutes', 0
+);
+SELECT is(
+  (SELECT count(*)::integer FROM public.turn_requests WHERE user_id = 'pgtap_tr_user'),
+  1,
+  'valid pending request is inserted'
+);
+
+-- Duplicate (user_id, request_id) is rejected
+SELECT throws_ok(
+  $$INSERT INTO public.turn_requests (
+       user_id, request_id, payload_hash_sha256, status,
+       lease_owner, lease_expires_at
+     ) VALUES (
+       'pgtap_tr_user', '11111111-1111-4111-8111-111111111111', repeat('b', 64), 'pending',
+       'worker-b', now() + interval '5 minutes'
+     )$$,
+  '23505', NULL, 'duplicate (user_id, request_id) is rejected'
+);
+
+-- Same request_id for a different user is allowed
+INSERT INTO public.profiles (user_id) VALUES ('pgtap_tr_user_2');
+INSERT INTO public.turn_requests (
+  user_id, request_id, payload_hash_sha256, status,
+  lease_owner, lease_expires_at
+) VALUES (
+  'pgtap_tr_user_2', '11111111-1111-4111-8111-111111111111', repeat('c', 64), 'pending',
+  'worker-c', now() + interval '5 minutes'
+);
+SELECT is(
+  (SELECT count(*)::integer FROM public.turn_requests
+   WHERE request_id = '11111111-1111-4111-8111-111111111111'),
+  2,
+  'same request_id is allowed for different users'
+);
+
+-- Invalid status is rejected
+SELECT throws_ok(
+  $$INSERT INTO public.turn_requests (
+       user_id, request_id, payload_hash_sha256, status,
+       lease_owner, lease_expires_at
+     ) VALUES (
+       'pgtap_tr_user', gen_random_uuid(), repeat('d', 64), 'bogus',
+       'worker-d', now() + interval '5 minutes'
+     )$$,
+  '23514', NULL, 'invalid request status is rejected'
+);
+
+-- Incoherent status/lease/completion combinations are rejected
+SELECT throws_ok(
+  $$INSERT INTO public.turn_requests (
+       user_id, request_id, payload_hash_sha256, status
+     ) VALUES (
+       'pgtap_tr_user', gen_random_uuid(), repeat('e', 64), 'pending'
+     )$$,
+  '23514', NULL, 'pending without lease is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.turn_requests (
+       user_id, request_id, payload_hash_sha256, status, completed_at
+     ) VALUES (
+       'pgtap_tr_user', gen_random_uuid(), repeat('f', 64), 'completed', now()
+     )$$,
+  '23514', NULL, 'completed without committed revision or replay payload is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.turn_requests (
+       user_id, request_id, payload_hash_sha256, status
+     ) VALUES (
+       'pgtap_tr_user', gen_random_uuid(), repeat('g', 64), 'expired'
+     )$$,
+  '23514', NULL, 'expired without error code is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.turn_requests (
+       user_id, request_id, payload_hash_sha256, status, lease_owner
+     ) VALUES (
+       'pgtap_tr_user', gen_random_uuid(), repeat('h', 64), 'pending', 'worker-h'
+     )$$,
+  '23514', NULL, 'lease owner without expiry is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.turn_requests (
+       user_id, request_id, payload_hash_sha256, status, error_code
+     ) VALUES (
+       'pgtap_tr_user', gen_random_uuid(), repeat('m', 64), 'expired', 'Bad Error!'
+     )$$,
+  '23514', NULL, 'unsanitized error code is rejected'
+);
+
+-- FKs reject nonexistent references
+SELECT throws_ok(
+  $$INSERT INTO public.turn_requests (
+       user_id, request_id, payload_hash_sha256, status,
+       lease_owner, lease_expires_at, user_message_chat_log_id
+     ) VALUES (
+       'pgtap_tr_user', gen_random_uuid(), repeat('i', 64), 'pending',
+       'worker-i', now() + interval '5 minutes', 999999
+     )$$,
+  '23503', NULL, 'FK rejects nonexistent chat_log reference'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.turn_requests (
+       user_id, request_id, payload_hash_sha256, status,
+       lease_owner, lease_expires_at
+     ) VALUES (
+       'pgtap_no_such_user', gen_random_uuid(), repeat('j', 64), 'pending',
+       'worker-j', now() + interval '5 minutes'
+     )$$,
+  '23503', NULL, 'FK rejects nonexistent user reference'
+);
+
+-- =================================================================
+-- 5. turn_requests cascades (documented ON DELETE policy)
+-- =================================================================
+-- chat_log deletion nulls message references (SET NULL), keeps the request
+INSERT INTO public.chat_logs (id, user_id, role, content)
+VALUES (500001, 'pgtap_tr_user', 'user', 'cascade user message');
+INSERT INTO public.turn_requests (
+  user_id, request_id, payload_hash_sha256, status,
+  lease_owner, lease_expires_at, user_message_chat_log_id
+) VALUES (
+  'pgtap_tr_user', '22222222-2222-4222-8222-222222222222', repeat('k', 64), 'pending',
+  'worker-k', now() + interval '5 minutes', 500001
+);
+DELETE FROM public.chat_logs WHERE id = 500001;
+SELECT is(
+  (SELECT count(*)::integer FROM public.turn_requests
+   WHERE user_id = 'pgtap_tr_user'
+     AND request_id = '22222222-2222-4222-8222-222222222222'
+     AND user_message_chat_log_id IS NULL),
+  1,
+  'chat_log deletion nulls message reference but keeps the request'
+);
+
+-- Profile deletion cascades turn_requests (no orphans)
+DELETE FROM public.profiles WHERE user_id = 'pgtap_tr_user_2';
+SELECT is(
+  (SELECT count(*)::integer FROM public.turn_requests WHERE user_id = 'pgtap_tr_user_2'),
+  0,
+  'profile deletion cascades turn_requests (no orphans)'
+);
+
+-- =================================================================
+-- 6. outbox_events structure
+-- =================================================================
+SELECT has_table('public', 'outbox_events', 'outbox_events table exists');
+SELECT has_column('public', 'outbox_events', 'id', 'outbox_events has id');
+SELECT has_column('public', 'outbox_events', 'event_type', 'outbox_events has event_type');
+SELECT has_column('public', 'outbox_events', 'contract_version', 'outbox_events has contract_version');
+SELECT has_column('public', 'outbox_events', 'user_id', 'outbox_events has user_id');
+SELECT has_column('public', 'outbox_events', 'turn_request_id', 'outbox_events has turn_request_id');
+SELECT has_column('public', 'outbox_events', 'payload', 'outbox_events has payload');
+SELECT has_column('public', 'outbox_events', 'status', 'outbox_events has status');
+SELECT has_column('public', 'outbox_events', 'attempts', 'outbox_events has attempts');
+SELECT has_column('public', 'outbox_events', 'next_attempt_at', 'outbox_events has next_attempt_at');
+SELECT has_column('public', 'outbox_events', 'lease_owner', 'outbox_events has lease_owner');
+SELECT has_column('public', 'outbox_events', 'lease_expires_at', 'outbox_events has lease_expires_at');
+SELECT has_column('public', 'outbox_events', 'idempotency_key', 'outbox_events has idempotency_key');
+SELECT has_column('public', 'outbox_events', 'error_code', 'outbox_events has error_code');
+SELECT has_column('public', 'outbox_events', 'processed_at', 'outbox_events has processed_at');
+SELECT has_column('public', 'outbox_events', 'dead_lettered_at', 'outbox_events has dead_lettered_at');
+SELECT has_column('public', 'outbox_events', 'retention_until', 'outbox_events has retention_until');
+
+SELECT col_not_null('public', 'outbox_events', 'event_type', 'event_type NOT NULL');
+SELECT col_not_null('public', 'outbox_events', 'user_id', 'user_id NOT NULL');
+SELECT col_not_null('public', 'outbox_events', 'payload', 'payload NOT NULL');
+SELECT col_not_null('public', 'outbox_events', 'status', 'status NOT NULL');
+SELECT col_not_null('public', 'outbox_events', 'attempts', 'attempts NOT NULL');
+SELECT col_not_null('public', 'outbox_events', 'idempotency_key', 'idempotency_key NOT NULL');
+SELECT col_type_is('public', 'outbox_events', 'payload', 'jsonb', 'payload is jsonb');
+SELECT col_type_is('public', 'outbox_events', 'contract_version', 'integer', 'contract_version is integer');
+SELECT col_type_is('public', 'outbox_events', 'attempts', 'integer', 'attempts is integer');
+SELECT col_default_is('public', 'outbox_events', 'contract_version', '1', 'contract_version defaults to 1');
+SELECT col_default_is('public', 'outbox_events', 'attempts', '0', 'attempts defaults to 0');
+
+-- =================================================================
+-- 7. outbox_events constraints
+-- =================================================================
+SELECT is(
+  (SELECT pg_get_constraintdef(oid) FROM pg_constraint
+   WHERE conname = 'outbox_events_user_id_idempotency_key_key'),
+  'UNIQUE (user_id, idempotency_key)',
+  'outbox idempotency unique constraint is (user_id, idempotency_key)'
+);
+SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'outbox_events_status_check'), 'outbox has status check');
+SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'outbox_events_status_coherence_check'), 'outbox has status coherence check');
+SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'outbox_events_attempts_check'), 'outbox has attempts check');
+SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'outbox_events_lease_pair_check'), 'outbox has lease pair check');
+SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'outbox_events_payload_check'), 'outbox has payload check');
+SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'outbox_events_error_code_check'), 'outbox has error code check');
+
+-- =================================================================
+-- 8. outbox_events behavior
+-- =================================================================
+-- Valid pending event
+INSERT INTO public.outbox_events (
+  event_type, contract_version, user_id, turn_request_id, payload,
+  status, attempts, next_attempt_at, idempotency_key
+) VALUES (
+  'memory_indexed', 1, 'pgtap_tr_user', NULL, '{"ref": "turn-1"}'::jsonb,
+  'pending', 0, now(), 'pgtap-idem-1'
+);
+SELECT is(
+  (SELECT count(*)::integer FROM public.outbox_events WHERE user_id = 'pgtap_tr_user'),
+  1,
+  'valid pending outbox event is inserted'
+);
+
+-- Duplicate idempotency key within the same user is rejected
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{"ref": "dup"}'::jsonb,
+       'pending', 0, now(), 'pgtap-idem-1'
+     )$$,
+  '23505', NULL, 'duplicate outbox idempotency key is rejected'
+);
+
+-- Same idempotency key for a different user is allowed
+INSERT INTO public.profiles (user_id) VALUES ('pgtap_tr_user_3');
+INSERT INTO public.outbox_events (
+  event_type, contract_version, user_id, turn_request_id, payload,
+  status, attempts, next_attempt_at, idempotency_key
+) VALUES (
+  'memory_indexed', 1, 'pgtap_tr_user_3', NULL, '{"ref": "other-user"}'::jsonb,
+  'pending', 0, now(), 'pgtap-idem-1'
+);
+SELECT is(
+  (SELECT count(*)::integer FROM public.outbox_events WHERE idempotency_key = 'pgtap-idem-1'),
+  2,
+  'same idempotency key is allowed across users'
+);
+
+-- Invalid status is rejected
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{}'::jsonb,
+       'bogus', 0, now(), 'pgtap-idem-bogus'
+     )$$,
+  '23514', NULL, 'invalid outbox status is rejected'
+);
+
+-- Invalid attempts are rejected
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{}'::jsonb,
+       'failed', 11, now(), 'pgtap-idem-att11'
+     )$$,
+  '23514', NULL, 'attempts above 10 is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{}'::jsonb,
+       'pending', -1, now(), 'pgtap-idem-neg'
+     )$$,
+  '23514', NULL, 'negative attempts is rejected'
+);
+
+-- Invalid lease combinations are rejected
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, lease_owner, lease_expires_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{}'::jsonb,
+       'pending', 0, now(), 'worker-x', now() + interval '5 minutes', 'pgtap-idem-lease'
+     )$$,
+  '23514', NULL, 'pending event with a lease is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{}'::jsonb,
+       'processing', 1, NULL, 'pgtap-idem-proc'
+     )$$,
+  '23514', NULL, 'processing event without a lease is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{}'::jsonb,
+       'completed', 1, NULL, 'pgtap-idem-compl'
+     )$$,
+  '23514', NULL, 'completed event without processed_at is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{}'::jsonb,
+       'dead_letter', 10, NULL, 'pgtap-idem-dl'
+     )$$,
+  '23514', NULL, 'dead_letter event without dead_lettered_at is rejected'
+);
+
+-- =================================================================
+-- 9. Forbidden payload keys (prompt / internal fields) are rejected
+-- =================================================================
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{"prompt": "hidden"}'::jsonb,
+       'pending', 0, now(), 'pgtap-idem-prompt'
+     )$$,
+  '23514', NULL, 'outbox payload with prompt key is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{"meta_cognition": {}}'::jsonb,
+       'pending', 0, now(), 'pgtap-idem-meta'
+     )$$,
+  '23514', NULL, 'outbox payload with metacognition is rejected'
+);
+
+-- turn_requests replay_payload forbids internal fields too
+SELECT throws_ok(
+  $$INSERT INTO public.turn_requests (
+       user_id, request_id, payload_hash_sha256, status,
+       completed_at, committed_revision, replay_payload, error_code
+     ) VALUES (
+       'pgtap_tr_user', gen_random_uuid(), repeat('l', 64), 'completed',
+       now(), 1, '{"system_prompt": "hidden"}'::jsonb, NULL
+     )$$,
+  '23514', NULL, 'replay payload with system_prompt is rejected'
+);
+
+-- FK: outbox turn_request_id rejects nonexistent reference
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', '99999999-9999-4999-8999-999999999999', '{}'::jsonb,
+       'pending', 0, now(), 'pgtap-idem-fk'
+     )$$,
+  '23503', NULL, 'FK rejects nonexistent turn_request reference'
+);
+
+-- =================================================================
+-- 10. RLS, grants and policies (server-owned internal tables)
+-- =================================================================
+SELECT ok((SELECT relrowsecurity FROM pg_class WHERE oid = 'public.turn_requests'::regclass), 'RLS enabled on turn_requests');
+SELECT ok((SELECT relforcerowsecurity FROM pg_class WHERE oid = 'public.turn_requests'::regclass), 'FORCE RLS enabled on turn_requests');
+SELECT ok((SELECT relrowsecurity FROM pg_class WHERE oid = 'public.outbox_events'::regclass), 'RLS enabled on outbox_events');
+SELECT ok((SELECT relforcerowsecurity FROM pg_class WHERE oid = 'public.outbox_events'::regclass), 'FORCE RLS enabled on outbox_events');
+SELECT policies_are('public', 'turn_requests', ARRAY[]::text[], 'turn_requests has no policies');
+SELECT policies_are('public', 'outbox_events', ARRAY[]::text[], 'outbox_events has no policies');
+
+-- anon / authenticated have no table privileges
+SELECT table_privs_are('public', 'turn_requests', 'anon', ARRAY[]::text[]);
+SELECT table_privs_are('public', 'turn_requests', 'authenticated', ARRAY[]::text[]);
+SELECT table_privs_are('public', 'outbox_events', 'anon', ARRAY[]::text[]);
+SELECT table_privs_are('public', 'outbox_events', 'authenticated', ARRAY[]::text[]);
+
+-- service_role keeps full CRUD
+SELECT table_privs_are('public', 'turn_requests', 'service_role', ARRAY['SELECT', 'INSERT', 'UPDATE', 'DELETE']);
+SELECT table_privs_are('public', 'outbox_events', 'service_role', ARRAY['SELECT', 'INSERT', 'UPDATE', 'DELETE']);
+
+-- PUBLIC has no privileges
+SELECT ok(
+  NOT has_table_privilege('public', 'public.turn_requests', 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'),
+  'PUBLIC has no privileges on turn_requests'
+);
+SELECT ok(
+  NOT has_table_privilege('public', 'public.outbox_events', 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'),
+  'PUBLIC has no privileges on outbox_events'
+);
+
+-- =================================================================
+-- 11. Indexes (exact definitions — equivalent verification for the
+--     critical replay/claim queries)
+-- =================================================================
+SELECT has_index('public', 'turn_requests', 'turn_requests_user_id_created_at_idx', 'turn_requests user-created index exists');
+SELECT is(
+  pg_get_indexdef('public.turn_requests_user_id_created_at_idx'::regclass),
+  'CREATE INDEX turn_requests_user_id_created_at_idx ON public.turn_requests USING btree (user_id, created_at DESC)',
+  'user-created index has exact definition'
+);
+SELECT has_index('public', 'turn_requests', 'turn_requests_status_lease_expiry_idx', 'turn_requests status-lease index exists');
+SELECT is(
+  pg_get_indexdef('public.turn_requests_status_lease_expiry_idx'::regclass),
+  'CREATE INDEX turn_requests_status_lease_expiry_idx ON public.turn_requests USING btree (status, lease_expires_at)',
+  'status-lease index has exact definition'
+);
+SELECT has_index('public', 'turn_requests', 'turn_requests_user_committed_revision_idx', 'turn_requests revision index exists');
+SELECT is(
+  pg_get_indexdef('public.turn_requests_user_committed_revision_idx'::regclass),
+  'CREATE INDEX turn_requests_user_committed_revision_idx ON public.turn_requests USING btree (user_id, committed_revision)',
+  'revision index has exact definition'
+);
+SELECT has_index('public', 'turn_requests', 'turn_requests_user_id_request_id_key', 'turn_requests unique (user_id, request_id) index exists');
+SELECT is(
+  pg_get_indexdef('public.turn_requests_user_id_request_id_key'::regclass),
+  'CREATE UNIQUE INDEX turn_requests_user_id_request_id_key ON public.turn_requests USING btree (user_id, request_id)',
+  'unique (user_id, request_id) index has exact definition'
+);
+
+SELECT has_index('public', 'outbox_events', 'outbox_events_status_next_attempt_idx', 'outbox status-next_attempt index exists');
+SELECT is(
+  pg_get_indexdef('public.outbox_events_status_next_attempt_idx'::regclass),
+  'CREATE INDEX outbox_events_status_next_attempt_idx ON public.outbox_events USING btree (status, next_attempt_at)',
+  'status-next_attempt index has exact definition'
+);
+SELECT has_index('public', 'outbox_events', 'outbox_events_status_lease_expiry_idx', 'outbox status-lease index exists');
+SELECT is(
+  pg_get_indexdef('public.outbox_events_status_lease_expiry_idx'::regclass),
+  'CREATE INDEX outbox_events_status_lease_expiry_idx ON public.outbox_events USING btree (status, lease_expires_at)',
+  'status-lease index has exact definition'
+);
+SELECT has_index('public', 'outbox_events', 'outbox_events_turn_request_id_idx', 'outbox turn_request index exists');
+SELECT is(
+  pg_get_indexdef('public.outbox_events_turn_request_id_idx'::regclass),
+  'CREATE INDEX outbox_events_turn_request_id_idx ON public.outbox_events USING btree (turn_request_id)',
+  'turn_request index has exact definition'
+);
+SELECT has_index('public', 'outbox_events', 'outbox_events_user_id_idempotency_key_key', 'outbox unique (user_id, idempotency_key) index exists');
+SELECT is(
+  pg_get_indexdef('public.outbox_events_user_id_idempotency_key_key'::regclass),
+  'CREATE UNIQUE INDEX outbox_events_user_id_idempotency_key_key ON public.outbox_events USING btree (user_id, idempotency_key)',
+  'unique (user_id, idempotency_key) index has exact definition'
+);
+
+-- =================================================================
+-- 12. ON DELETE policy for every FK
+-- =================================================================
+SELECT is(
+  (SELECT confdeltype FROM pg_constraint WHERE conname = 'turn_requests_user_id_fkey'),
+  'c'::"char",
+  'turn_requests.user_id FK has ON DELETE CASCADE'
+);
+SELECT is(
+  (SELECT confdeltype FROM pg_constraint WHERE conname = 'turn_requests_user_message_chat_log_id_fkey'),
+  'n'::"char",
+  'turn_requests user-message FK has ON DELETE SET NULL'
+);
+SELECT is(
+  (SELECT confdeltype FROM pg_constraint WHERE conname = 'turn_requests_assistant_message_chat_log_id_fkey'),
+  'n'::"char",
+  'turn_requests assistant-message FK has ON DELETE SET NULL'
+);
+SELECT is(
+  (SELECT confdeltype FROM pg_constraint WHERE conname = 'outbox_events_user_id_fkey'),
+  'c'::"char",
+  'outbox_events.user_id FK has ON DELETE CASCADE'
+);
+SELECT is(
+  (SELECT confdeltype FROM pg_constraint WHERE conname = 'outbox_events_turn_request_id_fkey'),
+  'c'::"char",
+  'outbox_events.turn_request_id FK has ON DELETE CASCADE'
+);
+
+-- =================================================================
+-- 12b. Unexpected schema drift fails loudly
+-- =================================================================
+-- Re-creating any object that the migration owns must fail (the migration
+-- preflight and PostgreSQL duplicate-object errors are the drift guard).
+SELECT throws_ok(
+  $$ALTER TABLE public.profiles ADD COLUMN revision bigint$$,
+  '42701', NULL, 're-adding profiles.revision fails (drift)'
+);
+SELECT throws_ok(
+  $$CREATE TABLE public.turn_requests (id uuid)$$,
+  '42P07', NULL, 're-creating turn_requests fails (drift)'
+);
+SELECT throws_ok(
+  $$CREATE TABLE public.outbox_events (id uuid)$$,
+  '42P07', NULL, 're-creating outbox_events fails (drift)'
+);
+
+-- =================================================================
+-- 13. User deletion leaves no incompatible orphan data
+-- =================================================================
+INSERT INTO public.profiles (user_id) VALUES ('pgtap_orphan_user');
+INSERT INTO public.turn_requests (
+  user_id, request_id, payload_hash_sha256, status,
+  lease_owner, lease_expires_at
+) VALUES (
+  'pgtap_orphan_user', '33333333-3333-4333-8333-333333333333', repeat('n', 64), 'pending',
+  'worker-n', now() + interval '5 minutes'
+);
+INSERT INTO public.outbox_events (
+  event_type, contract_version, user_id, turn_request_id, payload,
+  status, attempts, next_attempt_at, idempotency_key
+) VALUES (
+  'memory_indexed', 1, 'pgtap_orphan_user', NULL, '{"ref": "orphan"}'::jsonb,
+  'pending', 0, now(), 'pgtap-idem-orphan'
+);
+DELETE FROM public.profiles WHERE user_id = 'pgtap_orphan_user';
+SELECT is(
+  (SELECT count(*)::integer FROM public.turn_requests WHERE user_id = 'pgtap_orphan_user'),
+  0,
+  'profile deletion leaves no orphan turn_requests'
+);
+SELECT is(
+  (SELECT count(*)::integer FROM public.outbox_events WHERE user_id = 'pgtap_orphan_user'),
+  0,
+  'profile deletion leaves no orphan outbox_events'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/03_transactional_turn_schema.test.sql
+++ b/supabase/tests/database/03_transactional_turn_schema.test.sql
@@ -554,6 +554,34 @@ SELECT throws_ok(
      )$$,
   '23514', NULL, 'processing event with error_code is rejected'
 );
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, lease_owner, lease_expires_at,
+       idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{"ref":"x"}'::jsonb,
+       'processing', 1, now(), 'worker-z', now() + interval '5 minutes',
+       'pgtap-idem-proc-na'
+     )$$,
+  '23514', NULL, 'processing event with next_attempt_at is rejected'
+);
+
+-- Valid processing shape (lease + attempts, no scheduling/retry field) is accepted
+INSERT INTO public.outbox_events (
+  event_type, contract_version, user_id, turn_request_id, payload,
+  status, attempts, next_attempt_at, lease_owner, lease_expires_at,
+  idempotency_key
+) VALUES (
+  'memory_indexed', 1, 'pgtap_tr_user', NULL, '{"ref":"turn-1"}'::jsonb,
+  'processing', 1, NULL, 'worker-z', now() + interval '5 minutes',
+  'pgtap-idem-proc-valid'
+);
+SELECT is(
+  (SELECT count(*)::integer FROM public.outbox_events WHERE idempotency_key = 'pgtap-idem-proc-valid'),
+  1,
+  'valid processing event is inserted'
+);
 
 -- Valid dead_letter event with a full exact shape is accepted
 INSERT INTO public.outbox_events (
@@ -663,6 +691,124 @@ SELECT throws_ok(
   '23514', NULL, 'outbox payload with unknown top-level key is rejected'
 );
 
+-- Value contract: references/identifiers are scalar, sanitized and bounded.
+-- Raw content must never fit under an allowed key.
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL,
+       '{"ref": "' || repeat('x', 129) || '"}'::jsonb,
+       'pending', 0, now(), 'pgtap-idem-reflong'
+     )$$,
+  '23514', NULL, 'outbox ref over 128 chars is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL,
+       '{"ref": {"text": "conteudo sem chave proibida"}}'::jsonb,
+       'pending', 0, now(), 'pgtap-idem-refobj'
+     )$$,
+  '23514', NULL, 'nested object under ref without denylist keys is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL,
+       '{"ref": ["item"]}'::jsonb,
+       'pending', 0, now(), 'pgtap-idem-refarr'
+     )$$,
+  '23514', NULL, 'array under ref is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL,
+       '{"ref": "conteudo com espaco"}'::jsonb,
+       'pending', 0, now(), 'pgtap-idem-refspace'
+     )$$,
+  '23514', NULL, 'outbox ref with invalid characters is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL,
+       '{"version": "abc"}'::jsonb,
+       'pending', 0, now(), 'pgtap-idem-verstr'
+     )$$,
+  '23514', NULL, 'outbox version as string is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL,
+       '{"version": 0}'::jsonb,
+       'pending', 0, now(), 'pgtap-idem-ver0'
+     )$$,
+  '23514', NULL, 'outbox version below range is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL,
+       '{"version": 1001}'::jsonb,
+       'pending', 0, now(), 'pgtap-idem-ver1001'
+     )$$,
+  '23514', NULL, 'outbox version above range is rejected'
+);
+-- JSON null values are not valid contract values (fail-closed)
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL,
+       '{"ref": null}'::jsonb,
+       'pending', 0, now(), 'pgtap-idem-refnull'
+     )$$,
+  '23514', NULL, 'outbox ref as JSON null is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL,
+       '{"version": null}'::jsonb,
+       'pending', 0, now(), 'pgtap-idem-vernull'
+     )$$,
+  '23514', NULL, 'outbox version as JSON null is rejected'
+);
+
+-- A conforming payload (scalar ref, kind, version in range) is accepted
+INSERT INTO public.outbox_events (
+  event_type, contract_version, user_id, turn_request_id, payload,
+  status, attempts, next_attempt_at, idempotency_key
+) VALUES (
+  'memory_indexed', 1, 'pgtap_tr_user', NULL,
+  '{"ref": "turn-1", "kind": "memory_indexed", "version": 1}'::jsonb,
+  'pending', 0, now(), 'pgtap-idem-validvalue'
+);
+SELECT is(
+  (SELECT count(*)::integer FROM public.outbox_events WHERE idempotency_key = 'pgtap-idem-validvalue'),
+  1,
+  'outbox payload with conforming scalar values is inserted'
+);
+
 -- turn_requests replay_payload forbids internal fields too (top level + nested)
 SELECT throws_ok(
   $$INSERT INTO public.turn_requests (
@@ -758,18 +904,72 @@ SELECT ok(
   'PUBLIC has no privileges on outbox_events'
 );
 
--- Payload helpers are server-only (anon cannot execute)
+-- Payload helpers and trigger function are server-only: the exact EXECUTE
+-- matrix is asserted for every function created by the migration (helpers +
+-- SECURITY DEFINER trigger function).
+SELECT ok(
+  NOT has_function_privilege('public', 'public.jsonb_has_forbidden_key(jsonb, text[])', 'EXECUTE'),
+  'PUBLIC cannot execute jsonb_has_forbidden_key'
+);
+SELECT ok(
+  NOT has_function_privilege('authenticated', 'public.jsonb_has_forbidden_key(jsonb, text[])', 'EXECUTE'),
+  'authenticated cannot execute jsonb_has_forbidden_key'
+);
 SELECT ok(
   NOT has_function_privilege('anon', 'public.jsonb_has_forbidden_key(jsonb, text[])', 'EXECUTE'),
   'anon cannot execute jsonb_has_forbidden_key'
+);
+SELECT ok(
+  NOT has_function_privilege('public', 'public.jsonb_keys_subset_of(jsonb, text[])', 'EXECUTE'),
+  'PUBLIC cannot execute jsonb_keys_subset_of'
+);
+SELECT ok(
+  NOT has_function_privilege('authenticated', 'public.jsonb_keys_subset_of(jsonb, text[])', 'EXECUTE'),
+  'authenticated cannot execute jsonb_keys_subset_of'
 );
 SELECT ok(
   NOT has_function_privilege('anon', 'public.jsonb_keys_subset_of(jsonb, text[])', 'EXECUTE'),
   'anon cannot execute jsonb_keys_subset_of'
 );
 SELECT ok(
+  NOT has_function_privilege('public', 'public.jsonb_outbox_payload_value_contract(jsonb)', 'EXECUTE'),
+  'PUBLIC cannot execute jsonb_outbox_payload_value_contract'
+);
+SELECT ok(
+  NOT has_function_privilege('authenticated', 'public.jsonb_outbox_payload_value_contract(jsonb)', 'EXECUTE'),
+  'authenticated cannot execute jsonb_outbox_payload_value_contract'
+);
+SELECT ok(
+  NOT has_function_privilege('anon', 'public.jsonb_outbox_payload_value_contract(jsonb)', 'EXECUTE'),
+  'anon cannot execute jsonb_outbox_payload_value_contract'
+);
+SELECT ok(
+  NOT has_function_privilege('public', 'public.turn_requests_null_message_refs()', 'EXECUTE'),
+  'PUBLIC cannot execute turn_requests_null_message_refs (SECURITY DEFINER)'
+);
+SELECT ok(
+  NOT has_function_privilege('authenticated', 'public.turn_requests_null_message_refs()', 'EXECUTE'),
+  'authenticated cannot execute turn_requests_null_message_refs'
+);
+SELECT ok(
+  NOT has_function_privilege('anon', 'public.turn_requests_null_message_refs()', 'EXECUTE'),
+  'anon cannot execute turn_requests_null_message_refs'
+);
+SELECT ok(
   has_function_privilege('service_role', 'public.jsonb_has_forbidden_key(jsonb, text[])', 'EXECUTE'),
   'service_role can execute jsonb_has_forbidden_key'
+);
+SELECT ok(
+  has_function_privilege('service_role', 'public.jsonb_keys_subset_of(jsonb, text[])', 'EXECUTE'),
+  'service_role can execute jsonb_keys_subset_of'
+);
+SELECT ok(
+  has_function_privilege('service_role', 'public.jsonb_outbox_payload_value_contract(jsonb)', 'EXECUTE'),
+  'service_role can execute jsonb_outbox_payload_value_contract'
+);
+SELECT ok(
+  has_function_privilege('service_role', 'public.turn_requests_null_message_refs()', 'EXECUTE'),
+  'service_role can execute turn_requests_null_message_refs'
 );
 
 -- =================================================================
@@ -867,6 +1067,11 @@ SELECT throws_ok(
   $$CREATE FUNCTION public.jsonb_has_forbidden_key(jsonb, text[]) RETURNS boolean
     LANGUAGE sql IMMUTABLE AS 'SELECT true'$$,
   '42723', NULL, 're-creating jsonb_has_forbidden_key fails (drift)'
+);
+SELECT throws_ok(
+  $$CREATE FUNCTION public.jsonb_outbox_payload_value_contract(jsonb) RETURNS boolean
+    LANGUAGE sql IMMUTABLE AS 'SELECT true'$$,
+  '42723', NULL, 're-creating jsonb_outbox_payload_value_contract fails (drift)'
 );
 
 -- =================================================================

--- a/supabase/tests/database/03_transactional_turn_schema.test.sql
+++ b/supabase/tests/database/03_transactional_turn_schema.test.sql
@@ -693,13 +693,17 @@ SELECT throws_ok(
 
 -- Value contract: references/identifiers are scalar, sanitized and bounded.
 -- Raw content must never fit under an allowed key.
+-- NOTE: jsonb_build_object is used (not text concatenation with a trailing
+-- ::jsonb cast) so the long ref reaches the payload CHECK. A cast applied
+-- to the final fragment of a concatenation would raise 22P02 at the parser
+-- stage, before the INSERT ever exercises outbox_events_payload_check.
 SELECT throws_ok(
   $$INSERT INTO public.outbox_events (
        event_type, contract_version, user_id, turn_request_id, payload,
        status, attempts, next_attempt_at, idempotency_key
      ) VALUES (
        'memory_indexed', 1, 'pgtap_tr_user', NULL,
-       '{"ref": "' || repeat('x', 129) || '"}'::jsonb,
+       jsonb_build_object('ref', repeat('x', 129)),
        'pending', 0, now(), 'pgtap-idem-reflong'
      )$$,
   '23514', NULL, 'outbox ref over 128 chars is rejected'

--- a/supabase/tests/database/03_transactional_turn_schema.test.sql
+++ b/supabase/tests/database/03_transactional_turn_schema.test.sql
@@ -42,7 +42,7 @@ SELECT ok(
 INSERT INTO public.profiles (user_id) VALUES ('pgtap_tr_user');
 SELECT is(
   (SELECT revision FROM public.profiles WHERE user_id = 'pgtap_tr_user'),
-  0,
+  0::bigint,
   'new profile starts at revision 0'
 );
 
@@ -94,14 +94,33 @@ SELECT is(
   'UNIQUE (user_id, request_id)',
   'turn_requests unique constraint is (user_id, request_id)'
 );
+SELECT is(
+  (SELECT pg_get_constraintdef(oid) FROM pg_constraint
+   WHERE conname = 'turn_requests_user_id_id_key'),
+  'UNIQUE (user_id, id)',
+  'turn_requests has candidate key (user_id, id)'
+);
 SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'turn_requests_status_check'), 'turn_requests has status check');
 SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'turn_requests_status_coherence_check'), 'turn_requests has status coherence check');
 SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'turn_requests_lease_pair_check'), 'turn_requests has lease pair check');
+SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'turn_requests_lease_owner_check'), 'turn_requests has lease owner check');
 SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'turn_requests_payload_hash_sha256_check'), 'turn_requests has payload hash check');
 SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'turn_requests_expected_revision_check'), 'turn_requests has expected revision check');
 SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'turn_requests_committed_revision_check'), 'turn_requests has committed revision check');
 SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'turn_requests_replay_payload_check'), 'turn_requests has replay payload check');
 SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'turn_requests_error_code_check'), 'turn_requests has error code check');
+
+-- Composite message FKs enforce per-user isolation
+SELECT is(
+  (SELECT confdeltype FROM pg_constraint WHERE conname = 'turn_requests_user_message_chat_log_id_fkey'),
+  'n'::"char",
+  'user message FK has ON DELETE SET NULL'
+);
+SELECT is(
+  (SELECT confdeltype FROM pg_constraint WHERE conname = 'turn_requests_assistant_message_chat_log_id_fkey'),
+  'n'::"char",
+  'assistant message FK has ON DELETE SET NULL'
+);
 
 -- =================================================================
 -- 4. turn_requests behavior
@@ -181,7 +200,7 @@ SELECT throws_ok(
   $$INSERT INTO public.turn_requests (
        user_id, request_id, payload_hash_sha256, status
      ) VALUES (
-       'pgtap_tr_user', gen_random_uuid(), repeat('g', 64), 'expired'
+       'pgtap_tr_user', gen_random_uuid(), repeat('1', 64), 'expired'
      )$$,
   '23514', NULL, 'expired without error code is rejected'
 );
@@ -189,7 +208,7 @@ SELECT throws_ok(
   $$INSERT INTO public.turn_requests (
        user_id, request_id, payload_hash_sha256, status, lease_owner
      ) VALUES (
-       'pgtap_tr_user', gen_random_uuid(), repeat('h', 64), 'pending', 'worker-h'
+       'pgtap_tr_user', gen_random_uuid(), repeat('2', 64), 'pending', 'worker-h'
      )$$,
   '23514', NULL, 'lease owner without expiry is rejected'
 );
@@ -197,7 +216,7 @@ SELECT throws_ok(
   $$INSERT INTO public.turn_requests (
        user_id, request_id, payload_hash_sha256, status, error_code
      ) VALUES (
-       'pgtap_tr_user', gen_random_uuid(), repeat('m', 64), 'expired', 'Bad Error!'
+       'pgtap_tr_user', gen_random_uuid(), repeat('7', 64), 'expired', 'Bad Error!'
      )$$,
   '23514', NULL, 'unsanitized error code is rejected'
 );
@@ -208,7 +227,7 @@ SELECT throws_ok(
        user_id, request_id, payload_hash_sha256, status,
        lease_owner, lease_expires_at, user_message_chat_log_id
      ) VALUES (
-       'pgtap_tr_user', gen_random_uuid(), repeat('i', 64), 'pending',
+       'pgtap_tr_user', gen_random_uuid(), repeat('3', 64), 'pending',
        'worker-i', now() + interval '5 minutes', 999999
      )$$,
   '23503', NULL, 'FK rejects nonexistent chat_log reference'
@@ -218,10 +237,39 @@ SELECT throws_ok(
        user_id, request_id, payload_hash_sha256, status,
        lease_owner, lease_expires_at
      ) VALUES (
-       'pgtap_no_such_user', gen_random_uuid(), repeat('j', 64), 'pending',
+       'pgtap_no_such_user', gen_random_uuid(), repeat('4', 64), 'pending',
        'worker-j', now() + interval '5 minutes'
      )$$,
   '23503', NULL, 'FK rejects nonexistent user reference'
+);
+
+-- Cross-user message reference is rejected (composite FK on (user_id, message_id))
+INSERT INTO public.chat_logs (id, user_id, role, content)
+VALUES (500002, 'pgtap_tr_user', 'user', 'cross-user isolation message');
+SELECT throws_ok(
+  $$INSERT INTO public.turn_requests (
+       user_id, request_id, payload_hash_sha256, status,
+       lease_owner, lease_expires_at, user_message_chat_log_id
+     ) VALUES (
+       'pgtap_tr_user_2', gen_random_uuid(), repeat('b', 64), 'pending',
+       'worker-v', now() + interval '5 minutes', 500002
+     )$$,
+  '23503', NULL, 'cross-user message reference is rejected'
+);
+
+-- Valid completed request with a public replay contract is accepted
+INSERT INTO public.turn_requests (
+  user_id, request_id, payload_hash_sha256, status,
+  completed_at, committed_revision, replay_payload
+) VALUES (
+  'pgtap_tr_user', '44444444-4444-4444-8444-444444444444', repeat('c', 64), 'completed',
+  now(), 1, '{"response": "ok", "emotion_state": {"schema_version": 1}}'::jsonb
+);
+SELECT is(
+  (SELECT count(*)::integer FROM public.turn_requests
+   WHERE user_id = 'pgtap_tr_user' AND request_id = '44444444-4444-4444-8444-444444444444'),
+  1,
+  'valid completed request with public replay payload is inserted'
 );
 
 -- =================================================================
@@ -234,7 +282,7 @@ INSERT INTO public.turn_requests (
   user_id, request_id, payload_hash_sha256, status,
   lease_owner, lease_expires_at, user_message_chat_log_id
 ) VALUES (
-  'pgtap_tr_user', '22222222-2222-4222-8222-222222222222', repeat('k', 64), 'pending',
+  'pgtap_tr_user', '22222222-2222-4222-8222-222222222222', repeat('5', 64), 'pending',
   'worker-k', now() + interval '5 minutes', 500001
 );
 DELETE FROM public.chat_logs WHERE id = 500001;
@@ -301,8 +349,17 @@ SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'outbox_events_stat
 SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'outbox_events_status_coherence_check'), 'outbox has status coherence check');
 SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'outbox_events_attempts_check'), 'outbox has attempts check');
 SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'outbox_events_lease_pair_check'), 'outbox has lease pair check');
+SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'outbox_events_lease_owner_check'), 'outbox has lease owner check');
+SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'outbox_events_idempotency_key_check'), 'outbox has idempotency key check');
 SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'outbox_events_payload_check'), 'outbox has payload check');
 SELECT ok(EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'outbox_events_error_code_check'), 'outbox has error code check');
+
+-- Composite FK enforces per-user isolation for the request reference
+SELECT is(
+  (SELECT confdeltype FROM pg_constraint WHERE conname = 'outbox_events_turn_request_id_fkey'),
+  'c'::"char",
+  'outbox turn_request FK has ON DELETE CASCADE'
+);
 
 -- =================================================================
 -- 8. outbox_events behavior
@@ -424,8 +481,130 @@ SELECT throws_ok(
   '23514', NULL, 'dead_letter event without dead_lettered_at is rejected'
 );
 
+-- Exact state shapes: no field of another state can leak in
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, processed_at, retention_until,
+       idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{"ref":"x"}'::jsonb,
+       'completed', 1, now(), now(), now() + interval '30 days',
+       'pgtap-idem-cpl-na'
+     )$$,
+  '23514', NULL, 'completed event with next_attempt_at is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, processed_at, dead_lettered_at,
+       retention_until, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{"ref":"x"}'::jsonb,
+       'completed', 1, NULL, now(), now(),
+       now() + interval '30 days', 'pgtap-idem-cpl-dl'
+     )$$,
+  '23514', NULL, 'completed event with dead_lettered_at is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, dead_lettered_at, retention_until,
+       error_code, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{"ref":"x"}'::jsonb,
+       'dead_letter', 10, NULL, now(), now() + interval '30 days',
+       NULL, 'pgtap-idem-dl-noerr'
+     )$$,
+  '23514', NULL, 'dead_letter event without error_code is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, dead_lettered_at, retention_until,
+       error_code, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{"ref":"x"}'::jsonb,
+       'dead_letter', 10, now(), now(), now() + interval '30 days',
+       'exhausted', 'pgtap-idem-dl-na'
+     )$$,
+  '23514', NULL, 'dead_letter event with next_attempt_at is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, dead_lettered_at,
+       error_code, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{"ref":"x"}'::jsonb,
+       'dead_letter', 10, NULL, now(),
+       'exhausted', 'pgtap-idem-dl-noreten'
+     )$$,
+  '23514', NULL, 'dead_letter event without retention_until is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, lease_owner, lease_expires_at,
+       error_code, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{"ref":"x"}'::jsonb,
+       'processing', 1, NULL, 'worker-y', now() + interval '5 minutes',
+       'boom', 'pgtap-idem-proc-err'
+     )$$,
+  '23514', NULL, 'processing event with error_code is rejected'
+);
+
+-- Valid dead_letter event with a full exact shape is accepted
+INSERT INTO public.outbox_events (
+  event_type, contract_version, user_id, turn_request_id, payload,
+  status, attempts, next_attempt_at, dead_lettered_at, retention_until,
+  error_code, idempotency_key
+) VALUES (
+  'memory_indexed', 1, 'pgtap_tr_user', NULL, '{"ref":"turn-1"}'::jsonb,
+  'dead_letter', 10, NULL, now(), now() + interval '30 days',
+  'exhausted', 'pgtap-idem-dl-valid'
+);
+SELECT is(
+  (SELECT count(*)::integer FROM public.outbox_events WHERE idempotency_key = 'pgtap-idem-dl-valid'),
+  1,
+  'valid dead_letter event is inserted'
+);
+
+-- Identifier bounds are enforced (fail-closed)
+SELECT throws_ok(
+  $$INSERT INTO public.turn_requests (
+       user_id, request_id, payload_hash_sha256, status,
+       lease_owner, lease_expires_at
+     ) VALUES (
+       'pgtap_tr_user', gen_random_uuid(), repeat('8', 64), 'pending',
+       repeat('x', 65), now() + interval '5 minutes'
+     )$$,
+  '23514', NULL, 'turn_requests lease_owner over 64 chars is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{}'::jsonb,
+       'pending', 0, now(), repeat('k', 129)
+     )$$,
+  '23514', NULL, 'outbox idempotency_key over 128 chars is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL, '{}'::jsonb,
+       'pending', 0, now(), 'bad key with space'
+     )$$,
+  '23514', NULL, 'outbox idempotency_key with invalid characters is rejected'
+);
+
 -- =================================================================
--- 9. Forbidden payload keys (prompt / internal fields) are rejected
+-- 9. Forbidden payload keys (prompt / internal fields) — top level and nested
 -- =================================================================
 SELECT throws_ok(
   $$INSERT INTO public.outbox_events (
@@ -447,17 +626,73 @@ SELECT throws_ok(
      )$$,
   '23514', NULL, 'outbox payload with metacognition is rejected'
 );
+-- Nested forbidden keys are rejected at any depth
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL,
+       '{"ref": {"system_prompt": "hidden"}}'::jsonb,
+       'pending', 0, now(), 'pgtap-idem-nested'
+     )$$,
+  '23514', NULL, 'nested system_prompt in outbox payload is rejected'
+);
+-- Message content can never be stored in the outbox
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL,
+       '{"ref": "turn-1", "message": "conteudo sensivel"}'::jsonb,
+       'pending', 0, now(), 'pgtap-idem-msg'
+     )$$,
+  '23514', NULL, 'outbox payload with message content is rejected'
+);
+-- Unknown top-level keys are rejected by the allowlist
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user', NULL,
+       '{"ref": "turn-1", "unknown_key": 1}'::jsonb,
+       'pending', 0, now(), 'pgtap-idem-unknown'
+     )$$,
+  '23514', NULL, 'outbox payload with unknown top-level key is rejected'
+);
 
--- turn_requests replay_payload forbids internal fields too
+-- turn_requests replay_payload forbids internal fields too (top level + nested)
 SELECT throws_ok(
   $$INSERT INTO public.turn_requests (
        user_id, request_id, payload_hash_sha256, status,
        completed_at, committed_revision, replay_payload, error_code
      ) VALUES (
-       'pgtap_tr_user', gen_random_uuid(), repeat('l', 64), 'completed',
+       'pgtap_tr_user', gen_random_uuid(), repeat('6', 64), 'completed',
        now(), 1, '{"system_prompt": "hidden"}'::jsonb, NULL
      )$$,
   '23514', NULL, 'replay payload with system_prompt is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.turn_requests (
+       user_id, request_id, payload_hash_sha256, status,
+       completed_at, committed_revision, replay_payload, error_code
+     ) VALUES (
+       'pgtap_tr_user', gen_random_uuid(), repeat('0', 64), 'completed',
+       now(), 1, '{"response": {"system_prompt": "hidden"}}'::jsonb, NULL
+     )$$,
+  '23514', NULL, 'nested system_prompt in replay payload is rejected'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.turn_requests (
+       user_id, request_id, payload_hash_sha256, status,
+       completed_at, committed_revision, replay_payload, error_code
+     ) VALUES (
+       'pgtap_tr_user', gen_random_uuid(), repeat('a', 64), 'completed',
+       now(), 1, '{"response": "ok", "prompt": "hidden"}'::jsonb, NULL
+     )$$,
+  '23514', NULL, 'replay payload with prompt key is rejected'
 );
 
 -- FK: outbox turn_request_id rejects nonexistent reference
@@ -470,6 +705,27 @@ SELECT throws_ok(
        'pending', 0, now(), 'pgtap-idem-fk'
      )$$,
   '23503', NULL, 'FK rejects nonexistent turn_request reference'
+);
+
+-- Cross-user turn_request reference is rejected (composite FK)
+INSERT INTO public.turn_requests (
+  user_id, request_id, payload_hash_sha256, status,
+  lease_owner, lease_expires_at
+) VALUES (
+  'pgtap_tr_user', '55555555-5555-4555-8555-555555555555', repeat('d', 64), 'pending',
+  'worker-y', now() + interval '5 minutes'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.outbox_events (
+       event_type, contract_version, user_id, turn_request_id, payload,
+       status, attempts, next_attempt_at, idempotency_key
+     ) VALUES (
+       'memory_indexed', 1, 'pgtap_tr_user_3',
+       (SELECT id FROM public.turn_requests WHERE request_id = '55555555-5555-4555-8555-555555555555'),
+       '{"ref":"turn-1"}'::jsonb,
+       'pending', 0, now(), 'pgtap-idem-xuser'
+     )$$,
+  '23503', NULL, 'cross-user turn_request reference is rejected'
 );
 
 -- =================================================================
@@ -502,10 +758,36 @@ SELECT ok(
   'PUBLIC has no privileges on outbox_events'
 );
 
+-- Payload helpers are server-only (anon cannot execute)
+SELECT ok(
+  NOT has_function_privilege('anon', 'public.jsonb_has_forbidden_key(jsonb, text[])', 'EXECUTE'),
+  'anon cannot execute jsonb_has_forbidden_key'
+);
+SELECT ok(
+  NOT has_function_privilege('anon', 'public.jsonb_keys_subset_of(jsonb, text[])', 'EXECUTE'),
+  'anon cannot execute jsonb_keys_subset_of'
+);
+SELECT ok(
+  has_function_privilege('service_role', 'public.jsonb_has_forbidden_key(jsonb, text[])', 'EXECUTE'),
+  'service_role can execute jsonb_has_forbidden_key'
+);
+
 -- =================================================================
 -- 11. Indexes (exact definitions — equivalent verification for the
 --     critical replay/claim queries)
 -- =================================================================
+SELECT has_index('public', 'turn_requests', 'turn_requests_user_id_request_id_key', 'turn_requests unique (user_id, request_id) index exists');
+SELECT is(
+  pg_get_indexdef('public.turn_requests_user_id_request_id_key'::regclass),
+  'CREATE UNIQUE INDEX turn_requests_user_id_request_id_key ON public.turn_requests USING btree (user_id, request_id)',
+  'unique (user_id, request_id) index has exact definition'
+);
+SELECT has_index('public', 'turn_requests', 'turn_requests_user_id_id_key', 'turn_requests unique (user_id, id) index exists');
+SELECT is(
+  pg_get_indexdef('public.turn_requests_user_id_id_key'::regclass),
+  'CREATE UNIQUE INDEX turn_requests_user_id_id_key ON public.turn_requests USING btree (user_id, id)',
+  'unique (user_id, id) index has exact definition'
+);
 SELECT has_index('public', 'turn_requests', 'turn_requests_user_id_created_at_idx', 'turn_requests user-created index exists');
 SELECT is(
   pg_get_indexdef('public.turn_requests_user_id_created_at_idx'::regclass),
@@ -524,13 +806,13 @@ SELECT is(
   'CREATE INDEX turn_requests_user_committed_revision_idx ON public.turn_requests USING btree (user_id, committed_revision)',
   'revision index has exact definition'
 );
-SELECT has_index('public', 'turn_requests', 'turn_requests_user_id_request_id_key', 'turn_requests unique (user_id, request_id) index exists');
-SELECT is(
-  pg_get_indexdef('public.turn_requests_user_id_request_id_key'::regclass),
-  'CREATE UNIQUE INDEX turn_requests_user_id_request_id_key ON public.turn_requests USING btree (user_id, request_id)',
-  'unique (user_id, request_id) index has exact definition'
-);
 
+SELECT has_index('public', 'outbox_events', 'outbox_events_user_id_idempotency_key_key', 'outbox unique (user_id, idempotency_key) index exists');
+SELECT is(
+  pg_get_indexdef('public.outbox_events_user_id_idempotency_key_key'::regclass),
+  'CREATE UNIQUE INDEX outbox_events_user_id_idempotency_key_key ON public.outbox_events USING btree (user_id, idempotency_key)',
+  'unique (user_id, idempotency_key) index has exact definition'
+);
 SELECT has_index('public', 'outbox_events', 'outbox_events_status_next_attempt_idx', 'outbox status-next_attempt index exists');
 SELECT is(
   pg_get_indexdef('public.outbox_events_status_next_attempt_idx'::regclass),
@@ -549,12 +831,6 @@ SELECT is(
   'CREATE INDEX outbox_events_turn_request_id_idx ON public.outbox_events USING btree (turn_request_id)',
   'turn_request index has exact definition'
 );
-SELECT has_index('public', 'outbox_events', 'outbox_events_user_id_idempotency_key_key', 'outbox unique (user_id, idempotency_key) index exists');
-SELECT is(
-  pg_get_indexdef('public.outbox_events_user_id_idempotency_key_key'::regclass),
-  'CREATE UNIQUE INDEX outbox_events_user_id_idempotency_key_key ON public.outbox_events USING btree (user_id, idempotency_key)',
-  'unique (user_id, idempotency_key) index has exact definition'
-);
 
 -- =================================================================
 -- 12. ON DELETE policy for every FK
@@ -565,24 +841,9 @@ SELECT is(
   'turn_requests.user_id FK has ON DELETE CASCADE'
 );
 SELECT is(
-  (SELECT confdeltype FROM pg_constraint WHERE conname = 'turn_requests_user_message_chat_log_id_fkey'),
-  'n'::"char",
-  'turn_requests user-message FK has ON DELETE SET NULL'
-);
-SELECT is(
-  (SELECT confdeltype FROM pg_constraint WHERE conname = 'turn_requests_assistant_message_chat_log_id_fkey'),
-  'n'::"char",
-  'turn_requests assistant-message FK has ON DELETE SET NULL'
-);
-SELECT is(
   (SELECT confdeltype FROM pg_constraint WHERE conname = 'outbox_events_user_id_fkey'),
   'c'::"char",
   'outbox_events.user_id FK has ON DELETE CASCADE'
-);
-SELECT is(
-  (SELECT confdeltype FROM pg_constraint WHERE conname = 'outbox_events_turn_request_id_fkey'),
-  'c'::"char",
-  'outbox_events.turn_request_id FK has ON DELETE CASCADE'
 );
 
 -- =================================================================
@@ -602,6 +863,11 @@ SELECT throws_ok(
   $$CREATE TABLE public.outbox_events (id uuid)$$,
   '42P07', NULL, 're-creating outbox_events fails (drift)'
 );
+SELECT throws_ok(
+  $$CREATE FUNCTION public.jsonb_has_forbidden_key(jsonb, text[]) RETURNS boolean
+    LANGUAGE sql IMMUTABLE AS 'SELECT true'$$,
+  '42723', NULL, 're-creating jsonb_has_forbidden_key fails (drift)'
+);
 
 -- =================================================================
 -- 13. User deletion leaves no incompatible orphan data
@@ -611,8 +877,8 @@ INSERT INTO public.turn_requests (
   user_id, request_id, payload_hash_sha256, status,
   lease_owner, lease_expires_at
 ) VALUES (
-  'pgtap_orphan_user', '33333333-3333-4333-8333-333333333333', repeat('n', 64), 'pending',
-  'worker-n', now() + interval '5 minutes'
+  'pgtap_orphan_user', '33333333-3333-4333-8333-333333333333', repeat('9', 64), 'pending',
+  'worker-o', now() + interval '5 minutes'
 );
 INSERT INTO public.outbox_events (
   event_type, contract_version, user_id, turn_request_id, payload,


### PR DESCRIPTION
Closes #270

## Problema e causa raiz

O processamento de turno grava mensagens e snapshots em operações separadas, sem uma revisão persistida para detectar lost updates, e sem estruturas duráveis para claim de `request_id`, estados pendente/concluída/expirada, replay após perda de conexão e outbox atômica futura. A #270 cria a fundação de persistência para #271 (commit atômico) e #272 (worker da outbox).

## Solução

Migration aditiva `20240101000004_transactional_turn_schema.sql` + contratos de serialização mínimos + testes reais de banco. Nenhum fluxo ativo do `ConversationEngine` foi integrado.

- **`profiles.revision`**: `bigint NOT NULL DEFAULT 0` com `CHECK (revision >= 0)`; backfill determinístico (metadata-only); compatível com upsert futuro. `updated_at` continua application-maintained (sem trigger).
- **`turn_requests`**: ledger server-owned com `UNIQUE (user_id, request_id)` (mesmo `request_id` permitido entre usuários), chave candidata `UNIQUE (user_id, id)`, FKs **compostas** `(user_id, message_id)` → `chat_logs(user_id, id)` com `ON DELETE SET NULL` via trigger `BEFORE DELETE` (SECURITY DEFINER), status `pending/completed/expired` com CHECK de coerência fail-closed, hash canônico `^[0-9a-f]{64}$`, `replay_payload` com allowlist explícita + validação recursiva de chaves proibidas (prompts/metacognição/mensagens jamais persistidos, mesmo aninhados).
- **`outbox_events`**: `UNIQUE (user_id, idempotency_key)` (idempotência por usuário), FK composta `(user_id, turn_request_id)` → `turn_requests(user_id, id)` com `CASCADE`, estados `pending/processing/completed/failed/dead_letter` com **forma exata e mutuamente exclusiva** (`processing` exige `next_attempt_at IS NULL`), `attempts 0..10`, bounds sanitizados em `lease_owner` (64) e `idempotency_key` (128), e **contrato de valores** (`jsonb_outbox_payload_value_contract`): `ref`/IDs/`kind` escalares sanitizados (1..128), `version` inteiro 1..1000, objetos/arrays/JSON null rejeitados sob qualquer chave permitida.
- **RLS/grants**: ambas as tabelas com RLS + FORCE RLS, zero políticas, zero privilégios para `anon`/`authenticated`/`PUBLIC`; `service_role` com CRUD completo. As 4 funções da migration (helpers + trigger) têm **EXECUTE revogado de PUBLIC/anon/authenticated** e concedido apenas a `service_role`, com matriz exata testada no pgTAP.
- **Índices** para replay, claim de leases e idempotência; consultas críticas verificadas por `pg_get_indexdef` exato.
- **Drift**: preflight fail-closed e testes de drift (`42701`/`42P07`/`42723`).
- **Rollback operacional** documentado e exercitado (aditivo, não destrutivo; sem downgrade fake).

## Arquivos/áreas afetadas

- `supabase/migrations/20240101000004_transactional_turn_schema.sql`
- `supabase/tests/database/03_transactional_turn_schema.test.sql`
- `backend/transactional_schema.py` (contratos puros: hash canônico `allow_nan=False`, records tipados, imutabilidade profunda de qualquer `Mapping`)
- `backend/tests/test_transactional_schema.py` (unitários)
- `backend/tests/test_transactional_schema_legacy.py` (upgrade legado + rollback)
- `backend/tests/test_transactional_schema_integration.py` (authz + comportamento reais)
- `.github/workflows/ci.yml` (etapas de banco; teste legacy esconde 03 **e** 04 com trap fail-safe)
- `docs/architecture/transactional-turn-schema.md` (ADR completa)

## Riscos tratados

- **Cascata**: FKs compostas impedem referências cross-user; `SET NULL` preservado sem violar `user_id NOT NULL`; deleção de usuário não deixa órfãos (testado).
- **RLS permissiva**: fail-closed; cliente autenticado não alcança tabelas internas (matriz testada).
- **Hash/idempotência**: `allow_nan=False` (NaN/Infinity rejeitados como no `jsonb`); `(user_id, request_id)` e `(user_id, idempotency_key)` únicos.
- **Requests/eventos presos**: estados com forma exata + leases com par both-or-neither + bounds.
- **Payload excessivo**: allowlists + denylist recursiva + contrato de valores + cap de 8 KB.
- **Migration incompatível**: preflight anti-drift; banco vazio e legado migram sem perda.
- **Contratos divergentes SQL/Python**: Python nunca reimplementa regras do banco; SQL é fonte de verdade (validação), Python só serializa; constantes espelhadas testadas disjuntas da denylist.

## Testes executados (HEAD final `c14011a06c0c34e37acabc736a8549cf06bf4cbf`)

- `python -m compileall -q backend` — ✅
- Unitários `test_transactional_schema.py` — **28 passed** ✅
- Suíte backend offline (equivalente ao CI backend job) — **1903 passed** ✅
- Revisão de código: passes com veredito final **APPROVE** ✅
- **CI completa verde no mesmo HEAD `c14011a`** (run `30646542996` — conclusion `success`):
  - **backend** ✅ (compileall + suíte offline)
  - **frontend** ✅ (tests, lint, build, npm audit)
  - **database** ✅ com **todos** os passos executados até o fim, sem `skipped` por falha anterior:
    1. pgTAP — **202 testes** ✅
    2. admission ledger integration ✅
    3. legacy hardening válido **e** inválido (SQLSTATE 23514) ✅
    4. transactional schema legacy (upgrade + rollback operacional) ✅
    5. transactional schema integration ✅
    6. database authorization integration ✅

### Correções finais desta rodada

- `93a0fae` — pgTAP `outbox ref over 128 chars` agora constrói o payload com `jsonb_build_object` (o cast `::jsonb` por precedência gerava `22P02` antes do CHECK; mantém a expectativa `23514`).
- `8bf89aa` / `790678a` — teste legacy: após `migration up --local`, força reload do schema cache do PostgREST (`NOTIFY pgrst, 'reload schema'`) + espera com poll e fallback de restart do container (estabiliza o flake PGRST205 pré-existente; sem enfraquecer asserções).
- `c14011a` — `test_operational_rollback`: verificações de existência usam `to_regclass(...)` em vez de `::regclass` (o cast levanta erro quando a relação foi dropada pelo rollback).

## Migração e rollback

- **Forward-only**: após dados reais, recuperação via nova migration (sem downgrade destrutivo).
- **Rollback operacional** (antes de dados reais): drop do trigger, das tabelas, da coluna e das 4 funções em ordem de dependência — exercitado por `test_transactional_schema_legacy.py`.

## Itens deliberadamente fora de escopo

`commit_turn`, claim/reclaim completo, worker da outbox, integração com `ConversationEngine`, `save_turn()`/`sync_state()`, `backend/trusted_context.py`, prompts, domínio emocional/relacional, frontend/DTO público, Redis, #271/#272.
