### PR TITLE
refactor(backend): integrate transactional process turn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,21 @@ jobs:
           set -euo pipefail
           python -m pytest -q -ra backend/tests/test_atomic_turn_commit_integration.py
 
+      - name: Reset database for process turn integration tests
+        run: |
+          set -euo pipefail
+          supabase db reset
+
+      - name: Run Process Turn Integration Tests (replay RPC + multi-worker)
+        env:
+          SUPABASE_URL: "http://127.0.0.1:54321"
+          SUPABASE_ANON_KEY: "${{ env.SUPABASE_ANON_KEY }}"
+          SUPABASE_SERVICE_ROLE_KEY: "${{ env.SUPABASE_SERVICE_ROLE_KEY }}"
+          PYTHONPATH: "."
+        run: |
+          set -euo pipefail
+          python -m pytest -q -ra backend/tests/test_process_turn_integration.py
+
       - name: Stop Supabase
         if: always()
         run: supabase stop
@@ -248,6 +263,7 @@ jobs:
               --ignore=backend/tests/test_transactional_schema_legacy.py \
               --ignore=backend/tests/test_transactional_schema_integration.py \
               --ignore=backend/tests/test_atomic_turn_commit_integration.py \
+              --ignore=backend/tests/test_process_turn_integration.py \
               -ra
 
   frontend:

--- a/backend/admission.py
+++ b/backend/admission.py
@@ -22,6 +22,7 @@ from .admission_contracts import (
 
 MESSAGE_HMAC_DOMAIN = b"message"
 NETWORK_HMAC_DOMAIN = b"network"
+TURN_CORRELATION_DOMAIN = b"turn-correlation"
 UNKNOWN_NETWORK_IDENTITY = "unknown"
 
 ADMITTED = "admitted"
@@ -235,6 +236,35 @@ def compute_hmac_sha256(secret_bytes: bytes, domain: bytes, payload: str) -> str
     return hmac.new(
         validated_secret,
         domain + b"\x00" + payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def compute_turn_correlation(
+    config: AdmissionRuntimeConfig,
+    request_id: object,
+) -> str:
+    """Compute the sanitized, non-reversible correlation reference for a turn.
+
+    The correlation is an HMAC-SHA256 of the canonical request id under the
+    dedicated ``turn-correlation`` domain, using the already-validated
+    admission secret. It is stable across the endpoint and the ProcessTurn
+    use case for the same request, never reversible (no truncated UUID or
+    unauthenticated hash), never echoed in HTTP responses, and can be logged
+    without exposing the raw request id, user id, message or any secret.
+
+    Returns the exact lowercase 64-character hex HMAC.
+    """
+    if not isinstance(config, AdmissionRuntimeConfig):
+        raise AdmissionUnavailable()
+    try:
+        canonical_request_id = RequestIdentity(request_id).request_id
+    except AdmissionError:
+        raise AdmissionUnavailable() from None
+    validated_secret = _validate_secret_bytes(config.secret_bytes)
+    return hmac.new(
+        validated_secret,
+        TURN_CORRELATION_DOMAIN + b"\x00" + canonical_request_id.encode("utf-8"),
         hashlib.sha256,
     ).hexdigest()
 

--- a/backend/atomic_turn_commit.py
+++ b/backend/atomic_turn_commit.py
@@ -869,6 +869,42 @@ def parse_commit_turn_result(result: Mapping[str, Any]) -> CommittedTurn:
     )
 
 
+def build_canonical_commit_payload(
+    authenticated_user_id: str,
+    request_id: str,
+    expected_revision: int,
+    user_message: str,
+    assistant_message: str,
+    emotional_state: Optional[Mapping[str, Any]],
+    relationship_state: Optional[Mapping[str, Any]],
+    public_response: str,
+    replay_payload: Mapping[str, Any],
+    outbox_events: list[tuple[str, Mapping[str, Any], str]],
+) -> dict[str, Any]:
+    """Build the canonical payload hashed for the ``payload_hash_sha256``.
+
+    The canonical payload covers every input that determines the turn's
+    identity, content and side effects (outbox + replay). Single source of
+    truth shared by the async ``commit_turn`` entry point and the synchronous
+    repository adapter used by the ProcessTurn use case (#272).
+    """
+    return {
+        "authenticated_user_id": authenticated_user_id,
+        "request_id": request_id,
+        "expected_revision": expected_revision,
+        "user_message": user_message,
+        "assistant_message": assistant_message,
+        "emotional_state": emotional_state,
+        "relationship_state": relationship_state,
+        "public_response": public_response,
+        "replay_payload": replay_payload,
+        "outbox_events": [
+            {"event_type": et, "payload": pl, "idempotency_key": ik}
+            for et, pl, ik in outbox_events
+        ],
+    }
+
+
 # Type alias for the RPC function callable
 # The actual implementation depends on the database client being used
 RpcCallable = Any
@@ -925,21 +961,18 @@ async def commit_turn(
 
     # The canonical payload hash covers every input that determines the turn's
     # identity, content and side effects (outbox + replay).
-    canonical_payload = {
-        "authenticated_user_id": authenticated_user_id,
-        "request_id": request_id,
-        "expected_revision": expected_revision,
-        "user_message": user_message,
-        "assistant_message": assistant_message,
-        "emotional_state": emotional_state,
-        "relationship_state": relationship_state,
-        "public_response": public_response,
-        "replay_payload": replay_payload,
-        "outbox_events": [
-            {"event_type": et, "payload": pl, "idempotency_key": ik}
-            for et, pl, ik in outbox_events
-        ],
-    }
+    canonical_payload = build_canonical_commit_payload(
+        authenticated_user_id=authenticated_user_id,
+        request_id=request_id,
+        expected_revision=expected_revision,
+        user_message=user_message,
+        assistant_message=assistant_message,
+        emotional_state=emotional_state,
+        relationship_state=relationship_state,
+        public_response=public_response,
+        replay_payload=replay_payload,
+        outbox_events=outbox_events,
+    )
     payload_hash_sha256 = canonical_payload_hash(canonical_payload)
 
     rpc_payload = build_commit_turn_rpc_payload(

--- a/backend/chat_engine.py
+++ b/backend/chat_engine.py
@@ -2,29 +2,60 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
 from typing import Optional
 
-from fastapi import BackgroundTasks
-
 from .engine import ConversationEngine
-from .turn_execution import TurnBudget, create_budget
+from .process_turn import (
+    ProcessTurnInput,
+    TurnMode,
+    build_process_turn,
+)
+from .turn_execution import (
+    TurnBudget,
+    TurnExecutionConfig,
+    DeadlineExceeded,
+    create_budget,
+)
 
 
 class ChatConversationEngine(ConversationEngine):
     """Conversation engine used by the active request path.
+
+    The active path delegates the whole turn to the idempotent, transactional
+    ``ProcessTurn`` use case (#272): state is loaded with its revision, the
+    provider runs outside the transaction, and a single ``commit_turn`` RPC
+    persists messages, snapshots, request completion and outbox atomically
+    with CAS. ``save_turn`` / ``sync_state`` / ``BackgroundTasks`` are never
+    used by this class.
 
     Internal callers may omit ``budget`` and retain the existing behavior.
     The HTTP admission path supplies the already-started budget so admission,
     lock acquisition, generation, and commit share one monotonic deadline.
     """
 
+    def __init__(
+        self,
+        clock=time.time,
+        archival_extraction_enabled: bool = False,
+        turn_config: Optional[TurnExecutionConfig] = None,
+    ):
+        super().__init__(
+            clock=clock,
+            archival_extraction_enabled=archival_extraction_enabled,
+            turn_config=turn_config,
+        )
+        self._process_turn = build_process_turn(self)
+
     async def process_turn(
         self,
         user_id: str,
         user_message: str,
-        background_tasks: Optional[BackgroundTasks] = None,
+        request_id: str,
         *,
         budget: Optional[TurnBudget] = None,
+        mode: TurnMode = TurnMode.normal,
     ):
         active_budget = (
             budget
@@ -36,6 +67,32 @@ class ChatConversationEngine(ConversationEngine):
         return await self._run_turn_locked(
             user_id,
             user_message,
-            background_tasks,
+            request_id,
             active_budget,
+            mode,
         )
+
+    async def _run_turn_locked(self, user_id, user_message, request_id, budget, mode):
+        # Only the lock acquisition is bounded by remaining_before_reserve.
+        # Once acquired, the turn runs under budget checks (each stage
+        # checks remaining_before_reserve).  This prevents the outer timeout
+        # from firing while the commit section (protected by the write drain
+        # in run_blocking_write) is executing, which would release the lock
+        # prematurely.
+        lock_timeout = budget.remaining_before_reserve
+        ctx = self.lock_manager.lock(user_id)
+        try:
+            await asyncio.wait_for(ctx.__aenter__(), timeout=lock_timeout)
+        except asyncio.TimeoutError:
+            raise DeadlineExceeded()
+        try:
+            inp = ProcessTurnInput(
+                authenticated_user_id=user_id,
+                request_id=request_id,
+                user_message=user_message,
+                budget=budget,
+                mode=mode,
+            )
+            return await self._process_turn.execute(inp)
+        finally:
+            await ctx.__aexit__(None, None, None)

--- a/backend/chat_engine.py
+++ b/backend/chat_engine.py
@@ -56,6 +56,7 @@ class ChatConversationEngine(ConversationEngine):
         *,
         budget: Optional[TurnBudget] = None,
         mode: TurnMode = TurnMode.normal,
+        correlation: str,
     ):
         active_budget = (
             budget
@@ -70,9 +71,10 @@ class ChatConversationEngine(ConversationEngine):
             request_id,
             active_budget,
             mode,
+            correlation,
         )
 
-    async def _run_turn_locked(self, user_id, user_message, request_id, budget, mode):
+    async def _run_turn_locked(self, user_id, user_message, request_id, budget, mode, correlation):
         # Only the lock acquisition is bounded by remaining_before_reserve.
         # Once acquired, the turn runs under budget checks (each stage
         # checks remaining_before_reserve).  This prevents the outer timeout
@@ -91,6 +93,7 @@ class ChatConversationEngine(ConversationEngine):
                 request_id=request_id,
                 user_message=user_message,
                 budget=budget,
+                correlation=correlation,
                 mode=mode,
             )
             return await self._process_turn.execute(inp)

--- a/backend/engine.py
+++ b/backend/engine.py
@@ -227,6 +227,29 @@ class ConversationEngine:
     def _project_emotion_state(state: EmotionalStateV1, appraisal: AppraisalV1) -> EmotionStateResponse:
         return project_public_emotion(state, appraisal)
 
+    # ─── ProcessTurn provider port (#272) ──────────────────────────────────────
+    # Public surface used by the ProcessTurn use case so provider calls stay
+    # outside the transaction while keeping the domain logic unchanged.
+
+    async def appraise(self, message: str, budget: TurnBudget) -> AppraisalV1:
+        """Public appraisal port for the ProcessTurn use case."""
+        return await self._appraise(message, budget)
+
+    async def generate(self, messages: list, budget: TurnBudget) -> str:
+        """Public generation port for the ProcessTurn use case."""
+        return await self._generate_with_messages(messages, budget)
+
+    def build_trusted_policy(
+        self,
+        emotional_state: EmotionalStateV1,
+        relationship: RelationshipStateV1,
+        adaptation_strategy: str = "",
+    ) -> str:
+        """Public trusted-policy builder for the ProcessTurn use case."""
+        return self._build_trusted_policy(
+            emotional_state, relationship, adaptation_strategy
+        )
+
     @staticmethod
     def _classify_commit_error(
         exc: BaseException,

--- a/backend/main.py
+++ b/backend/main.py
@@ -29,6 +29,7 @@ from .admission import (
     AdmissionRuntimeConfig,
     AdmissionUnavailable,
     build_admission_request,
+    compute_turn_correlation,
     reserve_admission_sync,
     resolve_network_identity,
 )
@@ -380,19 +381,30 @@ async def chat_endpoint(
             admission_request,
             allowlist_exceptions=(AdmissionUnavailable,),
         )
+        # Sanitized correlation reference for observability: HMAC-SHA256 of
+        # the canonical request id under the dedicated turn-correlation domain
+        # (never the raw request id, user id, message or any secret).
+        correlation = compute_turn_correlation(_admission_config, identity.request_id)
         if admission_result.decision == ADMITTED:
             mode = TurnMode.normal
+            logger.info("event=admission_admitted correlation=%s", correlation)
         elif admission_result.decision == REQUEST_REPLAY_UNAVAILABLE:
             # The ledger detected a repeated (user, request_id): try the
-            # persisted transactional result BEFORE any provider call.
+            # persisted transactional result BEFORE any provider call. A
+            # replay is a distinct observable event from a fresh admission.
             mode = TurnMode.replay_attempt
+            logger.info("event=admission_replay correlation=%s", correlation)
         else:
             logger.info("event=admission_rejected code=%s", admission_result.decision)
             raise _map_admission_rejection(admission_result)
 
-        logger.info("event=admission_admitted")
         result = await engine.process_turn(
-            user_id, input_data.message, identity.request_id, budget=budget, mode=mode
+            user_id,
+            input_data.message,
+            identity.request_id,
+            budget=budget,
+            mode=mode,
+            correlation=correlation,
         )
         # The public DTO exposes exactly response + emotion_state; revisions,
         # outbox refs, internal IDs and CommittedTurn are never exposed.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,5 @@
 import asyncio
-from fastapi import FastAPI, HTTPException, Depends, BackgroundTasks, Request
+from fastapi import FastAPI, HTTPException, Depends, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
@@ -33,9 +33,11 @@ from .admission import (
     resolve_network_identity,
 )
 from .admission_contracts import AdmissionError, RequestIdentity, validate_new_message
+from .atomic_turn_commit import ConflictError, PersistenceError
 from .chat_engine import ChatConversationEngine
 from .memory import StatePersistenceError
 from .emotion_presentation import EmotionStateResponse
+from .process_turn import TurnMode
 from .turn_execution import (
     TurnExecutionConfig,
     TurnExecutionError,
@@ -268,11 +270,53 @@ def _map_turn_error(exc: Exception) -> HTTPException:
             detail={"code": TurnErrorCode.persistence_unavailable.value, "message": "Persistence service unavailable."},
         )
 
+    if isinstance(exc, PersistenceError):
+        # Unexpected persistence failure: sanitized, never PostgreSQL messages.
+        return HTTPException(
+            status_code=503,
+            detail={"code": TurnErrorCode.persistence_unavailable.value, "message": "Persistence service unavailable."},
+        )
+
     # Unknown/unexpected — sanitize to generic 500
     return HTTPException(
         status_code=500,
         detail={"code": TurnErrorCode.internal_error.value, "message": "Internal server error."},
     )
+
+
+# Stable conflict mapping for the ProcessTurn use case (#272). One single
+# documented policy per code; messages are public constants, never raw
+# PostgreSQL/Supabase text. request_id / message / revisions are never echoed.
+_PROCESS_TURN_CONFLICT_HTTP = {
+    "revision_mismatch": (
+        409,
+        {"code": "revision_conflict", "message": "Request conflicts with a concurrent update."},
+    ),
+    "request_payload_conflict": (
+        409,
+        {"code": "request_id_conflict", "message": "Request identifier conflicts with a different message."},
+    ),
+    "request_in_progress": (
+        409,
+        {"code": "request_in_progress", "message": "Request is already being processed."},
+    ),
+    "lease_conflict": (
+        409,
+        {"code": "lease_conflict", "message": "Request lease conflict."},
+    ),
+    "request_replay_unavailable": (
+        409,
+        {"code": "request_replay_unavailable", "message": "Request was already received but its response is unavailable."},
+    ),
+}
+
+
+def _map_process_turn_conflict(exc: ConflictError) -> HTTPException:
+    status_code, detail = _PROCESS_TURN_CONFLICT_HTTP.get(
+        exc.code,
+        (409, {"code": "request_conflict", "message": "Request conflict."}),
+    )
+    return HTTPException(status_code=status_code, detail=detail)
 
 
 _ADMISSION_HTTP = {
@@ -308,7 +352,6 @@ def _admission_unavailable_error() -> HTTPException:
 async def chat_endpoint(
     input_data: ChatInput,
     request: Request,
-    background_tasks: BackgroundTasks,
     current_user = Depends(get_current_user)
 ):
     try:
@@ -337,15 +380,23 @@ async def chat_endpoint(
             admission_request,
             allowlist_exceptions=(AdmissionUnavailable,),
         )
-        if admission_result.decision != ADMITTED:
+        if admission_result.decision == ADMITTED:
+            mode = TurnMode.normal
+        elif admission_result.decision == REQUEST_REPLAY_UNAVAILABLE:
+            # The ledger detected a repeated (user, request_id): try the
+            # persisted transactional result BEFORE any provider call.
+            mode = TurnMode.replay_attempt
+        else:
             logger.info("event=admission_rejected code=%s", admission_result.decision)
             raise _map_admission_rejection(admission_result)
 
         logger.info("event=admission_admitted")
-        response_text, current_emotion = await engine.process_turn(
-            user_id, input_data.message, background_tasks, budget=budget
+        result = await engine.process_turn(
+            user_id, input_data.message, identity.request_id, budget=budget, mode=mode
         )
-        return ChatResponse(response=response_text, emotion_state=current_emotion)
+        # The public DTO exposes exactly response + emotion_state; revisions,
+        # outbox refs, internal IDs and CommittedTurn are never exposed.
+        return ChatResponse(response=result.response, emotion_state=result.emotion_state)
     except asyncio.CancelledError:
         # CancelledError must NOT be converted to HTTP 500 — propagate
         raise
@@ -354,8 +405,10 @@ async def chat_endpoint(
     except AdmissionUnavailable:
         logger.error("event=admission_unavailable")
         raise _admission_unavailable_error()
+    except ConflictError as exc:
+        raise _map_process_turn_conflict(exc)
     except (DeadlineExceeded, TurnExecutionError, GroqPoolExhaustedError,
-            GroqRequestError, StatePersistenceError) as exc:
+            GroqRequestError, StatePersistenceError, PersistenceError) as exc:
         raise _map_turn_error(exc)
     except Exception:
         # Sanitize logging: avoid logging raw exceptions that might contain secrets or tracebacks

--- a/backend/process_turn.py
+++ b/backend/process_turn.py
@@ -1,0 +1,444 @@
+"""
+Idempotent, transactional turn processing use case (#272).
+
+Replaces the legacy active flow (``load state -> provider -> save_turn ->
+sync_state -> BackgroundTasks``) with a single transactional unit:
+
+    authenticated request identity
+    -> admission result
+    -> replay check when applicable
+    -> load state + revision
+    -> load trusted context
+    -> appraisal / transitions / generation outside the transaction
+    -> commit_turn atomically with expected_revision
+    -> bounded revision retry
+    -> return exactly the persisted result
+
+Consistency comes from PostgreSQL (``public.commit_turn``); the process-local
+``UserLockManager`` remains only a local optimization. The use case is
+stateless: no per-user state lives in any global or singleton.
+
+Public result contract: ``ProcessTurnResult`` is derived from
+``CommittedTurn.replay_payload`` — even for a fresh commit the response and
+public emotion state are read back from the persisted result, never from the
+pre-commit variables.
+"""
+
+from __future__ import annotations
+
+import logging
+import time as _time
+import uuid as _uuid
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Mapping, Optional, Protocol
+
+from .atomic_turn_commit import (
+    CommittedTurn,
+    ConflictError,
+    PersistenceError,
+    ValidationError,
+)
+from .emotional_domain import (
+    AppraisalV1,
+    TransitionConfig,
+    migrate_legacy_snapshot,
+    transition,
+)
+from .emotion_presentation import EmotionStateResponse, project_public_emotion
+from .relationship import (
+    RelationshipStateV1,
+    RelationshipTransitionConfig,
+    migrate_legacy_relationship_snapshot,
+    transition_relationship,
+)
+from .trusted_context import (
+    TrustedContextError,
+    build_context_bundle,
+    build_envelope,
+)
+from .turn_execution import (
+    DeadlineExceeded,
+    TurnBudget,
+    TurnErrorCode,
+    TurnExecutionError,
+    run_blocking_read,
+    run_blocking_write,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Stable lease owner used when commit_turn needs to claim/reclaim a
+#: pending/expired request row with the same payload hash.
+LEASE_OWNER = "process-turn-v1"
+
+#: Maximum total commit attempts (initial + exactly one revision retry).
+MAX_COMMIT_ATTEMPTS = 2
+
+#: Outbox event for archival extraction (references only, no content).
+ARCHIVAL_EVENT_TYPE = "archival_extraction_requested"
+
+#: Exceptions the repository adapters may raise that must propagate through
+#: the read/write helpers without being wrapped into persistence_unavailable.
+_REPOSITORY_ERRORS = (ConflictError, ValidationError, PersistenceError)
+
+
+class TurnMode(str, Enum):
+    """Whether the request is a fresh admission or a replay attempt."""
+
+    normal = "normal"
+    replay_attempt = "replay_attempt"
+
+
+@dataclass(frozen=True)
+class ProcessTurnInput:
+    """Immutable input for one ProcessTurn execution."""
+
+    authenticated_user_id: str
+    request_id: str
+    user_message: str
+    budget: TurnBudget
+    mode: TurnMode = TurnMode.normal
+
+
+@dataclass(frozen=True)
+class ProcessTurnResult:
+    """Public outcome built exclusively from the persisted ``CommittedTurn``."""
+
+    committed: CommittedTurn
+    response: str
+    emotion_state: EmotionStateResponse
+
+
+class ProviderPort(Protocol):
+    """Provider + policy surface used outside the transaction.
+
+    The engine implements this port with its existing appraisal, generation
+    and trusted-policy builders; tests substitute fakes.
+    """
+
+    async def appraise(self, message: str, budget: TurnBudget) -> AppraisalV1: ...
+
+    async def generate(self, messages: list, budget: TurnBudget) -> str: ...
+
+    def build_trusted_policy(
+        self,
+        emotional_state: Any,
+        relationship: Any,
+        adaptation_strategy: str = "",
+    ) -> str: ...
+
+
+@dataclass(frozen=True)
+class _RevisionConflict:
+    expected_revision: int
+    actual_revision: Optional[int]
+
+
+def parse_public_result(committed: CommittedTurn) -> ProcessTurnResult:
+    """Parse the persisted public result (same parser for commit and replay).
+
+    Raises ``ValidationError`` (internal contract error, sanitized 500) when
+    the persisted contract is missing the required public fields.
+    """
+    payload = committed.replay_payload
+    response = payload.get("response")
+    if not isinstance(response, str):
+        raise ValidationError("invalid_replay_payload", "persisted response missing")
+    raw_emotion = payload.get("emotion_state")
+    if not isinstance(raw_emotion, Mapping):
+        raise ValidationError("invalid_replay_payload", "persisted emotion_state missing")
+    try:
+        emotion = EmotionStateResponse.model_validate(dict(raw_emotion))
+    except Exception:
+        raise ValidationError("invalid_replay_payload", "persisted emotion_state invalid") from None
+    return ProcessTurnResult(committed=committed, response=response, emotion_state=emotion)
+
+
+def build_archival_outbox_event(request_id: str) -> tuple[str, Mapping[str, Any], str]:
+    """Build the idempotent archival outbox event (sanitized references only).
+
+    Payload carries only the user message id (equal to request_id), the event
+    kind and a version. Never includes the message, user id, prompt, response,
+    snapshots, HMAC or any secret.
+    """
+    return (
+        ARCHIVAL_EVENT_TYPE,
+        {"message_id": request_id, "kind": "archival", "version": 1},
+        f"archival:{request_id}:v1",
+    )
+
+
+def build_process_turn(engine: Any) -> "ProcessTurn":
+    """Wire a ``ProcessTurn`` around a ``ConversationEngine`` instance."""
+    from .turn_repositories import (
+        TurnCommitRepository,
+        TurnReplayRepository,
+        UserStateRepository,
+    )
+
+    client_provider: Callable[[], Any] = lambda: engine.memory_manager.supabase
+    return ProcessTurn(
+        state_repository=UserStateRepository(client_provider),
+        commit_repository=TurnCommitRepository(client_provider),
+        replay_repository=TurnReplayRepository(client_provider),
+        context_loader=engine.memory_manager.load_context_data,
+        provider=engine,
+        transition_config=engine.transition_config,
+        relationship_config=engine.relationship_config,
+        clock=engine._clock,
+        supabase_timeout=engine._turn_config.supabase_timeout,
+        archival_extraction_enabled=engine.archival_extraction_enabled,
+        lease_owner=LEASE_OWNER,
+    )
+
+
+class ProcessTurn:
+    """Idempotent, transactional turn processing use case."""
+
+    def __init__(
+        self,
+        *,
+        state_repository: Any,
+        commit_repository: Any,
+        replay_repository: Any,
+        context_loader: Callable[..., Any],
+        provider: ProviderPort,
+        transition_config: TransitionConfig,
+        relationship_config: RelationshipTransitionConfig,
+        clock: Callable[[], float] = _time.time,
+        supabase_timeout: float = 5.0,
+        archival_extraction_enabled: bool = False,
+        lease_owner: str = LEASE_OWNER,
+    ) -> None:
+        self._state_repository = state_repository
+        self._commit_repository = commit_repository
+        self._replay_repository = replay_repository
+        self._context_loader = context_loader
+        self._provider = provider
+        self._transition_config = transition_config
+        self._relationship_config = relationship_config
+        self._clock = clock
+        self._supabase_timeout = supabase_timeout
+        self._archival_extraction_enabled = archival_extraction_enabled
+        self._lease_owner = lease_owner
+
+    # ─── Entry point ───────────────────────────────────────────────────────────
+
+    async def execute(self, inp: ProcessTurnInput) -> ProcessTurnResult:
+        if not isinstance(inp, ProcessTurnInput):
+            raise TypeError("inp must be a ProcessTurnInput")
+        if inp.mode is TurnMode.replay_attempt:
+            committed = await self._replay(inp)
+        else:
+            committed = await self._execute_normal(inp)
+        return parse_public_result(committed)
+
+    # ─── Replay path (before the provider) ─────────────────────────────────────
+
+    async def _replay(self, inp: ProcessTurnInput) -> CommittedTurn:
+        logger.info("event=process_turn_attempt attempt=1 mode=replay")
+        outcome = await run_blocking_read(
+            "replay_turn",
+            inp.budget,
+            self._supabase_timeout,
+            self._replay_repository.replay,
+            inp.authenticated_user_id,
+            inp.request_id,
+            allowlist_exceptions=_REPOSITORY_ERRORS,
+        )
+        if outcome.status == "completed":
+            logger.info("event=process_turn_replay")
+            return outcome.committed
+        if outcome.status == "request_in_progress":
+            raise ConflictError(
+                code="request_in_progress",
+                message="Request is already in progress.",
+                expected_revision=0,
+            )
+        raise ConflictError(
+            code="request_replay_unavailable",
+            message="Request replay is unavailable.",
+            expected_revision=0,
+        )
+
+    # ─── Normal path with bounded revision retry ───────────────────────────────
+
+    async def _execute_normal(self, inp: ProcessTurnInput) -> CommittedTurn:
+        attempt = 1
+        while True:
+            logger.info("event=process_turn_attempt attempt=%s", attempt)
+            result = await self._run_once(inp, attempt)
+            if isinstance(result, CommittedTurn):
+                logger.info("event=process_turn_commit_completed attempt=%s", attempt)
+                return result
+
+            # revision_mismatch: bounded retry (initial + exactly one retry).
+            if attempt >= MAX_COMMIT_ATTEMPTS:
+                logger.info(
+                    "event=process_turn_conflict_exhausted attempt=%s", attempt
+                )
+                raise ConflictError(
+                    code="revision_mismatch",
+                    message="Profile revision changed concurrently.",
+                    expected_revision=result.expected_revision,
+                    actual_revision=result.actual_revision,
+                )
+
+            logger.info("event=process_turn_revision_conflict attempt=%s", attempt)
+            # Verify budget before retrying: an exhausted deadline never retries.
+            if inp.budget.remaining_before_reserve <= 0.0:
+                raise DeadlineExceeded()
+            attempt += 1
+
+    async def _run_once(
+        self, inp: ProcessTurnInput, attempt: int
+    ) -> CommittedTurn | _RevisionConflict:
+        budget = inp.budget
+        if budget.remaining_before_reserve <= 0.0:
+            raise DeadlineExceeded()
+        current_time = self._clock()
+        t0 = _time.monotonic()
+
+        # ---- 1. Load state + revision (read-only, never inserts) --------------
+        state = await run_blocking_read(
+            "load_user_state",
+            budget,
+            self._supabase_timeout,
+            self._state_repository.load,
+            inp.authenticated_user_id,
+            current_time,
+            allowlist_exceptions=_REPOSITORY_ERRORS,
+        )
+
+        try:
+            emotional_state = migrate_legacy_snapshot(state.emotional_state)
+        except Exception:
+            raise TurnExecutionError(
+                TurnErrorCode.internal_error, "Invalid persisted emotional state."
+            ) from None
+
+        if state.relationship_state:
+            try:
+                relationship = migrate_legacy_relationship_snapshot(
+                    state.relationship_state
+                )
+            except Exception:
+                raise TurnExecutionError(
+                    TurnErrorCode.internal_error,
+                    "Invalid persisted relationship state.",
+                ) from None
+        else:
+            relationship = RelationshipStateV1.neutral(timestamp=current_time)
+
+        # ---- 2. Load trusted context (read-only, authorized) ------------------
+        user_state = {
+            "persona_config": state.persona_config,
+            "user_profile": state.user_profile,
+        }
+        try:
+            loaded_context_data = await run_blocking_read(
+                "load_context",
+                budget,
+                self._supabase_timeout,
+                self._context_loader,
+                inp.authenticated_user_id,
+                inp.user_message,
+                user_state,
+                allowlist_exceptions=(TrustedContextError,),
+            )
+        except TrustedContextError:
+            logger.error("event=provider_input_invalid stage=load_context")
+            raise TurnExecutionError(
+                TurnErrorCode.provider_invalid_request,
+                "Loaded context data is structurally invalid.",
+            )
+
+        # ---- 3. Appraisal (LLM, outside the transaction) ----------------------
+        appraisal = await self._provider.appraise(inp.user_message, budget)
+
+        # ---- 4. Transitions (pure domain, outside the transaction) ------------
+        transition_result = transition(
+            previous_state=emotional_state,
+            appraisal=appraisal,
+            current_time=current_time,
+            config=self._transition_config,
+        )
+        new_state = transition_result.state
+        relationship = transition_relationship(
+            previous_state=relationship,
+            appraisal=appraisal,
+            current_time=current_time,
+            config=self._relationship_config,
+        )
+
+        # ---- 5. Provider envelope (pure domain, no I/O) -----------------------
+        adaptation_strategy = ""
+        trusted_policy = self._provider.build_trusted_policy(
+            new_state, relationship, adaptation_strategy
+        )
+        try:
+            context_bundle = build_context_bundle(
+                trusted_policy=trusted_policy,
+                loaded_data=loaded_context_data,
+            )
+            envelope_result = build_envelope(context_bundle, inp.user_message)
+            generation_messages = envelope_result.messages
+        except TrustedContextError:
+            logger.error("event=provider_input_invalid stage=generation")
+            raise TurnExecutionError(
+                TurnErrorCode.provider_invalid_request,
+                "Provider input envelope construction failed.",
+            )
+
+        # ---- 6. Generation (LLM, outside the transaction) ---------------------
+        response_text = await self._provider.generate(generation_messages, budget)
+
+        duration_ms = max(0, int((_time.monotonic() - t0) * 1000))
+
+        # ---- 7/8/9. Snapshots v1, replay payload, outbox events ---------------
+        emotional_snapshot = new_state.to_dict()
+        relationship_snapshot = relationship.to_dict()
+
+        # assistant_message_id is generated BEFORE the commit (secure UUID);
+        # the user message id continues to be derived from request_id.
+        assistant_message_id = str(_uuid.uuid4())
+        public_emotion = project_public_emotion(new_state, appraisal)
+        replay_payload = {
+            "response": response_text,
+            "emotion_state": public_emotion.model_dump(),
+            "message_id": assistant_message_id,
+            "duration_ms": duration_ms,
+        }
+
+        outbox_events: list[tuple[str, Mapping[str, Any], str]] = []
+        if self._archival_extraction_enabled:
+            outbox_events.append(build_archival_outbox_event(inp.request_id))
+
+        # ---- 10. Atomic commit with CAS (exactly one operation) ---------------
+        try:
+            return await run_blocking_write(
+                "commit_turn",
+                budget,
+                self._supabase_timeout,
+                self._commit_repository.commit,
+                authenticated_user_id=inp.authenticated_user_id,
+                request_id=inp.request_id,
+                expected_revision=state.revision,
+                user_message=inp.user_message,
+                assistant_message=response_text,
+                emotional_state=emotional_snapshot,
+                relationship_state=relationship_snapshot,
+                public_response=response_text,
+                outbox_events=outbox_events,
+                replay_payload=replay_payload,
+                lease_owner=self._lease_owner,
+                allowlist_exceptions=_REPOSITORY_ERRORS,
+            )
+        except ConflictError as exc:
+            if exc.code == "revision_mismatch":
+                return _RevisionConflict(
+                    expected_revision=exc.expected_revision,
+                    actual_revision=exc.actual_revision,
+                )
+            raise

--- a/backend/process_turn.py
+++ b/backend/process_turn.py
@@ -27,6 +27,7 @@ pre-commit variables.
 from __future__ import annotations
 
 import logging
+import re as _re
 import time as _time
 import uuid as _uuid
 from dataclasses import dataclass
@@ -68,12 +69,28 @@ from .turn_execution import (
 
 logger = logging.getLogger(__name__)
 
-#: Stable lease owner used when commit_turn needs to claim/reclaim a
-#: pending/expired request row with the same payload hash.
-LEASE_OWNER = "process-turn-v1"
+#: Stable prefix for per-instance lease owners. Every ProcessTurn instance
+#: generates its OWN owner (``process-turn-v1:<uuidhex>``) so workers never
+#: share an effective lease owner; the value is stable for the instance life,
+#: sanitized for the database CHECK (^[A-Za-z0-9_.:-]{1,64}$) and injectable
+#: for tests.
+LEASE_OWNER_PREFIX = "process-turn-v1"
 
 #: Maximum total commit attempts (initial + exactly one revision retry).
 MAX_COMMIT_ATTEMPTS = 2
+
+#: Correlation reference contract: exact lowercase 64-char HMAC-SHA256 hex.
+_CORRELATION_RE = _re.compile(r"^[0-9a-f]{64}$")
+
+
+def new_lease_owner() -> str:
+    """Generate a unique, sanitized lease owner for one ProcessTurn instance.
+
+    Not derived from user id, request id, message, raw PID or any secret:
+    a fresh random UUID hex under the stable prefix. Format stays within the
+    database limit (``process-turn-v1:`` + 32 hex chars = 47 chars <= 64).
+    """
+    return f"{LEASE_OWNER_PREFIX}:{_uuid.uuid4().hex}"
 
 #: Outbox event for archival extraction (references only, no content).
 ARCHIVAL_EVENT_TYPE = "archival_extraction_requested"
@@ -92,13 +109,25 @@ class TurnMode(str, Enum):
 
 @dataclass(frozen=True)
 class ProcessTurnInput:
-    """Immutable input for one ProcessTurn execution."""
+    """Immutable input for one ProcessTurn execution.
+
+    ``correlation`` is the sanitized HMAC correlation reference computed by
+    the admission runtime for the canonical request id (exact lowercase
+    64-char hex). It is the only request-derived value ProcessTurn logs.
+    """
 
     authenticated_user_id: str
     request_id: str
     user_message: str
     budget: TurnBudget
+    correlation: str
     mode: TurnMode = TurnMode.normal
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.correlation, str) or not _CORRELATION_RE.fullmatch(
+            self.correlation
+        ):
+            raise ValueError("correlation must be a 64-char lowercase hex HMAC")
 
 
 @dataclass(frozen=True)
@@ -170,7 +199,11 @@ def build_archival_outbox_event(request_id: str) -> tuple[str, Mapping[str, Any]
 
 
 def build_process_turn(engine: Any) -> "ProcessTurn":
-    """Wire a ``ProcessTurn`` around a ``ConversationEngine`` instance."""
+    """Wire a ``ProcessTurn`` around a ``ConversationEngine`` instance.
+
+    Each call creates a fresh per-instance lease owner so distinct engine
+    instances (and processes) never share an effective lease owner.
+    """
     from .turn_repositories import (
         TurnCommitRepository,
         TurnReplayRepository,
@@ -189,7 +222,7 @@ def build_process_turn(engine: Any) -> "ProcessTurn":
         clock=engine._clock,
         supabase_timeout=engine._turn_config.supabase_timeout,
         archival_extraction_enabled=engine.archival_extraction_enabled,
-        lease_owner=LEASE_OWNER,
+        lease_owner=new_lease_owner(),
     )
 
 
@@ -209,7 +242,7 @@ class ProcessTurn:
         clock: Callable[[], float] = _time.time,
         supabase_timeout: float = 5.0,
         archival_extraction_enabled: bool = False,
-        lease_owner: str = LEASE_OWNER,
+        lease_owner: Optional[str] = None,
     ) -> None:
         self._state_repository = state_repository
         self._commit_repository = commit_repository
@@ -221,7 +254,9 @@ class ProcessTurn:
         self._clock = clock
         self._supabase_timeout = supabase_timeout
         self._archival_extraction_enabled = archival_extraction_enabled
-        self._lease_owner = lease_owner
+        # Per-instance lease owner: stable for the instance life, unique across
+        # instances, never shared, injectable for tests.
+        self._lease_owner = lease_owner if lease_owner is not None else new_lease_owner()
 
     # ─── Entry point ───────────────────────────────────────────────────────────
 
@@ -237,7 +272,10 @@ class ProcessTurn:
     # ─── Replay path (before the provider) ─────────────────────────────────────
 
     async def _replay(self, inp: ProcessTurnInput) -> CommittedTurn:
-        logger.info("event=process_turn_attempt attempt=1 mode=replay")
+        logger.info(
+            "event=process_turn_attempt correlation=%s attempt=1 mode=replay",
+            inp.correlation,
+        )
         outcome = await run_blocking_read(
             "replay_turn",
             inp.budget,
@@ -248,14 +286,20 @@ class ProcessTurn:
             allowlist_exceptions=_REPOSITORY_ERRORS,
         )
         if outcome.status == "completed":
-            logger.info("event=process_turn_replay")
+            logger.info("event=process_turn_replay correlation=%s", inp.correlation)
             return outcome.committed
         if outcome.status == "request_in_progress":
+            # Active lease of another worker: the request IS being processed;
+            # never recompute and never fall back to the normal path (no
+            # replay<->normal loop).
             raise ConflictError(
                 code="request_in_progress",
                 message="Request is already in progress.",
                 expected_revision=0,
             )
+        # request_replay_unavailable: no confirmed turn exists and this version
+        # performs NO automatic reclaim. Stale pending (expired lease) and
+        # expired reservations require a new request id or operational action.
         raise ConflictError(
             code="request_replay_unavailable",
             message="Request replay is unavailable.",
@@ -267,16 +311,26 @@ class ProcessTurn:
     async def _execute_normal(self, inp: ProcessTurnInput) -> CommittedTurn:
         attempt = 1
         while True:
-            logger.info("event=process_turn_attempt attempt=%s", attempt)
+            logger.info(
+                "event=process_turn_attempt correlation=%s attempt=%s",
+                inp.correlation,
+                attempt,
+            )
             result = await self._run_once(inp, attempt)
             if isinstance(result, CommittedTurn):
-                logger.info("event=process_turn_commit_completed attempt=%s", attempt)
+                logger.info(
+                    "event=process_turn_commit_completed correlation=%s attempt=%s",
+                    inp.correlation,
+                    attempt,
+                )
                 return result
 
             # revision_mismatch: bounded retry (initial + exactly one retry).
             if attempt >= MAX_COMMIT_ATTEMPTS:
                 logger.info(
-                    "event=process_turn_conflict_exhausted attempt=%s", attempt
+                    "event=process_turn_conflict_exhausted correlation=%s attempt=%s",
+                    inp.correlation,
+                    attempt,
                 )
                 raise ConflictError(
                     code="revision_mismatch",
@@ -285,7 +339,11 @@ class ProcessTurn:
                     actual_revision=result.actual_revision,
                 )
 
-            logger.info("event=process_turn_revision_conflict attempt=%s", attempt)
+            logger.info(
+                "event=process_turn_revision_conflict correlation=%s attempt=%s",
+                inp.correlation,
+                attempt,
+            )
             # Verify budget before retrying: an exhausted deadline never retries.
             if inp.budget.remaining_before_reserve <= 0.0:
                 raise DeadlineExceeded()

--- a/backend/tests/test_admission_additional_invariants.py
+++ b/backend/tests/test_admission_additional_invariants.py
@@ -5,7 +5,7 @@ import threading
 from types import SimpleNamespace
 
 import pytest
-from fastapi import BackgroundTasks, Request
+from fastapi import Request
 
 import backend.main as main
 from backend.admission import (
@@ -106,7 +106,6 @@ def test_endpoint_cancellation_drains_reservation_and_never_calls_engine(monkeyp
             main.chat_endpoint(
                 main.ChatInput(request_id=UUID, message="hello"),
                 request,
-                BackgroundTasks(),
                 current_user=SimpleNamespace(id="user-a"),
             )
         )

--- a/backend/tests/test_admission_runtime.py
+++ b/backend/tests/test_admission_runtime.py
@@ -21,6 +21,7 @@ from backend.admission import (
     NETWORK_RATE_LIMITED,
     REQUEST_ID_CONFLICT,
     REQUEST_REPLAY_UNAVAILABLE,
+    TURN_CORRELATION_DOMAIN,
     UNKNOWN_NETWORK_IDENTITY,
     USER_DAILY_REQUEST_QUOTA_EXCEEDED,
     USER_DAILY_UNIT_QUOTA_EXCEEDED,
@@ -32,6 +33,7 @@ from backend.admission import (
     AdmissionUnavailable,
     build_admission_request,
     compute_hmac_sha256,
+    compute_turn_correlation,
     parse_admission_result,
     reserve_admission_sync,
     resolve_network_identity,
@@ -91,6 +93,65 @@ def test_hmac_is_exact_utf8_and_domain_separated():
     assert message_digest != network_digest
     assert len(message_digest) == 64
     assert message_digest == message_digest.lower()
+
+
+class TestTurnCorrelation:
+    def test_correlation_is_exact_hmac_with_domain_separation(self):
+        config = AdmissionRuntimeConfig.from_values(SECRET)
+        request_id = RequestIdentity(UUID).request_id
+        expected = hmac.new(
+            SECRET.encode("utf-8"),
+            TURN_CORRELATION_DOMAIN + b"\x00" + request_id.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        assert compute_turn_correlation(config, UUID) == expected
+        assert len(expected) == 64
+        assert expected == expected.lower()
+
+    def test_same_request_same_correlation_across_calls(self):
+        config = AdmissionRuntimeConfig.from_values(SECRET)
+        assert compute_turn_correlation(config, UUID.upper()) == compute_turn_correlation(
+            config, UUID.lower()
+        )
+
+    def test_different_requests_produce_different_correlations(self):
+        config = AdmissionRuntimeConfig.from_values(SECRET)
+        other = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        assert compute_turn_correlation(config, UUID) != compute_turn_correlation(
+            config, other
+        )
+
+    def test_correlation_is_not_a_truncated_uuid_and_not_reversible(self):
+        config = AdmissionRuntimeConfig.from_values(SECRET)
+        correlation = compute_turn_correlation(config, UUID)
+        # never the raw request id, never a truncated UUID
+        assert correlation != UUID
+        assert UUID not in correlation
+        assert "550e8400" not in correlation
+        # domain separation: differs from the message HMAC of the same value
+        message_digest = compute_hmac_sha256(
+            SECRET.encode("utf-8"), MESSAGE_HMAC_DOMAIN, UUID
+        )
+        assert correlation != message_digest
+
+    def test_secret_never_appears_in_repr_or_exception(self):
+        config = AdmissionRuntimeConfig.from_values(SECRET)
+        correlation = compute_turn_correlation(config, UUID)
+        assert SECRET not in correlation
+        assert SECRET not in repr(config)
+        assert SECRET not in repr(correlation)
+
+    @pytest.mark.parametrize(
+        "request_id", ["not-a-uuid", "", None, 123, "x" * 128]
+    )
+    def test_invalid_request_id_fails_closed(self, request_id):
+        config = AdmissionRuntimeConfig.from_values(SECRET)
+        with pytest.raises(AdmissionUnavailable):
+            compute_turn_correlation(config, request_id)
+
+    def test_invalid_config_fails_closed(self):
+        with pytest.raises(AdmissionUnavailable):
+            compute_turn_correlation(object(), UUID)
 
 
 def test_untrusted_peer_ignores_forwarded_header():

--- a/backend/tests/test_archival_memory_integration.py
+++ b/backend/tests/test_archival_memory_integration.py
@@ -395,10 +395,17 @@ def test_chat_response_format(client_app, mock_supabase, monkeypatch):
         ],
         timestamp=1700000000.0,
     )
+    from backend.process_turn import ProcessTurnResult
     monkeypatch.setattr(
         engine,
         "process_turn",
-        AsyncMock(return_value=("My response text", mock_emotion)),
+        AsyncMock(
+            return_value=ProcessTurnResult(
+                committed=object(),
+                response="My response text",
+                emotion_state=mock_emotion,
+            )
+        ),
     )
     
     response = client_app.post(

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -78,6 +78,7 @@ def mock_supabase():
 def mock_engine_process():
     from backend.main import engine
     from backend.emotion_presentation import EmotionStateResponse, PublicPAD
+    from backend.process_turn import ProcessTurnResult
     fake_emotion = EmotionStateResponse(
         schema_version=1,
         mood_label="NEUTRA",
@@ -85,7 +86,12 @@ def mock_engine_process():
         dominant_emotions=[],
         timestamp=1_700_000_000.0,
     )
-    with patch.object(engine, 'process_turn', return_value=("Mock response", fake_emotion)) as mock_process:
+    fake_result = ProcessTurnResult(
+        committed=object(),
+        response="Mock response",
+        emotion_state=fake_emotion,
+    )
+    with patch.object(engine, 'process_turn', return_value=fake_result) as mock_process:
         yield mock_process
 
 
@@ -181,7 +187,9 @@ def test_valid_token(client_app, mock_supabase, mock_engine_process):
 
     assert response.status_code == 200
     assert response.json()["response"] == "Mock response"
-    mock_engine_process.assert_called_once_with("user123", "Hello", ANY, budget=ANY)
+    mock_engine_process.assert_called_once_with(
+        "user123", "Hello", REQUEST_ID, budget=ANY, mode=ANY
+    )
 
 
 def test_spoofing_user_id_in_chat(client_app, mock_supabase, mock_engine_process):
@@ -404,7 +412,9 @@ def test_chat_message_exactly_at_limit(client_app, mock_supabase, mock_engine_pr
 
     assert response.status_code == 200
     assert response.json()["response"] == "Mock response"
-    mock_engine_process.assert_called_once_with("user123", message, ANY, budget=ANY)
+    mock_engine_process.assert_called_once_with(
+        "user123", message, REQUEST_ID, budget=ANY, mode=ANY
+    )
 
 
 def test_chat_message_exceeds_limit(client_app, mock_supabase, mock_engine_process):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -188,7 +188,7 @@ def test_valid_token(client_app, mock_supabase, mock_engine_process):
     assert response.status_code == 200
     assert response.json()["response"] == "Mock response"
     mock_engine_process.assert_called_once_with(
-        "user123", "Hello", REQUEST_ID, budget=ANY, mode=ANY
+        "user123", "Hello", REQUEST_ID, budget=ANY, mode=ANY, correlation=ANY
     )
 
 
@@ -413,7 +413,7 @@ def test_chat_message_exactly_at_limit(client_app, mock_supabase, mock_engine_pr
     assert response.status_code == 200
     assert response.json()["response"] == "Mock response"
     mock_engine_process.assert_called_once_with(
-        "user123", message, REQUEST_ID, budget=ANY, mode=ANY
+        "user123", message, REQUEST_ID, budget=ANY, mode=ANY, correlation=ANY
     )
 
 

--- a/backend/tests/test_chat_admission.py
+++ b/backend/tests/test_chat_admission.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -20,7 +21,9 @@ from backend.admission import (
     AdmissionRuntimeConfig,
     AdmissionUnavailable,
 )
+from backend.atomic_turn_commit import ConflictError
 from backend.emotion_presentation import EmotionStateResponse
+from backend.process_turn import ProcessTurnResult, TurnMode
 from backend.turn_execution import TurnBudget
 
 UUID = "550e8400-e29b-41d4-a716-446655440000"
@@ -36,28 +39,33 @@ def emotion_response() -> EmotionStateResponse:
     )
 
 
+def _turn_result(mode: str = "normal") -> ProcessTurnResult:
+    return ProcessTurnResult(
+        committed=object(),
+        response="response text",
+        emotion_state=emotion_response(),
+    )
+
+
 class FakeEngine:
     def __init__(self):
         self.memory_manager = SimpleNamespace(supabase=object())
         self.calls = []
+        self.error = None
 
-    async def process_turn(
-        self,
-        user_id,
-        message,
-        background_tasks=None,
-        *,
-        budget=None,
-    ):
+    async def process_turn(self, user_id, message, request_id, *, budget=None, mode=None):
         self.calls.append(
             {
                 "user_id": user_id,
                 "message": message,
-                "background_tasks": background_tasks,
+                "request_id": request_id,
                 "budget": budget,
+                "mode": mode,
             }
         )
-        return "response", emotion_response()
+        if self.error is not None:
+            raise self.error
+        return _turn_result()
 
 
 @pytest.fixture
@@ -98,7 +106,7 @@ def endpoint(monkeypatch):
         main.app.dependency_overrides.clear()
 
 
-def test_admitted_normalises_uuid_and_shares_one_budget(endpoint, monkeypatch):
+def test_admitted_runs_process_turn_normal_with_request_id_and_one_budget(endpoint, monkeypatch):
     client, fake_engine, captured = endpoint
     rpc_calls = []
 
@@ -115,21 +123,70 @@ def test_admitted_normalises_uuid_and_shares_one_budget(endpoint, monkeypatch):
 
     assert response.status_code == 200
     assert set(response.json()) == {"response", "emotion_state"}
+    assert response.json()["response"] == "response text"
     assert len(rpc_calls) == 1
     request = rpc_calls[0]
     assert request.user_id == "user-a"
     assert request.request_id == UUID
     assert request.estimated_units == len("Olá".encode("utf-8"))
     assert len(fake_engine.calls) == 1
-    assert fake_engine.calls[0]["budget"] is captured["budget"]
+    call = fake_engine.calls[0]
+    # request_id is forwarded to the ProcessTurn-backed engine and the SAME
+    # budget flows from admission through the engine call.
+    assert call["request_id"] == UUID
+    assert call["mode"] is TurnMode.normal
+    assert call["budget"] is captured["budget"]
     assert captured["stage_label"] == "reserve_admission"
     assert captured["allowlist_exceptions"] == (AdmissionUnavailable,)
+
+
+def test_replay_unavailable_runs_process_turn_replay_mode(endpoint, monkeypatch):
+    client, fake_engine, _captured = endpoint
+    monkeypatch.setattr(
+        main,
+        "reserve_admission_sync",
+        lambda _client, _request: AdmissionResult(REQUEST_REPLAY_UNAVAILABLE, 0),
+    )
+
+    response = client.post(
+        "/chat",
+        json={"request_id": UUID, "message": "hello"},
+    )
+
+    assert response.status_code == 200
+    assert len(fake_engine.calls) == 1
+    call = fake_engine.calls[0]
+    assert call["request_id"] == UUID
+    assert call["mode"] is TurnMode.replay_attempt
+
+
+def test_replay_unavailable_without_confirmed_result_returns_409(endpoint, monkeypatch):
+    client, fake_engine, _captured = endpoint
+    monkeypatch.setattr(
+        main,
+        "reserve_admission_sync",
+        lambda _client, _request: AdmissionResult(REQUEST_REPLAY_UNAVAILABLE, 0),
+    )
+    fake_engine.error = ConflictError(
+        code="request_replay_unavailable",
+        message="Request replay is unavailable.",
+        expected_revision=0,
+    )
+
+    response = client.post(
+        "/chat",
+        json={"request_id": UUID, "message": "hello"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "request_replay_unavailable"
+    assert UUID not in response.text
+    assert fake_engine.calls[0]["mode"] is TurnMode.replay_attempt
 
 
 @pytest.mark.parametrize(
     ("decision", "retry", "status", "header"),
     [
-        (REQUEST_REPLAY_UNAVAILABLE, 0, 409, None),
         (REQUEST_ID_CONFLICT, 0, 409, None),
         (USER_RATE_LIMITED, 60, 429, "60"),
         (NETWORK_RATE_LIMITED, 60, 429, "60"),
@@ -163,6 +220,68 @@ def test_rejections_map_exactly_without_calling_engine(
     assert response.json()["detail"]["code"] == decision
     assert response.headers.get("Retry-After") == header
     assert fake_engine.calls == []
+
+
+@pytest.mark.parametrize(
+    ("code", "status", "public_code"),
+    [
+        ("revision_mismatch", 409, "revision_conflict"),
+        ("request_payload_conflict", 409, "request_id_conflict"),
+        ("request_in_progress", 409, "request_in_progress"),
+        ("lease_conflict", 409, "lease_conflict"),
+        ("request_replay_unavailable", 409, "request_replay_unavailable"),
+    ],
+)
+def test_process_turn_conflicts_map_without_leaking_request_id(
+    endpoint, monkeypatch, code, status, public_code
+):
+    client, fake_engine, _captured = endpoint
+    monkeypatch.setattr(
+        main,
+        "reserve_admission_sync",
+        lambda _client, _request: AdmissionResult(ADMITTED, 0),
+    )
+    fake_engine.error = ConflictError(
+        code=code,
+        message="internal details that must never be exposed",
+        expected_revision=7,
+        actual_revision=8,
+        request_id=UUID,
+    )
+
+    response = client.post(
+        "/chat",
+        json={"request_id": UUID, "message": "hello"},
+    )
+
+    assert response.status_code == status
+    detail = response.json()["detail"]
+    assert detail["code"] == public_code
+    # ConflictError text, revisions and request_id never reach the client.
+    assert "internal details" not in response.text
+    assert UUID not in response.text
+    assert "expected_revision" not in response.text
+    assert "actual_revision" not in response.text
+
+
+def test_persistence_error_maps_to_503(endpoint, monkeypatch):
+    from backend.atomic_turn_commit import PersistenceError
+
+    client, fake_engine, _captured = endpoint
+    monkeypatch.setattr(
+        main,
+        "reserve_admission_sync",
+        lambda _client, _request: AdmissionResult(ADMITTED, 0),
+    )
+    fake_engine.error = PersistenceError("database_error", "persistence error")
+
+    response = client.post(
+        "/chat",
+        json={"request_id": UUID, "message": "hello"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "persistence_unavailable"
 
 
 def test_store_unavailable_fails_closed_without_engine(endpoint, monkeypatch):
@@ -306,3 +425,50 @@ def test_expired_budget_returns_timeout_before_rpc(endpoint, monkeypatch):
     assert response.json()["detail"]["code"] == "turn_timeout"
     assert called is False
     assert fake_engine.calls == []
+
+
+def test_cancellation_is_propagated_not_converted_to_500(monkeypatch):
+    """The endpoint must re-raise CancelledError, never map it to HTTP 500."""
+    fake_engine = FakeEngine()
+    monkeypatch.setattr(main, "engine", fake_engine)
+    monkeypatch.setattr(
+        main,
+        "_admission_config",
+        AdmissionRuntimeConfig.from_values("s" * 32),
+    )
+    monkeypatch.setattr(
+        main,
+        "reserve_admission_sync",
+        lambda _client, _request: AdmissionResult(ADMITTED, 0),
+    )
+
+    async def fake_run_blocking_write(*_args, **_kwargs):
+        return AdmissionResult(ADMITTED, 0)
+
+    monkeypatch.setattr(main, "run_blocking_write", fake_run_blocking_write)
+
+    async def boom(*_args, **_kwargs):
+        raise asyncio.CancelledError()
+
+    fake_engine.process_turn = boom
+
+    input_data = main.ChatInput(request_id=UUID, message="hello")
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/chat",
+        "headers": [],
+        "client": ("127.0.0.1", 1234),
+        "server": ("test", 80),
+    }
+    request = main.Request(scope)
+
+    async def run():
+        with pytest.raises(asyncio.CancelledError):
+            await main.chat_endpoint(
+                input_data=input_data,
+                request=request,
+                current_user=SimpleNamespace(id="user-a"),
+            )
+
+    asyncio.run(run())

--- a/backend/tests/test_chat_admission.py
+++ b/backend/tests/test_chat_admission.py
@@ -25,8 +25,10 @@ from backend.atomic_turn_commit import ConflictError
 from backend.emotion_presentation import EmotionStateResponse
 from backend.process_turn import ProcessTurnResult, TurnMode
 from backend.turn_execution import TurnBudget
+from backend.admission import compute_turn_correlation
 
 UUID = "550e8400-e29b-41d4-a716-446655440000"
+SECRET = "s" * 32
 
 
 def emotion_response() -> EmotionStateResponse:
@@ -53,7 +55,9 @@ class FakeEngine:
         self.calls = []
         self.error = None
 
-    async def process_turn(self, user_id, message, request_id, *, budget=None, mode=None):
+    async def process_turn(
+        self, user_id, message, request_id, *, budget=None, mode=None, correlation=None
+    ):
         self.calls.append(
             {
                 "user_id": user_id,
@@ -61,6 +65,7 @@ class FakeEngine:
                 "request_id": request_id,
                 "budget": budget,
                 "mode": mode,
+                "correlation": correlation,
             }
         )
         if self.error is not None:
@@ -472,3 +477,135 @@ def test_cancellation_is_propagated_not_converted_to_500(monkeypatch):
             )
 
     asyncio.run(run())
+
+
+class TestCorrelationFlow:
+    def _expected(self) -> str:
+        return compute_turn_correlation(
+            AdmissionRuntimeConfig.from_values(SECRET), UUID
+        )
+
+    def test_same_request_same_correlation_between_endpoint_and_engine(
+        self, endpoint, monkeypatch
+    ):
+        client, fake_engine, _captured = endpoint
+        monkeypatch.setattr(
+            main,
+            "reserve_admission_sync",
+            lambda _client, _request: AdmissionResult(ADMITTED, 0),
+        )
+
+        response = client.post(
+            "/chat",
+            json={"request_id": UUID, "message": "hello"},
+        )
+
+        assert response.status_code == 200
+        expected = self._expected()
+        assert len(expected) == 64
+        assert fake_engine.calls[0]["correlation"] == expected
+        # the raw request id is never forwarded as the correlation
+        assert fake_engine.calls[0]["correlation"] != UUID
+
+    def test_different_requests_produce_different_correlations(self, endpoint, monkeypatch):
+        client, fake_engine, _captured = endpoint
+        monkeypatch.setattr(
+            main,
+            "reserve_admission_sync",
+            lambda _client, _request: AdmissionResult(ADMITTED, 0),
+        )
+
+        client.post("/chat", json={"request_id": UUID, "message": "hello"})
+        client.post(
+            "/chat",
+            json={"request_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "message": "hi"},
+        )
+
+        correlations = {call["correlation"] for call in fake_engine.calls}
+        assert len(correlations) == 2
+
+    def test_replay_attempt_receives_same_correlation(self, endpoint, monkeypatch):
+        client, fake_engine, _captured = endpoint
+        monkeypatch.setattr(
+            main,
+            "reserve_admission_sync",
+            lambda _client, _request: AdmissionResult(REQUEST_REPLAY_UNAVAILABLE, 0),
+        )
+
+        response = client.post(
+            "/chat",
+            json={"request_id": UUID, "message": "hello"},
+        )
+
+        assert response.status_code == 200
+        assert fake_engine.calls[0]["mode"] is TurnMode.replay_attempt
+        assert fake_engine.calls[0]["correlation"] == self._expected()
+
+    def test_admission_events_are_distinct_and_correlated(self, endpoint, monkeypatch, caplog):
+        import logging
+
+        client, fake_engine, _captured = endpoint
+        monkeypatch.setattr(
+            main,
+            "reserve_admission_sync",
+            lambda _client, _request: AdmissionResult(REQUEST_REPLAY_UNAVAILABLE, 0),
+        )
+
+        with caplog.at_level(logging.INFO, logger="backend.main"):
+            client.post(
+                "/chat",
+                json={"request_id": UUID, "message": "hello"},
+            )
+
+        expected = self._expected()
+        messages = [r.getMessage() for r in caplog.records]
+        assert f"event=admission_replay correlation={expected}" in messages
+        # a replay is NEVER logged as a normal admission
+        assert not any("event=admission_admitted" in m for m in messages)
+
+    def test_admitted_event_logged_only_for_fresh_admission(
+        self, endpoint, monkeypatch, caplog
+    ):
+        import logging
+
+        client, fake_engine, _captured = endpoint
+        monkeypatch.setattr(
+            main,
+            "reserve_admission_sync",
+            lambda _client, _request: AdmissionResult(ADMITTED, 0),
+        )
+
+        with caplog.at_level(logging.INFO, logger="backend.main"):
+            client.post(
+                "/chat",
+                json={"request_id": UUID, "message": "hello"},
+            )
+
+        expected = self._expected()
+        messages = [r.getMessage() for r in caplog.records]
+        assert f"event=admission_admitted correlation={expected}" in messages
+        assert not any("event=admission_replay" in m for m in messages)
+
+    def test_no_raw_uuid_and_no_secret_in_http_or_logs(
+        self, endpoint, monkeypatch, caplog
+    ):
+        import logging
+
+        client, fake_engine, _captured = endpoint
+        monkeypatch.setattr(
+            main,
+            "reserve_admission_sync",
+            lambda _client, _request: AdmissionResult(ADMITTED, 0),
+        )
+
+        with caplog.at_level(logging.INFO, logger="backend.main"):
+            response = client.post(
+                "/chat",
+                json={"request_id": UUID, "message": "hello"},
+            )
+
+        assert response.status_code == 200
+        assert UUID not in response.text
+        assert SECRET not in response.text
+        assert UUID not in caplog.text
+        assert SECRET not in caplog.text

--- a/backend/tests/test_engine_budget_passthrough.py
+++ b/backend/tests/test_engine_budget_passthrough.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import asyncio
 
 from backend.chat_engine import ChatConversationEngine
+from backend.process_turn import TurnMode
 from backend.turn_execution import TurnBudget, TurnExecutionConfig
+
+UUID = "550e8400-e29b-41d4-a716-446655440000"
 
 
 def test_process_turn_uses_explicit_budget_object():
@@ -11,21 +14,26 @@ def test_process_turn_uses_explicit_budget_object():
     provided = TurnBudget(deadline=100.0, reserve=10.0, now_provider=lambda: 0.0)
     captured = {}
 
-    async def fake_run(user_id, message, background_tasks, budget):
+    async def fake_run(user_id, message, request_id, budget, mode):
         captured.update(
             user_id=user_id,
             message=message,
-            background_tasks=background_tasks,
+            request_id=request_id,
             budget=budget,
+            mode=mode,
         )
         return "ok"
 
     engine._run_turn_locked = fake_run
     result = asyncio.run(
-        engine.process_turn("user-a", "hello", None, budget=provided)
+        engine.process_turn(
+            "user-a", "hello", UUID, budget=provided, mode=TurnMode.normal
+        )
     )
     assert result == "ok"
     assert captured["budget"] is provided
+    assert captured["request_id"] == UUID
+    assert captured["mode"] is TurnMode.normal
 
 
 def test_process_turn_still_creates_budget_for_internal_callers():
@@ -34,12 +42,12 @@ def test_process_turn_still_creates_budget_for_internal_callers():
     engine._monotonic = lambda: 10.0
     captured = {}
 
-    async def fake_run(_user_id, _message, _background_tasks, budget):
+    async def fake_run(_user_id, _message, _request_id, budget, _mode):
         captured["budget"] = budget
         return "ok"
 
     engine._run_turn_locked = fake_run
-    assert asyncio.run(engine.process_turn("user-a", "hello")) == "ok"
+    assert asyncio.run(engine.process_turn("user-a", "hello", UUID)) == "ok"
     budget = captured["budget"]
     assert isinstance(budget, TurnBudget)
     assert budget.deadline == 55.0

--- a/backend/tests/test_engine_budget_passthrough.py
+++ b/backend/tests/test_engine_budget_passthrough.py
@@ -7,6 +7,7 @@ from backend.process_turn import TurnMode
 from backend.turn_execution import TurnBudget, TurnExecutionConfig
 
 UUID = "550e8400-e29b-41d4-a716-446655440000"
+CORRELATION = "c" * 64
 
 
 def test_process_turn_uses_explicit_budget_object():
@@ -14,26 +15,33 @@ def test_process_turn_uses_explicit_budget_object():
     provided = TurnBudget(deadline=100.0, reserve=10.0, now_provider=lambda: 0.0)
     captured = {}
 
-    async def fake_run(user_id, message, request_id, budget, mode):
+    async def fake_run(user_id, message, request_id, budget, mode, correlation):
         captured.update(
             user_id=user_id,
             message=message,
             request_id=request_id,
             budget=budget,
             mode=mode,
+            correlation=correlation,
         )
         return "ok"
 
     engine._run_turn_locked = fake_run
     result = asyncio.run(
         engine.process_turn(
-            "user-a", "hello", UUID, budget=provided, mode=TurnMode.normal
+            "user-a",
+            "hello",
+            UUID,
+            budget=provided,
+            mode=TurnMode.normal,
+            correlation=CORRELATION,
         )
     )
     assert result == "ok"
     assert captured["budget"] is provided
     assert captured["request_id"] == UUID
     assert captured["mode"] is TurnMode.normal
+    assert captured["correlation"] == CORRELATION
 
 
 def test_process_turn_still_creates_budget_for_internal_callers():
@@ -42,13 +50,22 @@ def test_process_turn_still_creates_budget_for_internal_callers():
     engine._monotonic = lambda: 10.0
     captured = {}
 
-    async def fake_run(_user_id, _message, _request_id, budget, _mode):
+    async def fake_run(_user_id, _message, _request_id, budget, _mode, correlation):
         captured["budget"] = budget
+        captured["correlation"] = correlation
         return "ok"
 
     engine._run_turn_locked = fake_run
-    assert asyncio.run(engine.process_turn("user-a", "hello", UUID)) == "ok"
+    assert (
+        asyncio.run(
+            engine.process_turn(
+                "user-a", "hello", UUID, correlation=CORRELATION
+            )
+        )
+        == "ok"
+    )
     budget = captured["budget"]
     assert isinstance(budget, TurnBudget)
     assert budget.deadline == 55.0
     assert budget.reserve == 10.0
+    assert captured["correlation"] == CORRELATION

--- a/backend/tests/test_process_turn.py
+++ b/backend/tests/test_process_turn.py
@@ -12,21 +12,34 @@ context loader — no database, no network, no provider. Coverage:
  4. Result comes from the persisted CommittedTurn, not pre-commit variables
  5. Replay returns the persisted result without the provider
  6. Replay does not run transitions / appraisal / context loading
- 7. Same-ID conflicts never retry the provider
- 8. revision_mismatch retries exactly once, reloads state + context and
+ 7. Replay semantics: pending with ACTIVE lease -> request_in_progress;
+    pending with EXPIRED lease and expired -> request_replay_unavailable;
+    no provider when the policy does not authorize recomputation; replay
+    outcomes are terminal (no replay<->normal loop)
+ 8. Same-ID conflicts never retry the provider
+ 9. revision_mismatch retries exactly once, reloads state + context and
     recomputes a fresh response; a third attempt never occurs
- 9. Provider failure produces no committed turn
-10. Deadline prevents retry
-11. Cancellation before commit writes nothing; cancellation after commit
-    allows replay
-12. Outbox event is idempotent and sanitized (no content / identity)
-13. Logs and errors never contain sensitive markers
+10. Provider failure produces no committed turn
+11. Deadline prevents retry
+12. Lease owner is unique per instance, stable for the instance, sanitized
+    and never shared / never logged
+13. Cancellation before commit writes nothing; cancellation DURING commit
+    drains a stateful write to completion before propagating the original
+    CancelledError; replay recovers exactly the written result; a worker
+    failing after cancellation never leaves an unretrieved task exception
+14. Outbox event is idempotent and sanitized (no content / identity)
+15. Correlation is the sanitized HMAC of the canonical request id, present
+    in every ProcessTurn event, consistent across attempts and never the
+    raw request id; replay and commit events are semantically distinct
+16. Logs and errors never contain sensitive markers
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import re as _re
+import threading
 from dataclasses import dataclass, field
 from types import SimpleNamespace
 from typing import Any, Mapping, Optional
@@ -46,12 +59,14 @@ from backend.emotional_domain import (
     TransitionConfig,
 )
 from backend.process_turn import (
+    LEASE_OWNER_PREFIX,
     MAX_COMMIT_ATTEMPTS,
     ProcessTurn,
     ProcessTurnInput,
     ProcessTurnResult,
     TurnMode,
     build_archival_outbox_event,
+    new_lease_owner,
     parse_public_result,
 )
 from backend.relationship import (
@@ -76,6 +91,9 @@ from backend.trusted_context import LoadedContextData
 
 UUID = "550e8400-e29b-41d4-a716-446655440000"
 MESSAGE_ID = "87654321-4321-4321-4321-cba987654321"
+CORRELATION = "c" * 64
+
+_LEASE_OWNER_RE = _re.compile(r"^[A-Za-z0-9_.:-]{1,64}$")
 
 
 def _budget() -> TurnBudget:
@@ -217,7 +235,7 @@ def _use_case(**kwargs: Any) -> ProcessTurn:
         "clock": lambda: 1000.0,
         "supabase_timeout": 5.0,
         "archival_extraction_enabled": False,
-        "lease_owner": "process-turn-v1",
+        # lease_owner omitted: every instance generates its OWN owner.
     }
     params.update(kwargs)
     return ProcessTurn(**params)
@@ -229,6 +247,7 @@ def _input(mode: TurnMode = TurnMode.normal) -> ProcessTurnInput:
         request_id=UUID,
         user_message="hello",
         budget=_budget(),
+        correlation=CORRELATION,
         mode=mode,
     )
 
@@ -258,7 +277,11 @@ class TestNominalPath:
         assert commit["request_id"] == UUID
         assert commit["authenticated_user_id"] == "user-a"
         assert commit["user_message"] == "hello"
-        assert commit["lease_owner"] == "process-turn-v1"
+        # the instance owns a unique, sanitized, per-instance lease owner
+        owner = commit["lease_owner"]
+        assert owner.startswith(LEASE_OWNER_PREFIX + ":")
+        assert _LEASE_OWNER_RE.fullmatch(owner)
+        assert len(owner) <= 64
         # the assistant message id is generated before commit (valid UUID)
         assert len(commit["replay_payload"]["message_id"]) == 36
 
@@ -340,11 +363,13 @@ class TestReplayPath:
         provider = FakeProvider()
         state_repo = FakeStateRepository()
         context_loader = FakeContextLoader()
+        commit_repo = FakeCommitRepository()
         use_case = _use_case(
             replay_repository=replay_repo,
             provider=provider,
             state_repository=state_repo,
             context_loader=context_loader,
+            commit_repository=commit_repo,
         )
 
         result = await _execute(use_case, _input(mode=TurnMode.replay_attempt))
@@ -356,6 +381,7 @@ class TestReplayPath:
         assert provider.appraisals == 0
         assert provider.generations == 0
         assert len(state_repo.loads) == 0
+        assert len(commit_repo.calls) == 0
 
     @pytest.mark.asyncio
     async def test_replay_in_progress_raises_structured_conflict(self):
@@ -378,6 +404,122 @@ class TestReplayPath:
         with pytest.raises(ConflictError) as exc:
             await _execute(use_case, _input(mode=TurnMode.replay_attempt))
         assert exc.value.code == "request_replay_unavailable"
+
+
+class TestReplaySemantics:
+    """Stale/pending/reclaim policy (#308 review).
+
+    Policy chosen: NO automatic reclaim through the endpoint in this version.
+    A replay outcome is always terminal:
+      * completed -> persisted result, never recomputes;
+      * pending with ACTIVE lease -> request_in_progress (it IS being
+        processed; retry the same request id later);
+      * pending with EXPIRED lease / expired / missing -> the reservation can
+        never complete on its own; the client needs a NEW request id (or
+        operational cleanup).
+    The provider is never called for any non-completed outcome and there is
+    never a transition from replay back to the normal (commit) path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pending_active_lease_is_request_in_progress_no_provider(self):
+        provider = FakeProvider()
+        commit_repo = FakeCommitRepository()
+        use_case = _use_case(
+            replay_repository=FakeReplayRepository(
+                outcome=ReplayOutcome(status=REPLAY_STATUS_IN_PROGRESS)
+            ),
+            provider=provider,
+            commit_repository=commit_repo,
+        )
+        with pytest.raises(ConflictError) as exc:
+            await _execute(use_case, _input(mode=TurnMode.replay_attempt))
+        assert exc.value.code == "request_in_progress"
+        # The policy does not authorize recomputation: no provider, no commit.
+        assert provider.appraisals == 0
+        assert provider.generations == 0
+        assert len(commit_repo.calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_pending_expired_lease_is_replay_unavailable_no_provider(self):
+        provider = FakeProvider()
+        commit_repo = FakeCommitRepository()
+        use_case = _use_case(
+            replay_repository=FakeReplayRepository(
+                outcome=ReplayOutcome(status=REPLAY_STATUS_UNAVAILABLE)
+            ),
+            provider=provider,
+            commit_repository=commit_repo,
+        )
+        with pytest.raises(ConflictError) as exc:
+            await _execute(use_case, _input(mode=TurnMode.replay_attempt))
+        assert exc.value.code == "request_replay_unavailable"
+        assert provider.appraisals == 0
+        assert provider.generations == 0
+        assert len(commit_repo.calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_expired_status_is_replay_unavailable_no_provider(self):
+        provider = FakeProvider()
+        use_case = _use_case(
+            replay_repository=FakeReplayRepository(
+                outcome=ReplayOutcome(status=REPLAY_STATUS_UNAVAILABLE)
+            ),
+            provider=provider,
+        )
+        with pytest.raises(ConflictError) as exc:
+            await _execute(use_case, _input(mode=TurnMode.replay_attempt))
+        assert exc.value.code == "request_replay_unavailable"
+        assert provider.appraisals == 0
+        assert provider.generations == 0
+
+    @pytest.mark.asyncio
+    async def test_no_loop_between_replay_and_normal(self):
+        """A failed replay never falls back to the normal commit path."""
+        replay_repo = FakeReplayRepository(
+            outcome=ReplayOutcome(status=REPLAY_STATUS_UNAVAILABLE)
+        )
+        state_repo = FakeStateRepository()
+        commit_repo = FakeCommitRepository()
+        context_loader = FakeContextLoader()
+        provider = FakeProvider()
+        use_case = _use_case(
+            replay_repository=replay_repo,
+            state_repository=state_repo,
+            commit_repository=commit_repo,
+            context_loader=context_loader,
+            provider=provider,
+        )
+
+        with pytest.raises(ConflictError) as exc:
+            await _execute(use_case, _input(mode=TurnMode.replay_attempt))
+
+        assert exc.value.code == "request_replay_unavailable"
+        # Terminal outcome: no state load, no context, no provider, no commit.
+        assert len(state_repo.loads) == 0
+        assert context_loader.calls == 0
+        assert provider.appraisals == 0
+        assert provider.generations == 0
+        assert len(commit_repo.calls) == 0
+        # The same request re-sent as NORMAL is a distinct admission; only a
+        # repeated admission can enter replay mode. A single execution never
+        # cycles replay -> normal.
+        assert len(replay_repo.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_replay_does_not_claim_any_request(self):
+        """Replay performs reads only: no commit_turn call is ever made."""
+        replay_repo = FakeReplayRepository(
+            outcome=ReplayOutcome(status="completed", committed=_committed())
+        )
+        commit_repo = FakeCommitRepository()
+        use_case = _use_case(
+            replay_repository=replay_repo, commit_repository=commit_repo
+        )
+
+        await _execute(use_case, _input(mode=TurnMode.replay_attempt))
+
+        assert len(commit_repo.calls) == 0
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -500,6 +642,7 @@ class TestRevisionRetry:
             request_id=UUID,
             user_message="hello",
             budget=budget,
+            correlation=CORRELATION,
             mode=TurnMode.normal,
         )
 
@@ -553,21 +696,73 @@ class TestCancellation:
         # Cancellation before the commit started: nothing written.
         assert len(commit_repo.calls) == 0
 
+
+class StatefulWriteRepository:
+    """commit() that really writes to a shared store, gated by threading
+    events so the test can cancel the caller while the worker is active.
+
+    Contract mirrors the real repository inside `run_blocking_write`: the
+    write starts, blocks until released, writes the result to the shared
+    store and only then returns. A configured ``error`` is raised instead.
+    """
+
+    def __init__(
+        self,
+        store: dict,
+        started: threading.Event,
+        release: threading.Event,
+        finished: threading.Event,
+        error: Optional[BaseException] = None,
+        result: Optional[CommittedTurn] = None,
+    ) -> None:
+        self.store = store
+        self.started = started
+        self.release = release
+        self.finished = finished
+        self.error = error
+        self.result = result
+
+    def commit(self, **kwargs: Any) -> CommittedTurn:
+        self.started.set()
+        released = self.release.wait(timeout=10.0)
+        assert released, "worker release timed out"
+        if self.error is not None:
+            raise self.error
+        committed = self.result if self.result is not None else _committed()
+        self.store["committed"] = committed
+        self.finished.set()
+        return committed
+
+
+class StoreBackedReplayRepository:
+    """Replay repository that reads exactly what the stateful write wrote."""
+
+    def __init__(self, store: dict) -> None:
+        self.store = store
+        self.calls = 0
+
+    def replay(self, authenticated_user_id: str, request_id: str) -> ReplayOutcome:
+        self.calls += 1
+        committed = self.store.get("committed")
+        if committed is None:
+            return ReplayOutcome(status=REPLAY_STATUS_UNAVAILABLE)
+        return ReplayOutcome(status="completed", committed=committed)
+
+
+class TestCancelDrainsStatefulWrite:
     @pytest.mark.asyncio
-    async def test_cancel_after_commit_allows_replay(self):
-        # The write helper re-raises the original CancelledError after the
-        # underlying write has been drained (commit actually succeeded).
-        committed = _committed()
-
-        class CommitThenCancel(FakeCommitRepository):
-            def commit(self, **kwargs):
-                self.calls.append(kwargs)
-                raise asyncio.CancelledError()
-
-        commit_repo = CommitThenCancel()
-        replay_repo = FakeReplayRepository(
-            outcome=ReplayOutcome(status="completed", committed=committed)
-        )
+    async def test_cancel_during_commit_drains_then_replay_reads_written_result(self):
+        """The write starts, the caller is cancelled while the worker is
+        active, the worker writes the result and only then is released;
+        run_blocking_write waits for the worker and only then propagates the
+        original CancelledError; replay reads exactly the written result and
+        the provider is not called again."""
+        store: dict = {}
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+        commit_repo = StatefulWriteRepository(store, started, release, finished)
+        replay_repo = StoreBackedReplayRepository(store)
         provider = FakeProvider()
         use_case = _use_case(
             commit_repository=commit_repo,
@@ -575,13 +770,115 @@ class TestCancellation:
             provider=provider,
         )
 
+        task = asyncio.create_task(_execute(use_case, _input()))
+        # 1. The write started inside run_blocking_write (worker active).
+        started_ok = await asyncio.to_thread(started.wait, 5.0)
+        assert started_ok, "commit write did not start"
+        # 2. Cancel the calling task while the worker is still active.
+        task.cancel()
+        await asyncio.sleep(0.05)
+        assert not task.done(), "task must still be draining the write"
+        # 3. The worker writes the result and only then is released.
+        release.set()
         with pytest.raises(asyncio.CancelledError):
-            await _execute(use_case, _input())
-
-        # The retried delivery recovers the persisted replay without provider.
+            await task
+        assert finished.wait(5.0), "worker never finished"
+        # 4. The write really completed before the cancellation propagated.
+        assert "committed" in store
+        # 5. Replay recovers exactly the written result, without provider.
         result = await _execute(use_case, _input(mode=TurnMode.replay_attempt))
         assert result.response == "persisted response"
-        assert provider.generations == 1  # only the first (cancelled) attempt
+        assert result.committed is store["committed"]
+        assert provider.generations == 1
+        assert provider.appraisals == 1
+
+    @pytest.mark.asyncio
+    async def test_worker_failure_after_cancel_is_recovered_without_asyncio_warning(
+        self, caplog
+    ):
+        """If the worker fails after the cancellation, the original
+        CancelledError propagates and the worker's exception is retrieved:
+        asyncio must never log 'Task exception was never retrieved'."""
+        store: dict = {}
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+        commit_repo = StatefulWriteRepository(
+            store,
+            started,
+            release,
+            finished,
+            error=RuntimeError("worker exploded after cancel"),
+        )
+        use_case = _use_case(commit_repository=commit_repo)
+
+        task = asyncio.create_task(_execute(use_case, _input()))
+        started_ok = await asyncio.to_thread(started.wait, 5.0)
+        assert started_ok, "commit write did not start"
+        task.cancel()
+        await asyncio.sleep(0.05)
+        release.set()
+
+        with caplog.at_level(logging.ERROR, logger="asyncio"):
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        # run_blocking_write only propagates after the worker task is done:
+        # the CancelledError above is itself the proof the drain finished.
+        assert "Task exception was never retrieved" not in caplog.text
+        assert "worker exploded" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_run_blocking_write_regression_consumes_worker_outcome_on_cancel(
+        self, caplog
+    ):
+        """Regression for the helper race that could exit the drain loop
+        without consuming ``worker_task.result()`` after a cancellation:
+        the worker completes while the caller is cancelled and the outcome
+        (success or failure) is always retrieved."""
+        from backend.turn_execution import run_blocking_write
+
+        store: dict = {}
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+        commit_repo = StatefulWriteRepository(store, started, release, finished)
+        replay_repo = StoreBackedReplayRepository(store)
+
+        async def run():
+            return await run_blocking_write(
+                "commit_turn",
+                _budget(),
+                5.0,
+                commit_repo.commit,
+                authenticated_user_id="user-a",
+                request_id=UUID,
+                expected_revision=0,
+                user_message="hello",
+                assistant_message="ok",
+                emotional_state=None,
+                relationship_state=None,
+                public_response="ok",
+                outbox_events=[],
+                replay_payload={},
+                lease_owner=new_lease_owner(),
+                allowlist_exceptions=(ConflictError, ValidationError, PersistenceError),
+            )
+
+        task = asyncio.create_task(run())
+        started_ok = await asyncio.to_thread(started.wait, 5.0)
+        assert started_ok, "commit write did not start"
+        task.cancel()
+        await asyncio.sleep(0.05)
+        release.set()
+        with caplog.at_level(logging.ERROR, logger="asyncio"):
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        # The worker's successful result was consumed; the write landed.
+        assert finished.wait(5.0)
+        assert "committed" in store
+        assert "Task exception was never retrieved" not in caplog.text
+        # The replay store is authoritative for what was drained.
+        assert replay_repo.store["committed"] is store["committed"]
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -653,10 +950,158 @@ class TestObservability:
             await _execute(use_case, _input())
 
         messages = [r.getMessage() for r in caplog.records]
-        assert "event=process_turn_attempt attempt=1" in messages
-        assert "event=process_turn_revision_conflict attempt=1" in messages
-        assert "event=process_turn_attempt attempt=2" in messages
-        assert "event=process_turn_commit_completed attempt=2" in messages
+        assert f"event=process_turn_attempt correlation={CORRELATION} attempt=1" in messages
+        assert f"event=process_turn_revision_conflict correlation={CORRELATION} attempt=1" in messages
+        assert f"event=process_turn_attempt correlation={CORRELATION} attempt=2" in messages
+        assert f"event=process_turn_commit_completed correlation={CORRELATION} attempt=2" in messages
+
+    @pytest.mark.asyncio
+    async def test_lease_owner_never_appears_in_logs(self, caplog):
+        commit_repo = FakeCommitRepository()
+        use_case = _use_case(commit_repository=commit_repo)
+
+        with caplog.at_level(logging.INFO, logger="backend.process_turn"):
+            await _execute(use_case, _input())
+
+        assert use_case._lease_owner not in caplog.text
+
+
+class TestLeaseOwner:
+    def test_two_instances_receive_different_owners(self):
+        first = _use_case()
+        second = _use_case()
+        assert first._lease_owner != second._lease_owner
+
+    def test_same_instance_reuses_the_same_owner(self):
+        use_case = _use_case()
+        owner = use_case._lease_owner
+        assert use_case._lease_owner == owner
+        assert _LEASE_OWNER_RE.fullmatch(owner)
+        assert owner.startswith(LEASE_OWNER_PREFIX + ":")
+        assert len(owner) <= 64
+
+    def test_injected_owner_is_respected(self):
+        use_case = _use_case(lease_owner="custom-owner-1")
+        assert use_case._lease_owner == "custom-owner-1"
+
+    def test_new_lease_owner_is_always_sanitized_and_unique(self):
+        owners = {new_lease_owner() for _ in range(100)}
+        assert len(owners) == 100
+        for owner in owners:
+            assert _LEASE_OWNER_RE.fullmatch(owner)
+            assert owner.startswith(LEASE_OWNER_PREFIX + ":")
+            assert len(owner) <= 64
+
+    @pytest.mark.asyncio
+    async def test_active_lease_of_another_instance_is_request_in_progress(self):
+        """An active lease held by a DIFFERENT instance must surface as
+        request_in_progress, never as a continuation of the same worker."""
+        other_instance_owner = new_lease_owner()
+        commit_repo = FakeCommitRepository(
+            error=ConflictError(
+                code="request_in_progress",
+                message="Request is already in progress by another worker",
+                expected_revision=0,
+                request_id=UUID,
+            )
+        )
+        use_case = _use_case(commit_repository=commit_repo)
+
+        with pytest.raises(ConflictError) as exc:
+            await _execute(use_case, _input())
+
+        assert exc.value.code == "request_in_progress"
+        # The instance must not have claimed the other worker's lease.
+        assert use_case._lease_owner != other_instance_owner
+        assert commit_repo.calls[0]["lease_owner"] != other_instance_owner
+
+    @pytest.mark.asyncio
+    async def test_owner_is_injectable_per_instance_for_tests(self):
+        commit_repo = FakeCommitRepository()
+        first = _use_case(commit_repository=commit_repo, lease_owner="worker-A")
+        second = _use_case(commit_repository=commit_repo, lease_owner="worker-B")
+
+        await _execute(first, _input())
+        await _execute(second, _input())
+
+        assert [c["lease_owner"] for c in commit_repo.calls] == [
+            "worker-A",
+            "worker-B",
+        ]
+
+
+class TestCorrelationObservability:
+    def test_invalid_correlation_fails_closed(self):
+        with pytest.raises(ValueError):
+            ProcessTurnInput(
+                authenticated_user_id="user-a",
+                request_id=UUID,
+                user_message="hello",
+                budget=_budget(),
+                correlation="not-a-hex-hmac",
+            )
+        with pytest.raises(ValueError):
+            ProcessTurnInput(
+                authenticated_user_id="user-a",
+                request_id=UUID,
+                user_message="hello",
+                budget=_budget(),
+                correlation=UUID,  # raw request id is never a valid correlation
+            )
+
+    @pytest.mark.asyncio
+    async def test_replay_and_commit_events_are_semantically_distinct(self, caplog):
+        replay_repo = FakeReplayRepository(
+            outcome=ReplayOutcome(status="completed", committed=_committed())
+        )
+        use_case = _use_case(replay_repository=replay_repo)
+
+        with caplog.at_level(logging.INFO, logger="backend.process_turn"):
+            await _execute(use_case, _input(mode=TurnMode.replay_attempt))
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert f"event=process_turn_attempt correlation={CORRELATION} attempt=1 mode=replay" in messages
+        assert f"event=process_turn_replay correlation={CORRELATION}" in messages
+        # A replay is NEVER logged as a commit completion.
+        assert not any(
+            "event=process_turn_commit_completed" in message for message in messages
+        )
+
+    @pytest.mark.asyncio
+    async def test_correlation_is_consistent_across_retry_attempts(self, caplog):
+        commit_repo = FakeCommitRepository(results=[_mismatch(0, 1), _committed()])
+        use_case = _use_case(commit_repository=commit_repo)
+
+        with caplog.at_level(logging.INFO, logger="backend.process_turn"):
+            await _execute(use_case, _input())
+
+        messages = [r.getMessage() for r in caplog.records]
+        for message in messages:
+            assert f"correlation={CORRELATION}" in message
+        # the raw request id never appears in any event
+        assert all(UUID not in message for message in messages)
+
+    @pytest.mark.asyncio
+    async def test_different_correlations_produce_distinct_events(self, caplog):
+        other = "d" * 64
+        commit_repo = FakeCommitRepository()
+        use_case = _use_case(commit_repository=commit_repo)
+        first_inp = _input()
+        second_inp = ProcessTurnInput(
+            authenticated_user_id="user-a",
+            request_id=UUID,
+            user_message="hello",
+            budget=_budget(),
+            correlation=other,
+        )
+
+        with caplog.at_level(logging.INFO, logger="backend.process_turn"):
+            await _execute(use_case, first_inp)
+            await _execute(use_case, second_inp)
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert f"event=process_turn_commit_completed correlation={CORRELATION} attempt=1" in messages
+        assert f"event=process_turn_commit_completed correlation={other} attempt=1" in messages
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -831,13 +1276,19 @@ class TestEngineDelegation:
         engine._turn_config = SimpleNamespace()
 
         result = await engine.process_turn(
-            "user-a", "hello", UUID, budget=_budget(), mode=TurnMode.normal
+            "user-a",
+            "hello",
+            UUID,
+            budget=_budget(),
+            mode=TurnMode.normal,
+            correlation=CORRELATION,
         )
         assert result == "ok"
         assert captured["inp"].authenticated_user_id == "user-a"
         assert captured["inp"].request_id == UUID
         assert captured["inp"].user_message == "hello"
         assert captured["inp"].mode is TurnMode.normal
+        assert captured["inp"].correlation == CORRELATION
         assert captured["inp"].budget is not None
 
 
@@ -877,6 +1328,8 @@ class TestActivePathNeverCallsLegacyWriters:
         engine._monotonic = lambda: 0.0
         engine._turn_config = SimpleNamespace()
 
-        result = await engine.process_turn("user-a", "hello", UUID, budget=_budget())
+        result = await engine.process_turn(
+            "user-a", "hello", UUID, budget=_budget(), correlation=CORRELATION
+        )
         assert result == "ok"
         assert captured["mode"] is TurnMode.normal

--- a/backend/tests/test_process_turn.py
+++ b/backend/tests/test_process_turn.py
@@ -1,0 +1,882 @@
+"""
+Unit tests for the ProcessTurn use case and its repositories (#272).
+
+Everything is tested with fake repositories, a fake provider and a fake
+context loader — no database, no network, no provider. Coverage:
+
+ 1. Loaded state includes revision; missing profile yields defaults + rev 0
+    with NO insert; duplicate rows / invalid revision fail closed
+ 2. Nominal path commits exactly once with the loaded revision
+ 3. Nominal path writes only through the commit repository (never
+    save_turn / sync_state, never BackgroundTasks)
+ 4. Result comes from the persisted CommittedTurn, not pre-commit variables
+ 5. Replay returns the persisted result without the provider
+ 6. Replay does not run transitions / appraisal / context loading
+ 7. Same-ID conflicts never retry the provider
+ 8. revision_mismatch retries exactly once, reloads state + context and
+    recomputes a fresh response; a third attempt never occurs
+ 9. Provider failure produces no committed turn
+10. Deadline prevents retry
+11. Cancellation before commit writes nothing; cancellation after commit
+    allows replay
+12. Outbox event is idempotent and sanitized (no content / identity)
+13. Logs and errors never contain sensitive markers
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any, Mapping, Optional
+
+import pytest
+
+from backend.atomic_turn_commit import (
+    CommittedTurn,
+    ConflictError,
+    PersistenceError,
+    ValidationError,
+)
+from backend.emotion_presentation import EmotionStateResponse
+from backend.emotional_domain import (
+    AppraisalV1,
+    EmotionalStateV1,
+    TransitionConfig,
+)
+from backend.process_turn import (
+    MAX_COMMIT_ATTEMPTS,
+    ProcessTurn,
+    ProcessTurnInput,
+    ProcessTurnResult,
+    TurnMode,
+    build_archival_outbox_event,
+    parse_public_result,
+)
+from backend.relationship import (
+    RelationshipStateV1,
+    RelationshipTransitionConfig,
+)
+from backend.turn_execution import (
+    DeadlineExceeded,
+    TurnBudget,
+    TurnErrorCode,
+    TurnExecutionError,
+)
+from backend.turn_repositories import (
+    REPLAY_STATUS_IN_PROGRESS,
+    REPLAY_STATUS_UNAVAILABLE,
+    LoadedUserState,
+    ReplayOutcome,
+    UserStateRepository,
+    parse_replay_committed_turn_result,
+)
+from backend.trusted_context import LoadedContextData
+
+UUID = "550e8400-e29b-41d4-a716-446655440000"
+MESSAGE_ID = "87654321-4321-4321-4321-cba987654321"
+
+
+def _budget() -> TurnBudget:
+    return TurnBudget(deadline=1000.0, reserve=10.0, now_provider=lambda: 0.0)
+
+
+def _emotion_dict() -> dict:
+    return EmotionStateResponse(
+        schema_version=1,
+        mood_label="NEUTRA",
+        pad={"pleasure": 0.0, "arousal": 0.0, "dominance": 0.0},
+        dominant_emotions=[],
+        timestamp=1000.0,
+    ).model_dump()
+
+
+def _committed(revision: int = 1, response: str = "persisted response") -> CommittedTurn:
+    return CommittedTurn(
+        user_id="user-a",
+        request_id=UUID,
+        committed_revision=revision,
+        user_message_id=UUID,
+        assistant_message_id=MESSAGE_ID,
+        replay_payload={
+            "response": response,
+            "emotion_state": _emotion_dict(),
+            "message_id": MESSAGE_ID,
+            "duration_ms": 42,
+        },
+        outbox_events=(),
+        created_at="2024-01-01T00:00:00Z",
+        completed_at="2024-01-01T00:00:00Z",
+    )
+
+
+def _default_state(revision: int = 0) -> LoadedUserState:
+    return LoadedUserState(
+        user_id="user-a",
+        revision=revision,
+        persona_config="Katherine...",
+        user_profile={},
+        emotional_state=EmotionalStateV1.neutral(timestamp=1000.0).to_dict(),
+        relationship_state=RelationshipStateV1.neutral(timestamp=1000.0).to_dict(),
+    )
+
+
+@dataclass
+class FakeStateRepository:
+    states: list[LoadedUserState] = field(default_factory=list)
+    error: Optional[BaseException] = None
+    loads: list[float] = field(default_factory=list)
+
+    def load(self, user_id: str, default_timestamp: float) -> LoadedUserState:
+        self.loads.append(default_timestamp)
+        if self.error is not None:
+            raise self.error
+        if self.states:
+            return self.states.pop(0)
+        return _default_state()
+
+
+@dataclass
+class FakeCommitRepository:
+    results: list = field(default_factory=list)
+    error: Optional[BaseException] = None
+    calls: list[dict] = field(default_factory=list)
+
+    def commit(self, **kwargs: Any) -> CommittedTurn:
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        if self.results:
+            return self.results.pop(0)
+        return _committed()
+
+
+@dataclass
+class FakeReplayRepository:
+    outcome: Optional[ReplayOutcome] = None
+    error: Optional[BaseException] = None
+    calls: list[tuple] = field(default_factory=list)
+
+    def replay(self, authenticated_user_id: str, request_id: str) -> ReplayOutcome:
+        self.calls.append((authenticated_user_id, request_id))
+        if self.error is not None:
+            raise self.error
+        if self.outcome is None:
+            return ReplayOutcome(status="completed", committed=_committed())
+        return self.outcome
+
+
+@dataclass
+class FakeContextLoader:
+    calls: int = 0
+    error: Optional[BaseException] = None
+
+    def __call__(self, user_id: str, current_message: str, user_state: dict):
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        return LoadedContextData()
+
+
+@dataclass
+class FakeProvider:
+    responses: list[str] = field(default_factory=lambda: ["generated response"])
+    appraise_error: Optional[BaseException] = None
+    generate_error: Optional[BaseException] = None
+    appraisals: int = 0
+    generations: int = 0
+
+    async def appraise(self, message: str, budget: TurnBudget) -> AppraisalV1:
+        self.appraisals += 1
+        if self.appraise_error is not None:
+            raise self.appraise_error
+        return AppraisalV1.neutral()
+
+    async def generate(self, messages: list, budget: TurnBudget) -> str:
+        self.generations += 1
+        if self.generate_error is not None:
+            raise self.generate_error
+        if self.responses:
+            return self.responses.pop(0)
+        return "generated response"
+
+    def build_trusted_policy(self, emotional_state, relationship, adaptation_strategy=""):
+        return "policy"
+
+
+def _use_case(**kwargs: Any) -> ProcessTurn:
+    params: dict[str, Any] = {
+        "state_repository": FakeStateRepository(),
+        "commit_repository": FakeCommitRepository(),
+        "replay_repository": FakeReplayRepository(),
+        "context_loader": FakeContextLoader(),
+        "provider": FakeProvider(),
+        "transition_config": TransitionConfig.defaults(),
+        "relationship_config": RelationshipTransitionConfig.defaults(),
+        "clock": lambda: 1000.0,
+        "supabase_timeout": 5.0,
+        "archival_extraction_enabled": False,
+        "lease_owner": "process-turn-v1",
+    }
+    params.update(kwargs)
+    return ProcessTurn(**params)
+
+
+def _input(mode: TurnMode = TurnMode.normal) -> ProcessTurnInput:
+    return ProcessTurnInput(
+        authenticated_user_id="user-a",
+        request_id=UUID,
+        user_message="hello",
+        budget=_budget(),
+        mode=mode,
+    )
+
+
+async def _execute(use_case: ProcessTurn, inp: ProcessTurnInput) -> ProcessTurnResult:
+    return await use_case.execute(inp)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 1. Nominal path
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestNominalPath:
+    @pytest.mark.asyncio
+    async def test_commit_called_exactly_once_with_loaded_revision(self):
+        state_repo = FakeStateRepository(states=[_default_state(revision=3)])
+        commit_repo = FakeCommitRepository()
+        use_case = _use_case(state_repository=state_repo, commit_repository=commit_repo)
+
+        result = await _execute(use_case, _input())
+
+        assert isinstance(result, ProcessTurnResult)
+        assert len(commit_repo.calls) == 1
+        commit = commit_repo.calls[0]
+        assert commit["expected_revision"] == 3
+        assert commit["request_id"] == UUID
+        assert commit["authenticated_user_id"] == "user-a"
+        assert commit["user_message"] == "hello"
+        assert commit["lease_owner"] == "process-turn-v1"
+        # the assistant message id is generated before commit (valid UUID)
+        assert len(commit["replay_payload"]["message_id"]) == 36
+
+    @pytest.mark.asyncio
+    async def test_result_comes_from_committed_turn_not_precommit_variables(self):
+        # The provider generates one text, but the persisted result says
+        # another: the use case must return the persisted one.
+        provider = FakeProvider(responses=["generated text"])
+        commit_repo = FakeCommitRepository(results=[_committed(response="persisted text")])
+        use_case = _use_case(
+            provider=provider, commit_repository=commit_repo
+        )
+
+        result = await _execute(use_case, _input())
+
+        assert result.response == "persisted text"
+        assert isinstance(result.emotion_state, EmotionStateResponse)
+        assert result.committed.committed_revision == 1
+
+    @pytest.mark.asyncio
+    async def test_only_write_path_is_commit_repository(self):
+        state_repo = FakeStateRepository()
+        commit_repo = FakeCommitRepository()
+        use_case = _use_case(state_repository=state_repo, commit_repository=commit_repo)
+
+        await _execute(use_case, _input())
+
+        # The use case has no reference to memory managers at all: the only
+        # write-capable repository invoked is the commit repository.
+        assert len(commit_repo.calls) == 1
+        assert not hasattr(use_case, "save_turn")
+        assert not hasattr(use_case, "sync_state")
+
+    @pytest.mark.asyncio
+    async def test_state_and_context_loaded_before_commit(self):
+        state_repo = FakeStateRepository(states=[_default_state(revision=0)])
+        context_loader = FakeContextLoader()
+        use_case = _use_case(
+            state_repository=state_repo, context_loader=context_loader
+        )
+
+        await _execute(use_case, _input())
+
+        assert len(state_repo.loads) == 1
+        assert context_loader.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_input_type_validated(self):
+        use_case = _use_case()
+        with pytest.raises(TypeError):
+            await use_case.execute("not an input")
+
+    @pytest.mark.asyncio
+    async def test_persistence_error_propagates_without_retry(self):
+        commit_repo = FakeCommitRepository(
+            error=PersistenceError("database_error", "persistence error")
+        )
+        provider = FakeProvider()
+        use_case = _use_case(commit_repository=commit_repo, provider=provider)
+
+        with pytest.raises(PersistenceError):
+            await _execute(use_case, _input())
+        assert provider.appraisals == 1
+        assert provider.generations == 1
+        assert len(commit_repo.calls) == 1
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 2. Replay path
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestReplayPath:
+    @pytest.mark.asyncio
+    async def test_replay_returns_persisted_result_without_provider(self):
+        replay_repo = FakeReplayRepository(
+            outcome=ReplayOutcome(status="completed", committed=_committed())
+        )
+        provider = FakeProvider()
+        state_repo = FakeStateRepository()
+        context_loader = FakeContextLoader()
+        use_case = _use_case(
+            replay_repository=replay_repo,
+            provider=provider,
+            state_repository=state_repo,
+            context_loader=context_loader,
+        )
+
+        result = await _execute(use_case, _input(mode=TurnMode.replay_attempt))
+
+        assert result.response == "persisted response"
+        # no context load, no appraisal, no generation, no transitions,
+        # no state load, no commit
+        assert context_loader.calls == 0
+        assert provider.appraisals == 0
+        assert provider.generations == 0
+        assert len(state_repo.loads) == 0
+
+    @pytest.mark.asyncio
+    async def test_replay_in_progress_raises_structured_conflict(self):
+        use_case = _use_case(
+            replay_repository=FakeReplayRepository(
+                outcome=ReplayOutcome(status=REPLAY_STATUS_IN_PROGRESS)
+            )
+        )
+        with pytest.raises(ConflictError) as exc:
+            await _execute(use_case, _input(mode=TurnMode.replay_attempt))
+        assert exc.value.code == "request_in_progress"
+
+    @pytest.mark.asyncio
+    async def test_replay_unavailable_raises_structured_conflict(self):
+        use_case = _use_case(
+            replay_repository=FakeReplayRepository(
+                outcome=ReplayOutcome(status=REPLAY_STATUS_UNAVAILABLE)
+            )
+        )
+        with pytest.raises(ConflictError) as exc:
+            await _execute(use_case, _input(mode=TurnMode.replay_attempt))
+        assert exc.value.code == "request_replay_unavailable"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 3. Conflicts
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestConflicts:
+    @pytest.mark.asyncio
+    async def test_payload_conflict_never_retries_provider(self):
+        commit_repo = FakeCommitRepository(
+            error=ConflictError(
+                code="request_payload_conflict",
+                message="conflict",
+                expected_revision=0,
+                request_id=UUID,
+            )
+        )
+        provider = FakeProvider()
+        use_case = _use_case(commit_repository=commit_repo, provider=provider)
+
+        with pytest.raises(ConflictError) as exc:
+            await _execute(use_case, _input())
+        assert exc.value.code == "request_payload_conflict"
+        assert provider.appraisals == 1
+        assert provider.generations == 1
+        assert len(commit_repo.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_request_in_progress_never_retries(self):
+        commit_repo = FakeCommitRepository(
+            error=ConflictError(
+                code="request_in_progress", message="in progress", expected_revision=0
+            )
+        )
+        provider = FakeProvider()
+        use_case = _use_case(commit_repository=commit_repo, provider=provider)
+
+        with pytest.raises(ConflictError) as exc:
+            await _execute(use_case, _input())
+        assert exc.value.code == "request_in_progress"
+        assert len(commit_repo.calls) == 1
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 4. Bounded revision retry
+# ═══════════════════════════════════════════════════════════════════
+
+
+def _mismatch(expected: int, actual: int) -> ConflictError:
+    return ConflictError(
+        code="revision_mismatch",
+        message="Profile revision does not match",
+        expected_revision=expected,
+        actual_revision=actual,
+    )
+
+
+class TestRevisionRetry:
+    @pytest.mark.asyncio
+    async def test_mismatch_retries_exactly_once_and_reloads(self):
+        state_repo = FakeStateRepository(
+            states=[_default_state(revision=0), _default_state(revision=1)]
+        )
+        commit_repo = FakeCommitRepository(results=[_mismatch(0, 1), _committed(revision=2)])
+        context_loader = FakeContextLoader()
+        provider = FakeProvider(responses=["first", "second"])
+        use_case = _use_case(
+            state_repository=state_repo,
+            commit_repository=commit_repo,
+            context_loader=context_loader,
+            provider=provider,
+        )
+
+        result = await _execute(use_case, _input())
+
+        # two commit attempts: first with revision 0 (conflict), second with
+        # the reloaded revision 1; the second response is fresh, not reused.
+        assert [c["expected_revision"] for c in commit_repo.calls] == [0, 1]
+        assert [c["public_response"] for c in commit_repo.calls] == ["first", "second"]
+        assert len(state_repo.loads) == 2
+        assert context_loader.calls == 2
+        assert provider.appraisals == 2
+        assert provider.generations == 2
+        assert result.response == "persisted response"
+
+    @pytest.mark.asyncio
+    async def test_third_attempt_never_occurs(self):
+        commit_repo = FakeCommitRepository(results=[_mismatch(0, 1), _mismatch(1, 2)])
+        provider = FakeProvider()
+        use_case = _use_case(commit_repository=commit_repo, provider=provider)
+
+        with pytest.raises(ConflictError) as exc:
+            await _execute(use_case, _input())
+        assert exc.value.code == "revision_mismatch"
+        assert exc.value.expected_revision == 1
+        assert exc.value.actual_revision == 2
+        assert len(commit_repo.calls) == MAX_COMMIT_ATTEMPTS
+        assert provider.appraisals == MAX_COMMIT_ATTEMPTS
+
+    @pytest.mark.asyncio
+    async def test_deadline_prevents_retry(self):
+        now = {"t": 0.0}
+        budget = TurnBudget(deadline=100.0, reserve=0.0, now_provider=lambda: now["t"])
+
+        class AdvanceThenMismatch(FakeCommitRepository):
+            def commit(self, **kwargs):
+                self.calls.append(kwargs)
+                # The first commit succeeds on the wire but reports a revision
+                # conflict after the deadline has passed.
+                now["t"] = 200.0
+                raise _mismatch(0, 1)
+
+        commit_repo = AdvanceThenMismatch()
+        provider = FakeProvider()
+        use_case = _use_case(commit_repository=commit_repo, provider=provider)
+
+        inp = ProcessTurnInput(
+            authenticated_user_id="user-a",
+            request_id=UUID,
+            user_message="hello",
+            budget=budget,
+            mode=TurnMode.normal,
+        )
+
+        # The retry is refused because the deadline is exhausted.
+        with pytest.raises(DeadlineExceeded):
+            await _execute(use_case, inp)
+        assert len(commit_repo.calls) == 1
+        assert provider.generations == 1
+
+    @pytest.mark.asyncio
+    async def test_provider_failure_produces_no_committed_turn(self):
+        provider = FakeProvider(generate_error=TurnExecutionError(
+            TurnErrorCode.provider_unavailable, "provider unavailable"
+        ))
+        commit_repo = FakeCommitRepository()
+        use_case = _use_case(provider=provider, commit_repository=commit_repo)
+
+        with pytest.raises(TurnExecutionError) as exc:
+            await _execute(use_case, _input())
+        assert exc.value.code == TurnErrorCode.provider_unavailable
+        assert len(commit_repo.calls) == 0
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 5. Cancellation
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestCancellation:
+    @pytest.mark.asyncio
+    async def test_cancel_before_commit_writes_nothing(self):
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_generate(messages, budget):
+            started.set()
+            await release.wait()
+            return "late response"
+
+        provider = FakeProvider()
+        provider.generate = slow_generate
+        commit_repo = FakeCommitRepository()
+        use_case = _use_case(provider=provider, commit_repository=commit_repo)
+
+        task = asyncio.create_task(_execute(use_case, _input()))
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # Cancellation before the commit started: nothing written.
+        assert len(commit_repo.calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_cancel_after_commit_allows_replay(self):
+        # The write helper re-raises the original CancelledError after the
+        # underlying write has been drained (commit actually succeeded).
+        committed = _committed()
+
+        class CommitThenCancel(FakeCommitRepository):
+            def commit(self, **kwargs):
+                self.calls.append(kwargs)
+                raise asyncio.CancelledError()
+
+        commit_repo = CommitThenCancel()
+        replay_repo = FakeReplayRepository(
+            outcome=ReplayOutcome(status="completed", committed=committed)
+        )
+        provider = FakeProvider()
+        use_case = _use_case(
+            commit_repository=commit_repo,
+            replay_repository=replay_repo,
+            provider=provider,
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await _execute(use_case, _input())
+
+        # The retried delivery recovers the persisted replay without provider.
+        result = await _execute(use_case, _input(mode=TurnMode.replay_attempt))
+        assert result.response == "persisted response"
+        assert provider.generations == 1  # only the first (cancelled) attempt
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 6. Outbox
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestOutbox:
+    @pytest.mark.asyncio
+    async def test_archival_enabled_adds_exactly_one_sanitized_event(self):
+        commit_repo = FakeCommitRepository()
+        use_case = _use_case(
+            commit_repository=commit_repo, archival_extraction_enabled=True
+        )
+
+        await _execute(use_case, _input())
+
+        events = commit_repo.calls[0]["outbox_events"]
+        assert len(events) == 1
+        event_type, payload, idempotency_key = events[0]
+        assert event_type == "archival_extraction_requested"
+        assert set(payload) == {"message_id", "kind", "version"}
+        assert payload["message_id"] == UUID
+        assert payload["kind"] == "archival"
+        assert payload["version"] == 1
+        assert idempotency_key == f"archival:{UUID}:v1"
+        serialized = str(payload)
+        assert "user-a" not in serialized
+        assert "hello" not in serialized
+
+    @pytest.mark.asyncio
+    async def test_archival_disabled_adds_no_events(self):
+        commit_repo = FakeCommitRepository()
+        use_case = _use_case(commit_repository=commit_repo)
+
+        await _execute(use_case, _input())
+
+        assert commit_repo.calls[0]["outbox_events"] == []
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 7. Observability
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestObservability:
+    @pytest.mark.asyncio
+    async def test_logs_never_contain_sensitive_markers(self, caplog):
+        commit_repo = FakeCommitRepository(results=[_mismatch(0, 1), _committed()])
+        use_case = _use_case(commit_repository=commit_repo)
+
+        with caplog.at_level(logging.INFO, logger="backend.process_turn"):
+            await _execute(use_case, _input())
+
+        text = caplog.text
+        assert UUID not in text
+        assert "user-a" not in text
+        assert "hello" not in text
+        assert "persisted response" not in text
+        for record in caplog.records:
+            assert record.levelname in ("INFO",)
+
+    @pytest.mark.asyncio
+    async def test_retry_events_are_low_cardinality(self, caplog):
+        commit_repo = FakeCommitRepository(results=[_mismatch(0, 1), _committed()])
+        use_case = _use_case(commit_repository=commit_repo)
+
+        with caplog.at_level(logging.INFO, logger="backend.process_turn"):
+            await _execute(use_case, _input())
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert "event=process_turn_attempt attempt=1" in messages
+        assert "event=process_turn_revision_conflict attempt=1" in messages
+        assert "event=process_turn_attempt attempt=2" in messages
+        assert "event=process_turn_commit_completed attempt=2" in messages
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 8. UserStateRepository (fake client, no insert)
+# ═══════════════════════════════════════════════════════════════════
+
+
+class FakeQueryBuilder:
+    def __init__(self, rows: list):
+        self.rows = rows
+        self.calls: list[str] = []
+
+    def select(self, *cols):
+        self.calls.append("select")
+        return self
+
+    def eq(self, key, value):
+        self.calls.append("eq")
+        return self
+
+    def execute(self):
+        self.calls.append("execute")
+        return SimpleNamespace(data=self.rows)
+
+
+class FakeTableClient:
+    def __init__(self, rows: list):
+        self.builder = FakeQueryBuilder(rows)
+        self.insert_calls = 0
+        self.upsert_calls = 0
+
+    def table(self, name: str) -> FakeQueryBuilder:
+        return self.builder
+
+    def insert(self, *args, **kwargs):
+        self.insert_calls += 1
+        return SimpleNamespace(execute=lambda: SimpleNamespace(data=[]))
+
+    def upsert(self, *args, **kwargs):
+        self.upsert_calls += 1
+        return SimpleNamespace(execute=lambda: SimpleNamespace(data=[]))
+
+
+class TestUserStateRepository:
+    def test_missing_profile_returns_defaults_with_revision_zero_and_no_insert(self):
+        client = FakeTableClient(rows=[])
+        repo = UserStateRepository(lambda: client)
+
+        state = repo.load("user-a", default_timestamp=1000.0)
+
+        assert state.revision == 0
+        assert state.emotional_state["schema_version"] == 1
+        assert state.relationship_state["schema_version"] == 1
+        assert client.insert_calls == 0
+        assert client.upsert_calls == 0
+        assert client.builder.calls == ["select", "eq", "execute"]
+
+    def test_existing_profile_returns_persisted_revision(self):
+        row = {
+            "revision": 7,
+            "persona_config": "Katherine...",
+            "user_profile": {"name": "x"},
+            "emotional_state": EmotionalStateV1.neutral(timestamp=1.0).to_dict(),
+            "relationship_state": RelationshipStateV1.neutral(timestamp=1.0).to_dict(),
+        }
+        repo = UserStateRepository(lambda: FakeTableClient(rows=[row]))
+
+        state = repo.load("user-a", default_timestamp=1000.0)
+
+        assert state.revision == 7
+        assert state.user_profile == {"name": "x"}
+
+    def test_duplicate_rows_fail_closed(self):
+        row = {"revision": 1}
+        repo = UserStateRepository(lambda: FakeTableClient(rows=[row, row]))
+
+        with pytest.raises(TurnExecutionError) as exc:
+            repo.load("user-a", default_timestamp=1000.0)
+        assert exc.value.code == TurnErrorCode.internal_error
+
+    @pytest.mark.parametrize(
+        "revision", [True, False, -1, 1.5, "1", None]
+    )
+    def test_invalid_revision_fails_closed(self, revision):
+        repo = UserStateRepository(
+            lambda: FakeTableClient(rows=[{"revision": revision}])
+        )
+        with pytest.raises(TurnExecutionError) as exc:
+            repo.load("user-a", default_timestamp=1000.0)
+        assert exc.value.code == TurnErrorCode.internal_error
+
+    def test_invalid_snapshot_fails_closed(self):
+        repo = UserStateRepository(
+            lambda: FakeTableClient(rows=[{"revision": 1, "emotional_state": "nope"}])
+        )
+        with pytest.raises(TurnExecutionError):
+            repo.load("user-a", default_timestamp=1000.0)
+
+    def test_no_client_fails_closed_as_persistence(self):
+        repo = UserStateRepository(lambda: None)
+        with pytest.raises(PersistenceError):
+            repo.load("user-a", default_timestamp=1000.0)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 9. Replay result parsing
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestReplayResultParsing:
+    def test_completed_uses_canonical_parser(self):
+        result = _committed().to_db_row()
+        outcome = parse_replay_committed_turn_result(result)
+        assert outcome.status == "completed"
+        assert isinstance(outcome.committed, CommittedTurn)
+
+    def test_structured_statuses(self):
+        for status in (REPLAY_STATUS_IN_PROGRESS, REPLAY_STATUS_UNAVAILABLE):
+            outcome = parse_replay_committed_turn_result({"status": status})
+            assert outcome.status == status
+            assert outcome.committed is None
+
+    def test_unknown_status_fails_closed(self):
+        with pytest.raises(ValidationError):
+            parse_replay_committed_turn_result({"status": "mystery"})
+
+    def test_malformed_envelope_fails_closed(self):
+        with pytest.raises(ValidationError):
+            parse_replay_committed_turn_result("nope")
+        with pytest.raises(ValidationError):
+            parse_replay_committed_turn_result([])
+
+    def test_error_envelope_propagates_canonical_conflict(self):
+        with pytest.raises(ConflictError) as exc:
+            parse_replay_committed_turn_result(
+                {
+                    "error": {
+                        "code": "request_in_progress",
+                        "message": "in progress",
+                        "request_id": UUID,
+                    }
+                }
+            )
+        assert exc.value.code == "request_in_progress"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 10. Engine delegation (active path never touches legacy writers)
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestEngineDelegation:
+    @pytest.mark.asyncio
+    async def test_engine_delegates_to_process_turn_with_mode_and_request_id(self):
+        from backend.chat_engine import ChatConversationEngine
+
+        engine = object.__new__(ChatConversationEngine)
+        captured = {}
+
+        async def fake_execute(inp):
+            captured["inp"] = inp
+            return "ok"
+
+        engine._process_turn = SimpleNamespace(execute=fake_execute)
+        engine.lock_manager = SimpleNamespace(
+            lock=lambda _user_id: SimpleNamespace(
+                __aenter__=lambda: _noop_async(),
+                __aexit__=lambda *a: _noop_async(),
+            )
+        )
+        engine._monotonic = lambda: 0.0
+        engine._turn_config = SimpleNamespace()
+
+        result = await engine.process_turn(
+            "user-a", "hello", UUID, budget=_budget(), mode=TurnMode.normal
+        )
+        assert result == "ok"
+        assert captured["inp"].authenticated_user_id == "user-a"
+        assert captured["inp"].request_id == UUID
+        assert captured["inp"].user_message == "hello"
+        assert captured["inp"].mode is TurnMode.normal
+        assert captured["inp"].budget is not None
+
+
+async def _noop_async():
+    return None
+
+
+class TestActivePathNeverCallsLegacyWriters:
+    @pytest.mark.asyncio
+    async def test_active_path_runs_without_save_turn_or_sync_state(self):
+        """If the active path ever called save_turn/sync_state, this fails."""
+        from backend.chat_engine import ChatConversationEngine
+
+        engine = object.__new__(ChatConversationEngine)
+
+        def forbidden(*_args, **_kwargs):
+            raise AssertionError("legacy write method called in active path")
+
+        engine.memory_manager = SimpleNamespace(
+            supabase=object(),
+            save_turn=forbidden,
+            sync_state=forbidden,
+        )
+        captured = {}
+
+        async def fake_execute(inp):
+            captured["mode"] = inp.mode
+            return "ok"
+
+        engine._process_turn = SimpleNamespace(execute=fake_execute)
+        engine.lock_manager = SimpleNamespace(
+            lock=lambda _user_id: SimpleNamespace(
+                __aenter__=lambda: _noop_async(),
+                __aexit__=lambda *a: _noop_async(),
+            )
+        )
+        engine._monotonic = lambda: 0.0
+        engine._turn_config = SimpleNamespace()
+
+        result = await engine.process_turn("user-a", "hello", UUID, budget=_budget())
+        assert result == "ok"
+        assert captured["mode"] is TurnMode.normal

--- a/backend/tests/test_process_turn_integration.py
+++ b/backend/tests/test_process_turn_integration.py
@@ -30,6 +30,7 @@ import pytest
 from postgrest.exceptions import APIError
 from supabase import Client, create_client
 
+from backend.admission import AdmissionRuntimeConfig, compute_turn_correlation
 from backend.emotional_domain import EmotionalStateV1
 from backend.relationship import RelationshipStateV1
 
@@ -310,6 +311,29 @@ def test_pending_request_is_not_treated_as_completed(service_client: Client):
         _cleanup_user(service_client, user_id)
 
 
+def test_pending_request_with_expired_lease_is_stale(service_client: Client):
+    """A pending reservation whose lease expired can never complete on its
+    own: v1 performs NO automatic reclaim through the endpoint, so replay is
+    unavailable and the client needs a new request id."""
+    user_id = _uid("pending_stale")
+    request_id = str(uuid.uuid4())
+    try:
+        _run_sql(
+            "INSERT INTO public.profiles (user_id) VALUES "
+            f"('{user_id}')"
+        )
+        _run_sql(
+            "INSERT INTO public.turn_requests "
+            "(user_id, request_id, payload_hash_sha256, status, lease_owner, lease_expires_at) "
+            f"VALUES ('{user_id}', '{request_id}', '{'d' * 64}', 'pending', "
+            "'worker-x', timezone('utc'::text, now()) - INTERVAL '1 hour')"
+        )
+        replay = _call_replay(service_client, user_id, request_id)
+        assert replay == {"status": "request_replay_unavailable"}
+    finally:
+        _cleanup_user(service_client, user_id)
+
+
 def test_expired_request_is_not_treated_as_completed(service_client: Client):
     user_id = _uid("expired")
     request_id = str(uuid.uuid4())
@@ -431,13 +455,18 @@ def test_same_request_different_message_conflicts(service_client: Client):
 
 
 # ---------------------------------------------------------------------------
-# 4. Multi-worker consistency (independent subprocesses, separate clients)
+# 4. Multi-worker consistency (independent subprocesses, real ProcessTurn)
 # ---------------------------------------------------------------------------
 
-# Each worker: loads the profile revision, synchronizes on a file barrier,
-# then runs the ProcessTurn commit loop (bounded retry on revision_mismatch).
-# It reports its attempts and the revision it committed at.
+# Each worker instantiates the REAL repositories and the REAL ProcessTurn use
+# case over an INDEPENDENT Supabase client, with a deterministic fake provider
+# and fake context loader (no network). The state repository is wrapped by a
+# deterministic file barrier: both workers load the same revision and only
+# then race their commits. The loser receives revision_mismatch, reloads
+# state/context and runs its second generation; the bounded retry lives inside
+# ProcessTurn.execute() — the worker never reimplements the retry loop.
 _WORKER_SCRIPT = r"""
+import asyncio
 import json
 import os
 import sys
@@ -446,61 +475,118 @@ import uuid
 
 from supabase import create_client
 
+from backend.admission import (
+    AdmissionRuntimeConfig,
+    compute_turn_correlation,
+)
+from backend.emotional_domain import AppraisalV1, TransitionConfig
+from backend.process_turn import (
+    ProcessTurn,
+    ProcessTurnInput,
+    TurnMode,
+    new_lease_owner,
+)
+from backend.relationship import RelationshipTransitionConfig
+from backend.trusted_context import LoadedContextData
+from backend.turn_execution import (
+    TurnExecutionConfig,
+    create_budget,
+)
+from backend.turn_repositories import (
+    TurnCommitRepository,
+    TurnReplayRepository,
+    UserStateRepository,
+)
+
 url = os.environ["SUPABASE_URL"]
 key = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
 user_id = os.environ["WORKER_USER"]
 request_id = os.environ["WORKER_REQUEST"]
 ready_file = os.environ["WORKER_READY"]
 peer_file = os.environ["WORKER_PEER"]
-
-client = create_client(url, key)
-
-
-def load_revision():
-    rows = (
-        client.table("profiles")
-        .select("revision")
-        .eq("user_id", user_id)
-        .execute()
-        .data
-    )
-    return rows[0]["revision"] if rows else 0
+start_ready_file = os.environ["WORKER_START_READY"]
+start_peer_file = os.environ["WORKER_START_PEER"]
+correlation = os.environ["WORKER_CORRELATION"]
 
 
-def commit(expected_revision, attempt):
-    emotional = {
-        "schema_version": 1, "pleasure": 0.1, "arousal": 0.1, "dominance": 0.1,
-        "libido": 0.1, "aggression": 0.1, "connection": 0.5, "energy": 0.5,
-        "tension": 0.1, "coping_mode": "HEALTHY", "timestamp": 1700000000.0,
-    }
-    relationship = {
-        "schema_version": 1, "trust": 0.5, "affection": 0.3, "tension": 0.1,
-        "triggers": [], "timestamp": 1700000000.0,
-    }
-    replay = {
-        "response": "Hi from worker " + request_id[:8],
-        "message_id": str(uuid.uuid4()),
-        "duration_ms": 7,
-    }
-    params = {
-        "p_authenticated_user_id": user_id,
-        "p_request_id": request_id,
-        "p_expected_revision": expected_revision,
-        "p_user_message": "Hello",
-        "p_assistant_message": replay["response"],
-        "p_payload_hash_sha256": ("a" + str(attempt)) * 32,
-        "p_emotional_state": emotional,
-        "p_relationship_state": relationship,
-        "p_public_response": replay["response"],
-        "p_replay_payload": replay,
-        "p_outbox_events": [],
-        "p_lease_owner": "worker-" + str(attempt),
-    }
-    response = client.rpc("commit_turn", params).execute()
-    data = response.data
-    if isinstance(data, list):
-        data = data[0]
-    return data
+class BarrierStateRepository:
+    '''Real UserStateRepository + deterministic barrier AFTER the first load.
+
+    Both workers signal after loading the same revision and wait for each
+    other before any commit can start. Retries (reloads) never re-sync.
+    '''
+
+    def __init__(self, inner, ready_file, peer_file, timeout=60.0):
+        self._inner = inner
+        self._ready_file = ready_file
+        self._peer_file = peer_file
+        self._timeout = timeout
+        self._synced = False
+
+    def load(self, *args, **kwargs):
+        state = self._inner.load(*args, **kwargs)
+        if not self._synced:
+            self._synced = True
+            open(self._ready_file, "w").close()
+            deadline = time.monotonic() + self._timeout
+            while not os.path.exists(self._peer_file):
+                if time.monotonic() > deadline:
+                    raise RuntimeError("barrier_timeout")
+                time.sleep(0.02)
+        return state
+
+
+def wait_for_start_peer():
+    '''Absorb subprocess startup skew OUTSIDE the turn budget.
+
+    Both workers signal once imports and the client are ready, then wait for
+    each other. The post-load barrier inside BarrierStateRepository then
+    resolves within milliseconds instead of racing against startup.
+    '''
+    open(start_ready_file, "w").close()
+    deadline = time.monotonic() + 60.0
+    while not os.path.exists(start_peer_file):
+        if time.monotonic() > deadline:
+            raise RuntimeError("start_sync_timeout")
+        time.sleep(0.02)
+
+
+class FakeProvider:
+    '''Deterministic provider: no network, counts provider generations.'''
+
+    def __init__(self):
+        self.generations = 0
+        self.appraisals = 0
+
+    async def appraise(self, message, budget):
+        self.appraisals += 1
+        return AppraisalV1.neutral()
+
+    async def generate(self, messages, budget):
+        self.generations += 1
+        return f"worker response {self.generations}"
+
+    def build_trusted_policy(self, emotional_state, relationship, adaptation_strategy=""):
+        return "policy"
+
+
+def close_client(client):
+    if client is None:
+        return
+    for attr, session_attr in (
+        ("_postgrest", "session"),
+        ("_storage", "session"),
+        ("_functions", "_client"),
+    ):
+        transport = getattr(client, attr, None)
+        if transport is None:
+            continue
+        session = getattr(transport, session_attr, None)
+        if session is not None and hasattr(session, "close"):
+            session.close()
+    auth = getattr(client, "auth", None)
+    if auth is not None and hasattr(auth, "close"):
+        auth.close()
 
 
 def fail(reason):
@@ -508,36 +594,72 @@ def fail(reason):
     sys.exit(1)
 
 
-# Load revision BEFORE the barrier so both workers race the same revision.
-revision = load_revision()
-open(ready_file, "w").close()
-deadline = time.monotonic() + 30
-while not os.path.exists(peer_file):
-    if time.monotonic() > deadline:
-        fail("barrier_timeout")
-    time.sleep(0.02)
+def main():
+    client = create_client(url, key)
+    try:
+        wait_for_start_peer()
+        asyncio.run(run(client))
+    except Exception as exc:  # noqa: BLE001 - worker reports structured failure
+        fail(type(exc).__name__ + ": " + str(exc))
+    finally:
+        for f in (ready_file, start_ready_file):
+            try:
+                os.unlink(f)
+            except OSError:
+                pass
+        close_client(client)
 
-attempts = 0
-for attempt in (1, 2):
-    if attempt == 2:
-        revision = load_revision()
-    data = commit(revision, attempt)
-    attempts = attempt
-    if "error" not in data:
+
+async def run(client):
+    try:
+        client_provider = lambda: client
+        state_repo = UserStateRepository(client_provider)
+        commit_repo = TurnCommitRepository(client_provider)
+        replay_repo = TurnReplayRepository(client_provider)
+        context_loader = lambda uid, message, user_state: LoadedContextData()
+        provider = FakeProvider()
+        config = TurnExecutionConfig.defaults()
+        use_case = ProcessTurn(
+            state_repository=BarrierStateRepository(state_repo, ready_file, peer_file),
+            commit_repository=commit_repo,
+            replay_repository=replay_repo,
+            context_loader=context_loader,
+            provider=provider,
+            transition_config=TransitionConfig.defaults(),
+            relationship_config=RelationshipTransitionConfig.defaults(),
+            clock=time.time,
+            supabase_timeout=90.0,
+            archival_extraction_enabled=False,
+            # Per-instance lease owner: this worker NEVER shares an owner.
+            lease_owner=new_lease_owner(),
+        )
+        inp = ProcessTurnInput(
+            authenticated_user_id=user_id,
+            request_id=request_id,
+            user_message="Hello",
+            budget=create_budget(config),
+            correlation=correlation,
+            mode=TurnMode.normal,
+        )
+        result = await use_case.execute(inp)
         print(
             json.dumps(
                 {
                     "ok": True,
-                    "attempts": attempts,
-                    "revision": data["committed_revision"],
-                    "request_id": data["request_id"],
+                    "generations": provider.generations,
+                    "committed_revision": result.committed.committed_revision,
+                    "response": result.response,
+                    "request_id": result.committed.request_id,
+                    "user_message_id": result.committed.user_message_id,
+                    "assistant_message_id": result.committed.assistant_message_id,
                 }
             )
         )
-        sys.exit(0)
-    if data["error"]["code"] != "revision_mismatch":
-        fail(data["error"]["code"])
-fail("exhausted")
+    except Exception as exc:  # noqa: BLE001 - worker reports structured failure
+        fail(type(exc).__name__ + ": " + str(exc))
+
+
+main()
 """
 
 
@@ -545,11 +667,14 @@ def _run_worker_pair(url: str, key: str, user_a: str, user_b: str) -> list[dict]
     """Run two independent subprocess workers synchronized by a file barrier."""
     ready_dir = f"/tmp/opencode/pt_workers_{uuid.uuid4().hex}"
     os.makedirs(ready_dir, exist_ok=True)
+    admission_config = AdmissionRuntimeConfig.from_values("s" * 32)
 
     def spawn(user: str, index: int) -> tuple[subprocess.Popen, str, str, str]:
         request_id = str(uuid.uuid4())
         ready = os.path.join(ready_dir, f"ready_{index}")
         peer = os.path.join(ready_dir, f"ready_{1 - index}")
+        start_ready = os.path.join(ready_dir, f"start_ready_{index}")
+        start_peer = os.path.join(ready_dir, f"start_ready_{1 - index}")
         env = dict(os.environ)
         env.update(
             SUPABASE_URL=url,
@@ -558,6 +683,9 @@ def _run_worker_pair(url: str, key: str, user_a: str, user_b: str) -> list[dict]
             WORKER_REQUEST=request_id,
             WORKER_READY=ready,
             WORKER_PEER=peer,
+            WORKER_START_READY=start_ready,
+            WORKER_START_PEER=start_peer,
+            WORKER_CORRELATION=compute_turn_correlation(admission_config, request_id),
         )
         proc = subprocess.Popen(
             [sys.executable, "-c", _WORKER_SCRIPT],
@@ -572,12 +700,17 @@ def _run_worker_pair(url: str, key: str, user_a: str, user_b: str) -> list[dict]
     proc_b, ready_b, request_b, _ = spawn(user_b, 1)
     assert ready_a != ready_b
     try:
-        out_a, err_a = proc_a.communicate(timeout=60)
-        out_b, err_b = proc_b.communicate(timeout=60)
+        out_a, err_a = proc_a.communicate(timeout=90)
+        out_b, err_b = proc_b.communicate(timeout=90)
     finally:
         proc_a.kill()
         proc_b.kill()
-        for f in (ready_a, ready_b):
+        for f in (
+            ready_a,
+            ready_b,
+            os.path.join(ready_dir, "start_ready_0"),
+            os.path.join(ready_dir, "start_ready_1"),
+        ):
             try:
                 os.unlink(f)
             except OSError:
@@ -586,25 +719,34 @@ def _run_worker_pair(url: str, key: str, user_a: str, user_b: str) -> list[dict]
             os.rmdir(ready_dir)
         except OSError:
             pass
-    assert proc_a.returncode == 0, f"worker A failed: {err_a}"
-    assert proc_b.returncode == 0, f"worker B failed: {err_b}"
+    assert proc_a.returncode == 0, f"worker A failed: {err_a} | out: {out_a}"
+    assert proc_b.returncode == 0, f"worker B failed: {err_b} | out: {out_b}"
     return [
         json.loads(out_a),
         json.loads(out_b),
     ]
 
 
-def test_multi_worker_same_user_cas_consistency(supabase_url, service_role_key):
-    """Two independent workers race the same revision: one wins, the other
-    receives revision_mismatch, reloads and commits on the next revision."""
+def test_multi_worker_same_user_cas_consistency(
+    supabase_url, service_role_key, service_client
+):
+    """Two independent ProcessTurn workers race the same revision: exactly one
+    commit wins the first attempt, the loser receives revision_mismatch,
+    reloads state/context and runs its second generation."""
     user_id = _uid("mw_same")
     client = create_client(supabase_url, service_role_key)
     try:
         results = _run_worker_pair(supabase_url, service_role_key, user_id, user_id)
         assert [r["ok"] for r in results] == [True, True]
-        attempts = sorted(r["attempts"] for r in results)
-        # exactly one worker retried once; the other committed on the first try
-        assert attempts == [1, 2]
+        # exactly one worker needed a second generation; the other won on the
+        # first attempt (order between workers is nondeterministic)
+        assert sorted(r["generations"] for r in results) == [1, 2]
+        assert sorted(r["committed_revision"] for r in results) == [1, 2]
+        # each worker returned the CommittedTurn the database persisted
+        for result in results:
+            assert result["response"].startswith("worker response ")
+            assert result["user_message_id"] == result["request_id"]
+            assert len(result["assistant_message_id"]) == 36
         # the revision increased exactly twice (one per committed request)
         rows = _run_sql(
             f"SELECT revision FROM public.profiles WHERE user_id = '{user_id}'"
@@ -614,6 +756,11 @@ def test_multi_worker_same_user_cas_consistency(supabase_url, service_role_key):
         assert _count("chat_logs", user_id) == 4
         assert _count("profiles", user_id) == 1
         assert _count("outbox_events", user_id) == 0
+        # persisted results are exactly what the workers returned: replay of
+        # each committed request returns the same response
+        for result in results:
+            replay = _call_replay(service_client, user_id, result["request_id"])
+            assert replay["replay_payload"]["response"] == result["response"]
     finally:
         _cleanup_user(client, user_id)
         _close_client(client)
@@ -628,8 +775,9 @@ def test_multi_worker_different_users_progress_independently(
     try:
         results = _run_worker_pair(supabase_url, service_role_key, user_a, user_b)
         assert [r["ok"] for r in results] == [True, True]
-        # no conflicts across users: each commits on its first attempt
-        assert [r["attempts"] for r in results] == [1, 1]
+        # no conflicts across users: each commits on its first attempt,
+        # proving there is no global lock between workers
+        assert [r["generations"] for r in results] == [1, 1]
         for user in (user_a, user_b):
             rows = _run_sql(
                 f"SELECT revision FROM public.profiles WHERE user_id = '{user}'"

--- a/backend/tests/test_process_turn_integration.py
+++ b/backend/tests/test_process_turn_integration.py
@@ -460,10 +460,14 @@ def test_same_request_different_message_conflicts(service_client: Client):
 
 # Each worker instantiates the REAL repositories and the REAL ProcessTurn use
 # case over an INDEPENDENT Supabase client, with a deterministic fake provider
-# and fake context loader (no network). The state repository is wrapped by a
-# deterministic file barrier: both workers load the same revision and only
-# then race their commits. The loser receives revision_mismatch, reloads
-# state/context and runs its second generation; the bounded retry lives inside
+# and fake context loader (no network). Coordination happens ONLY in the
+# commit path: the commit repository is wrapped by a file rendezvous on the
+# FIRST commit attempt (expected_revision == 0), so both workers must have
+# loaded revision 0 and entered their first commit before either commit
+# proceeds. The rendezvous runs inside run_blocking_write(), which never
+# abandons the operation, so the artificial wait does NOT consume the turn
+# budget. The loser receives revision_mismatch, reloads state/context and
+# runs its second generation; the bounded retry lives inside
 # ProcessTurn.execute() — the worker never reimplements the retry loop.
 _WORKER_SCRIPT = r"""
 import asyncio
@@ -493,6 +497,7 @@ from backend.turn_execution import (
     create_budget,
 )
 from backend.turn_repositories import (
+    PersistenceError,
     TurnCommitRepository,
     TurnReplayRepository,
     UserStateRepository,
@@ -502,18 +507,33 @@ url = os.environ["SUPABASE_URL"]
 key = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
 user_id = os.environ["WORKER_USER"]
 request_id = os.environ["WORKER_REQUEST"]
-ready_file = os.environ["WORKER_READY"]
-peer_file = os.environ["WORKER_PEER"]
+commit_ready_file = os.environ["WORKER_COMMIT_READY"]
+commit_peer_file = os.environ["WORKER_COMMIT_PEER"]
 start_ready_file = os.environ["WORKER_START_READY"]
 start_peer_file = os.environ["WORKER_START_PEER"]
 correlation = os.environ["WORKER_CORRELATION"]
+trace_file = os.environ["WORKER_TRACE"]
 
 
-class BarrierStateRepository:
-    '''Real UserStateRepository + deterministic barrier AFTER the first load.
+def trace(event, **fields):
+    with open(trace_file, "a") as f:
+        f.write(
+            json.dumps(
+                {"event": event, "ts": round(time.time(), 3), "pid": os.getpid(), **fields}
+            )
+            + "\n"
+        )
 
-    Both workers signal after loading the same revision and wait for each
-    other before any commit can start. Retries (reloads) never re-sync.
+
+class CommitBarrierRepository:
+    '''Real TurnCommitRepository + deterministic rendezvous on the FIRST
+    commit attempt (expected_revision == 0).
+
+    Both workers signal that they have loaded revision 0 and entered their
+    first commit, then wait for each other before any commit proceeds. The
+    wait runs inside run_blocking_write(), which never abandons the write,
+    so it does NOT consume the turn budget (the pre-commit budget check has
+    already passed). Retry commits (expected_revision > 0) never re-sync.
     '''
 
     def __init__(self, inner, ready_file, peer_file, timeout=60.0):
@@ -521,34 +541,43 @@ class BarrierStateRepository:
         self._ready_file = ready_file
         self._peer_file = peer_file
         self._timeout = timeout
-        self._synced = False
 
-    def load(self, *args, **kwargs):
-        state = self._inner.load(*args, **kwargs)
-        if not self._synced:
-            self._synced = True
+    def commit(self, *args, **kwargs):
+        expected = kwargs.get("expected_revision")
+        trace("commit_enter", expected=expected)
+        if expected == 0:
+            trace("barrier_wait_start")
             open(self._ready_file, "w").close()
             deadline = time.monotonic() + self._timeout
             while not os.path.exists(self._peer_file):
                 if time.monotonic() > deadline:
-                    raise RuntimeError("barrier_timeout")
+                    # Surfaces distinctly in the worker failure reason
+                    # (allowlisted: propagates as-is, never wrapped).
+                    raise PersistenceError(
+                        "database_error", "commit rendezvous timed out"
+                    )
                 time.sleep(0.02)
-        return state
+            trace("barrier_wait_end")
+        result = self._inner.commit(*args, **kwargs)
+        trace("commit_done", revision=result.committed_revision)
+        return result
 
 
 def wait_for_start_peer():
     '''Absorb subprocess startup skew OUTSIDE the turn budget.
 
     Both workers signal once imports and the client are ready, then wait for
-    each other. The post-load barrier inside BarrierStateRepository then
-    resolves within milliseconds instead of racing against startup.
+    each other. The commit rendezvous then resolves within milliseconds
+    instead of racing against startup.
     '''
+    trace("start_ready")
     open(start_ready_file, "w").close()
     deadline = time.monotonic() + 60.0
     while not os.path.exists(start_peer_file):
         if time.monotonic() > deadline:
             raise RuntimeError("start_sync_timeout")
         time.sleep(0.02)
+    trace("start_peer_seen")
 
 
 class FakeProvider:
@@ -600,27 +629,38 @@ def main():
         wait_for_start_peer()
         asyncio.run(run(client))
     except Exception as exc:  # noqa: BLE001 - worker reports structured failure
+        trace("error", error=type(exc).__name__ + ": " + str(exc))
         fail(type(exc).__name__ + ": " + str(exc))
     finally:
-        for f in (ready_file, start_ready_file):
-            try:
-                os.unlink(f)
-            except OSError:
-                pass
+        # Marker files (start/commit rendezvous) are removed by the harness
+        # after BOTH workers exit: a slow peer must never lose the peer marker
+        # mid-flight.
         close_client(client)
 
 
 async def run(client):
     try:
         client_provider = lambda: client
-        state_repo = UserStateRepository(client_provider)
-        commit_repo = TurnCommitRepository(client_provider)
+
+        class TracingStateRepository:
+            def __init__(self, inner):
+                self._inner = inner
+
+            def load(self, *args, **kwargs):
+                state = self._inner.load(*args, **kwargs)
+                trace("state_loaded", revision=state.revision)
+                return state
+
+        state_repo = TracingStateRepository(UserStateRepository(client_provider))
+        commit_repo = CommitBarrierRepository(
+            TurnCommitRepository(client_provider), commit_ready_file, commit_peer_file
+        )
         replay_repo = TurnReplayRepository(client_provider)
         context_loader = lambda uid, message, user_state: LoadedContextData()
         provider = FakeProvider()
         config = TurnExecutionConfig.defaults()
         use_case = ProcessTurn(
-            state_repository=BarrierStateRepository(state_repo, ready_file, peer_file),
+            state_repository=state_repo,
             commit_repository=commit_repo,
             replay_repository=replay_repo,
             context_loader=context_loader,
@@ -628,7 +668,10 @@ async def run(client):
             transition_config=TransitionConfig.defaults(),
             relationship_config=RelationshipTransitionConfig.defaults(),
             clock=time.time,
-            supabase_timeout=90.0,
+            # Coherent with the same config that drives the budget; the
+            # rendezvous never counts against it (write path is never
+            # abandoned).
+            supabase_timeout=config.supabase_timeout,
             archival_extraction_enabled=False,
             # Per-instance lease owner: this worker NEVER shares an owner.
             lease_owner=new_lease_owner(),
@@ -663,28 +706,52 @@ main()
 """
 
 
-def _run_worker_pair(url: str, key: str, user_a: str, user_b: str) -> list[dict]:
-    """Run two independent subprocess workers synchronized by a file barrier."""
+def _read_trace_events(path: str) -> list[dict]:
+    """Parse a worker trace file (one JSON event per line) into a list."""
+    events: list[dict] = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                events.append(json.loads(line))
+    return events
+
+
+def _trace_field_values(events: list[dict], event: str, field: str) -> list:
+    return [ev[field] for ev in events if ev["event"] == event]
+
+
+def _run_worker_pair(
+    url: str, key: str, user_a: str, user_b: str
+) -> tuple[list[dict], tuple[list[dict], list[dict]]]:
+    """Run two independent subprocess workers synchronized by a file barrier.
+
+    Returns ``(results, traces)`` where ``results`` is the parsed stdout of
+    each worker and ``traces`` the parsed structured trace events of each
+    worker (captured before the rendezvous directory is removed).
+    """
     ready_dir = f"/tmp/opencode/pt_workers_{uuid.uuid4().hex}"
     os.makedirs(ready_dir, exist_ok=True)
     admission_config = AdmissionRuntimeConfig.from_values("s" * 32)
 
-    def spawn(user: str, index: int) -> tuple[subprocess.Popen, str, str, str]:
+    def spawn(user: str, index: int) -> tuple[subprocess.Popen, str, str, str, str]:
         request_id = str(uuid.uuid4())
-        ready = os.path.join(ready_dir, f"ready_{index}")
-        peer = os.path.join(ready_dir, f"ready_{1 - index}")
+        commit_ready = os.path.join(ready_dir, f"commit_ready_{index}")
+        commit_peer = os.path.join(ready_dir, f"commit_ready_{1 - index}")
         start_ready = os.path.join(ready_dir, f"start_ready_{index}")
         start_peer = os.path.join(ready_dir, f"start_ready_{1 - index}")
+        trace_file = os.path.join(ready_dir, f"trace_{index}.jsonl")
         env = dict(os.environ)
         env.update(
             SUPABASE_URL=url,
             SUPABASE_SERVICE_ROLE_KEY=key,
             WORKER_USER=user,
             WORKER_REQUEST=request_id,
-            WORKER_READY=ready,
-            WORKER_PEER=peer,
+            WORKER_COMMIT_READY=commit_ready,
+            WORKER_COMMIT_PEER=commit_peer,
             WORKER_START_READY=start_ready,
             WORKER_START_PEER=start_peer,
+            WORKER_TRACE=trace_file,
             WORKER_CORRELATION=compute_turn_correlation(admission_config, request_id),
         )
         proc = subprocess.Popen(
@@ -694,14 +761,27 @@ def _run_worker_pair(url: str, key: str, user_a: str, user_b: str) -> list[dict]
             stderr=subprocess.PIPE,
             text=True,
         )
-        return proc, ready, request_id, user
+        return proc, commit_ready, request_id, user, trace_file
 
-    proc_a, ready_a, request_a, user_a_final = spawn(user_a, 0)
-    proc_b, ready_b, request_b, _ = spawn(user_b, 1)
+    # Profiles pre-exist at revision 0 with valid neutral snapshots BEFORE
+    # either worker spawns: both deterministically load revision 0 and enter
+    # their first commit with expected_revision == 0. (Concurrent
+    # first-profile creation is covered by a dedicated test.)
+    _run_sql(
+        "INSERT INTO public.profiles (user_id, revision, emotional_state, relationship_state) VALUES "
+        f"('{user_a}', 0, '{json.dumps(_emotional_state())}'::jsonb, '{json.dumps(_relationship_state())}'::jsonb), "
+        f"('{user_b}', 0, '{json.dumps(_emotional_state())}'::jsonb, '{json.dumps(_relationship_state())}'::jsonb) "
+        "ON CONFLICT (user_id) DO NOTHING"
+    )
+    proc_a, ready_a, request_a, user_a_final, trace_a = spawn(user_a, 0)
+    proc_b, ready_b, request_b, _, trace_b = spawn(user_b, 1)
     assert ready_a != ready_b
     try:
         out_a, err_a = proc_a.communicate(timeout=90)
         out_b, err_b = proc_b.communicate(timeout=90)
+        # Capture trace contents BEFORE the rendezvous directory is removed.
+        events_a = _read_trace_events(trace_a)
+        events_b = _read_trace_events(trace_b)
     finally:
         proc_a.kill()
         proc_b.kill()
@@ -719,12 +799,19 @@ def _run_worker_pair(url: str, key: str, user_a: str, user_b: str) -> list[dict]
             os.rmdir(ready_dir)
         except OSError:
             pass
+    if proc_a.returncode != 0 or proc_b.returncode != 0:
+        for label, trace_path in (("A", trace_a), ("B", trace_b)):
+            try:
+                print(f"--- worker {label} trace ---")
+                print(open(trace_path).read())
+            except OSError:
+                print(f"--- worker {label} trace: missing ---")
     assert proc_a.returncode == 0, f"worker A failed: {err_a} | out: {out_a}"
     assert proc_b.returncode == 0, f"worker B failed: {err_b} | out: {out_b}"
     return [
         json.loads(out_a),
         json.loads(out_b),
-    ]
+    ], (events_a, events_b)
 
 
 def test_multi_worker_same_user_cas_consistency(
@@ -736,7 +823,9 @@ def test_multi_worker_same_user_cas_consistency(
     user_id = _uid("mw_same")
     client = create_client(supabase_url, service_role_key)
     try:
-        results = _run_worker_pair(supabase_url, service_role_key, user_id, user_id)
+        results, (events_a, events_b) = _run_worker_pair(
+            supabase_url, service_role_key, user_id, user_id
+        )
         assert [r["ok"] for r in results] == [True, True]
         # exactly one worker needed a second generation; the other won on the
         # first attempt (order between workers is nondeterministic)
@@ -747,6 +836,29 @@ def test_multi_worker_same_user_cas_consistency(
             assert result["response"].startswith("worker response ")
             assert result["user_message_id"] == result["request_id"]
             assert len(result["assistant_message_id"]) == 36
+        # trace proof: both workers loaded revision 0 and entered their first
+        # commit with expected_revision == 0 (the rendezvous); the loser then
+        # reloaded revision 1 and committed expected_revision == 1 exactly
+        # once. No third attempt exists: commit_enter count == generations.
+        initial_revisions = sorted(
+            _trace_field_values(events, "state_loaded", "revision")[0]
+            for events in (events_a, events_b)
+        )
+        assert initial_revisions == [0, 0]
+        first_commits = sorted(
+            _trace_field_values(events, "commit_enter", "expected")[0]
+            for events in (events_a, events_b)
+        )
+        assert first_commits == [0, 0]
+        commit_sequences = sorted(
+            _trace_field_values(events, "commit_enter", "expected")
+            for events in (events_a, events_b)
+        )
+        assert commit_sequences == [[0], [0, 1]]
+        for events, result in zip((events_a, events_b), results):
+            assert len(_trace_field_values(events, "commit_enter", "expected")) == (
+                result["generations"]
+            )
         # the revision increased exactly twice (one per committed request)
         rows = _run_sql(
             f"SELECT revision FROM public.profiles WHERE user_id = '{user_id}'"
@@ -773,11 +885,19 @@ def test_multi_worker_different_users_progress_independently(
     user_b = _uid("mw_b")
     client = create_client(supabase_url, service_role_key)
     try:
-        results = _run_worker_pair(supabase_url, service_role_key, user_a, user_b)
+        results, (events_a, events_b) = _run_worker_pair(
+            supabase_url, service_role_key, user_a, user_b
+        )
         assert [r["ok"] for r in results] == [True, True]
         # no conflicts across users: each commits on its first attempt,
         # proving there is no global lock between workers
         assert [r["generations"] for r in results] == [1, 1]
+        # trace proof: each worker loaded revision 0 and entered exactly one
+        # commit with expected_revision == 0, committing revision 0 -> 1
+        for events in (events_a, events_b):
+            assert _trace_field_values(events, "state_loaded", "revision") == [0]
+            assert _trace_field_values(events, "commit_enter", "expected") == [0]
+            assert _trace_field_values(events, "commit_done", "revision") == [1]
         for user in (user_a, user_b):
             rows = _run_sql(
                 f"SELECT revision FROM public.profiles WHERE user_id = '{user}'"

--- a/backend/tests/test_process_turn_integration.py
+++ b/backend/tests/test_process_turn_integration.py
@@ -1,0 +1,821 @@
+"""Real Supabase integration tests for the ProcessTurn foundation (#272).
+
+Executed ONLY by the database CI job against a freshly reset local Supabase
+instance (no mocks: real PostgreSQL transactions, locks, FKs, leases and
+rollbacks). Never collected by the ordinary backend unit job.
+
+Covers:
+
+  1. replay_committed_turn RPC behavior against real rows
+  2. replay RPC authorization matrix (anon / authenticated / service_role)
+  3. replay does not alter any table; repeated replays are equivalent
+  4. multi-worker consistency using INDEPENDENT subprocess workers, each with
+     its own Supabase client (never two coroutines over one client)
+  5. outbox atomicity (one event, replay adds none, rollback removes it)
+  6. idempotency: same request id replays; divergent message conflicts
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import threading
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from postgrest.exceptions import APIError
+from supabase import Client, create_client
+
+from backend.emotional_domain import EmotionalStateV1
+from backend.relationship import RelationshipStateV1
+
+_SUPABASE_CLI = ["supabase"] if shutil.which("supabase") else ["npx", "supabase"]
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name)
+    assert value, f"{name} is required for process turn integration tests"
+    return value
+
+
+@pytest.fixture(scope="module")
+def supabase_url() -> str:
+    return _required_env("SUPABASE_URL")
+
+
+@pytest.fixture(scope="module")
+def anon_key() -> str:
+    return _required_env("SUPABASE_ANON_KEY")
+
+
+@pytest.fixture(scope="module")
+def service_role_key() -> str:
+    return _required_env("SUPABASE_SERVICE_ROLE_KEY")
+
+
+def _close_http_transports(client: Client) -> None:
+    if client is None:
+        return
+    for attr, session_attr in (
+        ("_postgrest", "session"),
+        ("_storage", "session"),
+        ("_functions", "_client"),
+    ):
+        transport = getattr(client, attr, None)
+        if transport is None:
+            continue
+        session = getattr(transport, session_attr, None)
+        if session is not None and hasattr(session, "close"):
+            session.close()
+
+
+def _close_client(client: Client) -> None:
+    if client is None:
+        return
+    _close_http_transports(client)
+    auth = getattr(client, "auth", None)
+    if auth is not None and hasattr(auth, "close"):
+        auth.close()
+
+
+@pytest.fixture(scope="module")
+def service_client(supabase_url: str, service_role_key: str) -> Client:
+    client = create_client(supabase_url, service_role_key)
+    yield client
+    _close_client(client)
+
+
+@pytest.fixture(scope="module")
+def anon_client(supabase_url: str, anon_key: str) -> Client:
+    client = create_client(supabase_url, anon_key)
+    yield client
+    _close_client(client)
+
+
+@pytest.fixture(scope="module")
+def authenticated_client(
+    supabase_url: str,
+    anon_key: str,
+    service_client: Client,
+) -> Client:
+    email = "process-turn-replay-auth@test.local"
+    password = "password123"
+    client = create_client(supabase_url, anon_key)
+    for user in service_client.auth.admin.list_users():
+        if user.email == email:
+            service_client.auth.admin.delete_user(user.id)
+    client.auth.sign_up({"email": email, "password": password})
+    client.auth.sign_in_with_password({"email": email, "password": password})
+    yield client
+    _close_http_transports(client)
+    client.auth.sign_out()
+    for user in service_client.auth.admin.list_users():
+        if user.email == email:
+            service_client.auth.admin.delete_user(user.id)
+    _close_client(client)
+
+
+def _run_sql(sql: str) -> list[dict]:
+    child_env = dict(os.environ)
+    child_env["SUPABASE_TELEMETRY_DISABLED"] = "1"
+    child_env["SUPABASE_ANALYTICS_ENABLED"] = "false"
+    result = subprocess.run(
+        [
+            *_SUPABASE_CLI,
+            "db",
+            "query",
+            "--agent=no",
+            "--output",
+            "json",
+            sql,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=child_env,
+    )
+    assert result.returncode == 0, "sanitized process turn test SQL operation failed"
+    output = result.stdout.strip()
+    if not output or output[0] not in "[{":
+        return []
+    parsed = json.loads(output)
+    assert isinstance(parsed, list)
+    return parsed
+
+
+def _count(table: str, user_id: str) -> int:
+    rows = _run_sql(
+        f"SELECT count(*)::integer AS count FROM public.{table} "
+        f"WHERE user_id = '{user_id}'"
+    )
+    return rows[0]["count"]
+
+
+def _uid(label: str) -> str:
+    return f"pt_{label}_{uuid.uuid4().hex[:12]}"
+
+
+def _emotional_state() -> dict:
+    return EmotionalStateV1.neutral(timestamp=1700000000.0).to_dict()
+
+
+def _relationship_state() -> dict:
+    return RelationshipStateV1.neutral(timestamp=1700000000.0).to_dict()
+
+
+def _replay_payload(response: str = "Hi there!") -> dict:
+    return {"response": response, "message_id": str(uuid.uuid4()), "duration_ms": 42}
+
+
+def _commit_params(
+    user_id: str,
+    request_id: str,
+    *,
+    payload_hash: str,
+    expected_revision: int = 0,
+    response: str = "Hi there!",
+    outbox_events: list[dict] | None = None,
+) -> dict:
+    return {
+        "p_authenticated_user_id": user_id,
+        "p_request_id": request_id,
+        "p_expected_revision": expected_revision,
+        "p_user_message": "Hello",
+        "p_assistant_message": response,
+        "p_payload_hash_sha256": payload_hash,
+        "p_emotional_state": _emotional_state(),
+        "p_relationship_state": _relationship_state(),
+        "p_public_response": response,
+        "p_replay_payload": _replay_payload(response),
+        "p_outbox_events": outbox_events if outbox_events is not None else [],
+        "p_lease_owner": "worker-1",
+    }
+
+
+def _call_commit(client: Client, params: dict) -> dict:
+    response = client.rpc("commit_turn", params).execute()
+    data = response.data
+    if isinstance(data, list):
+        assert len(data) == 1
+        data = data[0]
+    assert isinstance(data, dict)
+    return data
+
+
+def _call_replay(client: Client, user_id: str, request_id: str) -> dict:
+    response = client.rpc(
+        "replay_committed_turn",
+        {"p_authenticated_user_id": user_id, "p_request_id": request_id},
+    ).execute()
+    data = response.data
+    if isinstance(data, list):
+        assert len(data) == 1
+        data = data[0]
+    assert isinstance(data, dict)
+    return data
+
+
+def _normalized(result: dict) -> dict:
+    assert "error" not in result and "status" not in result
+    return {
+        "user_id": result["user_id"],
+        "request_id": result["request_id"],
+        "committed_revision": result["committed_revision"],
+        "user_message_id": result["user_message_id"],
+        "assistant_message_id": result["assistant_message_id"],
+        "replay_payload": result["replay_payload"],
+        "outbox_events": result["outbox_events"],
+        "created_at": result["created_at"],
+        "completed_at": result["completed_at"],
+    }
+
+
+def _cleanup_user(client: Client, user_id: str) -> None:
+    try:
+        client.table("chat_logs").delete().eq("user_id", user_id).execute()
+    except Exception:
+        pass
+    try:
+        client.table("profiles").delete().eq("user_id", user_id).execute()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# 1. replay_committed_turn RPC behavior
+# ---------------------------------------------------------------------------
+
+
+def test_completed_turn_replays_canonical_contract(service_client: Client):
+    user_id = _uid("replay_ok")
+    request_id = str(uuid.uuid4())
+    try:
+        first = _call_commit(
+            service_client, _commit_params(user_id, request_id, payload_hash="a" * 64)
+        )
+        assert "error" not in first
+
+        replay = _call_replay(service_client, user_id, request_id)
+        # Exactly the canonical CommittedTurn contract (no status marker).
+        assert "status" not in replay
+        assert _normalized(replay) == _normalized(first)
+        assert replay["replay_payload"]["response"] == "Hi there!"
+    finally:
+        _cleanup_user(service_client, user_id)
+
+
+def test_user_a_cannot_recover_user_b_turn(service_client: Client):
+    user_a = _uid("user_a")
+    user_b = _uid("user_b")
+    request_id = str(uuid.uuid4())
+    try:
+        result = _call_commit(
+            service_client, _commit_params(user_a, request_id, payload_hash="a" * 64)
+        )
+        assert "error" not in result
+        replay = _call_replay(service_client, user_b, request_id)
+        assert replay == {"status": "request_replay_unavailable"}
+    finally:
+        _cleanup_user(service_client, user_a)
+        _cleanup_user(service_client, user_b)
+
+
+def test_missing_request_returns_structured_result(service_client: Client):
+    user_id = _uid("missing")
+    replay = _call_replay(service_client, user_id, str(uuid.uuid4()))
+    assert replay == {"status": "request_replay_unavailable"}
+
+
+def test_pending_request_is_not_treated_as_completed(service_client: Client):
+    user_id = _uid("pending")
+    request_id = str(uuid.uuid4())
+    try:
+        _run_sql(
+            "INSERT INTO public.profiles (user_id) VALUES "
+            f"('{user_id}')"
+        )
+        _run_sql(
+            "INSERT INTO public.turn_requests "
+            "(user_id, request_id, payload_hash_sha256, status, lease_owner, lease_expires_at) "
+            f"VALUES ('{user_id}', '{request_id}', '{'b' * 64}', 'pending', "
+            "'worker-x', timezone('utc'::text, now()) + INTERVAL '1 hour')"
+        )
+        replay = _call_replay(service_client, user_id, request_id)
+        assert replay == {"status": "request_in_progress"}
+    finally:
+        _cleanup_user(service_client, user_id)
+
+
+def test_expired_request_is_not_treated_as_completed(service_client: Client):
+    user_id = _uid("expired")
+    request_id = str(uuid.uuid4())
+    try:
+        _run_sql(
+            "INSERT INTO public.profiles (user_id) VALUES "
+            f"('{user_id}')"
+        )
+        _run_sql(
+            "INSERT INTO public.turn_requests "
+            "(user_id, request_id, payload_hash_sha256, status, error_code) "
+            f"VALUES ('{user_id}', '{request_id}', '{'c' * 64}', 'expired', 'timeout')"
+        )
+        replay = _call_replay(service_client, user_id, request_id)
+        assert replay == {"status": "request_replay_unavailable"}
+    finally:
+        _cleanup_user(service_client, user_id)
+
+
+def test_invalid_identity_fails_sanitized(service_client: Client):
+    result = _call_replay(service_client, "", str(uuid.uuid4()))
+    assert result["error"]["code"] == "validation_failed"
+    text = json.dumps(result)
+    # never echoes SQLSTATE, constraint names or raw input
+    assert "42501" not in text
+    assert "P0001" not in text
+
+
+def test_replay_does_not_alter_tables_and_repeats_are_equivalent(
+    service_client: Client,
+):
+    user_id = _uid("no_write")
+    request_id = str(uuid.uuid4())
+    try:
+        _call_commit(service_client, _commit_params(user_id, request_id, payload_hash="a" * 64))
+        before = (
+            _count("chat_logs", user_id),
+            _count("turn_requests", user_id),
+            _count("outbox_events", user_id),
+            _run_sql(f"SELECT revision FROM public.profiles WHERE user_id = '{user_id}'")[0]["revision"],
+        )
+        replay_a = _call_replay(service_client, user_id, request_id)
+        replay_b = _call_replay(service_client, user_id, request_id)
+        assert replay_a == replay_b
+        after = (
+            _count("chat_logs", user_id),
+            _count("turn_requests", user_id),
+            _count("outbox_events", user_id),
+            _run_sql(f"SELECT revision FROM public.profiles WHERE user_id = '{user_id}'")[0]["revision"],
+        )
+        assert after == before
+    finally:
+        _cleanup_user(service_client, user_id)
+
+
+# ---------------------------------------------------------------------------
+# 2. replay_committed_turn authorization matrix
+# ---------------------------------------------------------------------------
+
+
+def test_anon_cannot_execute_replay_rpc(anon_client: Client):
+    with pytest.raises(APIError) as exc_info:
+        anon_client.rpc(
+            "replay_committed_turn",
+            {"p_authenticated_user_id": "x", "p_request_id": str(uuid.uuid4())},
+        ).execute()
+    assert getattr(exc_info.value, "code", None) == "42501"
+
+
+def test_authenticated_cannot_execute_replay_rpc(authenticated_client: Client):
+    with pytest.raises(APIError) as exc_info:
+        authenticated_client.rpc(
+            "replay_committed_turn",
+            {"p_authenticated_user_id": "x", "p_request_id": str(uuid.uuid4())},
+        ).execute()
+    assert getattr(exc_info.value, "code", None) == "42501"
+
+
+def test_service_role_can_execute_replay_rpc(service_client: Client):
+    result = _call_replay(service_client, _uid("sr"), str(uuid.uuid4()))
+    assert result == {"status": "request_replay_unavailable"}
+
+
+# ---------------------------------------------------------------------------
+# 3. Idempotency through commit_turn (used by the normal ProcessTurn path)
+# ---------------------------------------------------------------------------
+
+
+def test_same_request_after_commit_replays_without_new_writes(service_client: Client):
+    user_id = _uid("retry_same")
+    request_id = str(uuid.uuid4())
+    try:
+        first = _call_commit(
+            service_client, _commit_params(user_id, request_id, payload_hash="a" * 64)
+        )
+        assert "error" not in first
+        replay = _call_commit(
+            service_client, _commit_params(user_id, request_id, payload_hash="a" * 64)
+        )
+        assert _normalized(replay) == _normalized(first)
+        assert _count("chat_logs", user_id) == 2
+        assert _count("turn_requests", user_id) == 1
+    finally:
+        _cleanup_user(service_client, user_id)
+
+
+def test_same_request_different_message_conflicts(service_client: Client):
+    user_id = _uid("diff_msg")
+    request_id = str(uuid.uuid4())
+    try:
+        _call_commit(service_client, _commit_params(user_id, request_id, payload_hash="a" * 64))
+        conflict = _call_commit(
+            service_client, _commit_params(user_id, request_id, payload_hash="b" * 64)
+        )
+        assert conflict["error"]["code"] == "request_payload_conflict"
+        assert _count("chat_logs", user_id) == 2
+    finally:
+        _cleanup_user(service_client, user_id)
+
+
+# ---------------------------------------------------------------------------
+# 4. Multi-worker consistency (independent subprocesses, separate clients)
+# ---------------------------------------------------------------------------
+
+# Each worker: loads the profile revision, synchronizes on a file barrier,
+# then runs the ProcessTurn commit loop (bounded retry on revision_mismatch).
+# It reports its attempts and the revision it committed at.
+_WORKER_SCRIPT = r"""
+import json
+import os
+import sys
+import time
+import uuid
+
+from supabase import create_client
+
+url = os.environ["SUPABASE_URL"]
+key = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
+user_id = os.environ["WORKER_USER"]
+request_id = os.environ["WORKER_REQUEST"]
+ready_file = os.environ["WORKER_READY"]
+peer_file = os.environ["WORKER_PEER"]
+
+client = create_client(url, key)
+
+
+def load_revision():
+    rows = (
+        client.table("profiles")
+        .select("revision")
+        .eq("user_id", user_id)
+        .execute()
+        .data
+    )
+    return rows[0]["revision"] if rows else 0
+
+
+def commit(expected_revision, attempt):
+    emotional = {
+        "schema_version": 1, "pleasure": 0.1, "arousal": 0.1, "dominance": 0.1,
+        "libido": 0.1, "aggression": 0.1, "connection": 0.5, "energy": 0.5,
+        "tension": 0.1, "coping_mode": "HEALTHY", "timestamp": 1700000000.0,
+    }
+    relationship = {
+        "schema_version": 1, "trust": 0.5, "affection": 0.3, "tension": 0.1,
+        "triggers": [], "timestamp": 1700000000.0,
+    }
+    replay = {
+        "response": "Hi from worker " + request_id[:8],
+        "message_id": str(uuid.uuid4()),
+        "duration_ms": 7,
+    }
+    params = {
+        "p_authenticated_user_id": user_id,
+        "p_request_id": request_id,
+        "p_expected_revision": expected_revision,
+        "p_user_message": "Hello",
+        "p_assistant_message": replay["response"],
+        "p_payload_hash_sha256": ("a" + str(attempt)) * 32,
+        "p_emotional_state": emotional,
+        "p_relationship_state": relationship,
+        "p_public_response": replay["response"],
+        "p_replay_payload": replay,
+        "p_outbox_events": [],
+        "p_lease_owner": "worker-" + str(attempt),
+    }
+    response = client.rpc("commit_turn", params).execute()
+    data = response.data
+    if isinstance(data, list):
+        data = data[0]
+    return data
+
+
+def fail(reason):
+    print(json.dumps({"ok": False, "reason": reason}))
+    sys.exit(1)
+
+
+# Load revision BEFORE the barrier so both workers race the same revision.
+revision = load_revision()
+open(ready_file, "w").close()
+deadline = time.monotonic() + 30
+while not os.path.exists(peer_file):
+    if time.monotonic() > deadline:
+        fail("barrier_timeout")
+    time.sleep(0.02)
+
+attempts = 0
+for attempt in (1, 2):
+    if attempt == 2:
+        revision = load_revision()
+    data = commit(revision, attempt)
+    attempts = attempt
+    if "error" not in data:
+        print(
+            json.dumps(
+                {
+                    "ok": True,
+                    "attempts": attempts,
+                    "revision": data["committed_revision"],
+                    "request_id": data["request_id"],
+                }
+            )
+        )
+        sys.exit(0)
+    if data["error"]["code"] != "revision_mismatch":
+        fail(data["error"]["code"])
+fail("exhausted")
+"""
+
+
+def _run_worker_pair(url: str, key: str, user_a: str, user_b: str) -> list[dict]:
+    """Run two independent subprocess workers synchronized by a file barrier."""
+    ready_dir = f"/tmp/opencode/pt_workers_{uuid.uuid4().hex}"
+    os.makedirs(ready_dir, exist_ok=True)
+
+    def spawn(user: str, index: int) -> tuple[subprocess.Popen, str, str, str]:
+        request_id = str(uuid.uuid4())
+        ready = os.path.join(ready_dir, f"ready_{index}")
+        peer = os.path.join(ready_dir, f"ready_{1 - index}")
+        env = dict(os.environ)
+        env.update(
+            SUPABASE_URL=url,
+            SUPABASE_SERVICE_ROLE_KEY=key,
+            WORKER_USER=user,
+            WORKER_REQUEST=request_id,
+            WORKER_READY=ready,
+            WORKER_PEER=peer,
+        )
+        proc = subprocess.Popen(
+            [sys.executable, "-c", _WORKER_SCRIPT],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        return proc, ready, request_id, user
+
+    proc_a, ready_a, request_a, user_a_final = spawn(user_a, 0)
+    proc_b, ready_b, request_b, _ = spawn(user_b, 1)
+    assert ready_a != ready_b
+    try:
+        out_a, err_a = proc_a.communicate(timeout=60)
+        out_b, err_b = proc_b.communicate(timeout=60)
+    finally:
+        proc_a.kill()
+        proc_b.kill()
+        for f in (ready_a, ready_b):
+            try:
+                os.unlink(f)
+            except OSError:
+                pass
+        try:
+            os.rmdir(ready_dir)
+        except OSError:
+            pass
+    assert proc_a.returncode == 0, f"worker A failed: {err_a}"
+    assert proc_b.returncode == 0, f"worker B failed: {err_b}"
+    return [
+        json.loads(out_a),
+        json.loads(out_b),
+    ]
+
+
+def test_multi_worker_same_user_cas_consistency(supabase_url, service_role_key):
+    """Two independent workers race the same revision: one wins, the other
+    receives revision_mismatch, reloads and commits on the next revision."""
+    user_id = _uid("mw_same")
+    client = create_client(supabase_url, service_role_key)
+    try:
+        results = _run_worker_pair(supabase_url, service_role_key, user_id, user_id)
+        assert [r["ok"] for r in results] == [True, True]
+        attempts = sorted(r["attempts"] for r in results)
+        # exactly one worker retried once; the other committed on the first try
+        assert attempts == [1, 2]
+        # the revision increased exactly twice (one per committed request)
+        rows = _run_sql(
+            f"SELECT revision FROM public.profiles WHERE user_id = '{user_id}'"
+        )
+        assert rows[0]["revision"] == 2
+        assert _count("turn_requests", user_id) == 2
+        assert _count("chat_logs", user_id) == 4
+        assert _count("profiles", user_id) == 1
+        assert _count("outbox_events", user_id) == 0
+    finally:
+        _cleanup_user(client, user_id)
+        _close_client(client)
+
+
+def test_multi_worker_different_users_progress_independently(
+    supabase_url, service_role_key
+):
+    user_a = _uid("mw_a")
+    user_b = _uid("mw_b")
+    client = create_client(supabase_url, service_role_key)
+    try:
+        results = _run_worker_pair(supabase_url, service_role_key, user_a, user_b)
+        assert [r["ok"] for r in results] == [True, True]
+        # no conflicts across users: each commits on its first attempt
+        assert [r["attempts"] for r in results] == [1, 1]
+        for user in (user_a, user_b):
+            rows = _run_sql(
+                f"SELECT revision FROM public.profiles WHERE user_id = '{user}'"
+            )
+            assert rows[0]["revision"] == 1
+            assert _count("turn_requests", user) == 1
+            assert _count("profiles", user) == 1
+    finally:
+        for user in (user_a, user_b):
+            _cleanup_user(client, user)
+        _close_client(client)
+
+
+def test_concurrent_first_profile_creation_single_row(supabase_url, service_role_key):
+    """N workers creating the first profile concurrently produce one row."""
+    user_id = _uid("mw_profile")
+    workers = 4
+    barrier = threading.Barrier(workers)
+
+    def one(index: int) -> dict:
+        client = create_client(supabase_url, service_role_key)
+        try:
+            barrier.wait(timeout=30)
+            params = _commit_params(
+                user_id,
+                str(uuid.uuid4()),
+                payload_hash=f"{index}" * 64,
+                expected_revision=0,
+            )
+            return _call_commit(client, params)
+        finally:
+            _close_client(client)
+
+    client = create_client(supabase_url, service_role_key)
+    try:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = [pool.submit(one, i) for i in range(workers)]
+            results = [f.result(timeout=60) for f in futures]
+        successes = [r for r in results if "error" not in r]
+        mismatches = [r["error"]["code"] for r in results if "error" in r]
+        assert len(successes) == 1
+        assert mismatches.count("revision_mismatch") == workers - 1
+        assert _count("profiles", user_id) == 1
+        rows = _run_sql(
+            f"SELECT revision FROM public.profiles WHERE user_id = '{user_id}'"
+        )
+        assert rows[0]["revision"] == 1
+    finally:
+        _cleanup_user(client, user_id)
+        _close_client(client)
+
+
+# ---------------------------------------------------------------------------
+# 5. Outbox
+# ---------------------------------------------------------------------------
+
+
+def test_eligible_turn_creates_exactly_one_event(service_client: Client):
+    user_id = _uid("outbox_one")
+    request_id = str(uuid.uuid4())
+    events = [
+        {
+            "event_type": "archival_extraction_requested",
+            "payload": {"message_id": request_id, "kind": "archival", "version": 1},
+            "idempotency_key": f"archival:{request_id}:v1",
+        }
+    ]
+    try:
+        result = _call_commit(
+            service_client,
+            _commit_params(user_id, request_id, payload_hash="a" * 64, outbox_events=events),
+        )
+        assert "error" not in result
+        assert len(result["outbox_events"]) == 1
+        assert _count("outbox_events", user_id) == 1
+
+        # replay (same request id) does not create a new event
+        replay = _call_commit(
+            service_client,
+            _commit_params(user_id, request_id, payload_hash="a" * 64, outbox_events=events),
+        )
+        assert replay["outbox_events"] == result["outbox_events"]
+        assert _count("outbox_events", user_id) == 1
+
+        # payload carries references only: no content, no identity
+        rows = _run_sql(
+            "SELECT payload FROM public.outbox_events "
+            f"WHERE user_id = '{user_id}'"
+        )
+        payload = rows[0]["payload"]
+        assert set(payload) == {"message_id", "kind", "version"}
+        text = json.dumps(payload)
+        assert user_id not in text
+        assert "Hello" not in text
+        assert "Hi there" not in text
+    finally:
+        _cleanup_user(service_client, user_id)
+
+
+def test_revision_retry_that_later_wins_creates_single_event(service_client: Client):
+    user_id = _uid("outbox_retry")
+    try:
+        # consume revision 0 with a first turn
+        first = _call_commit(
+            service_client, _commit_params(user_id, str(uuid.uuid4()), payload_hash="a" * 64)
+        )
+        assert first["committed_revision"] == 1
+
+        # second turn attempts stale revision 0 -> revision_mismatch (no writes)
+        request_id = str(uuid.uuid4())
+        events = [
+            {
+                "event_type": "archival_extraction_requested",
+                "payload": {"message_id": request_id, "kind": "archival", "version": 1},
+                "idempotency_key": f"archival:{request_id}:v1",
+            }
+        ]
+        stale = _call_commit(
+            service_client,
+            _commit_params(
+                user_id,
+                request_id,
+                payload_hash="b" * 64,
+                expected_revision=0,
+                outbox_events=events,
+            ),
+        )
+        assert stale["error"]["code"] == "revision_mismatch"
+        assert _count("outbox_events", user_id) == 0
+        assert _count("chat_logs", user_id) == 2
+
+        # retry with the reloaded revision 1 -> exactly one event
+        ok = _call_commit(
+            service_client,
+            _commit_params(
+                user_id,
+                request_id,
+                payload_hash="b" * 64,
+                expected_revision=1,
+                outbox_events=events,
+            ),
+        )
+        assert "error" not in ok
+        assert len(ok["outbox_events"]) == 1
+        assert _count("outbox_events", user_id) == 1
+        assert _count("chat_logs", user_id) == 4
+    finally:
+        _cleanup_user(service_client, user_id)
+
+
+def test_rollback_removes_outbox_event(service_client: Client):
+    user_id = _uid("outbox_rollback")
+    request_id = str(uuid.uuid4())
+    events = [
+        {
+            "event_type": "archival_extraction_requested",
+            "payload": {"message_id": request_id, "kind": "archival", "version": 1},
+            "idempotency_key": f"archival:{request_id}:v1",
+        }
+    ]
+    trigger_fn = f"pt_rb_{user_id[-8:]}_fn"
+    trigger_name = f"pt_rb_{user_id[-8:]}_trg"
+    try:
+        _run_sql(
+            f"CREATE OR REPLACE FUNCTION public.{trigger_fn}() RETURNS trigger "
+            "LANGUAGE plpgsql AS $$ BEGIN "
+            "RAISE EXCEPTION 'injected fail'; END $$;"
+        )
+        _run_sql(
+            f"CREATE TRIGGER {trigger_name} AFTER INSERT ON public.chat_logs "
+            "FOR EACH ROW WHEN (NEW.role = 'assistant') "
+            f"EXECUTE FUNCTION public.{trigger_fn}()"
+        )
+        with pytest.raises(APIError) as exc:
+            _call_commit(
+                service_client,
+                _commit_params(
+                    user_id, request_id, payload_hash="a" * 64, outbox_events=events
+                ),
+            )
+        assert exc.value.code == "P0001"
+        # the event was born in the same transaction: rollback removed it
+        assert _count("outbox_events", user_id) == 0
+        assert _count("chat_logs", user_id) == 0
+        assert _count("turn_requests", user_id) == 0
+    finally:
+        _run_sql(f"DROP TRIGGER IF EXISTS {trigger_name} ON public.chat_logs")
+        _run_sql(f"DROP FUNCTION IF EXISTS public.{trigger_fn}()")
+        _cleanup_user(service_client, user_id)

--- a/backend/turn_execution.py
+++ b/backend/turn_execution.py
@@ -255,9 +255,13 @@ async def run_blocking_write(
             worker_exc = exc
             break
 
-    # Phase 2: If the worker finished but we didn't retrieve the result
-    # above (e.g. it completed between iterations), retrieve it now.
-    if worker_task.done() and worker_exc is None and original_cancel is None:
+    # Phase 2: If the worker finished but we didn't retrieve the outcome
+    # above (e.g. it completed between iterations, or it completed during the
+    # cancellation drain loop), retrieve it now. This runs even when a
+    # cancellation was recorded, so the worker's result/exception is ALWAYS
+    # consumed: an unretrieved task exception would make asyncio log "Task
+    # exception was never retrieved" and the write would still have finished.
+    if worker_task.done() and worker_exc is None:
         try:
             worker_result = worker_task.result()
         except BaseException as exc:

--- a/backend/turn_repositories.py
+++ b/backend/turn_repositories.py
@@ -1,0 +1,260 @@
+"""
+Minimal repository adapters for the ProcessTurn use case (#272).
+
+Each adapter owns one narrow persistence responsibility and is a thin,
+duck-typed wrapper around the Supabase client (or ``None`` when the store is
+unconfigured). All methods are synchronous: the ProcessTurn use case dispatches
+them through ``run_blocking_read`` / ``run_blocking_write`` so reads never
+consume the commit reserve and writes are never abandoned on cancellation.
+
+Error contract:
+- ``PersistenceError`` — unexpected store failure (sanitized constant message)
+- ``ConflictError`` / ``ValidationError`` — stable domain results parsed from
+  the RPC envelopes (never by parsing exception text)
+- ``TurnExecutionError(internal_error)`` — persisted data violates the
+  contract (duplicate profile row, invalid revision, malformed snapshot)
+
+The adapters never create profiles and never write on read paths: initial
+profile creation happens exclusively inside ``commit_turn`` (race-safe).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time as _time
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional
+
+from .atomic_turn_commit import (
+    CommittedTurn,
+    ConflictError,
+    PersistenceError,
+    ValidationError,
+    _parse_error_envelope,
+    _validate_lease_owner,
+    commit_turn,
+    parse_commit_turn_result,
+)
+from .emotional_domain import EmotionalStateV1
+from .relationship import RelationshipStateV1
+from .turn_execution import TurnErrorCode, TurnExecutionError
+
+REPLAY_STATUS_COMPLETED = "completed"
+REPLAY_STATUS_IN_PROGRESS = "request_in_progress"
+REPLAY_STATUS_UNAVAILABLE = "request_replay_unavailable"
+
+_REPLAY_STATUSES = frozenset({REPLAY_STATUS_IN_PROGRESS, REPLAY_STATUS_UNAVAILABLE})
+
+
+def _unwrap_rpc_data(data: Any) -> Mapping[str, Any]:
+    """Normalize a PostgREST RPC response into a single mapping.
+
+    Raises ``ValidationError`` (internal contract error) when the shape is
+    not a single JSON object; the malformed payload is never echoed.
+    """
+    if isinstance(data, list):
+        if len(data) != 1:
+            raise ValidationError("invalid_rpc_result", "unexpected result shape")
+        data = data[0]
+    if not isinstance(data, Mapping):
+        raise ValidationError("invalid_rpc_result", "result must be a mapping")
+    return data
+
+
+@dataclass(frozen=True)
+class LoadedUserState:
+    """Snapshot data loaded from ``profiles`` together with ``revision``.
+
+    A missing profile yields default in-memory v1 state with ``revision == 0``
+    and is NEVER inserted during loading (creation happens inside
+    ``commit_turn``, which is race-safe).
+    """
+
+    user_id: str
+    revision: int
+    persona_config: Any
+    user_profile: Mapping[str, Any]
+    emotional_state: Mapping[str, Any]
+    relationship_state: Mapping[str, Any]
+
+
+class UserStateRepository:
+    """Loads profile snapshots and ``revision`` without creating profiles."""
+
+    def __init__(self, client_provider: Callable[[], Any]) -> None:
+        self._client_provider = client_provider
+
+    def load(self, user_id: str, default_timestamp: float) -> LoadedUserState:
+        client = self._client_provider()
+        if client is None:
+            raise PersistenceError("database_error", "persistence error")
+        try:
+            response = (
+                client.table("profiles")
+                .select("revision, persona_config, user_profile, emotional_state, relationship_state")
+                .eq("user_id", user_id)
+                .execute()
+            )
+        except Exception:
+            raise PersistenceError("database_error", "persistence error") from None
+
+        data = getattr(response, "data", None)
+        if not isinstance(data, list):
+            raise PersistenceError("database_error", "persistence error")
+
+        if len(data) == 0:
+            # Missing profile: default in-memory v1 state, revision 0, no insert.
+            effective_timestamp = default_timestamp if default_timestamp is not None else _time.time()
+            neutral_emotional = EmotionalStateV1.neutral(timestamp=effective_timestamp).to_dict()
+            neutral_relationship = RelationshipStateV1.neutral(
+                timestamp=effective_timestamp
+            ).to_dict()
+            return LoadedUserState(
+                user_id=user_id,
+                revision=0,
+                persona_config=None,
+                user_profile={},
+                emotional_state=neutral_emotional,
+                relationship_state=neutral_relationship,
+            )
+
+        if len(data) > 1:
+            # Duplicate profile row: fail closed (contract corruption).
+            raise TurnExecutionError(
+                TurnErrorCode.internal_error, "Invalid persisted profile state."
+            )
+
+        row = data[0]
+        if not isinstance(row, Mapping):
+            raise TurnExecutionError(
+                TurnErrorCode.internal_error, "Invalid persisted profile state."
+            )
+
+        revision = row.get("revision", 0)
+        if isinstance(revision, bool) or not isinstance(revision, int) or revision < 0:
+            raise TurnExecutionError(
+                TurnErrorCode.internal_error, "Invalid persisted profile revision."
+            )
+
+        emotional = row.get("emotional_state")
+        relationship = row.get("relationship_state")
+        profile = row.get("user_profile")
+        persona = row.get("persona_config")
+
+        if emotional is not None and not isinstance(emotional, Mapping):
+            raise TurnExecutionError(
+                TurnErrorCode.internal_error, "Invalid persisted emotional state."
+            )
+        if relationship is not None and not isinstance(relationship, Mapping):
+            raise TurnExecutionError(
+                TurnErrorCode.internal_error, "Invalid persisted relationship state."
+            )
+        if profile is not None and not isinstance(profile, Mapping):
+            profile = {}
+        if not isinstance(persona, str):
+            persona = None
+
+        return LoadedUserState(
+            user_id=user_id,
+            revision=revision,
+            persona_config=persona,
+            user_profile=dict(profile) if profile is not None else {},
+            emotional_state=dict(emotional) if emotional is not None else {},
+            relationship_state=dict(relationship) if relationship is not None else {},
+        )
+
+
+class TurnCommitRepository:
+    """Invokes ``commit_turn`` exactly once and interprets its result.
+
+    Reuses the validation / hashing / parsing of ``atomic_turn_commit`` (via
+    ``asyncio.run`` inside the worker thread) so the RPC payload and the
+    interpretation of ``CommittedTurn`` / ``ConflictError`` / ``ValidationError``
+    / ``PersistenceError`` have a single source of truth.
+    """
+
+    def __init__(self, client_provider: Callable[[], Any]) -> None:
+        self._client_provider = client_provider
+
+    def commit(self, **kwargs: Any) -> CommittedTurn:
+        client = self._client_provider()
+        if client is None:
+            raise PersistenceError("database_error", "persistence error")
+
+        lease_owner = kwargs.get("lease_owner")
+        if lease_owner is not None:
+            _validate_lease_owner(lease_owner)
+
+        async def _rpc_client(name: str, params: Mapping[str, Any]) -> Mapping[str, Any]:
+            response = client.rpc(name, dict(params)).execute()
+            return _unwrap_rpc_data(response.data)
+
+        try:
+            return asyncio.run(commit_turn(_rpc_client, **kwargs))
+        except (ConflictError, ValidationError, PersistenceError):
+            raise
+        except Exception:
+            # Unexpected persistence failure: never expose the underlying error.
+            raise PersistenceError("database_error", "persistence error") from None
+
+
+@dataclass(frozen=True)
+class ReplayOutcome:
+    """Structured result of a replay lookup.
+
+    ``status`` is one of ``completed`` / ``request_in_progress`` /
+    ``request_replay_unavailable``. ``committed`` is populated only for
+    ``completed`` and carries the canonical public contract.
+    """
+
+    status: str
+    committed: Optional[CommittedTurn] = None
+
+
+def parse_replay_committed_turn_result(result: Mapping[str, Any]) -> ReplayOutcome:
+    """Parse the ``replay_committed_turn`` RPC result (single format).
+
+    Completed rows reuse the canonical ``parse_commit_turn_result`` builder;
+    structured statuses are validated strictly. Malformed envelopes fail
+    closed with ``ValidationError``; domain error envelopes are converted via
+    the canonical error parser (never by parsing exception text).
+    """
+    if not isinstance(result, Mapping):
+        raise ValidationError("invalid_rpc_result", "result must be a mapping")
+
+    if "error" in result:
+        _parse_error_envelope(result["error"])
+
+    status = result.get("status")
+    if status is not None:
+        if status not in _REPLAY_STATUSES:
+            raise ValidationError("invalid_rpc_result", "unknown replay status")
+        return ReplayOutcome(status=status, committed=None)
+
+    return ReplayOutcome(
+        status=REPLAY_STATUS_COMPLETED,
+        committed=parse_commit_turn_result(result),
+    )
+
+
+class TurnReplayRepository:
+    """Retrieves an already-completed turn result without calling the provider."""
+
+    def __init__(self, client_provider: Callable[[], Any]) -> None:
+        self._client_provider = client_provider
+
+    def replay(self, authenticated_user_id: str, request_id: str) -> ReplayOutcome:
+        client = self._client_provider()
+        if client is None:
+            raise PersistenceError("database_error", "persistence error")
+        try:
+            response = client.rpc(
+                "replay_committed_turn",
+                {
+                    "p_authenticated_user_id": authenticated_user_id,
+                    "p_request_id": request_id,
+                },
+            ).execute()
+        except Exception:
+            raise PersistenceError("database_error", "persistence error") from None
+        return parse_replay_committed_turn_result(_unwrap_rpc_data(response.data))

--- a/docs/architecture/process-turn-v1.md
+++ b/docs/architecture/process-turn-v1.md
@@ -181,10 +181,14 @@ revisão). Ele nunca é tratado como garantia multi-worker.
 - Provado por `test_process_turn_integration.py` com **processos
   independentes**, cada um instanciando o `ProcessTurn` real com repositórios
   e clientes Supabase separados (provider e context loader determinísticos,
-  barrier determinística por arquivo, timeouts locais, sem sleeps longos). O
-  worker que perde o CAS recebe `revision_mismatch`, recarrega estado/contexto
-  e executa a segunda geração — o loop de retry vive dentro de
-  `ProcessTurn.execute()`, nunca reimplementado no teste.
+  sem sleeps longos). A coordenação artificial é um rendezvous por arquivo no
+  **commit** (primeira tentativa, `expected_revision == 0`), executado dentro
+  de `run_blocking_write()` — que nunca abandona a escrita — então a espera
+  não consome o orçamento pré-commit; ambos os workers carregam a revisão 0 e
+  entram no primeiro commit antes de qualquer commit prosseguir. O worker que
+  perde o CAS recebe `revision_mismatch`, recarrega estado/contexto e executa
+  a segunda geração — o loop de retry vive dentro de `ProcessTurn.execute()`,
+  nunca reimplementado no teste.
 
 ## Outbox em vez de BackgroundTasks
 

--- a/docs/architecture/process-turn-v1.md
+++ b/docs/architecture/process-turn-v1.md
@@ -41,8 +41,8 @@ Módulos:
 
 - `backend/process_turn.py` — caso de uso `ProcessTurn`, entrada imutável
   `ProcessTurnInput` (user id autenticado, request id canônico, mensagem
-  validada, `TurnBudget`, modo `normal`/`replay_attempt`), resultado
-  `ProcessTurnResult` construído **somente** a partir de
+  validada, `TurnBudget`, `correlation`, modo `normal`/`replay_attempt`),
+  resultado `ProcessTurnResult` construído **somente** a partir de
   `CommittedTurn.replay_payload`. Não possui estado por usuário em globais.
 - `backend/turn_repositories.py` — fronteiras mínimas de repositório:
   - `UserStateRepository` — carrega snapshots + `revision` sem criar perfil;
@@ -56,6 +56,36 @@ Módulos:
   para testes/rollback, isolado do `/chat`.
 - `supabase/migrations/20240101000006_process_turn_replay.sql` — RPC
   `replay_committed_turn`.
+
+## Lease de reserva por instância
+
+Cada instância do ProcessTurn recebe um `lease_owner` próprio
+(`process-turn-v1:<uuidhex>` gerado por `new_lease_owner()`). O dono do lease:
+
+- nunca é compartilhado entre instâncias/processos/workers (cada
+  `ProcessTurn.execute()` usa um dono novo);
+- identifica a reserva da linha `pending` criada por `commit_turn`, permitindo
+  diagnosticar qual worker detém a reserva;
+- não é usado para "dono único" global — a consistência continua vinda do CAS
+  de revisão sob o lock de usuário no banco.
+
+## Correlação sanitizada por turno
+
+O `/chat` calcula `correlation` = HMAC-SHA256 do request id canônico sob o
+segredo de admissão com domínio dedicado (`TURN_CORRELATION_DOMAIN`), em
+`backend/admission.py` (`compute_turn_correlation`). O valor é exatamente 64
+chars hex minúsculos e é o **único** valor derivado do request que o
+ProcessTurn registra em logs/eventos.
+
+A correlação:
+
+- é estável entre a admissão, o endpoint e o ProcessTurn;
+- nunca expõe o request id, user id, mensagem, segredo ou truncamento do UUID
+  (é não reversível);
+- aparece em todos os eventos do ProcessTurn
+  (`process_turn_started`, `process_turn_commit_completed`,
+  `process_turn_commit_conflict`, cancelamento, etc.) e no log de admissão
+  (`event=admission_admitted` / `event=admission_replay`).
 
 ## Carregamento de estado com revisão
 
@@ -87,8 +117,9 @@ Resultados estruturados da RPC (nunca SQLSTATE/constraint/payload bruto):
 | Estado                        | Resultado                        | HTTP |
 |-------------------------------|----------------------------------|------|
 | turno concluído               | envelope canônico `CommittedTurn`| 200  |
-| linha pendente                | `request_in_progress`            | 409  |
-| reserva sem turno confirmado  | `request_replay_unavailable`     | 409  |
+| linha pendente com lease ativo| `request_in_progress`            | 409  |
+| reserva pendente com lease expirado | `request_replay_unavailable`| 409  |
+| request expirado/falho        | `request_replay_unavailable`     | 409  |
 | identidade divergente/inválida| erro sanitizado                  | 500/409 |
 
 O builder canônico `commit_turn_build_result` é o único formato de replay —
@@ -148,8 +179,12 @@ revisão). Ele nunca é tratado como garantia multi-worker.
 - Replay do mesmo request id após commit não gera nova transição, mensagem
   ou outbox e não chama provider.
 - Provado por `test_process_turn_integration.py` com **processos
-  independentes** e clientes Supabase separados (barrier determinística por
-  arquivo, timeouts locais, sem sleeps longos).
+  independentes**, cada um instanciando o `ProcessTurn` real com repositórios
+  e clientes Supabase separados (provider e context loader determinísticos,
+  barrier determinística por arquivo, timeouts locais, sem sleeps longos). O
+  worker que perde o CAS recebe `revision_mismatch`, recarrega estado/contexto
+  e executa a segunda geração — o loop de retry vive dentro de
+  `ProcessTurn.execute()`, nunca reimplementado no teste.
 
 ## Outbox em vez de BackgroundTasks
 
@@ -191,8 +226,12 @@ idempotency_key: archival:<request_id>:v1
 
 - `revision_mismatch` após as 2 tentativas → 409 para o cliente; o usuário
   pode repetir a requisição (novo request id).
-- Replay de turno `pending` (worker morto) → 409 até o lease expirar; depois,
-  `commit_turn` com o mesmo request id pode reclamar o turno.
+- Reserva `pending` de worker morto → 409 (`request_in_progress`) enquanto o
+  lease estiver ativo; após a expiração do lease, o replay retorna
+  `request_replay_unavailable`. O v1 **não** faz reclaim automático via
+  endpoint: um request id abandonado exige um novo request id (ou ação
+  operacional) para prosseguir. O dono do lease (`process-turn-v1:<uuidhex>`)
+  permite diagnosticar qual instância abandonou a reserva.
 - A extração arquivística fica pendente até o worker da outbox existir
   (fora de escopo).
 - O lock local não protege entre processos; qualquer uso futuro deve

--- a/docs/architecture/process-turn-v1.md
+++ b/docs/architecture/process-turn-v1.md
@@ -1,0 +1,199 @@
+# ProcessTurn v1 — fluxo de turno idempotente e transacional
+
+Status: implementado na issue #272 (PR de integração do ProcessTurn).
+Depende de: #270 (schema transacional), #271 (commit atômico).
+
+## Problema e causa raiz
+
+O caminho ativo do `/chat` persistia um turno em várias operações separadas:
+
+```text
+load state        (MemoryManager.load_user_state — select → insert)
+→ provider        (appraisal + geração via Groq)
+→ save_turn       (insert de user/assistant em chat_logs)
+→ sync_state      (update de perfis)
+→ BackgroundTasks (extração arquivística)
+```
+
+Cada operação era uma transação independente: uma falha entre `save_turn` e
+`sync_state` deixava mensagens órfãs e snapshots obsoletos; uma resposta HTTP
+perdida não podia ser recuperada sem reprocessar o provider; e a contenção
+entre workers não era comprovada (o `UserLockManager` só serializa dentro de
+um único processo).
+
+## Arquitetura
+
+O novo fluxo substitui a dupla escrita por um único caso de uso:
+
+```text
+identidade autenticada
+→ resultado de admissão
+→ replay check quando aplicável
+→ load state + revision          (leitura, sem insert)
+→ load trusted context           (leitura autorizada)
+→ appraisal/transitions/generation (FORA da transação)
+→ commit_turn atômico com expected_revision (CAS)
+→ retry limitado de revisão
+→ retorna exatamente o resultado persistido
+```
+
+Módulos:
+
+- `backend/process_turn.py` — caso de uso `ProcessTurn`, entrada imutável
+  `ProcessTurnInput` (user id autenticado, request id canônico, mensagem
+  validada, `TurnBudget`, modo `normal`/`replay_attempt`), resultado
+  `ProcessTurnResult` construído **somente** a partir de
+  `CommittedTurn.replay_payload`. Não possui estado por usuário em globais.
+- `backend/turn_repositories.py` — fronteiras mínimas de repositório:
+  - `UserStateRepository` — carrega snapshots + `revision` sem criar perfil;
+  - `TurnCommitRepository` — chama `commit_turn` e interpreta `CommittedTurn`,
+    `ConflictError`, `ValidationError`, `PersistenceError`;
+  - `TurnReplayRepository` — recupera resultado já concluído sem provider.
+- `backend/atomic_turn_commit.py` — contrato do RPC (inalterado; extraído o
+  builder do payload canônico para reuso).
+- `backend/chat_engine.py` — `ChatConversationEngine` delega o caminho ativo
+  ao `ProcessTurn`; `ConversationEngine` (classe base) mantém o fluxo legado
+  para testes/rollback, isolado do `/chat`.
+- `supabase/migrations/20240101000006_process_turn_replay.sql` — RPC
+  `replay_committed_turn`.
+
+## Carregamento de estado com revisão
+
+O caminho novo lê de `profiles`: `revision`, `persona_config`,
+`user_profile`, `emotional_state`, `relationship_state`.
+
+- Perfil existente → revisão persistida.
+- Perfil ausente → estado padrão v1 em memória e `revision == 0`, **sem
+  insert**; a criação inicial acontece somente dentro de `commit_turn`
+  (race-safe, com lock de usuário no banco).
+- Linha duplicada, revisão inválida (bool/negativa/float/string) ou snapshot
+  malformado → falha fechada (`internal_error` sanitizado).
+- Identidade vem exclusivamente do usuário autenticado; `user_id` dentro de
+  JSON é sempre rejeitado pelo contrato do banco.
+
+## Replay antes do provider
+
+Quando a admissão retorna `request_replay_unavailable` (mesmo usuário repete
+o mesmo `request_id` com a mesma mensagem), o `/chat` executa o ProcessTurn
+em modo `replay_attempt`:
+
+1. consulta `replay_committed_turn(user_id, request_id)`;
+2. turno `completed` → retorna o `CommittedTurn` persistido;
+3. sem carregar contexto, sem appraisal, sem Groq, sem transições, sem
+   mensagens, sem outbox.
+
+Resultados estruturados da RPC (nunca SQLSTATE/constraint/payload bruto):
+
+| Estado                        | Resultado                        | HTTP |
+|-------------------------------|----------------------------------|------|
+| turno concluído               | envelope canônico `CommittedTurn`| 200  |
+| linha pendente                | `request_in_progress`            | 409  |
+| reserva sem turno confirmado  | `request_replay_unavailable`     | 409  |
+| identidade divergente/inválida| erro sanitizado                  | 500/409 |
+
+O builder canônico `commit_turn_build_result` é o único formato de replay —
+commit novo e replay passam pelo mesmo parser
+(`parse_commit_turn_result` / `parse_public_result`).
+
+## CAS e retry limitado
+
+O commit envia `expected_revision` = revisão carregada. O banco valida o CAS
+sob lock de usuário (advisory 64-bit) e incrementa a revisão exatamente uma
+vez por turno.
+
+Política de retry — somente para `revision_mismatch`:
+
+- no máximo uma repetição após a tentativa inicial (2 tentativas totais);
+- verificar o orçamento antes de repetir (deadline esgotado → `DeadlineExceeded`);
+- recarregar estado, revisão e contexto; recalcular appraisal, transições e
+  geração — a resposta anterior nunca é reutilizada sobre estado obsoleto;
+- registrar somente `event=process_turn_revision_conflict attempt=N`;
+- nunca criar loop ilimitado; ao esgotar, `ConflictError("revision_mismatch")`
+  recuperável e sanitizado, sem escrita parcial.
+
+Nunca repete provider para: replay confirmado, `request_payload_conflict`,
+`request_in_progress`, `lease_conflict`, entrada inválida, deadline esgotado,
+cancelamento ou falha permanente do provider.
+
+## Cancelamento e incerteza do commit
+
+Antes do commit não existe escrita (mensagens/snapshots/outbox só nascem em
+`commit_turn`), então cancelamento nesse estágio não grava nada.
+
+Depois que `commit_turn` começa, a operação roda sob `run_blocking_write`
+(protocolo de escrita não abandonável já existente): cancelamentos repetidos
+são consumidos enquanto a operação é drenada; o resultado ou exceção é
+recuperado obrigatoriamente; o lock local só é liberado após o término; e o
+`CancelledError` original é propagado no final.
+
+Se o commit foi confirmado mas a resposta HTTP se perdeu, o próximo envio com
+o mesmo request id passa pela admissão (`request_replay_unavailable`) e
+recupera o replay persistido sem provider.
+
+## Papel do lock local
+
+O `UserLockManager` continua existindo apenas como otimização local
+(evita dois ProcessTurn concorrentes no mesmo processo para o mesmo usuário).
+A consistência real vem do PostgreSQL (lock de usuário no banco + CAS de
+revisão). Ele nunca é tratado como garantia multi-worker.
+
+## Semântica multi-worker
+
+- Duas requisições distintas do mesmo usuário carregando a mesma revisão não
+  podem commitar ambas nessa revisão: uma vence, a outra recebe
+  `revision_mismatch`, recarrega e commita na revisão seguinte.
+- Usuários diferentes progridem independentemente (locks de usuário
+  distintos — nunca bloqueio global).
+- Criação concorrente do primeiro perfil produz uma única linha.
+- Replay do mesmo request id após commit não gera nova transição, mensagem
+  ou outbox e não chama provider.
+- Provado por `test_process_turn_integration.py` com **processos
+  independentes** e clientes Supabase separados (barrier determinística por
+  arquivo, timeouts locais, sem sleeps longos).
+
+## Outbox em vez de BackgroundTasks
+
+O caminho ativo não agenda `run_archival_extraction` em `BackgroundTasks`.
+Quando `ARCHIVAL_EXTRACTION_ENABLED` está habilitado, o commit inclui
+exatamente um evento idempotente de outbox:
+
+```text
+event_type: archival_extraction_requested
+payload:    {"message_id": <request_id>, "kind": "archival", "version": 1}
+idempotency_key: archival:<request_id>:v1
+```
+
+- contém somente referências sanitizadas: sem mensagem, user id, prompt,
+  resposta, snapshots, HMAC ou segredo;
+- nasce na mesma transação do turno (rollback remove);
+- retry/replay nunca duplica o evento;
+- o worker da outbox é fora de escopo desta issue.
+
+## Comportamento quando a resposta HTTP é perdida
+
+1. O commit foi confirmado (mensagens + snapshots + request + outbox).
+2. O cliente reenvia o mesmo request id.
+3. A admissão detecta repetição → `request_replay_unavailable`.
+4. O `/chat` tenta replay → `completed` → resposta persistida, sem custo de
+   provider e sem transições repetidas.
+
+## Rollback operacional
+
+- Reverter a PR restaura o fluxo legado (classe base `ConversationEngine`
+  continua intacta); a migration 06 é aditiva e pode permanecer (a RPC só é
+  chamada pelo caminho novo).
+- Se necessário, `supabase db reset` em ambiente local; em produção, aplicar
+  a migration 06 é seguro (nenhum objeto existente é alterado).
+- `save_turn` / `sync_state` permanecem para testes legados, mas nunca são
+  executados pelo `/chat`.
+
+## Riscos residuais
+
+- `revision_mismatch` após as 2 tentativas → 409 para o cliente; o usuário
+  pode repetir a requisição (novo request id).
+- Replay de turno `pending` (worker morto) → 409 até o lease expirar; depois,
+  `commit_turn` com o mesmo request id pode reclamar o turno.
+- A extração arquivística fica pendente até o worker da outbox existir
+  (fora de escopo).
+- O lock local não protege entre processos; qualquer uso futuro deve
+  continuar dependendo do CAS no banco.

--- a/docs/operations/process-turn-conflicts.md
+++ b/docs/operations/process-turn-conflicts.md
@@ -1,0 +1,68 @@
+# Runbook — conflitos do ProcessTurn (issue #272)
+
+Operação do fluxo transacional de turno (`ProcessTurn`). Para o desenho
+completo, veja `docs/architecture/process-turn-v1.md`.
+
+## Precedência de conflitos
+
+A precedência de decisão dentro de `commit_turn` (e refletida no ProcessTurn):
+
+1. `request_payload_conflict` — mesmo `(user_id, request_id)` com payload
+   divergente (mensagem/estado/resposta diferentes). Sempre 409; nunca retry.
+2. `request_in_progress` — linha `pending` com lease ativo de outro worker.
+   409; nunca retry.
+3. `lease_conflict` — corrida de claim/reclaim. 409; nunca retry.
+4. `revision_mismatch` — CAS falhou. Retry interno limitado (1 repetição);
+   esgotado → 409.
+5. `request_replay_unavailable` — admissão repetida sem turno confirmado.
+   409.
+6. `PersistenceError` — falha inesperada de banco. 503; nunca expõe texto do
+   PostgreSQL.
+7. Deadline esgotado — 504; nunca dispara retry.
+8. `CancelledError` — propagado; nunca vira 500.
+
+Mapeamento HTTP centralizado em `backend/main.py::_map_process_turn_conflict`.
+Mensagens públicas são constantes; request id, mensagem, revisões e texto do
+banco nunca são devolvidos ao cliente.
+
+## Sintomas e ações
+
+| Sintoma | Causa provável | Ação |
+|---|---|---|
+| 409 `revision_conflict` | dois turnos simultâneos do mesmo usuário | cliente reenvia com novo request id; sem ação manual |
+| 409 `request_in_progress` | worker anterior morreu com lease ativo | aguardar expiração do lease; o próximo commit reclaima |
+| 409 `request_replay_unavailable` | request id repetido sem turno confirmado | cliente usa novo request id |
+| 503 `persistence_unavailable` | banco/PostgREST indisponível | verificar conectividade; retry com novo request id |
+| 504 `turn_timeout` | orçamento de 16.000 unidades / deadline | reduzir mensagem; retry |
+| evento `process_turn_conflict_exhausted` | 2 tentativas de CAS falharam | sinal de contenção alta; monitorar `event=process_turn_revision_conflict` |
+
+## Logs úteis (baixa cardinalidade)
+
+```
+event=process_turn_attempt attempt=1
+event=process_turn_revision_conflict attempt=1
+event=process_turn_replay
+event=process_turn_commit_completed attempt=N
+event=process_turn_conflict_exhausted attempt=N
+```
+
+Nunca aparecem em logs: mensagem, resposta, prompt, contexto, memória,
+user id, request id bruto, message id bruto, snapshots, exceções upstream,
+tokens ou payloads de RPC.
+
+## Rollback operacional
+
+- Reverter a PR restaura o fluxo legado (classe base `ConversationEngine`).
+- A migration 06 é aditiva; manter ou reverter sem impacto para o fluxo
+  legado.
+- `save_turn`/`sync_state` continuam existindo para testes legados, mas não
+  são executados pelo `/chat`.
+
+## Verificação rápida pós-deploy
+
+1. `supabase db reset` local + pgTAP (`supabase test db supabase/tests/database`).
+2. `python -m pytest backend/tests/test_process_turn.py backend/tests/test_atomic_turn_commit.py`.
+3. Com Supabase local no ar:
+   `python -m pytest backend/tests/test_process_turn_integration.py`.
+4. Confirmar no banco: `revision` incrementa 1 por turno; `outbox_events`
+   nasce na mesma transação (rollback remove).

--- a/docs/operations/process-turn-conflicts.md
+++ b/docs/operations/process-turn-conflicts.md
@@ -30,25 +30,46 @@ banco nunca são devolvidos ao cliente.
 | Sintoma | Causa provável | Ação |
 |---|---|---|
 | 409 `revision_conflict` | dois turnos simultâneos do mesmo usuário | cliente reenvia com novo request id; sem ação manual |
-| 409 `request_in_progress` | worker anterior morreu com lease ativo | aguardar expiração do lease; o próximo commit reclaima |
-| 409 `request_replay_unavailable` | request id repetido sem turno confirmado | cliente usa novo request id |
+| 409 `request_in_progress` | worker anterior morreu com lease ativo | aguardar expiração do lease; enquanto ativo, replay responde 409 |
+| 409 `request_replay_unavailable` | request id repetido sem turno confirmado, ou reserva pendente com lease expirado | cliente usa novo request id; v1 não faz reclaim automático via endpoint |
 | 503 `persistence_unavailable` | banco/PostgREST indisponível | verificar conectividade; retry com novo request id |
 | 504 `turn_timeout` | orçamento de 16.000 unidades / deadline | reduzir mensagem; retry |
 | evento `process_turn_conflict_exhausted` | 2 tentativas de CAS falharam | sinal de contenção alta; monitorar `event=process_turn_revision_conflict` |
 
+## Reservas abandonadas (lease)
+
+Quando um worker morre após criar a linha `pending`, o replay responde:
+
+- `request_in_progress` enquanto o lease estiver ativo;
+- `request_replay_unavailable` após a expiração do lease (a reserva nunca
+  completa sozinha; o v1 **não** implementa reclaim automático via endpoint).
+
+O dono da reserva (`lease_owner = process-turn-v1:<uuidhex>`) é per-instância
+e nunca compartilhado entre workers; ele serve para diagnosticar qual
+instância abandonou o turno. Para liberar o usuário, o cliente deve enviar um
+novo request id.
+
 ## Logs úteis (baixa cardinalidade)
 
 ```
-event=process_turn_attempt attempt=1
-event=process_turn_revision_conflict attempt=1
-event=process_turn_replay
-event=process_turn_commit_completed attempt=N
-event=process_turn_conflict_exhausted attempt=N
+event=admission_admitted correlation=<hex64>
+event=admission_replay correlation=<hex64>
+event=process_turn_started correlation=<hex64>
+event=process_turn_attempt attempt=1 correlation=<hex64>
+event=process_turn_revision_conflict attempt=1 correlation=<hex64>
+event=process_turn_replay correlation=<hex64>
+event=process_turn_commit_completed attempt=N correlation=<hex64>
+event=process_turn_conflict_exhausted attempt=N correlation=<hex64>
 ```
+
+A `correlation` é um HMAC-SHA256 (64 hex minúsculos) do request id canônico,
+calculado com o segredo de admissão sob domínio dedicado. Ela permite
+correlacionar admissão → endpoint → ProcessTurn nos logs sem expor dados
+sensíveis.
 
 Nunca aparecem em logs: mensagem, resposta, prompt, contexto, memória,
 user id, request id bruto, message id bruto, snapshots, exceções upstream,
-tokens ou payloads de RPC.
+tokens, payloads de RPC ou a própria `correlation` de outro turno.
 
 ## Rollback operacional
 

--- a/supabase/migrations/20240101000006_process_turn_replay.sql
+++ b/supabase/migrations/20240101000006_process_turn_replay.sql
@@ -10,12 +10,21 @@
 --
 -- Result contract (structured, never raw):
 --   * completed row -> canonical CommittedTurn envelope (same as commit_turn)
---   * pending row    -> {"status": "request_in_progress"}
+--   * pending row with ACTIVE lease -> {"status": "request_in_progress"}
+--   * pending row with EXPIRED lease (stale worker, will never complete) ->
+--     {"status": "request_replay_unavailable"}
 --   * no row (only an admission reservation exists) -> {"status": "request_replay_unavailable"}
---   * expired row    -> {"status": "request_replay_unavailable"}
+--   * expired row -> {"status": "request_replay_unavailable"}
 --   * invalid input or corrupt persisted contract -> sanitized error envelope
 --     (validation_failed) or a raised constant sanitized error (P0001), never
 --     SQLSTATE, constraint names, payload or raw error text.
+--
+-- Reclaim policy (v1): there is NO automatic reclaim through this RPC or the
+-- /chat endpoint. A stale pending row (expired lease) and an expired row never
+-- complete on their own; clients must use a NEW request id or an operator must
+-- clear the reservation. commit_turn keeps its same-hash lease reclaim ONLY
+-- for exact byte-identical retries (never reachable from the endpoint, which
+-- always recomputes a different payload).
 --
 -- Security posture (mirrors commit_turn):
 --   * SECURITY DEFINER with fixed search_path = public, fully qualified objects
@@ -112,7 +121,16 @@ BEGIN
 
     -- pending: another worker is (or was) actively processing this request.
     IF v_row.status = 'pending' THEN
-        RETURN jsonb_build_object('status', 'request_in_progress');
+        -- Active lease: the request is really being processed right now.
+        IF v_row.lease_expires_at IS NOT NULL
+           AND v_row.lease_expires_at > now() THEN
+            RETURN jsonb_build_object('status', 'request_in_progress');
+        END IF;
+        -- Expired lease: the worker is gone and the reservation can never
+        -- complete. This version performs NO automatic reclaim through the
+        -- endpoint; the client needs a new request id (or operational
+        -- cleanup), so replay is unavailable.
+        RETURN jsonb_build_object('status', 'request_replay_unavailable');
     END IF;
 
     -- expired: reservation exists but the turn was never confirmed.
@@ -139,4 +157,4 @@ GRANT EXECUTE ON FUNCTION public.replay_committed_turn(text, uuid)
 -- 3. Documentation comment
 -- =================================================================
 COMMENT ON FUNCTION public.replay_committed_turn(text, uuid) IS
-'Idempotent replay RPC (#272). Returns the canonical public result of a previously committed turn without any writes, context loading, appraisal, provider call or transitions. Completed -> canonical CommittedTurn envelope; pending -> request_in_progress; missing/expired -> request_replay_unavailable. SECURITY DEFINER, service_role only, fixed search_path, sanitized failures.';
+'Idempotent replay RPC (#272). Returns the canonical public result of a previously committed turn without any writes, context loading, appraisal, provider call or transitions. Completed -> canonical CommittedTurn envelope; pending with ACTIVE lease -> request_in_progress; pending with EXPIRED lease / missing / expired -> request_replay_unavailable (no automatic reclaim in v1). SECURITY DEFINER, service_role only, fixed search_path, sanitized failures.';

--- a/supabase/migrations/20240101000006_process_turn_replay.sql
+++ b/supabase/migrations/20240101000006_process_turn_replay.sql
@@ -1,0 +1,142 @@
+-- 20240101000006_process_turn_replay.sql
+-- Idempotent replay RPC for the ProcessTurn use case (#272).
+--
+-- Reads a previously committed turn from turn_requests and returns the SAME
+-- canonical public contract produced by commit_turn (via the existing builder
+-- public.commit_turn_build_result). Used by the active /chat path when the
+-- admission ledger reports a repeated (user_id, request_id) so the persisted
+-- result can be recovered WITHOUT loading context, running appraisal, calling
+-- the provider, applying transitions or writing anything.
+--
+-- Result contract (structured, never raw):
+--   * completed row -> canonical CommittedTurn envelope (same as commit_turn)
+--   * pending row    -> {"status": "request_in_progress"}
+--   * no row (only an admission reservation exists) -> {"status": "request_replay_unavailable"}
+--   * expired row    -> {"status": "request_replay_unavailable"}
+--   * invalid input or corrupt persisted contract -> sanitized error envelope
+--     (validation_failed) or a raised constant sanitized error (P0001), never
+--     SQLSTATE, constraint names, payload or raw error text.
+--
+-- Security posture (mirrors commit_turn):
+--   * SECURITY DEFINER with fixed search_path = public, fully qualified objects
+--   * EXECUTE revoked from PUBLIC/anon/authenticated; granted to service_role
+--     only
+--   * no new grants on turn_requests: runtime roles never get direct access
+--   * identity comes exclusively from the authenticated user_id parameter;
+--     results are filtered simultaneously by user_id AND request_id
+--
+-- Depends on: #271 (commit_turn / commit_turn_build_result, migration 05)
+-- Issue: #272
+
+-- =================================================================
+-- 0. PREFLIGHT: verify dependencies
+-- =================================================================
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public' AND p.proname = 'commit_turn_build_result'
+    ) THEN
+        RAISE EXCEPTION 'Missing dependency: public.commit_turn_build_result (issue #271)'
+            USING ERRCODE = '23514';
+    END IF;
+END $$;
+
+-- =================================================================
+-- 1. replay_committed_turn RPC
+-- =================================================================
+CREATE OR REPLACE FUNCTION public.replay_committed_turn(
+    p_authenticated_user_id text,
+    p_request_id uuid
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_row public.turn_requests%ROWTYPE;
+BEGIN
+    -- =============================================================
+    -- Input validation (fail fast, stable envelopes)
+    -- =============================================================
+    IF p_authenticated_user_id IS NULL OR p_authenticated_user_id = '' THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'authenticated_user_id is required'
+            )
+        );
+    END IF;
+
+    IF p_request_id IS NULL THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'request_id is required'
+            )
+        );
+    END IF;
+
+    -- =============================================================
+    -- Lookup filtered simultaneously by user AND request id
+    -- =============================================================
+    SELECT * INTO v_row
+    FROM public.turn_requests
+    WHERE user_id = p_authenticated_user_id
+      AND request_id = p_request_id;
+
+    IF NOT FOUND THEN
+        -- The admission reservation exists, but no confirmed turn: replay
+        -- is unavailable. Never returns SQLSTATE or raw error text.
+        RETURN jsonb_build_object('status', 'request_replay_unavailable');
+    END IF;
+
+    IF v_row.status = 'completed' THEN
+        -- The canonical builder guarantees the same public contract as a
+        -- fresh commit (single authoritative replay format). Corrupt
+        -- persisted contracts fail closed with a constant sanitized error.
+        IF v_row.replay_payload IS NULL
+           OR jsonb_typeof(v_row.replay_payload) <> 'object'
+           OR jsonb_typeof(v_row.replay_payload->'response') <> 'string'
+           OR (v_row.replay_payload->>'message_id') IS NULL
+           OR NOT ((v_row.replay_payload->>'message_id')
+                   ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
+           OR v_row.committed_revision IS NULL
+           OR v_row.completed_at IS NULL THEN
+            RAISE EXCEPTION 'persistence error' USING ERRCODE = 'P0001';
+        END IF;
+        RETURN public.commit_turn_build_result(p_authenticated_user_id, p_request_id);
+    END IF;
+
+    -- pending: another worker is (or was) actively processing this request.
+    IF v_row.status = 'pending' THEN
+        RETURN jsonb_build_object('status', 'request_in_progress');
+    END IF;
+
+    -- expired: reservation exists but the turn was never confirmed.
+    RETURN jsonb_build_object('status', 'request_replay_unavailable');
+EXCEPTION
+    WHEN OTHERS THEN
+        -- Unexpected PostgreSQL failure or corrupt contract. Never expose
+        -- SQLERRM, SQLSTATE, constraint names or payload; propagate a
+        -- constant sanitized error so the RPC fails (rollback is automatic)
+        -- and the Python layer maps it to PersistenceError.
+        RAISE EXCEPTION 'persistence error' USING ERRCODE = 'P0001';
+END;
+$$;
+
+-- =================================================================
+-- 2. Grants for replay_committed_turn
+-- =================================================================
+REVOKE ALL ON FUNCTION public.replay_committed_turn(text, uuid)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.replay_committed_turn(text, uuid)
+    TO service_role;
+
+-- =================================================================
+-- 3. Documentation comment
+-- =================================================================
+COMMENT ON FUNCTION public.replay_committed_turn(text, uuid) IS
+'Idempotent replay RPC (#272). Returns the canonical public result of a previously committed turn without any writes, context loading, appraisal, provider call or transitions. Completed -> canonical CommittedTurn envelope; pending -> request_in_progress; missing/expired -> request_replay_unavailable. SECURITY DEFINER, service_role only, fixed search_path, sanitized failures.';

--- a/supabase/tests/database/04_process_turn_replay.test.sql
+++ b/supabase/tests/database/04_process_turn_replay.test.sql
@@ -1,0 +1,253 @@
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgtap;
+SELECT plan(25);
+
+-- =================================================================
+-- 1. replay_committed_turn function shape and security posture
+-- =================================================================
+
+SELECT has_function(
+    'public', 'replay_committed_turn', ARRAY['text', 'uuid'],
+    'replay_committed_turn(text, uuid) exists'
+);
+
+SELECT is(
+    (SELECT prosecdef
+     FROM pg_proc
+     WHERE proname = 'replay_committed_turn'
+       AND pronamespace = 'public'::regnamespace
+       AND pronargs = 2),
+    true,
+    'replay_committed_turn is SECURITY DEFINER'
+);
+
+SELECT is(
+    (SELECT COALESCE(
+        (SELECT setting
+         FROM pg_proc p
+         CROSS JOIN LATERAL unnest(proconfig) AS cfg(setting)
+         WHERE p.proname = 'replay_committed_turn'
+           AND p.pronamespace = 'public'::regnamespace
+           AND p.pronargs = 2
+           AND cfg.setting LIKE 'search_path=%'),
+        '')
+    ),
+    'search_path=public',
+    'replay_committed_turn has a fixed search_path = public'
+);
+
+-- =================================================================
+-- 2. Execution privileges: only service_role
+-- =================================================================
+
+SELECT function_privs_are(
+    'public', 'replay_committed_turn', ARRAY['text', 'uuid'],
+    'anon', ARRAY[]::text[],
+    'anon has no EXECUTE on replay_committed_turn'
+);
+SELECT function_privs_are(
+    'public', 'replay_committed_turn', ARRAY['text', 'uuid'],
+    'authenticated', ARRAY[]::text[],
+    'authenticated has no EXECUTE on replay_committed_turn'
+);
+SELECT function_privs_are(
+    'public', 'replay_committed_turn', ARRAY['text', 'uuid'],
+    'service_role', ARRAY['EXECUTE'],
+    'service_role has EXECUTE on replay_committed_turn'
+);
+SELECT ok(
+    NOT has_function_privilege(
+        'public', 'public.replay_committed_turn(text, uuid)', 'EXECUTE'
+    ),
+    'PUBLIC has no EXECUTE on replay_committed_turn'
+);
+
+-- =================================================================
+-- 3. No runtime role gets direct access to turn_requests
+-- =================================================================
+
+SELECT table_privs_are(
+    'public', 'turn_requests', 'anon', ARRAY[]::text[],
+    'anon has no table privileges on turn_requests'
+);
+SELECT table_privs_are(
+    'public', 'turn_requests', 'authenticated', ARRAY[]::text[],
+    'authenticated has no table privileges on turn_requests'
+);
+SELECT ok(
+    NOT has_table_privilege(
+        'public', 'public.turn_requests',
+        'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'
+    ),
+    'PUBLIC has no privileges on turn_requests'
+);
+
+-- =================================================================
+-- 4. Behavior against real rows (service_role)
+-- =================================================================
+
+-- Fixture user and request
+INSERT INTO public.profiles (user_id, revision)
+VALUES ('replay_tap_user', 0);
+
+-- 4a. Completed turn returns the canonical contract
+SELECT ok(
+    (SELECT public.commit_turn(
+        'replay_tap_user',
+        'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
+        0,
+        'hello',
+        'hi there',
+        'a'::text || repeat('0', 63),
+        jsonb_build_object(
+            'schema_version', 1, 'pleasure', 0.1, 'arousal', 0.1,
+            'dominance', 0.1, 'libido', 0.1, 'aggression', 0.1,
+            'connection', 0.5, 'energy', 0.5, 'tension', 0.1,
+            'coping_mode', 'HEALTHY', 'timestamp', 1700000000.0
+        ),
+        jsonb_build_object(
+            'schema_version', 1, 'trust', 0.5, 'affection', 0.3,
+            'tension', 0.1, 'triggers', '[]'::jsonb, 'timestamp', 1700000000.0
+        ),
+        'hi there',
+        jsonb_build_object(
+            'response', 'hi there',
+            'message_id', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+        ),
+        '[]'::jsonb
+    ) IS NOT NULL),
+    'commit_turn fixture succeeds'
+);
+
+SELECT ok(
+    (SELECT (public.replay_committed_turn(
+        'replay_tap_user', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid
+    )->>'status') IS NULL),
+    'completed replay returns the canonical envelope (no status marker)'
+);
+
+SELECT is(
+    (SELECT public.replay_committed_turn(
+        'replay_tap_user', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid
+    )->>'user_id'),
+    'replay_tap_user',
+    'completed replay returns the canonical user_id'
+);
+
+SELECT is(
+    (SELECT public.replay_committed_turn(
+        'replay_tap_user', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid
+    )->>'request_id'),
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    'completed replay returns the canonical request_id'
+);
+
+SELECT is(
+    (SELECT public.replay_committed_turn(
+        'replay_tap_user', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid
+    )->'replay_payload'->>'message_id'),
+    'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    'completed replay returns replay_payload.message_id'
+);
+
+-- Repeated replays are byte-equivalent
+SELECT is(
+    (SELECT public.replay_committed_turn(
+        'replay_tap_user', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid
+    )),
+    (SELECT public.replay_committed_turn(
+        'replay_tap_user', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid
+    )),
+    'repeated replays return equivalent bytes'
+);
+
+-- 4b. Replay does not alter any table
+SELECT is(
+    (SELECT count(*)::integer FROM public.turn_requests WHERE user_id = 'replay_tap_user'),
+    1,
+    'turn_requests unchanged after replay'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.chat_logs WHERE user_id = 'replay_tap_user'),
+    2,
+    'chat_logs unchanged after replay'
+);
+SELECT is(
+    (SELECT revision FROM public.profiles WHERE user_id = 'replay_tap_user')::bigint,
+    1::bigint,
+    'profile revision unchanged after replay'
+);
+
+-- 4c. User A cannot retrieve user B turn
+SELECT is(
+    (SELECT public.replay_committed_turn(
+        'replay_other_user', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid
+    )->>'status'),
+    'request_replay_unavailable',
+    'another user cannot replay this turn (structured result)'
+);
+
+-- 4d. Missing request returns structured result
+SELECT is(
+    (SELECT public.replay_committed_turn(
+        'replay_tap_user', 'cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid
+    )->>'status'),
+    'request_replay_unavailable',
+    'missing request returns request_replay_unavailable'
+);
+
+-- 4e. Pending request is not treated as completed
+INSERT INTO public.turn_requests (
+    user_id, request_id, payload_hash_sha256, status,
+    lease_owner, lease_expires_at
+) VALUES (
+    'replay_tap_user', 'dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid,
+    'b'::text || repeat('0', 63), 'pending',
+    'worker-x', timezone('utc'::text, now()) + INTERVAL '1 hour'
+);
+
+SELECT is(
+    (SELECT public.replay_committed_turn(
+        'replay_tap_user', 'dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid
+    )->>'status'),
+    'request_in_progress',
+    'pending request returns request_in_progress'
+);
+
+-- 4f. Expired request is not treated as completed
+INSERT INTO public.turn_requests (
+    user_id, request_id, payload_hash_sha256, status, error_code
+) VALUES (
+    'replay_tap_user', 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid,
+    'c'::text || repeat('0', 63), 'expired', 'timeout'
+);
+
+SELECT is(
+    (SELECT public.replay_committed_turn(
+        'replay_tap_user', 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid
+    )->>'status'),
+    'request_replay_unavailable',
+    'expired request returns request_replay_unavailable'
+);
+
+-- 4g. Invalid identity fails sanitized (never leaks raw input)
+SELECT is(
+    (SELECT public.replay_committed_turn('', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid)
+        ->'error'->>'code'),
+    'validation_failed',
+    'empty authenticated_user_id fails with validation_failed'
+);
+
+SELECT ok(
+    (SELECT public.replay_committed_turn('', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid)
+        #>> '{error,message}') LIKE '%required%',
+    'validation failure message is sanitized (no raw input echoed)'
+);
+
+-- Cleanup (chat_logs first: profiles is FK-referenced by messages)
+DELETE FROM public.chat_logs WHERE user_id = 'replay_tap_user';
+DELETE FROM public.profiles WHERE user_id = 'replay_tap_user';
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/04_process_turn_replay.test.sql
+++ b/supabase/tests/database/04_process_turn_replay.test.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 CREATE EXTENSION IF NOT EXISTS pgtap;
-SELECT plan(25);
+SELECT plan(26);
 
 -- =================================================================
 -- 1. replay_committed_turn function shape and security posture
@@ -215,7 +215,27 @@ SELECT is(
     'pending request returns request_in_progress'
 );
 
--- 4f. Expired request is not treated as completed
+-- 4f. Pending request with EXPIRED lease is stale: replay unavailable
+-- (v1 has NO automatic reclaim through the endpoint; the reservation can
+-- never complete on its own).
+INSERT INTO public.turn_requests (
+    user_id, request_id, payload_hash_sha256, status,
+    lease_owner, lease_expires_at
+) VALUES (
+    'replay_tap_user', 'ffffffff-ffff-ffff-ffff-ffffffffffff'::uuid,
+    'd'::text || repeat('0', 63), 'pending',
+    'worker-x', timezone('utc'::text, now()) - INTERVAL '1 hour'
+);
+
+SELECT is(
+    (SELECT public.replay_committed_turn(
+        'replay_tap_user', 'ffffffff-ffff-ffff-ffff-ffffffffffff'::uuid
+    )->>'status'),
+    'request_replay_unavailable',
+    'pending request with EXPIRED lease returns request_replay_unavailable'
+);
+
+-- 4g. Expired request is not treated as completed
 INSERT INTO public.turn_requests (
     user_id, request_id, payload_hash_sha256, status, error_code
 ) VALUES (


### PR DESCRIPTION
Closes #272

## Causa raiz

O caminho ativo do `/chat` persistia um turno em operações separadas (`load state → provider → save_turn → sync_state → BackgroundTasks`), cada uma em transação independente: falha entre `save_turn` e `sync_state` deixava mensagens órfãs e snapshots obsoletos; resposta HTTP perdida não era recuperável sem reprocessar o provider; contenção multi-worker não era comprovada.

## Arquitetura do ProcessTurn

`backend/process_turn.py` — caso de uso idempotente e transacional com entrada imutável (`ProcessTurnInput`: user id autenticado, request id canônico, mensagem validada, `TurnBudget`, `correlation`, modo normal/replay). O resultado é construído exclusivamente a partir de `CommittedTurn.replay_payload`, inclusive no primeiro processamento. Sem estado por usuário em singleton.

`backend/turn_repositories.py` — fronteiras mínimas: `UserStateRepository` (carrega snapshots + revision sem `select → insert`), `TurnCommitRepository` (interpreta CommittedTurn/ConflictError/ValidationError/PersistenceError), `TurnReplayRepository` (replay sem provider).

Fluxo: load state + revision → load trusted context → appraisal/transitions/generation FORA da transação → `commit_turn` atômico com `expected_revision` → retry limitado → retorna exatamente o resultado persistido.

## Lease de reserva por instância

Cada instância do ProcessTurn recebe um `lease_owner` próprio (`process-turn-v1:<uuidhex>` via `new_lease_owner()`), nunca compartilhado entre instâncias/processos/workers. Ele identifica a reserva da linha `pending` criada por `commit_turn` (diagnóstico de qual worker abandonou o turno) e não é usado como "dono único" global — a consistência continua vinda do CAS de revisão sob o lock de usuário no banco.

## Correlação sanitizada por turno

`backend/admission.py::compute_turn_correlation` calcula um HMAC-SHA256 do request id canônico sob o segredo de admissão com domínio dedicado (`TURN_CORRELATION_DOMAIN`), resultando em exatamente 64 chars hex minúsculos. É o único valor derivado do request registrado nos logs/eventos do ProcessTurn (`process_turn_started`, `process_turn_commit_completed`, conflito, cancelamento, etc.) e da admissão (`admission_admitted`/`admission_replay`). Nunca expõe request id, user id, mensagem, segredo ou truncamento de UUID; é não reversível.

## Contrato de replay

Migration `supabase/migrations/20240101000006_process_turn_replay.sql`: RPC `public.replay_committed_turn(text, uuid)` — SECURITY DEFINER, search_path fixo, somente `service_role`, sem acesso direto a `turn_requests` para roles de runtime. Concluído → envelope canônico (builder existente `commit_turn_build_result`); pendente com lease ativo → `request_in_progress`; pendente com lease expirado / sem linha / expired → `request_replay_unavailable`; entradas inválidas → erro sanitizado. Nunca retorna SQLSTATE/constraint/payload bruto.

**Política v1 (sem reclaim automático):** reserva `pending` com lease expirado nunca completa sozinha e o v1 **não** implementa reclaim automático via endpoint; o cliente precisa de um novo request id (ou ação operacional). `request_payload_conflict` não foi enfraquecido.

## Carregamento de revisão

Perfil existente → revisão persistida; perfil ausente → estado padrão v1 em memória com `revision == 0` sem insert (criação somente dentro de `commit_turn`, race-safe). Linha duplicada/revisão inválida/snapshot inválido → falha fechada. Identidade exclusivamente do usuário autenticado.

## Política de retry

Somente `revision_mismatch`: no máximo 1 repetição (2 tentativas totais), verificação de orçamento antes de repetir, recarga de estado/revisão/contexto e recálculo completo (nunca reutiliza resposta sobre estado obsoleto). Exaustão → `ConflictError` recuperável sanitizado. Nunca repete provider para payload conflict, in-progress, lease conflict, entrada inválida, deadline, cancelamento ou falha permanente.

## Cancelamento

Antes do commit nada é gravado. Durante o commit, `run_blocking_write` (protocolo não abandonável existente) drena cancelamentos repetidos, recupera resultado/exceção obrigatoriamente e propaga o `CancelledError` original somente após o término; lock local liberado no finally. A fase 2 do `run_blocking_write` agora **sempre** consome `worker_task.result()` mesmo quando um cancelamento foi registrado — o resultado/exceção do worker nunca fica sem ser recuperado (corrige corrida entre término do worker e chegada do cancelamento).

## Outbox

`ARCHIVAL_EXTRACTION_ENABLED` → exatamente um evento `archival_extraction_requested` (`{message_id: request_id, kind: archival, version: 1}`, `archival:<request_id>:v1`) na mesma transação; sem `BackgroundTasks`; payload sem mensagem/user id/prompt/resposta/snapshots/segredos. Worker da outbox fora de escopo.

## Erros públicos

Centralizado em `backend/main.py`: revision_mismatch → 409 (retry interno, exaustão → conflito recuperável); request_payload_conflict → 409; request_in_progress → 409; lease_conflict → 409 (política única documentada); request_replay_unavailable → 409; PersistenceError → 503; deadline → 504; contrato interno → 500 sanitizado; cancelamento propagado. Nenhuma mensagem do PostgreSQL/Supabase é reutilizada; request id/mensagem nunca expostos.

## Testes

- Unit: `backend/tests/test_process_turn.py` (57 testes) — revisão carregada, perfil ausente sem insert, commit exatamente uma vez, resultado do CommittedTurn, replay sem provider/transições, retry exatamente 1 com recarga e resposta nova, 3ª tentativa nunca, deadline impede retry, cancelamento antes/depois do commit (com `TestCancelDrainsStatefulWrite` verificando drenagem real do worker), semântica de replay com lease ativo/expirado, dono de lease por instância, correlação nos logs, outbox sanitizado.
- Banco real: `backend/tests/test_process_turn_integration.py` (19 testes) — contrato canônico de replay, isolamento entre usuários, matriz de autorização, replay não altera tabelas, multi-worker com **processos independentes executando o `ProcessTurn` real** (CAS: 1 vence + 1 `revision_mismatch` + retry na revisão seguinte com 2ª geração, revisão final == 2, sem duplicação, replay confere com o persistido; a prova por trace confirma que ambos carregam a revisão 0, entram no primeiro commit com `expected_revision == 0` e que nunca existe terceira tentativa), usuários distintos independentes (uma geração cada, revisão 1, sem bloqueio global), criação concorrente do primeiro perfil, retry idempotente, conflito de mensagem, outbox atômico (1 evento, replay não duplica, rollback remove, payload sanitizado), reserva pendente com lease ativo/expirado.

  A coordenação artificial dos workers é um rendezvous por arquivo **somente no caminho de commit** (primeira tentativa, `expected_revision == 0`), executado dentro de `run_blocking_write()` — que nunca abandona a escrita — então a espera **não consome o orçamento pré-commit** e o deadline real do turno continua ativo. Isso corrige a flakiness `DeadlineExceeded` observada na CI (a barreira anterior ficava dentro de `load()`, disputando `remaining_before_reserve` com a espera pelo peer).
- pgTAP: `supabase/tests/database/04_process_turn_replay.test.sql` (26 testes) — SECURITY DEFINER, search_path fixo, anon/authenticated sem EXECUTE, service_role executa, sem grants em turn_requests, contrato canônico, isolamento, status estruturados (incl. lease expirado), repetições equivalentes, falha sanitizada.
- Endpoint (`test_chat_admission.py`): request_id encaminhado, replay tenta modo replay, replay concluído → 200, incompleto → código estruturado, conflito 409 sem provider, quota bloqueia, DTO com somente response+emotion_state, request id ausente de erros, mesmo budget da admissão ao commit, cancelamento não vira 500.
- Correlação: `test_admission_runtime.py::TestTurnCorrelation` (formato/estabilidade/domínio) e `test_chat_admission.py::TestCorrelationFlow` (admissão → endpoint → engine → ProcessTurn).

## Comandos executados

- `python -m compileall -q backend` ✓
- Suíte backend completa (job backend) ✓ (2168 passed)
- `supabase db reset` + pgTAP completo ✓ (363 testes, 4 arquivos)
- Integração banco real (reset limpo por etapa, job database, no mesmo HEAD): admission ledger 11 ✓, legacy upgrade 2 ✓, transactional schema legacy 2 ✓, transactional schema integration 22 ✓, database authorization 8 ✓, atomic turn commit 71 ✓, process turn integration 19 ✓ — os testes multi-worker foram revalidados repetidamente (3 execuções consecutivas) e são determinísticos (rendezvous no commit, sem aceitar `DeadlineExceeded` nem inflar timeouts).
- Frontend: `npm ci` + audit validator ✓ + `npm test` (46) ✓ + `npm run lint` ✓ + `npm run build` ✓
- Docker: `docker compose config --quiet` ✓ (esta revisão não altera arquivos de infraestrutura/docker)

## Riscos residuais

- Exaustão de `revision_mismatch` → 409; usuário repete com novo request id.
- Reserva `pending` de worker morto → 409 (`request_in_progress`) enquanto o lease estiver ativo; após expiração → `request_replay_unavailable` (sem reclaim automático no v1); novo request id ou ação operacional. `lease_owner` (`process-turn-v1:<uuidhex>`) permite diagnosticar a instância que abandonou a reserva.
- Extração arquivística depende do worker da outbox (fora de escopo).
- Lock local não protege entre processos; consistência depende do CAS no banco.
- `test_admission_ledger_integration.py` localmente requer o CLI Supabase no PATH (CI já o instala).

## Fora de escopo

Worker da outbox, aprovação/recuperação de memórias, #275/#276/#277/#278/#279/#280, alterações de Emotional Core/pesos/relacionamento, modelos/temperaturas/limites, quotas/HMAC, orçamento de 16.000 unidades, streaming, redesign frontend, Redis, remoção da contenção single-worker, atualização de dependências, `.Jules/palette.md`.

