### PR TITLE
refactor(ops): add explicit lifecycle and readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,10 @@ ARCHIVAL_EXTRACTION_ENABLED=false
 # embeddings component to pass. When false, the model is never constructed.
 EMBEDDINGS_RETRIEVAL_ENABLED=false
 
+# Optional: readiness probe timeout for the Auth service (/health), ms.
+# Range 100-30000; default 1000. The probe never reads user data.
+READINESS_AUTH_TIMEOUT_MS=1000
+
 # Frontend build-time variables (docker-compose build args).
 # The browser needs the public API URL and the public Supabase URL/anon key.
 VITE_API_URL=http://localhost:8000

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# Required. Deployment mode: local, test, staging or production.
+# Missing/empty APP_ENV fails closed (the backend never runs in an implicit mode).
+APP_ENV=local
+
 # Required. Admission HMAC secret with at least 32 UTF-8 bytes.
 # Generate and store the real value outside source control.
 ADMISSION_HMAC_SECRET=
@@ -19,6 +23,11 @@ GROQ_API_KEY_2=
 
 # Optional: enable archival extraction (valid values: true/false).
 ARCHIVAL_EXTRACTION_ENABLED=false
+
+# Optional: enable vector memory retrieval (SentenceTransformer + RPC).
+# When true, the embedding model is built at startup and /ready requires the
+# embeddings component to pass. When false, the model is never constructed.
+EMBEDDINGS_RETRIEVAL_ENABLED=false
 
 # Frontend build-time variables (docker-compose build args).
 # The browser needs the public API URL and the public Supabase URL/anon key.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,7 @@ jobs:
       - name: Create sanitized test environment
         run: |
           cat > .env <<'EOF'
+          APP_ENV=test
           ADMISSION_HMAC_SECRET=ci-test-secret-0123456789abcdef0123456789abcdef
           TRUSTED_PROXY_CIDRS=
           CORS_ALLOWED_ORIGINS=http://allowed.example

--- a/backend/admission.py
+++ b/backend/admission.py
@@ -23,6 +23,7 @@ from .admission_contracts import (
 MESSAGE_HMAC_DOMAIN = b"message"
 NETWORK_HMAC_DOMAIN = b"network"
 TURN_CORRELATION_DOMAIN = b"turn-correlation"
+USER_REFERENCE_DOMAIN = b"user-reference"
 UNKNOWN_NETWORK_IDENTITY = "unknown"
 
 ADMITTED = "admitted"
@@ -265,6 +266,28 @@ def compute_turn_correlation(
     return hmac.new(
         validated_secret,
         TURN_CORRELATION_DOMAIN + b"\x00" + canonical_request_id.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def compute_user_reference(
+    config: AdmissionRuntimeConfig,
+    user_id: object,
+) -> str:
+    """Compute a non-reversible HMAC reference for an authenticated user.
+
+    Domain-separated from the turn-correlation domain, so the same value never
+    collides across purposes. The raw ``user_id`` is never logged: only this
+    exact lowercase 64-character hex HMAC may be emitted by observability.
+    """
+    if not isinstance(config, AdmissionRuntimeConfig):
+        raise AdmissionUnavailable()
+    if not isinstance(user_id, str) or not user_id or not user_id.strip():
+        raise AdmissionUnavailable()
+    validated_secret = _validate_secret_bytes(config.secret_bytes)
+    return hmac.new(
+        validated_secret,
+        USER_REFERENCE_DOMAIN + b"\x00" + user_id.encode("utf-8"),
         hashlib.sha256,
     ).hexdigest()
 

--- a/backend/chat_engine.py
+++ b/backend/chat_engine.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import Optional
+from typing import Callable, Optional
 
 from .engine import ConversationEngine
 from .process_turn import (
@@ -40,11 +40,16 @@ class ChatConversationEngine(ConversationEngine):
         clock=time.time,
         archival_extraction_enabled: bool = False,
         turn_config: Optional[TurnExecutionConfig] = None,
+        *,
+        groq_keys: Optional[list] = None,
+        supabase_factory: Optional[Callable[[], Optional[object]]] = None,
     ):
         super().__init__(
             clock=clock,
             archival_extraction_enabled=archival_extraction_enabled,
             turn_config=turn_config,
+            groq_keys=groq_keys,
+            supabase_factory=supabase_factory,
         )
         self._process_turn = build_process_turn(self)
 

--- a/backend/chat_engine.py
+++ b/backend/chat_engine.py
@@ -39,6 +39,7 @@ class ChatConversationEngine(ConversationEngine):
         self,
         clock=time.time,
         archival_extraction_enabled: bool = False,
+        embeddings_enabled: bool = False,
         turn_config: Optional[TurnExecutionConfig] = None,
         *,
         groq_keys: Optional[list] = None,
@@ -47,6 +48,7 @@ class ChatConversationEngine(ConversationEngine):
         super().__init__(
             clock=clock,
             archival_extraction_enabled=archival_extraction_enabled,
+            embeddings_enabled=embeddings_enabled,
             turn_config=turn_config,
             groq_keys=groq_keys,
             supabase_factory=supabase_factory,

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -182,7 +182,10 @@ def build_default_dependencies(
         health_checks = build_health_registry(
             settings,
             engine,
+            auth_client=supabase_client,
+            persistence_client=supabase_client,
             database_probe_client=probe_client,
+            owns_probe_client=True,
         )
         created.append(health_checks)
 
@@ -198,15 +201,19 @@ def build_default_dependencies(
 
         # Owned resources created by this builder, closed at shutdown and on
         # partial startup:
-        # * ``health_checks`` closes every closable check, including the
-        #   database probe executor (no new probes are queued; an in-flight
-        #   probe self-terminates via its aligned transport timeout).
-        # * ``probe_client`` is closed when the SDK exposes a compatible
-        #   close/aclose contract (the pinned version does not).
+        # * ``health_checks`` is the sole owned resource: its async close
+        #   drains any in-flight database probe (bounded by the aligned
+        #   transport timeout) BEFORE closing the owned probe client, so the
+        #   client is never invalidated underneath a live probe thread.
+        #   ``close()`` (sync) is used for partial-startup cleanup and closes
+        #   the executor without touching the client.
+        # * ``probe_client`` is created here but owned by ``DatabaseCheck``
+        #   (``owns_probe_client=True``); it is closed by the registry after
+        #   drain, or by the partial-startup cleanup below.
         # The engine graph itself does not expose close()/aclose() contracts
         # today (Groq clients are request-scoped; the pinned Supabase SDK has
         # no close), so it is not part of the owned tuple.
-        owned: tuple[Any, ...] = (health_checks, probe_client)
+        owned: tuple[Any, ...] = (health_checks,)
 
         return dependencies, owned
     except BaseException:

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -129,6 +129,32 @@ def _build_readiness_probe_client(settings: Settings) -> Optional[Any]:
         return None
 
 
+def _build_auth_probe(settings: Settings) -> Optional[Callable[[], None]]:
+    """Build the real Auth service availability probe from validated settings.
+
+    Probes ``{supabase_url}/auth/v1/health`` (GoTrue health endpoint) with a
+    transport timeout aligned to ``readiness_auth_timeout_ms``. Returns
+    ``None`` when no Supabase URL is configured; the readiness ``auth``
+    component then fails honestly (an instance without a probed Auth service
+    must not report ready).
+    """
+    url = settings.supabase_url
+    if not url:
+        return None
+    key = (
+        settings.supabase_service_role_key.get_secret_value()
+        if settings.supabase_service_role_key is not None
+        else None
+    )
+    from .health import _auth_health_probe
+
+    return _auth_health_probe(
+        f"{url.rstrip('/')}/auth/v1",
+        key,
+        settings.readiness_auth_timeout_ms / 1000.0,
+    )
+
+
 def _close_sync(resource: Any) -> None:
     """Close one resource synchronously during partial startup cleanup."""
     closer = getattr(resource, "close", None)
@@ -183,6 +209,7 @@ def build_default_dependencies(
             settings,
             engine,
             auth_client=supabase_client,
+            auth_probe=_build_auth_probe(settings),
             persistence_client=supabase_client,
             database_probe_client=probe_client,
             owns_probe_client=True,

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -41,8 +41,12 @@ class ApplicationDependencies:
     """Composition root for the active request path.
 
     ``auth_client`` is the authenticated-auth surface used by the request
-    auth dependency (the Supabase client). ``health_checks`` aggregate the
-    readiness probes. ``clock`` provides wall time for domain code.
+    auth dependency (the Supabase client). ``persistence_client`` is the
+    persistence surface used by the history and admission routes; it is
+    exposed explicitly so routes never navigate engine internals and the two
+    surfaces can be injected independently in tests. ``health_checks``
+    aggregate the readiness probes. ``clock`` provides wall time for domain
+    code.
     """
 
     conversation_engine: ChatConversationEngine
@@ -51,6 +55,7 @@ class ApplicationDependencies:
     turn_config: TurnExecutionConfig
     health_checks: HealthRegistry
     clock: Callable[[], float] = field(default_factory=time.time)
+    persistence_client: Any = None
 
 
 def _supabase_factory_from_settings(settings: Settings) -> Callable[[], Optional[Any]]:
@@ -89,6 +94,41 @@ def _supabase_factory_from_settings(settings: Settings) -> Callable[[], Optional
     return factory
 
 
+def _build_readiness_probe_client(settings: Settings) -> Optional[Any]:
+    """Build the dedicated database probe client for readiness checks.
+
+    The transport timeout is aligned with ``readiness_database_timeout_ms`` so
+    a stuck probe self-terminates at the same bound the registry enforces via
+    ``asyncio.wait_for``; the worker thread is never abandoned indefinitely.
+    Returns ``None`` when the runtime Supabase configuration is absent
+    (local/test without a database), which makes the ``database`` check fail
+    honestly.
+    """
+    url = settings.supabase_url
+    key = (
+        settings.supabase_service_role_key.get_secret_value()
+        if settings.supabase_service_role_key is not None
+        else None
+    )
+    if not url or not key:
+        return None
+    try:
+        from supabase import create_client
+        from supabase.lib.client_options import ClientOptions
+
+        options = ClientOptions(
+            postgrest_client_timeout=settings.readiness_database_timeout_ms / 1000.0
+        )
+        return create_client(url, key, options=options)
+    except Exception:
+        emit_event(
+            logger,
+            EVENT_SUPABASE_CLIENT_CREATION_FAILED,
+            level=logging.ERROR,
+        )
+        return None
+
+
 def _close_sync(resource: Any) -> None:
     """Close one resource synchronously during partial startup cleanup."""
     closer = getattr(resource, "close", None)
@@ -123,6 +163,7 @@ def build_default_dependencies(
     try:
         engine = ChatConversationEngine(
             archival_extraction_enabled=settings.archival_extraction_enabled,
+            embeddings_enabled=settings.embeddings_retrieval_enabled,
             turn_config=settings.turn_config,
             groq_keys=list(settings.provider_keys()),
             supabase_factory=_supabase_factory_from_settings(settings),
@@ -135,16 +176,22 @@ def build_default_dependencies(
             cidrs,
         )
 
-        auth_client = engine.memory_manager.supabase
-        health_checks = build_health_registry(settings, engine, auth_client)
+        supabase_client = engine.memory_manager.supabase
+        probe_client = _build_readiness_probe_client(settings)
+        health_checks = build_health_registry(
+            settings,
+            engine,
+            database_probe_client=probe_client,
+        )
 
         dependencies = ApplicationDependencies(
             conversation_engine=engine,
-            auth_client=auth_client,
+            auth_client=supabase_client,
             admission_config=admission_config,
             turn_config=settings.turn_config,
             health_checks=health_checks,
             clock=time.time,
+            persistence_client=supabase_client,
         )
 
         # Owned resources created by this builder. The current engine graph

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -1,0 +1,194 @@
+"""Explicit dependency container and default composition for the backend.
+
+Ownership contract
+==================
+
+* Resources created by :func:`build_default_dependencies` are **owned** by the
+  application: the lifespan closes them on shutdown.
+* Resources injected externally through :class:`ApplicationDependencies` keep
+  their ownership with the caller: the application never closes them, unless
+  the caller explicitly adds them to ``owned_resources``.
+
+The container holds only process-wide, thread-safe infrastructure. It never
+stores per-user state: authenticated identity continues to be resolved per
+request, and emotional/relational snapshots never live here.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+from .admission import AdmissionRuntimeConfig
+from .chat_engine import ChatConversationEngine
+from .health import build_health_registry, HealthRegistry
+from .observability import (
+    EVENT_APP_SHUTDOWN_FAILED,
+    EVENT_SUPABASE_CLIENT_CREATION_FAILED,
+    emit_event,
+)
+from .settings import Settings
+from .turn_execution import TurnExecutionConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ApplicationDependencies:
+    """Composition root for the active request path.
+
+    ``auth_client`` is the authenticated-auth surface used by the request
+    auth dependency (the Supabase client). ``health_checks`` aggregate the
+    readiness probes. ``clock`` provides wall time for domain code.
+    """
+
+    conversation_engine: ChatConversationEngine
+    auth_client: Any
+    admission_config: AdmissionRuntimeConfig
+    turn_config: TurnExecutionConfig
+    health_checks: HealthRegistry
+    clock: Callable[[], float] = field(default_factory=time.time)
+
+
+def _supabase_factory_from_settings(settings: Settings) -> Callable[[], Optional[Any]]:
+    """Build the Supabase client factory from validated settings.
+
+    Returns a factory that yields ``None`` when the runtime configuration is
+    absent (local/test without a Supabase), preserving the historical
+    degraded behavior, and a configured client otherwise.
+    """
+    url = settings.supabase_url
+    key = (
+        settings.supabase_service_role_key.get_secret_value()
+        if settings.supabase_service_role_key is not None
+        else None
+    )
+    if not url or not key:
+        return lambda: None
+
+    timeout = settings.turn_config.supabase_timeout
+
+    def factory() -> Optional[Any]:
+        try:
+            from supabase import create_client
+            from supabase.lib.client_options import ClientOptions
+
+            options = ClientOptions(postgrest_client_timeout=timeout)
+            return create_client(url, key, options=options)
+        except Exception:
+            emit_event(
+                logger,
+                EVENT_SUPABASE_CLIENT_CREATION_FAILED,
+                level=logging.ERROR,
+            )
+            return None
+
+    return factory
+
+
+def _close_sync(resource: Any) -> None:
+    """Close one resource synchronously during partial startup cleanup."""
+    closer = getattr(resource, "close", None)
+    if closer is None:
+        return
+    try:
+        closer()
+    except Exception:
+        # Sanitized: never log exception text, secrets, or identifiers.
+        emit_event(
+            logger,
+            EVENT_APP_SHUTDOWN_FAILED,
+            level=logging.ERROR,
+        )
+
+
+def build_default_dependencies(
+    settings: Settings,
+) -> tuple[ApplicationDependencies, tuple[Any, ...]]:
+    """Build the default composition from validated settings.
+
+    Returns ``(dependencies, owned_resources)``. Everything this function
+    creates is owned by the application and closed at shutdown. This is the
+    only place where real Groq/Supabase/embedding resources are constructed
+    in the default path; it must only run inside the lifespan, never at
+    import time.
+
+    On partial failure, resources already created are closed before the
+    exception propagates, so a broken startup never leaks owned resources.
+    """
+    created: list[Any] = []
+    try:
+        engine = ChatConversationEngine(
+            archival_extraction_enabled=settings.archival_extraction_enabled,
+            turn_config=settings.turn_config,
+            groq_keys=list(settings.provider_keys()),
+            supabase_factory=_supabase_factory_from_settings(settings),
+        )
+        created.append(engine)
+
+        secret, cidrs = settings.to_admission_values()
+        admission_config = AdmissionRuntimeConfig.from_values(
+            secret,
+            cidrs,
+        )
+
+        auth_client = engine.memory_manager.supabase
+        health_checks = build_health_registry(settings, engine, auth_client)
+
+        dependencies = ApplicationDependencies(
+            conversation_engine=engine,
+            auth_client=auth_client,
+            admission_config=admission_config,
+            turn_config=settings.turn_config,
+            health_checks=health_checks,
+            clock=time.time,
+        )
+
+        # Owned resources created by this builder. The current engine graph
+        # does not expose close()/aclose() contracts (Supabase clients in the
+        # pinned SDK version have no close method; Groq clients are
+        # request-scoped), so this tuple is empty today but the mechanism is
+        # exercised by tests with injectable owned resources.
+        owned: tuple[Any, ...] = ()
+
+        return dependencies, owned
+    except BaseException:
+        for resource in reversed(created):
+            _close_sync(resource)
+        raise
+
+
+async def close_resource(resource: Any) -> None:
+    """Close one resource if it exposes ``aclose`` or ``close``.
+
+    Swallows and logs a sanitized event on failure so one broken resource
+    never aborts the shutdown of the remaining ones.
+    """
+    closer = getattr(resource, "aclose", None) or getattr(resource, "close", None)
+    if closer is None:
+        return
+    try:
+        result = closer()
+        if inspect.isawaitable(result):
+            await result
+    except Exception:
+        # Sanitized: never log exception text, secrets, or identifiers.
+        emit_event(
+            logger,
+            EVENT_APP_SHUTDOWN_FAILED,
+            level=logging.ERROR,
+        )
+
+
+async def shutdown_dependencies(owned_resources: tuple[Any, ...]) -> None:
+    """Close every owned resource, continuing past individual failures.
+
+    Idempotent by contract: callers must clear the owned-resource list from
+    ``app.state`` after the first invocation so a second shutdown closes
+    nothing.
+    """
+    for resource in owned_resources:
+        await close_resource(resource)

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -94,15 +94,16 @@ def _supabase_factory_from_settings(settings: Settings) -> Callable[[], Optional
     return factory
 
 
-def _build_readiness_probe_client(settings: Settings) -> Optional[Any]:
-    """Build the dedicated database probe client for readiness checks.
+def _build_database_probe(settings: Settings) -> Optional[Callable[[], Awaitable[None]]]:
+    """Build the real database/Supabase availability probe from settings.
 
-    The transport timeout is aligned with ``readiness_database_timeout_ms`` so
-    a stuck probe self-terminates at the same bound the registry enforces via
-    ``asyncio.wait_for``; the worker thread is never abandoned indefinitely.
-    Returns ``None`` when the runtime Supabase configuration is absent
-    (local/test without a database), which makes the ``database`` check fail
-    honestly.
+    The probe is a bounded async HTTP read of PostgREST
+    (``{supabase_url}/rest/v1/profiles?select=user_id&limit=1``) with the
+    transport timeout aligned to ``readiness_database_timeout_ms``. Because
+    it is plain async I/O, the readiness timeout truly cancels it (no worker
+    thread can outlive the lifespan). Returns ``None`` when the runtime
+    Supabase configuration is absent (local/test without a database), which
+    makes the ``database`` check fail honestly.
     """
     url = settings.supabase_url
     key = (
@@ -112,31 +113,24 @@ def _build_readiness_probe_client(settings: Settings) -> Optional[Any]:
     )
     if not url or not key:
         return None
-    try:
-        from supabase import create_client
-        from supabase.lib.client_options import ClientOptions
+    from .health import _database_health_probe
 
-        options = ClientOptions(
-            postgrest_client_timeout=settings.readiness_database_timeout_ms / 1000.0
-        )
-        return create_client(url, key, options=options)
-    except Exception:
-        emit_event(
-            logger,
-            EVENT_SUPABASE_CLIENT_CREATION_FAILED,
-            level=logging.ERROR,
-        )
-        return None
+    return _database_health_probe(
+        url,
+        key,
+        settings.readiness_database_timeout_ms / 1000.0,
+    )
 
 
-def _build_auth_probe(settings: Settings) -> Optional[Callable[[], None]]:
+def _build_auth_probe(settings: Settings) -> Optional[Callable[[], Awaitable[None]]]:
     """Build the real Auth service availability probe from validated settings.
 
     Probes ``{supabase_url}/auth/v1/health`` (GoTrue health endpoint) with a
-    transport timeout aligned to ``readiness_auth_timeout_ms``. Returns
-    ``None`` when no Supabase URL is configured; the readiness ``auth``
-    component then fails honestly (an instance without a probed Auth service
-    must not report ready).
+    transport timeout aligned to ``readiness_auth_timeout_ms`` over async
+    HTTP, so the readiness timeout truly cancels it. Returns ``None`` when no
+    Supabase URL is configured; the readiness ``auth`` component then fails
+    honestly (an instance without a probed Auth service must not report
+    ready).
     """
     url = settings.supabase_url
     if not url:
@@ -203,16 +197,13 @@ def build_default_dependencies(
         )
 
         supabase_client = engine.memory_manager.supabase
-        probe_client = _build_readiness_probe_client(settings)
-        created.append(probe_client)
         health_checks = build_health_registry(
             settings,
             engine,
             auth_client=supabase_client,
             auth_probe=_build_auth_probe(settings),
             persistence_client=supabase_client,
-            database_probe_client=probe_client,
-            owns_probe_client=True,
+            database_probe=_build_database_probe(settings),
         )
         created.append(health_checks)
 
@@ -229,14 +220,13 @@ def build_default_dependencies(
         # Owned resources created by this builder, closed at shutdown and on
         # partial startup:
         # * ``health_checks`` is the sole owned resource: its async close
-        #   drains any in-flight database probe (bounded by the aligned
-        #   transport timeout) BEFORE closing the owned probe client, so the
-        #   client is never invalidated underneath a live probe thread.
-        #   ``close()`` (sync) is used for partial-startup cleanup and closes
-        #   the executor without touching the client.
-        # * ``probe_client`` is created here but owned by ``DatabaseCheck``
-        #   (``owns_probe_client=True``); it is closed by the registry after
-        #   drain, or by the partial-startup cleanup below.
+        #   cancels any in-flight readiness probe (async HTTP I/O, so the
+        #   cancellation actually stops the request) and awaits its
+        #   termination before returning, so no owned work outlives the
+        #   lifespan. ``close()`` (sync) is used for partial-startup cleanup
+        #   and only rejects new probes.
+        # * Readiness probes are plain async HTTP requests (no client object,
+        #   no executor, no thread), so there is no probe client to own.
         # The engine graph itself does not expose close()/aclose() contracts
         # today (Groq clients are request-scoped; the pinned Supabase SDK has
         # no close), so it is not part of the owned tuple.

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -178,11 +178,13 @@ def build_default_dependencies(
 
         supabase_client = engine.memory_manager.supabase
         probe_client = _build_readiness_probe_client(settings)
+        created.append(probe_client)
         health_checks = build_health_registry(
             settings,
             engine,
             database_probe_client=probe_client,
         )
+        created.append(health_checks)
 
         dependencies = ApplicationDependencies(
             conversation_engine=engine,
@@ -194,12 +196,17 @@ def build_default_dependencies(
             persistence_client=supabase_client,
         )
 
-        # Owned resources created by this builder. The current engine graph
-        # does not expose close()/aclose() contracts (Supabase clients in the
-        # pinned SDK version have no close method; Groq clients are
-        # request-scoped), so this tuple is empty today but the mechanism is
-        # exercised by tests with injectable owned resources.
-        owned: tuple[Any, ...] = ()
+        # Owned resources created by this builder, closed at shutdown and on
+        # partial startup:
+        # * ``health_checks`` closes every closable check, including the
+        #   database probe executor (no new probes are queued; an in-flight
+        #   probe self-terminates via its aligned transport timeout).
+        # * ``probe_client`` is closed when the SDK exposes a compatible
+        #   close/aclose contract (the pinned version does not).
+        # The engine graph itself does not expose close()/aclose() contracts
+        # today (Groq clients are request-scoped; the pinned Supabase SDK has
+        # no close), so it is not part of the owned tuple.
+        owned: tuple[Any, ...] = (health_checks, probe_client)
 
         return dependencies, owned
     except BaseException:

--- a/backend/engine.py
+++ b/backend/engine.py
@@ -2,7 +2,7 @@ import json
 import asyncio
 import time
 import logging
-from typing import Optional
+from typing import Callable, Optional
 from fastapi import BackgroundTasks
 from .groq_manager import GroqClientManager, GroqPoolExhaustedError, GroqRequestError, ProviderFailure, provider_failure_to_turn_code
 from .emotional_core import AffectiveEngine
@@ -75,18 +75,25 @@ class ConversationEngine:
         clock=time.time,
         archival_extraction_enabled: bool = False,
         turn_config: Optional[TurnExecutionConfig] = None,
+        *,
+        groq_keys: Optional[list] = None,
+        supabase_factory: Optional[Callable[[], Optional[object]]] = None,
     ):
         self._clock = clock
         self._monotonic = time.monotonic
         self._turn_config = turn_config or TurnExecutionConfig.defaults()
         self.archival_extraction_enabled = archival_extraction_enabled
         groq_params = self._turn_config.to_groq_params()
-        self.groq_manager = GroqClientManager(groq_params=groq_params)
+        self.groq_manager = GroqClientManager(
+            groq_params=groq_params,
+            keys=groq_keys,
+        )
         self.presentation = AffectiveEngine()
         self.transition_config = TransitionConfig.defaults()
         self.memory_manager = MemoryManager(
             clock=clock,
             supabase_timeout=self._turn_config.supabase_timeout,
+            supabase_factory=supabase_factory,
         )
         self.relationship_config = RelationshipTransitionConfig.defaults()
         self.lock_manager = UserLockManager()

--- a/backend/engine.py
+++ b/backend/engine.py
@@ -74,6 +74,7 @@ class ConversationEngine:
         self,
         clock=time.time,
         archival_extraction_enabled: bool = False,
+        embeddings_enabled: bool = False,
         turn_config: Optional[TurnExecutionConfig] = None,
         *,
         groq_keys: Optional[list] = None,
@@ -94,6 +95,7 @@ class ConversationEngine:
             clock=clock,
             supabase_timeout=self._turn_config.supabase_timeout,
             supabase_factory=supabase_factory,
+            embeddings_enabled=embeddings_enabled,
         )
         self.relationship_config = RelationshipTransitionConfig.defaults()
         self.lock_manager = UserLockManager()

--- a/backend/groq_manager.py
+++ b/backend/groq_manager.py
@@ -185,6 +185,15 @@ class GroqClientManager:
         self._cooldown_duration = 10
         self._index = 0
 
+    def is_configured(self) -> bool:
+        """Return ``True`` when the manager holds validated provider keys.
+
+        Configuration-level availability only: never opens a connection,
+        never runs a completion, and never loads models. Used by the
+        readiness ``provider`` check.
+        """
+        return bool(self._keys)
+
     # ─── Request-scoped async clients ───────────────────────────────────────
     #
     # We use request-scoped AsyncGroq clients instead of a shared cache:

--- a/backend/health.py
+++ b/backend/health.py
@@ -23,10 +23,11 @@ exception text. A failed or timed-out check produces a sanitized
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Mapping, Protocol
+from typing import Any, Callable, Mapping, Optional, Protocol
 
 from .observability import (
     EVENT_READINESS_CHECK_FAILED,
@@ -76,7 +77,7 @@ class HealthRegistry:
 
     Order is deterministic: insertion order, which the default builder
     fixes as ``configuration``, ``database``, ``provider``, then
-    ``embeddings`` (only when the archival feature is enabled).
+    ``embeddings`` (only when the retrieval feature is enabled).
     """
 
     checks: Mapping[str, ReadinessCheck] = field(default_factory=dict)
@@ -144,27 +145,60 @@ class ConfigurationCheck:
 
 
 class DatabaseCheck:
-    """Minimal database/Supabase access check.
+    """Minimal database/Supabase access check with a bounded, non-abandoning probe.
 
-    The default implementation performs one cheap read (limit 1) against the
-    core ``profiles`` table using the application's own client, bounded by an
-    explicit timeout. It never touches user data: no rows are read into
-    memory beyond the transport-level response and no content is logged.
+    The probe runs on a dedicated single-worker executor whose transport
+    timeout is aligned with the readiness timeout (see
+    :func:`build_health_registry` and ``backend.dependencies``). While one
+    probe is still in flight (including after the registry-level timeout
+    cancelled the await), further polls fail fast instead of queueing new
+    work, so repeated readiness polling can never accumulate threads or
+    exhaust the executor. When the in-flight probe self-terminates (bounded
+    transport), the next poll runs a fresh probe.
+
+    It never touches user data: no rows are read into memory beyond the
+    transport-level response and no content is logged.
     """
 
     name = "database"
 
-    def __init__(self, client: Any, timeout_seconds: float) -> None:
+    def __init__(
+        self,
+        client: Any,
+        timeout_seconds: float,
+        *,
+        probe_executor: Optional[concurrent.futures.Executor] = None,
+    ) -> None:
         self._client = client
         self.timeout_seconds = timeout_seconds
+        self._executor = probe_executor or concurrent.futures.ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="readiness-db",
+        )
+        self._probe_future: Optional[concurrent.futures.Future] = None
 
     async def run(self) -> None:
         if self._client is None:
             raise CheckFailure()
+        if self._probe_future is not None and not self._probe_future.done():
+            # A previous probe is still in flight. Its aligned transport
+            # timeout will release the worker; never pile up work behind it.
+            raise CheckFailure()
+        if self._probe_future is None or self._probe_future.done():
+            self._probe_future = self._executor.submit(self._probe)
+        future = self._probe_future
         try:
-            response = await asyncio.to_thread(self._probe)
+            response = await asyncio.wait_for(
+                asyncio.wrap_future(future),
+                timeout=self.timeout_seconds,
+            )
+        except (asyncio.TimeoutError, concurrent.futures.TimeoutError):
+            raise CheckFailure() from None
         except Exception:
             raise CheckFailure() from None
+        finally:
+            if future.done():
+                self._probe_future = None
         if response is None:
             raise CheckFailure()
 
@@ -206,9 +240,11 @@ class ProviderCheck:
 class EmbeddingsCheck:
     """Checks that embeddings are available when the feature mode requires them.
 
-    Only registered when ``archival_extraction_enabled`` is true. The model is
+    Only registered when ``embeddings_retrieval_enabled`` is true. The model is
     loaded once during startup; this check only verifies the loaded resource
-    exists and never loads a model by itself.
+    exists and never loads a model by itself. A missing model means the active
+    mode cannot retrieve vector memory, so the instance must not serve
+    traffic.
     """
 
     name = "embeddings"
@@ -252,17 +288,18 @@ class LifespanCheck:
 def build_health_registry(
     settings: Settings,
     engine: Any,
-    auth_client: Any,
+    *,
+    database_probe_client: Any = None,
 ) -> HealthRegistry:
     """Build the default ordered registry for the running configuration.
 
     Components:
-    1. ``configuration`` — validated settings.
-    2. ``database`` — minimal Supabase read, bounded by
-       ``readiness_database_timeout_ms``.
+    1. ``configuration`` — validated settings (frozen model, fully revalidated).
+    2. ``database`` — minimal Supabase read via a dedicated probe client whose
+       transport timeout is aligned with ``readiness_database_timeout_ms``.
     3. ``provider`` — provider keys/client path, bounded by
        ``readiness_provider_timeout_ms``.
-    4. ``embeddings`` — only when ``archival_extraction_enabled`` is true.
+    4. ``embeddings`` — only when ``embeddings_retrieval_enabled`` is true.
 
     ``lifespan`` is appended by the application at request time because it
     observes ``app.state``.
@@ -273,7 +310,7 @@ def build_health_registry(
     )
     registry.add(
         DatabaseCheck(
-            auth_client,
+            database_probe_client,
             timeout_seconds=settings.readiness_database_timeout_ms / 1000.0,
         )
     )
@@ -283,7 +320,7 @@ def build_health_registry(
             timeout_seconds=settings.readiness_provider_timeout_ms / 1000.0,
         )
     )
-    if settings.archival_extraction_enabled:
+    if settings.embeddings_retrieval_enabled:
         registry.add(EmbeddingsCheck(engine.memory_manager))
     return registry
 

--- a/backend/health.py
+++ b/backend/health.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 import logging
 from dataclasses import dataclass, field
 from enum import Enum

--- a/backend/health.py
+++ b/backend/health.py
@@ -23,14 +23,13 @@ exception text. A failed or timed-out check produces a sanitized
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
-import inspect
+import contextlib
 import logging
-import urllib.error
-import urllib.request
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Mapping, Optional, Protocol
+from typing import Any, Awaitable, Callable, Mapping, Optional, Protocol
+
+import httpx
 
 from .observability import (
     EVENT_READINESS_CHECK_FAILED,
@@ -198,16 +197,16 @@ class ConfigurationCheck:
 
 
 class DatabaseCheck:
-    """Minimal database/Supabase access check with a bounded, non-abandoning probe.
+    """Minimal database/Supabase access check with a cancelable async probe.
 
-    The probe runs on a dedicated single-worker executor whose transport
-    timeout is aligned with the readiness timeout (see
-    :func:`build_health_registry` and ``backend.dependencies``). While one
-    probe is still in flight (including after the registry-level timeout
-    cancelled the await), further polls fail fast instead of queueing new
-    work, so repeated readiness polling can never accumulate threads or
-    exhaust the executor. When the in-flight probe self-terminates (bounded
-    transport), the next poll runs a fresh probe.
+    The probe is an ``async`` callable performing a bounded HTTP request (the
+    transport timeout is aligned with the readiness timeout; see
+    :func:`build_health_registry` and ``backend.dependencies``). Because the
+    probe is plain async I/O, the registry-level ``asyncio.wait_for`` truly
+    cancels it: no worker thread survives a timeout, so repeated polling can
+    never accumulate threads and ``aclose()`` needs no deferred cleanup.
+    While one probe is still in flight, further polls fail fast (single-probe
+    guard), so concurrent readiness polls do not stack duplicate requests.
 
     It never touches user data: no rows are read into memory beyond the
     transport-level response and no content is logged.
@@ -217,188 +216,120 @@ class DatabaseCheck:
 
     def __init__(
         self,
-        client: Any,
+        probe: Optional[Callable[[], Awaitable[None]]],
         timeout_seconds: float,
-        *,
-        probe_executor: Optional[concurrent.futures.Executor] = None,
-        owns_client: bool = False,
     ) -> None:
-        self._client = client
+        self._probe = probe
         self.timeout_seconds = timeout_seconds
-        self._executor = probe_executor or concurrent.futures.ThreadPoolExecutor(
-            max_workers=1,
-            thread_name_prefix="readiness-db",
-        )
-        self._probe_future: Optional[concurrent.futures.Future] = None
+        self._inflight: Optional[asyncio.Task] = None
         self._closed = False
-        # Deferred cleanup task for a probe still running at drain timeout.
-        # While set, ownership of the in-flight probe and client is tracked
-        # until the deferred task completes.
-        self._deferred_close: Optional[asyncio.Task] = None
-        # When True, this check owns the probe client and closes it in
-        # ``aclose`` only after the in-flight probe is proven done.
-        self._owns_client = owns_client
 
     def close(self) -> None:
-        """Synchronous best-effort close: stop new probes and release the
-        executor without waiting.
-
-        Deliberately does NOT close the probe client: an in-flight probe
-        thread may still be using it. Use :meth:`aclose` during async
-        shutdown for the full drain-and-close protocol.
-        """
+        """Synchronous best-effort close: reject new probes. No threads exist,
+        so there is nothing else to release here; use :meth:`aclose` during
+        async shutdown to cancel any in-flight probe."""
         self._closed = True
-        self._executor.shutdown(wait=False, cancel_futures=True)
 
     async def aclose(self) -> None:
-        """Full close protocol: stop new probes, drain the in-flight probe
-        with a bounded wait, then release the executor and close the owned
-        probe client.
+        """Full close protocol: reject new probes and cancel any in-flight
+        probe, awaiting its termination before returning.
 
-        The client is NEVER closed while a worker thread may still use it:
-
-        * If the probe completed (success or exception), the worker thread
-          has terminated; the client is closed after the drain. A probe
-          exception is absorbed, never propagated.
-        * If the drain bound expires while the probe is still running (a
-          probe ignoring its aligned transport timeout), the client is NOT
-          closed underneath the live thread. Ownership is kept traceable: the
-          in-flight future stays referenced and a deferred cleanup task
-          (``self._deferred_close``) closes the executor and the client only
-          after the probe actually terminates. The normal path (aligned
-          transport) completes inside the drain bound, so the deferred path
-          only exists for pathological probes.
+        The probe is async HTTP I/O, so cancellation actually stops the
+        request; no fire-and-forget cleanup is needed and no owned work
+        outlives the lifespan.
         """
         self._closed = True
-        if self._deferred_close is not None:
-            await self._deferred_close
-            return
-        future = self._probe_future
-        drained = future is None or future.done()
-        if future is not None and not future.done():
-            try:
-                await asyncio.wait_for(
-                    asyncio.wrap_future(future),
-                    timeout=self.timeout_seconds + 1.0,
-                )
-                drained = True
-            except (asyncio.TimeoutError, concurrent.futures.TimeoutError):
-                # The probe is still running past the drain bound. Defer the
-                # client close until the probe terminates; never invalidate
-                # the client underneath the live thread. The deferred task is
-                # tracked (``self._deferred_close``) so ownership survives
-                # until completion; a second aclose joins it.
-                self._deferred_close = asyncio.ensure_future(
-                    self._close_after_drain(future)
-                )
-                return
-            except Exception:
-                # The probe completed exceptionally: the worker thread has
-                # terminated. Cleanup below is safe; never propagate it.
-                drained = True
-        self._executor.shutdown(wait=False, cancel_futures=True)
-        self._probe_future = None
-        if self._owns_client:
-            await self._close_client()
-
-    async def _close_after_drain(self, future: concurrent.futures.Future) -> None:
-        """Deferred cleanup for a probe still running at drain timeout.
-
-        Awaits the probe's completion (the aligned transport bounds it),
-        then shuts the executor and closes the owned client only after the
-        worker thread is proven done. The future stays referenced by
-        ``self._probe_future`` and the task by ``self._deferred_close`` until
-        completion, so ownership is traceable and never GC'd mid-cleanup.
-        """
-        try:
-            await asyncio.wrap_future(future)
-        except Exception:
-            # Probe failed or was cancelled; the thread has terminated.
-            pass
-        self._executor.shutdown(wait=False, cancel_futures=True)
-        self._probe_future = None
-        if self._owns_client:
-            await self._close_client()
-
-    async def _close_client(self) -> None:
-        client, self._client = self._client, None
-        closer = getattr(client, "aclose", None) or getattr(client, "close", None)
-        if closer is None:
-            return
-        try:
-            result = closer()
-            if inspect.isawaitable(result):
-                await result
-        except Exception:
-            emit_event(
-                logger,
-                EVENT_READINESS_CHECK_FAILED,
-                level=logging.ERROR,
-                component=self.name,
-            )
+        task, self._inflight = self._inflight, None
+        if task is not None and not task.done():
+            task.cancel()
+            with contextlib.suppress(BaseException):
+                await task
 
     async def run(self) -> None:
-        if self._client is None or self._closed:
+        if self._probe is None or self._closed:
             raise CheckFailure()
-        if self._probe_future is not None and not self._probe_future.done():
-            # A previous probe is still in flight. Its aligned transport
-            # timeout will release the worker; never pile up work behind it.
+        if self._inflight is not None and not self._inflight.done():
+            # A previous probe is still in flight; never pile up duplicate
+            # requests behind it.
             raise CheckFailure()
-        if self._probe_future is None or self._probe_future.done():
-            self._probe_future = self._executor.submit(self._probe)
-        future = self._probe_future
+        task = asyncio.ensure_future(self._probe())
+        self._inflight = task
         try:
-            response = await asyncio.wait_for(
-                asyncio.wrap_future(future),
-                timeout=self.timeout_seconds,
-            )
-        except (asyncio.TimeoutError, concurrent.futures.TimeoutError):
+            await asyncio.wait_for(task, timeout=self.timeout_seconds)
+        except asyncio.TimeoutError:
             raise CheckFailure() from None
         except Exception:
             raise CheckFailure() from None
         finally:
-            # Guarded clear: only drop the reference this call owns. A
-            # concurrent poll may have already replaced the reference with a
-            # newer probe future before this finally runs; clearing it would
-            # let a third poll submit extra work and break the single-probe
-            # invariant. The comparison is atomic in the event loop because
-            # no await happens between reading and clearing.
-            if self._probe_future is future and future.done():
-                self._probe_future = None
-        if response is None:
-            raise CheckFailure()
-
-    def _probe(self) -> Any:
-        result = self._client.table("profiles").select("user_id").limit(1).execute()
-        if result is None:
-            raise CheckFailure()
-        if getattr(result, "error", None):
-            raise CheckFailure()
-        return result
+            if self._inflight is task:
+                self._inflight = None
+            if not task.done():
+                task.cancel()
+                with contextlib.suppress(BaseException):
+                    await task
 
 
 def _auth_health_probe(
     auth_url: str,
     apikey: Optional[str],
     timeout: float,
-) -> Callable[[], None]:
+) -> Callable[[], Awaitable[None]]:
     """Build the default Auth service availability probe.
 
-    Performs a bounded ``GET {auth_url}/health`` (GoTrue health endpoint).
-    The probe never depends on a user token and never reads user data: only
-    the HTTP status is observed and the body is discarded, so nothing
-    sensitive reaches responses or logs. ``timeout`` is a hard socket
-    transport bound aligned with the readiness timeout.
+    Performs a bounded ``GET {auth_url}/health`` (GoTrue health endpoint)
+    over async HTTP, so the operation is truly cancelable by the readiness
+    timeout (no worker thread can outlive it). The probe never depends on a
+    user token and never reads user data: only the HTTP status is observed
+    and the body is discarded, so nothing sensitive reaches responses or
+    logs. ``timeout`` is the transport bound, aligned with the readiness
+    timeout.
     """
     health_url = f"{auth_url.rstrip('/')}/health"
 
-    def probe() -> None:
-        request = urllib.request.Request(health_url, method="GET")
-        if apikey:
-            request.add_header("apikey", apikey)
+    async def probe() -> None:
         try:
-            with urllib.request.urlopen(request, timeout=timeout) as response:
-                if response.status != 200:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                headers = {"apikey": apikey} if apikey else {}
+                response = await client.get(health_url, headers=headers)
+                if response.status_code != 200:
+                    raise CheckFailure()
+        except CheckFailure:
+            raise
+        except Exception:
+            raise CheckFailure() from None
+
+    return probe
+
+
+def _database_health_probe(
+    supabase_url: str,
+    service_role_key: Optional[str],
+    timeout: float,
+) -> Callable[[], Awaitable[None]]:
+    """Build the default database/Supabase availability probe.
+
+    Performs a bounded ``GET {supabase_url}/rest/v1/profiles`` with
+    ``select=user_id&limit=1`` (the same read the previous SDK probe
+    executed) over async HTTP, so it is truly cancelable by the readiness
+    timeout. Uses the service-role credentials from validated settings; the
+    response body is discarded and only the HTTP status is observed, so no
+    user data or secret reaches responses or logs.
+    """
+    rest_url = f"{supabase_url.rstrip('/')}/rest/v1/profiles"
+
+    async def probe() -> None:
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                headers = {
+                    "apikey": service_role_key,
+                    "Authorization": f"Bearer {service_role_key}",
+                }
+                response = await client.get(
+                    rest_url,
+                    params={"select": "user_id", "limit": 1},
+                    headers=headers,
+                )
+                if response.status_code != 200:
                     raise CheckFailure()
         except CheckFailure:
             raise
@@ -415,15 +346,17 @@ class AuthClientCheck:
 
     1. Surface: the exact route path ``auth_client.auth.get_user`` exists and
        is callable (never invoked; no token involved).
-    2. Availability: a bounded probe of the Auth service (default: HTTP GET
-       of the GoTrue ``/health`` endpoint with the transport timeout aligned
-       to ``readiness_auth_timeout_ms``). This is a real network probe, so a
-       healthy PostgREST/database probe can never mask an Auth outage.
+    2. Availability: a bounded async probe of the Auth service (default: HTTP
+       GET of the GoTrue ``/health`` endpoint with the transport timeout
+       aligned to ``readiness_auth_timeout_ms``). This is a real network
+       probe, so a healthy PostgREST/database probe can never mask an Auth
+       outage.
 
     Either proof failing makes the component ``unavailable``: an instance
     whose ``/chat`` and ``/history`` authentication would 503 must not report
-    ready. The probe runs on a dedicated single-worker executor with an
-    in-flight guard, so repeated polls never accumulate threads.
+    ready. The probe is plain async I/O, so the readiness timeout truly
+    cancels it (no worker thread can outlive it) and ``aclose()`` cancels any
+    in-flight probe before returning.
     """
 
     name = "auth"
@@ -433,59 +366,30 @@ class AuthClientCheck:
         auth_client: Any,
         timeout_seconds: float,
         *,
-        probe: Optional[Callable[[], None]] = None,
-        probe_executor: Optional[concurrent.futures.Executor] = None,
+        probe: Optional[Callable[[], Awaitable[None]]] = None,
     ) -> None:
         self._auth_client = auth_client
         self.timeout_seconds = timeout_seconds
         self._probe = probe
-        self._executor = probe_executor or concurrent.futures.ThreadPoolExecutor(
-            max_workers=1,
-            thread_name_prefix="readiness-auth",
-        )
-        self._probe_future: Optional[concurrent.futures.Future] = None
+        self._inflight: Optional[asyncio.Task] = None
         self._closed = False
-        self._deferred_close: Optional[asyncio.Task] = None
 
     def close(self) -> None:
-        """Synchronous best-effort close: stop new probes and release the
-        executor without waiting (partial-startup cleanup)."""
+        """Synchronous best-effort close: reject new probes. No threads exist,
+        so there is nothing else to release here; use :meth:`aclose` during
+        async shutdown to cancel any in-flight probe."""
         self._closed = True
-        self._executor.shutdown(wait=False, cancel_futures=True)
 
     async def aclose(self) -> None:
-        """Full async close: drain an in-flight probe with a bounded wait,
-        then release the executor. A probe still running past the drain
-        bound is handed to a tracked deferred cleanup task (no owned thread
-        reference is dropped mid-flight)."""
+        """Full close protocol: reject new probes and cancel any in-flight
+        probe, awaiting its termination before returning. No fire-and-forget
+        cleanup is needed and no owned work outlives the lifespan."""
         self._closed = True
-        if self._deferred_close is not None:
-            await self._deferred_close
-            return
-        future = self._probe_future
-        if future is not None and not future.done():
-            try:
-                await asyncio.wait_for(
-                    asyncio.wrap_future(future),
-                    timeout=self.timeout_seconds + 1.0,
-                )
-            except (asyncio.TimeoutError, concurrent.futures.TimeoutError):
-                self._deferred_close = asyncio.ensure_future(
-                    self._close_after_drain(future)
-                )
-                return
-            except Exception:
-                pass
-        self._executor.shutdown(wait=False, cancel_futures=True)
-        self._probe_future = None
-
-    async def _close_after_drain(self, future: concurrent.futures.Future) -> None:
-        try:
-            await asyncio.wrap_future(future)
-        except Exception:
-            pass
-        self._executor.shutdown(wait=False, cancel_futures=True)
-        self._probe_future = None
+        task, self._inflight = self._inflight, None
+        if task is not None and not task.done():
+            task.cancel()
+            with contextlib.suppress(BaseException):
+                await task
 
     async def run(self) -> None:
         # 1. The exact callable path the routes use must exist.
@@ -500,27 +404,25 @@ class AuthClientCheck:
         if not callable(get_user):
             raise CheckFailure()
         # 2. The Auth service itself must be reachable.
-        if self._probe is None:
+        if self._probe is None or self._closed:
             raise CheckFailure()
-        if self._closed:
+        if self._inflight is not None and not self._inflight.done():
             raise CheckFailure()
-        if self._probe_future is not None and not self._probe_future.done():
-            raise CheckFailure()
-        if self._probe_future is None or self._probe_future.done():
-            self._probe_future = self._executor.submit(self._probe)
-        future = self._probe_future
+        task = asyncio.ensure_future(self._probe())
+        self._inflight = task
         try:
-            await asyncio.wait_for(
-                asyncio.wrap_future(future),
-                timeout=self.timeout_seconds,
-            )
-        except (asyncio.TimeoutError, concurrent.futures.TimeoutError):
+            await asyncio.wait_for(task, timeout=self.timeout_seconds)
+        except asyncio.TimeoutError:
             raise CheckFailure() from None
         except Exception:
             raise CheckFailure() from None
         finally:
-            if self._probe_future is future and future.done():
-                self._probe_future = None
+            if self._inflight is task:
+                self._inflight = None
+            if not task.done():
+                task.cancel()
+                with contextlib.suppress(BaseException):
+                    await task
 
 
 class PersistenceClientCheck:
@@ -644,21 +546,23 @@ def build_health_registry(
     engine: Any,
     *,
     auth_client: Any = None,
-    auth_probe: Optional[Callable[[], None]] = None,
+    auth_probe: Optional[Callable[[], Awaitable[None]]] = None,
     persistence_client: Any = None,
-    database_probe_client: Any = None,
-    owns_probe_client: bool = False,
+    database_probe: Optional[Callable[[], Awaitable[None]]] = None,
 ) -> HealthRegistry:
     """Build the default ordered registry for the running configuration.
 
     Components:
     1. ``configuration`` — validated settings (frozen model, fully revalidated).
     2. ``auth`` — the REAL authentication surface used by the routes is
-       callable AND the Auth service is reachable via a bounded availability
-       probe (``auth_probe``; default builds the GoTrue /health probe).
-    3. ``database`` — minimal Supabase read via a dedicated probe client whose
-       transport timeout is aligned with ``readiness_database_timeout_ms``;
-       never a substitute for the real surfaces.
+       callable AND the Auth service is reachable via a bounded async
+       availability probe (``auth_probe``; default builds the GoTrue /health
+       probe).
+    3. ``database`` — minimal Supabase read via a bounded async probe
+       (``database_probe``; default builds the PostgREST /rest/v1/profiles
+       probe with transport aligned to ``readiness_database_timeout_ms``).
+       Probes are plain async I/O: the readiness timeout truly cancels them,
+       so no worker thread or owned resource can outlive the lifespan.
     4. ``persistence`` — the REAL persistence surface used by admission and
        history exists.
     5. ``provider`` — provider keys/client path, bounded by
@@ -666,11 +570,9 @@ def build_health_registry(
     6. ``embeddings`` — only when ``embeddings_retrieval_enabled`` is true.
 
     ``lifespan`` is appended by the application at request time because it
-    observes ``app.state``. When ``owns_probe_client`` is true the registry
-    (through ``DatabaseCheck.aclose``) closes the probe client after draining
-    any in-flight probe. When ``auth_probe`` is omitted, no availability
-    probe is configured and the ``auth`` component is unavailable (an
-    instance whose auth cannot be probed must not report ready).
+    observes ``app.state``. When a probe is omitted, its component is
+    unavailable (an instance whose critical dependency cannot be probed must
+    not report ready).
     """
     registry = HealthRegistry()
     registry.add(
@@ -685,9 +587,8 @@ def build_health_registry(
     )
     registry.add(
         DatabaseCheck(
-            database_probe_client,
+            database_probe,
             timeout_seconds=settings.readiness_database_timeout_ms / 1000.0,
-            owns_client=owns_probe_client,
         )
     )
     registry.add(

--- a/backend/health.py
+++ b/backend/health.py
@@ -26,6 +26,8 @@ import asyncio
 import concurrent.futures
 import inspect
 import logging
+import urllib.error
+import urllib.request
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Mapping, Optional, Protocol
@@ -229,6 +231,10 @@ class DatabaseCheck:
         )
         self._probe_future: Optional[concurrent.futures.Future] = None
         self._closed = False
+        # Deferred cleanup task for a probe still running at drain timeout.
+        # While set, ownership of the in-flight probe and client is tracked
+        # until the deferred task completes.
+        self._deferred_close: Optional[asyncio.Task] = None
         # When True, this check owns the probe client and closes it in
         # ``aclose`` only after the in-flight probe is proven done.
         self._owns_client = owns_client
@@ -247,18 +253,26 @@ class DatabaseCheck:
     async def aclose(self) -> None:
         """Full close protocol: stop new probes, drain the in-flight probe
         with a bounded wait, then release the executor and close the owned
-        probe client. Cleanup is unconditional:
+        probe client.
+
+        The client is NEVER closed while a worker thread may still use it:
 
         * If the probe completed (success or exception), the worker thread
-          has terminated and the client is closed after the drain. A probe
-          exception is never propagated: it would otherwise escape the drain
-          and skip executor/client cleanup.
-        * If the drain bound expires (a probe ignoring its aligned transport
-          timeout), the owned client is still closed: closing the transport
-          fails the in-flight call, so the worker thread terminates instead
-          of surviving the lifespan. The future reference is always cleared.
+          has terminated; the client is closed after the drain. A probe
+          exception is absorbed, never propagated.
+        * If the drain bound expires while the probe is still running (a
+          probe ignoring its aligned transport timeout), the client is NOT
+          closed underneath the live thread. Ownership is kept traceable: the
+          in-flight future stays referenced and a deferred cleanup task
+          (``self._deferred_close``) closes the executor and the client only
+          after the probe actually terminates. The normal path (aligned
+          transport) completes inside the drain bound, so the deferred path
+          only exists for pathological probes.
         """
         self._closed = True
+        if self._deferred_close is not None:
+            await self._deferred_close
+            return
         future = self._probe_future
         drained = future is None or future.done()
         if future is not None and not future.done():
@@ -269,9 +283,15 @@ class DatabaseCheck:
                 )
                 drained = True
             except (asyncio.TimeoutError, concurrent.futures.TimeoutError):
-                # The probe is past the drain bound; closing the client below
-                # fails its in-flight call and terminates the worker thread.
-                drained = False
+                # The probe is still running past the drain bound. Defer the
+                # client close until the probe terminates; never invalidate
+                # the client underneath the live thread. The deferred task is
+                # tracked (``self._deferred_close``) so ownership survives
+                # until completion; a second aclose joins it.
+                self._deferred_close = asyncio.ensure_future(
+                    self._close_after_drain(future)
+                )
+                return
             except Exception:
                 # The probe completed exceptionally: the worker thread has
                 # terminated. Cleanup below is safe; never propagate it.
@@ -279,20 +299,43 @@ class DatabaseCheck:
         self._executor.shutdown(wait=False, cancel_futures=True)
         self._probe_future = None
         if self._owns_client:
-            client, self._client = self._client, None
-            closer = getattr(client, "aclose", None) or getattr(client, "close", None)
-            if closer is not None:
-                try:
-                    result = closer()
-                    if inspect.isawaitable(result):
-                        await result
-                except Exception:
-                    emit_event(
-                        logger,
-                        EVENT_READINESS_CHECK_FAILED,
-                        level=logging.ERROR,
-                        component=self.name,
-                    )
+            await self._close_client()
+
+    async def _close_after_drain(self, future: concurrent.futures.Future) -> None:
+        """Deferred cleanup for a probe still running at drain timeout.
+
+        Awaits the probe's completion (the aligned transport bounds it),
+        then shuts the executor and closes the owned client only after the
+        worker thread is proven done. The future stays referenced by
+        ``self._probe_future`` and the task by ``self._deferred_close`` until
+        completion, so ownership is traceable and never GC'd mid-cleanup.
+        """
+        try:
+            await asyncio.wrap_future(future)
+        except Exception:
+            # Probe failed or was cancelled; the thread has terminated.
+            pass
+        self._executor.shutdown(wait=False, cancel_futures=True)
+        self._probe_future = None
+        if self._owns_client:
+            await self._close_client()
+
+    async def _close_client(self) -> None:
+        client, self._client = self._client, None
+        closer = getattr(client, "aclose", None) or getattr(client, "close", None)
+        if closer is None:
+            return
+        try:
+            result = closer()
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            emit_event(
+                logger,
+                EVENT_READINESS_CHECK_FAILED,
+                level=logging.ERROR,
+                component=self.name,
+            )
 
     async def run(self) -> None:
         if self._client is None or self._closed:
@@ -334,28 +377,118 @@ class DatabaseCheck:
         return result
 
 
+def _auth_health_probe(
+    auth_url: str,
+    apikey: Optional[str],
+    timeout: float,
+) -> Callable[[], None]:
+    """Build the default Auth service availability probe.
+
+    Performs a bounded ``GET {auth_url}/health`` (GoTrue health endpoint).
+    The probe never depends on a user token and never reads user data: only
+    the HTTP status is observed and the body is discarded, so nothing
+    sensitive reaches responses or logs. ``timeout`` is a hard socket
+    transport bound aligned with the readiness timeout.
+    """
+    health_url = f"{auth_url.rstrip('/')}/health"
+
+    def probe() -> None:
+        request = urllib.request.Request(health_url, method="GET")
+        if apikey:
+            request.add_header("apikey", apikey)
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                if response.status != 200:
+                    raise CheckFailure()
+        except CheckFailure:
+            raise
+        except Exception:
+            raise CheckFailure() from None
+
+    return probe
+
+
 class AuthClientCheck:
-    """Checks that the real authentication surface used by the routes is
-    effectively callable (``client.auth.get_user``), not merely present.
+    """Checks that the Auth service can actually authenticate requests.
 
-    Attribute existence is not enough: ``hasattr(client, "auth")`` passes for
-    ``None`` and for objects without a ``get_user`` method, yet the request
-    auth dependency calls ``auth_client.auth.get_user(token)``. The check
-    therefore verifies the exact callable path the routes use. It never
-    invokes ``get_user`` (that would need a token and hit the network).
+    Two independent proofs, both cheap and sanitized:
 
-    A healthy probe client can never substitute for this: if the engine's
-    real Supabase client failed to build, ``/chat`` and ``/history`` cannot
-    authenticate no matter how healthy the dedicated database probe is.
+    1. Surface: the exact route path ``auth_client.auth.get_user`` exists and
+       is callable (never invoked; no token involved).
+    2. Availability: a bounded probe of the Auth service (default: HTTP GET
+       of the GoTrue ``/health`` endpoint with the transport timeout aligned
+       to ``readiness_auth_timeout_ms``). This is a real network probe, so a
+       healthy PostgREST/database probe can never mask an Auth outage.
+
+    Either proof failing makes the component ``unavailable``: an instance
+    whose ``/chat`` and ``/history`` authentication would 503 must not report
+    ready. The probe runs on a dedicated single-worker executor with an
+    in-flight guard, so repeated polls never accumulate threads.
     """
 
     name = "auth"
-    timeout_seconds = DEFAULT_CHECK_TIMEOUT_SECONDS
 
-    def __init__(self, auth_client: Any) -> None:
+    def __init__(
+        self,
+        auth_client: Any,
+        timeout_seconds: float,
+        *,
+        probe: Optional[Callable[[], None]] = None,
+        probe_executor: Optional[concurrent.futures.Executor] = None,
+    ) -> None:
         self._auth_client = auth_client
+        self.timeout_seconds = timeout_seconds
+        self._probe = probe
+        self._executor = probe_executor or concurrent.futures.ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="readiness-auth",
+        )
+        self._probe_future: Optional[concurrent.futures.Future] = None
+        self._closed = False
+        self._deferred_close: Optional[asyncio.Task] = None
+
+    def close(self) -> None:
+        """Synchronous best-effort close: stop new probes and release the
+        executor without waiting (partial-startup cleanup)."""
+        self._closed = True
+        self._executor.shutdown(wait=False, cancel_futures=True)
+
+    async def aclose(self) -> None:
+        """Full async close: drain an in-flight probe with a bounded wait,
+        then release the executor. A probe still running past the drain
+        bound is handed to a tracked deferred cleanup task (no owned thread
+        reference is dropped mid-flight)."""
+        self._closed = True
+        if self._deferred_close is not None:
+            await self._deferred_close
+            return
+        future = self._probe_future
+        if future is not None and not future.done():
+            try:
+                await asyncio.wait_for(
+                    asyncio.wrap_future(future),
+                    timeout=self.timeout_seconds + 1.0,
+                )
+            except (asyncio.TimeoutError, concurrent.futures.TimeoutError):
+                self._deferred_close = asyncio.ensure_future(
+                    self._close_after_drain(future)
+                )
+                return
+            except Exception:
+                pass
+        self._executor.shutdown(wait=False, cancel_futures=True)
+        self._probe_future = None
+
+    async def _close_after_drain(self, future: concurrent.futures.Future) -> None:
+        try:
+            await asyncio.wrap_future(future)
+        except Exception:
+            pass
+        self._executor.shutdown(wait=False, cancel_futures=True)
+        self._probe_future = None
 
     async def run(self) -> None:
+        # 1. The exact callable path the routes use must exist.
         client = self._auth_client
         if client is None:
             raise CheckFailure()
@@ -363,10 +496,31 @@ class AuthClientCheck:
             auth = getattr(client, "auth", None)
             get_user = getattr(auth, "get_user", None) if auth is not None else None
         except Exception:
-            # A surface that raises on attribute access is not usable either.
             raise CheckFailure() from None
         if not callable(get_user):
             raise CheckFailure()
+        # 2. The Auth service itself must be reachable.
+        if self._probe is None:
+            raise CheckFailure()
+        if self._closed:
+            raise CheckFailure()
+        if self._probe_future is not None and not self._probe_future.done():
+            raise CheckFailure()
+        if self._probe_future is None or self._probe_future.done():
+            self._probe_future = self._executor.submit(self._probe)
+        future = self._probe_future
+        try:
+            await asyncio.wait_for(
+                asyncio.wrap_future(future),
+                timeout=self.timeout_seconds,
+            )
+        except (asyncio.TimeoutError, concurrent.futures.TimeoutError):
+            raise CheckFailure() from None
+        except Exception:
+            raise CheckFailure() from None
+        finally:
+            if self._probe_future is future and future.done():
+                self._probe_future = None
 
 
 class PersistenceClientCheck:
@@ -490,6 +644,7 @@ def build_health_registry(
     engine: Any,
     *,
     auth_client: Any = None,
+    auth_probe: Optional[Callable[[], None]] = None,
     persistence_client: Any = None,
     database_probe_client: Any = None,
     owns_probe_client: bool = False,
@@ -498,7 +653,9 @@ def build_health_registry(
 
     Components:
     1. ``configuration`` — validated settings (frozen model, fully revalidated).
-    2. ``auth`` — the REAL authentication surface used by the routes exists.
+    2. ``auth`` — the REAL authentication surface used by the routes is
+       callable AND the Auth service is reachable via a bounded availability
+       probe (``auth_probe``; default builds the GoTrue /health probe).
     3. ``database`` — minimal Supabase read via a dedicated probe client whose
        transport timeout is aligned with ``readiness_database_timeout_ms``;
        never a substitute for the real surfaces.
@@ -511,14 +668,20 @@ def build_health_registry(
     ``lifespan`` is appended by the application at request time because it
     observes ``app.state``. When ``owns_probe_client`` is true the registry
     (through ``DatabaseCheck.aclose``) closes the probe client after draining
-    any in-flight probe.
+    any in-flight probe. When ``auth_probe`` is omitted, no availability
+    probe is configured and the ``auth`` component is unavailable (an
+    instance whose auth cannot be probed must not report ready).
     """
     registry = HealthRegistry()
     registry.add(
         ConfigurationCheck(settings)
     )
     registry.add(
-        AuthClientCheck(auth_client)
+        AuthClientCheck(
+            auth_client,
+            timeout_seconds=settings.readiness_auth_timeout_ms / 1000.0,
+            probe=auth_probe,
+        )
     )
     registry.add(
         DatabaseCheck(

--- a/backend/health.py
+++ b/backend/health.py
@@ -78,6 +78,10 @@ class HealthRegistry:
     Order is deterministic: insertion order, which the default builder
     fixes as ``configuration``, ``database``, ``provider``, then
     ``embeddings`` (only when the retrieval feature is enabled).
+
+    The registry is closable: ``close()`` delegates to every registered check
+    that exposes a ``close`` contract (e.g. the database probe executor), so
+    the application can own the whole registry as one lifecycle resource.
     """
 
     checks: Mapping[str, ReadinessCheck] = field(default_factory=dict)
@@ -88,6 +92,27 @@ class HealthRegistry:
     def add(self, check: ReadinessCheck) -> None:
         """Register one check (idempotent by name)."""
         self.checks[check.name] = check
+
+    def close(self) -> None:
+        """Close every closable check without aborting on individual failures.
+
+        Never abandons an active probe: each check's ``close`` shuts down its
+        own executor with ``wait=False`` so the in-flight probe self-terminates
+        through its aligned transport timeout and no new work is queued.
+        """
+        for check in self.checks.values():
+            closer = getattr(check, "close", None)
+            if closer is None:
+                continue
+            try:
+                closer()
+            except Exception:
+                emit_event(
+                    logger,
+                    EVENT_READINESS_CHECK_FAILED,
+                    level=logging.ERROR,
+                    component=check.name,
+                )
 
     async def run_all(self) -> list[CheckResult]:
         """Run every check in order with its own explicit timeout.
@@ -176,9 +201,22 @@ class DatabaseCheck:
             thread_name_prefix="readiness-db",
         )
         self._probe_future: Optional[concurrent.futures.Future] = None
+        self._closed = False
+
+    def close(self) -> None:
+        """Stop accepting new probes without abandoning the active one.
+
+        Shuts the executor down with ``wait=False``: the in-flight probe (if
+        any) keeps running and self-terminates through its aligned transport
+        timeout, and no new work can be queued. Non-daemon executor threads
+        finish on their own once the probe completes, so the process is never
+        blocked by an abandoned future.
+        """
+        self._closed = True
+        self._executor.shutdown(wait=False)
 
     async def run(self) -> None:
-        if self._client is None:
+        if self._client is None or self._closed:
             raise CheckFailure()
         if self._probe_future is not None and not self._probe_future.done():
             # A previous probe is still in flight. Its aligned transport
@@ -197,7 +235,13 @@ class DatabaseCheck:
         except Exception:
             raise CheckFailure() from None
         finally:
-            if future.done():
+            # Guarded clear: only drop the reference this call owns. A
+            # concurrent poll may have already replaced the reference with a
+            # newer probe future before this finally runs; clearing it would
+            # let a third poll submit extra work and break the single-probe
+            # invariant. The comparison is atomic in the event loop because
+            # no await happens between reading and clearing.
+            if self._probe_future is future and future.done():
                 self._probe_future = None
         if response is None:
             raise CheckFailure()

--- a/backend/health.py
+++ b/backend/health.py
@@ -242,19 +242,21 @@ class DatabaseCheck:
         shutdown for the full drain-and-close protocol.
         """
         self._closed = True
-        self._executor.shutdown(wait=False)
+        self._executor.shutdown(wait=False, cancel_futures=True)
 
     async def aclose(self) -> None:
         """Full close protocol: stop new probes, drain the in-flight probe
         with a bounded wait, then release the executor and close the owned
-        probe client only after the probe thread is proven done.
+        probe client. Cleanup is unconditional:
 
-        The bounded drain uses the aligned transport timeout (readiness
-        timeout plus a small margin), so a real probe self-terminates inside
-        the window. If a probe is still active after the bound (pathological
-        case), the client is deliberately left open: closing it underneath a
-        live thread would invalidate the surface the thread is using. New
-        probes are rejected from this point on.
+        * If the probe completed (success or exception), the worker thread
+          has terminated and the client is closed after the drain. A probe
+          exception is never propagated: it would otherwise escape the drain
+          and skip executor/client cleanup.
+        * If the drain bound expires (a probe ignoring its aligned transport
+          timeout), the owned client is still closed: closing the transport
+          fails the in-flight call, so the worker thread terminates instead
+          of surviving the lifespan. The future reference is always cleared.
         """
         self._closed = True
         future = self._probe_future
@@ -267,9 +269,16 @@ class DatabaseCheck:
                 )
                 drained = True
             except (asyncio.TimeoutError, concurrent.futures.TimeoutError):
+                # The probe is past the drain bound; closing the client below
+                # fails its in-flight call and terminates the worker thread.
                 drained = False
-        self._executor.shutdown(wait=False)
-        if drained and self._owns_client:
+            except Exception:
+                # The probe completed exceptionally: the worker thread has
+                # terminated. Cleanup below is safe; never propagate it.
+                drained = True
+        self._executor.shutdown(wait=False, cancel_futures=True)
+        self._probe_future = None
+        if self._owns_client:
             client, self._client = self._client, None
             closer = getattr(client, "aclose", None) or getattr(client, "close", None)
             if closer is not None:
@@ -326,7 +335,14 @@ class DatabaseCheck:
 
 
 class AuthClientCheck:
-    """Checks that the real authentication surface used by the routes exists.
+    """Checks that the real authentication surface used by the routes is
+    effectively callable (``client.auth.get_user``), not merely present.
+
+    Attribute existence is not enough: ``hasattr(client, "auth")`` passes for
+    ``None`` and for objects without a ``get_user`` method, yet the request
+    auth dependency calls ``auth_client.auth.get_user(token)``. The check
+    therefore verifies the exact callable path the routes use. It never
+    invokes ``get_user`` (that would need a token and hit the network).
 
     A healthy probe client can never substitute for this: if the engine's
     real Supabase client failed to build, ``/chat`` and ``/history`` cannot
@@ -341,17 +357,30 @@ class AuthClientCheck:
 
     async def run(self) -> None:
         client = self._auth_client
-        if client is None or not hasattr(client, "auth"):
+        if client is None:
+            raise CheckFailure()
+        try:
+            auth = getattr(client, "auth", None)
+            get_user = getattr(auth, "get_user", None) if auth is not None else None
+        except Exception:
+            # A surface that raises on attribute access is not usable either.
+            raise CheckFailure() from None
+        if not callable(get_user):
             raise CheckFailure()
 
 
 class PersistenceClientCheck:
-    """Checks that the real persistence surface used by the routes exists.
+    """Checks that the real persistence surface used by the routes is
+    effectively callable: ``table(...)`` and ``rpc(...)`` must exist, be
+    callable, and be invocable without raising.
 
-    Covers the client actually used by admission (``rpc``) and history
-    (``table``). A dedicated probe client cannot substitute for it: if the
-    real client is missing, persistence routes fail even when ``/ready``
-    probes pass.
+    Attribute existence is not enough: ``hasattr(client, "table")`` passes
+    for ``table=None``, yet history calls ``table("chat_logs").select(...)``
+    and admission calls ``rpc("reserve_admission", ...)``. The check builds a
+    query and an RPC request with benign arguments; on the real Supabase
+    client that is pure object construction (no network I/O), so the proof is
+    cheap and honest. A dedicated probe client can never substitute for this
+    surface.
     """
 
     name = "persistence"
@@ -364,7 +393,21 @@ class PersistenceClientCheck:
         client = self._persistence_client
         if client is None:
             raise CheckFailure()
-        if not hasattr(client, "table") or not hasattr(client, "rpc"):
+        try:
+            table = getattr(client, "table", None)
+            rpc = getattr(client, "rpc", None)
+        except Exception:
+            # A surface that raises on attribute access is not usable either.
+            raise CheckFailure() from None
+        if not callable(table) or not callable(rpc):
+            raise CheckFailure()
+        try:
+            table_builder = table("chat_logs")
+            rpc_builder = rpc("match_memories", {})
+        except Exception:
+            # The surfaces exist but fail when invoked; routes cannot use them.
+            raise CheckFailure() from None
+        if table_builder is None or rpc_builder is None:
             raise CheckFailure()
 
 

--- a/backend/health.py
+++ b/backend/health.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import inspect
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
@@ -76,12 +77,13 @@ class HealthRegistry:
     """Ordered registry of readiness checks with per-check timeouts.
 
     Order is deterministic: insertion order, which the default builder
-    fixes as ``configuration``, ``database``, ``provider``, then
-    ``embeddings`` (only when the retrieval feature is enabled).
+    fixes as ``configuration``, ``auth``, ``database``, ``persistence``,
+    ``provider``, then ``embeddings`` (only when the retrieval feature is
+    enabled).
 
-    The registry is closable: ``close()`` delegates to every registered check
-    that exposes a ``close`` contract (e.g. the database probe executor), so
-    the application can own the whole registry as one lifecycle resource.
+    The registry is closable: ``close()`` (sync, best-effort) and
+    ``aclose()`` (full async protocol) delegate to every registered check,
+    so the application can own the whole registry as one lifecycle resource.
     """
 
     checks: Mapping[str, ReadinessCheck] = field(default_factory=dict)
@@ -96,9 +98,9 @@ class HealthRegistry:
     def close(self) -> None:
         """Close every closable check without aborting on individual failures.
 
-        Never abandons an active probe: each check's ``close`` shuts down its
-        own executor with ``wait=False`` so the in-flight probe self-terminates
-        through its aligned transport timeout and no new work is queued.
+        Synchronous best-effort variant used for partial-startup cleanup: it
+        does NOT drain in-flight probes nor close owned probe clients. Use
+        :meth:`aclose` during the normal async shutdown for the full protocol.
         """
         for check in self.checks.values():
             closer = getattr(check, "close", None)
@@ -106,6 +108,30 @@ class HealthRegistry:
                 continue
             try:
                 closer()
+            except Exception:
+                emit_event(
+                    logger,
+                    EVENT_READINESS_CHECK_FAILED,
+                    level=logging.ERROR,
+                    component=check.name,
+                )
+
+    async def aclose(self) -> None:
+        """Full asynchronous close of every closable check.
+
+        Prefers each check's ``aclose`` (which drains an in-flight probe with
+        a bounded wait before closing the owned probe client, so the client is
+        never invalidated underneath a live thread) and falls back to
+        ``close``. Never aborts on individual failures.
+        """
+        for check in self.checks.values():
+            closer = getattr(check, "aclose", None) or getattr(check, "close", None)
+            if closer is None:
+                continue
+            try:
+                result = closer()
+                if inspect.isawaitable(result):
+                    await result
             except Exception:
                 emit_event(
                     logger,
@@ -193,6 +219,7 @@ class DatabaseCheck:
         timeout_seconds: float,
         *,
         probe_executor: Optional[concurrent.futures.Executor] = None,
+        owns_client: bool = False,
     ) -> None:
         self._client = client
         self.timeout_seconds = timeout_seconds
@@ -202,18 +229,61 @@ class DatabaseCheck:
         )
         self._probe_future: Optional[concurrent.futures.Future] = None
         self._closed = False
+        # When True, this check owns the probe client and closes it in
+        # ``aclose`` only after the in-flight probe is proven done.
+        self._owns_client = owns_client
 
     def close(self) -> None:
-        """Stop accepting new probes without abandoning the active one.
+        """Synchronous best-effort close: stop new probes and release the
+        executor without waiting.
 
-        Shuts the executor down with ``wait=False``: the in-flight probe (if
-        any) keeps running and self-terminates through its aligned transport
-        timeout, and no new work can be queued. Non-daemon executor threads
-        finish on their own once the probe completes, so the process is never
-        blocked by an abandoned future.
+        Deliberately does NOT close the probe client: an in-flight probe
+        thread may still be using it. Use :meth:`aclose` during async
+        shutdown for the full drain-and-close protocol.
         """
         self._closed = True
         self._executor.shutdown(wait=False)
+
+    async def aclose(self) -> None:
+        """Full close protocol: stop new probes, drain the in-flight probe
+        with a bounded wait, then release the executor and close the owned
+        probe client only after the probe thread is proven done.
+
+        The bounded drain uses the aligned transport timeout (readiness
+        timeout plus a small margin), so a real probe self-terminates inside
+        the window. If a probe is still active after the bound (pathological
+        case), the client is deliberately left open: closing it underneath a
+        live thread would invalidate the surface the thread is using. New
+        probes are rejected from this point on.
+        """
+        self._closed = True
+        future = self._probe_future
+        drained = future is None or future.done()
+        if future is not None and not future.done():
+            try:
+                await asyncio.wait_for(
+                    asyncio.wrap_future(future),
+                    timeout=self.timeout_seconds + 1.0,
+                )
+                drained = True
+            except (asyncio.TimeoutError, concurrent.futures.TimeoutError):
+                drained = False
+        self._executor.shutdown(wait=False)
+        if drained and self._owns_client:
+            client, self._client = self._client, None
+            closer = getattr(client, "aclose", None) or getattr(client, "close", None)
+            if closer is not None:
+                try:
+                    result = closer()
+                    if inspect.isawaitable(result):
+                        await result
+                except Exception:
+                    emit_event(
+                        logger,
+                        EVENT_READINESS_CHECK_FAILED,
+                        level=logging.ERROR,
+                        component=self.name,
+                    )
 
     async def run(self) -> None:
         if self._client is None or self._closed:
@@ -253,6 +323,49 @@ class DatabaseCheck:
         if getattr(result, "error", None):
             raise CheckFailure()
         return result
+
+
+class AuthClientCheck:
+    """Checks that the real authentication surface used by the routes exists.
+
+    A healthy probe client can never substitute for this: if the engine's
+    real Supabase client failed to build, ``/chat`` and ``/history`` cannot
+    authenticate no matter how healthy the dedicated database probe is.
+    """
+
+    name = "auth"
+    timeout_seconds = DEFAULT_CHECK_TIMEOUT_SECONDS
+
+    def __init__(self, auth_client: Any) -> None:
+        self._auth_client = auth_client
+
+    async def run(self) -> None:
+        client = self._auth_client
+        if client is None or not hasattr(client, "auth"):
+            raise CheckFailure()
+
+
+class PersistenceClientCheck:
+    """Checks that the real persistence surface used by the routes exists.
+
+    Covers the client actually used by admission (``rpc``) and history
+    (``table``). A dedicated probe client cannot substitute for it: if the
+    real client is missing, persistence routes fail even when ``/ready``
+    probes pass.
+    """
+
+    name = "persistence"
+    timeout_seconds = DEFAULT_CHECK_TIMEOUT_SECONDS
+
+    def __init__(self, persistence_client: Any) -> None:
+        self._persistence_client = persistence_client
+
+    async def run(self) -> None:
+        client = self._persistence_client
+        if client is None:
+            raise CheckFailure()
+        if not hasattr(client, "table") or not hasattr(client, "rpc"):
+            raise CheckFailure()
 
 
 class ProviderCheck:
@@ -333,30 +446,46 @@ def build_health_registry(
     settings: Settings,
     engine: Any,
     *,
+    auth_client: Any = None,
+    persistence_client: Any = None,
     database_probe_client: Any = None,
+    owns_probe_client: bool = False,
 ) -> HealthRegistry:
     """Build the default ordered registry for the running configuration.
 
     Components:
     1. ``configuration`` — validated settings (frozen model, fully revalidated).
-    2. ``database`` — minimal Supabase read via a dedicated probe client whose
-       transport timeout is aligned with ``readiness_database_timeout_ms``.
-    3. ``provider`` — provider keys/client path, bounded by
+    2. ``auth`` — the REAL authentication surface used by the routes exists.
+    3. ``database`` — minimal Supabase read via a dedicated probe client whose
+       transport timeout is aligned with ``readiness_database_timeout_ms``;
+       never a substitute for the real surfaces.
+    4. ``persistence`` — the REAL persistence surface used by admission and
+       history exists.
+    5. ``provider`` — provider keys/client path, bounded by
        ``readiness_provider_timeout_ms``.
-    4. ``embeddings`` — only when ``embeddings_retrieval_enabled`` is true.
+    6. ``embeddings`` — only when ``embeddings_retrieval_enabled`` is true.
 
     ``lifespan`` is appended by the application at request time because it
-    observes ``app.state``.
+    observes ``app.state``. When ``owns_probe_client`` is true the registry
+    (through ``DatabaseCheck.aclose``) closes the probe client after draining
+    any in-flight probe.
     """
     registry = HealthRegistry()
     registry.add(
         ConfigurationCheck(settings)
     )
     registry.add(
+        AuthClientCheck(auth_client)
+    )
+    registry.add(
         DatabaseCheck(
             database_probe_client,
             timeout_seconds=settings.readiness_database_timeout_ms / 1000.0,
+            owns_client=owns_probe_client,
         )
+    )
+    registry.add(
+        PersistenceClientCheck(persistence_client)
     )
     registry.add(
         ProviderCheck(

--- a/backend/health.py
+++ b/backend/health.py
@@ -1,0 +1,315 @@
+"""Readiness checks for the Katherine Bot backend.
+
+Semantics
+=========
+
+* ``/live`` (see ``backend.main``) proves only process/event-loop vitality and
+  never touches dependencies.
+* ``/ready`` aggregates small, typed checks over the critical dependencies an
+  instance needs to accept nominal traffic: valid configuration, minimal
+  database access, provider path availability, resources of the enabled
+  feature mode, and a completed lifespan.
+
+Check contract
+==============
+
+Each check implements :class:`ReadinessCheck` and is wrapped by
+:class:`HealthRegistry` with an explicit per-check timeout. Checks never
+execute a full generation, never include user content, and never return raw
+exception text. A failed or timed-out check produces a sanitized
+``unavailable`` result with no payload details.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Mapping, Protocol
+
+from .observability import (
+    EVENT_READINESS_CHECK_FAILED,
+    emit_event,
+)
+from .settings import Settings
+
+logger = logging.getLogger(__name__)
+
+#: Fallback timeout for checks that do not declare their own.
+DEFAULT_CHECK_TIMEOUT_SECONDS = 1.0
+
+
+class CheckStatus(str, Enum):
+    """Stable, sanitized readiness status values."""
+
+    ok = "ok"
+    unavailable = "unavailable"
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Result of one readiness check (name + sanitized status only)."""
+
+    name: str
+    status: CheckStatus
+
+
+class CheckFailure(Exception):
+    """Internal signal that a check did not pass (never rendered raw)."""
+
+
+class ReadinessCheck(Protocol):
+    """A single, cheap readiness check."""
+
+    name: str
+    timeout_seconds: float
+
+    async def run(self) -> None:  # pragma: no cover - protocol
+        """Return ``None`` when healthy; raise ``CheckFailure`` otherwise."""
+        ...
+
+
+@dataclass
+class HealthRegistry:
+    """Ordered registry of readiness checks with per-check timeouts.
+
+    Order is deterministic: insertion order, which the default builder
+    fixes as ``configuration``, ``database``, ``provider``, then
+    ``embeddings`` (only when the archival feature is enabled).
+    """
+
+    checks: Mapping[str, ReadinessCheck] = field(default_factory=dict)
+
+    def names(self) -> tuple[str, ...]:
+        return tuple(self.checks)
+
+    def add(self, check: ReadinessCheck) -> None:
+        """Register one check (idempotent by name)."""
+        self.checks[check.name] = check
+
+    async def run_all(self) -> list[CheckResult]:
+        """Run every check in order with its own explicit timeout.
+
+        A check that raises, times out, or never completes becomes
+        ``unavailable``. Raw exception text is never propagated: callers only
+        see names and statuses. A ``readiness_check_failed`` event is emitted
+        per failing component with the sanitized component name.
+        """
+        results: list[CheckResult] = []
+        for name, check in self.checks.items():
+            timeout = getattr(check, "timeout_seconds", DEFAULT_CHECK_TIMEOUT_SECONDS)
+            try:
+                await asyncio.wait_for(check.run(), timeout=timeout)
+                results.append(CheckResult(name, CheckStatus.ok))
+            except asyncio.CancelledError:
+                # Cancellation of the ready request must propagate, but the
+                # check itself must not leak.
+                raise
+            except Exception:
+                emit_event(
+                    logger,
+                    EVENT_READINESS_CHECK_FAILED,
+                    level=logging.ERROR,
+                    component=name,
+                )
+                results.append(CheckResult(name, CheckStatus.unavailable))
+        return results
+
+
+# ─── Concrete checks ────────────────────────────────────────────────────────
+
+
+class ConfigurationCheck:
+    """Validates that the running settings are still valid (no I/O).
+
+    Settings are fully validated at construction; this check re-runs the
+    cheap cross-field validation and guards against a missing or mutated
+    settings reference.
+    """
+
+    name = "configuration"
+    timeout_seconds = DEFAULT_CHECK_TIMEOUT_SECONDS
+
+    def __init__(self, settings: Settings | None) -> None:
+        self._settings = settings
+
+    async def run(self) -> None:
+        if self._settings is None:
+            raise CheckFailure()
+        try:
+            self._settings.ensure_valid()
+        except Exception:
+            raise CheckFailure() from None
+
+
+class DatabaseCheck:
+    """Minimal database/Supabase access check.
+
+    The default implementation performs one cheap read (limit 1) against the
+    core ``profiles`` table using the application's own client, bounded by an
+    explicit timeout. It never touches user data: no rows are read into
+    memory beyond the transport-level response and no content is logged.
+    """
+
+    name = "database"
+
+    def __init__(self, client: Any, timeout_seconds: float) -> None:
+        self._client = client
+        self.timeout_seconds = timeout_seconds
+
+    async def run(self) -> None:
+        if self._client is None:
+            raise CheckFailure()
+        try:
+            response = await asyncio.to_thread(self._probe)
+        except Exception:
+            raise CheckFailure() from None
+        if response is None:
+            raise CheckFailure()
+
+    def _probe(self) -> Any:
+        result = self._client.table("profiles").select("user_id").limit(1).execute()
+        if result is None:
+            raise CheckFailure()
+        if getattr(result, "error", None):
+            raise CheckFailure()
+        return result
+
+
+class ProviderCheck:
+    """Provider path availability check (configuration-level, no generation).
+
+    Verifies that the Groq manager holds validated keys and is ready to build
+    clients. It deliberately never runs a completion, never sends a request,
+    and never loads models. Deployments that want a real network probe must
+    inject their own check with an explicit, documented timeout.
+    """
+
+    name = "provider"
+
+    def __init__(self, groq_manager: Any, timeout_seconds: float) -> None:
+        self._groq_manager = groq_manager
+        self.timeout_seconds = timeout_seconds
+
+    async def run(self) -> None:
+        if self._groq_manager is None:
+            raise CheckFailure()
+        try:
+            configured = await asyncio.to_thread(self._groq_manager.is_configured)
+        except Exception:
+            raise CheckFailure() from None
+        if not configured:
+            raise CheckFailure()
+
+
+class EmbeddingsCheck:
+    """Checks that embeddings are available when the feature mode requires them.
+
+    Only registered when ``archival_extraction_enabled`` is true. The model is
+    loaded once during startup; this check only verifies the loaded resource
+    exists and never loads a model by itself.
+    """
+
+    name = "embeddings"
+    timeout_seconds = DEFAULT_CHECK_TIMEOUT_SECONDS
+
+    def __init__(self, memory_manager: Any) -> None:
+        self._memory_manager = memory_manager
+
+    async def run(self) -> None:
+        if self._memory_manager is None:
+            raise CheckFailure()
+        if getattr(self._memory_manager, "embedding_model", None) is None:
+            raise CheckFailure()
+
+
+class LifespanCheck:
+    """Checks that the application lifespan has completed startup.
+
+    The provider is a callable returning the current ``lifespan_started``
+    flag from ``app.state``, so the check always observes the live state.
+    """
+
+    name = "lifespan"
+    timeout_seconds = DEFAULT_CHECK_TIMEOUT_SECONDS
+
+    def __init__(self, state_provider: Callable[[], bool]) -> None:
+        self._state_provider = state_provider
+
+    async def run(self) -> None:
+        try:
+            started = bool(self._state_provider())
+        except Exception:
+            raise CheckFailure() from None
+        if not started:
+            raise CheckFailure()
+
+
+# ─── Default registry builder ───────────────────────────────────────────────
+
+
+def build_health_registry(
+    settings: Settings,
+    engine: Any,
+    auth_client: Any,
+) -> HealthRegistry:
+    """Build the default ordered registry for the running configuration.
+
+    Components:
+    1. ``configuration`` — validated settings.
+    2. ``database`` — minimal Supabase read, bounded by
+       ``readiness_database_timeout_ms``.
+    3. ``provider`` — provider keys/client path, bounded by
+       ``readiness_provider_timeout_ms``.
+    4. ``embeddings`` — only when ``archival_extraction_enabled`` is true.
+
+    ``lifespan`` is appended by the application at request time because it
+    observes ``app.state``.
+    """
+    registry = HealthRegistry()
+    registry.add(
+        ConfigurationCheck(settings)
+    )
+    registry.add(
+        DatabaseCheck(
+            auth_client,
+            timeout_seconds=settings.readiness_database_timeout_ms / 1000.0,
+        )
+    )
+    registry.add(
+        ProviderCheck(
+            engine.groq_manager,
+            timeout_seconds=settings.readiness_provider_timeout_ms / 1000.0,
+        )
+    )
+    if settings.archival_extraction_enabled:
+        registry.add(EmbeddingsCheck(engine.memory_manager))
+    return registry
+
+
+def build_ready_response(
+    results: list[CheckResult],
+    lifespan_started: bool,
+) -> tuple[int, dict]:
+    """Aggregate check results into the deterministic readiness response.
+
+    Returns ``(http_status, body)``. The body schema is stable:
+
+    .. code-block:: json
+
+        {"status": "ready", "components": {"configuration": "ok", ...}}
+
+    Component order is deterministic. Only sanitized status values are
+    included; no URLs, keys, names, counts, or exception text.
+    """
+    components: dict[str, str] = {}
+    for result in results:
+        components[result.name] = result.status.value
+    components["lifespan"] = (
+        CheckStatus.ok.value if lifespan_started else CheckStatus.unavailable.value
+    )
+    ready = all(status == CheckStatus.ok.value for status in components.values())
+    if ready:
+        return 200, {"status": "ready", "components": components}
+    return 503, {"status": "not_ready", "components": components}

--- a/backend/main.py
+++ b/backend/main.py
@@ -102,11 +102,15 @@ security = HTTPBearer(auto_error=False)
 def get_dependencies(request: Request) -> ApplicationDependencies:
     """Resolve the application dependency container from ``app.state``.
 
-    Returns 503 when the lifespan has not completed startup, so no endpoint
-    can run against a partially initialized application.
+    Returns 503 when the lifespan has not completed startup OR is no longer
+    active, so no endpoint can run against a partially initialized
+    application or a composition whose owned resources were already closed
+    (injected dependencies remain in ``app.state`` after shutdown, but routes
+    still refuse to operate outside the lifespan).
     """
     deps = getattr(request.app.state, "dependencies", None)
-    if deps is None:
+    lifespan_started = bool(getattr(request.app.state, "lifespan_started", False))
+    if deps is None or not lifespan_started:
         raise HTTPException(
             status_code=503,
             detail={"code": "service_unavailable", "message": "Service unavailable."},
@@ -470,10 +474,14 @@ def _admission_unavailable_error() -> HTTPException:
 async def _lifespan(app: FastAPI):
     """Start and stop application resources.
 
-    Startup: build owned resources when none were injected, store the
-    completed container, and only then mark startup as complete.
-    Shutdown: close owned resources, keep going past individual failures,
-    and record shutdown completion (idempotent).
+    Startup: build a fresh owned composition when none is present (injected
+    dependencies keep their ownership with the caller), store the completed
+    container, and only then mark startup as complete.
+    Shutdown: close owned resources, keep going past individual failures, and
+    drop the owned composition so a second lifespan cycle builds fresh
+    resources instead of reusing already-closed ones. Injected dependencies
+    are never closed and are left in ``app.state`` for the caller, but routes
+    refuse to operate once the lifespan is no longer active.
     """
     if app.state.dependencies is None:
         try:
@@ -488,6 +496,7 @@ async def _lifespan(app: FastAPI):
             raise
         app.state.dependencies = dependencies
         app.state.owned_resources = owned
+        app.state.dependencies_owned = True
     app.state.lifespan_started = True
     try:
         yield
@@ -495,6 +504,12 @@ async def _lifespan(app: FastAPI):
         app.state.lifespan_started = False
         await shutdown_dependencies(app.state.owned_resources)
         app.state.owned_resources = ()
+        if app.state.dependencies_owned:
+            # The owned composition is finished; drop it so the next lifespan
+            # cycle builds a new one with fresh resources. Injected
+            # dependencies (dependencies_owned False) stay with the caller.
+            app.state.dependencies = None
+            app.state.dependencies_owned = False
         app.state.shutdown_completed = True
 
 
@@ -536,6 +551,9 @@ def create_app(
 
     app.state.settings = settings
     app.state.dependencies = dependencies
+    # Only the lifespan marks a composition it builds as owned; injected
+    # dependencies belong to the caller and are never closed.
+    app.state.dependencies_owned = False
     app.state.lifespan_started = dependencies is not None
     app.state.owned_resources = ()
     app.state.shutdown_completed = False

--- a/backend/main.py
+++ b/backend/main.py
@@ -26,6 +26,7 @@ Health semantics
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
 from contextlib import asynccontextmanager
@@ -54,6 +55,7 @@ from .admission import (
     AdmissionUnavailable,
     build_admission_request,
     compute_turn_correlation,
+    compute_user_reference,
     reserve_admission_sync,
     resolve_network_identity,
 )
@@ -112,18 +114,54 @@ def get_dependencies(request: Request) -> ApplicationDependencies:
     return deps
 
 
+def _duration_ms(started_at: float) -> float:
+    """Render a monotonic elapsed time in milliseconds."""
+    return (time.monotonic() - started_at) * 1000
+
+
+async def get_turn_correlation(request: Request) -> Optional[str]:
+    """Best-effort sanitized correlation reference for the current request.
+
+    Parses the JSON body to extract the request identifier and computes the
+    HMAC correlation under the dedicated turn-correlation domain. This lets
+    auth events that belong to a turn carry the same correlation as the turn
+    events. Never logs raw identifiers; returns ``None`` when the body is
+    unavailable or invalid (for example on pre-validation auth failures).
+    """
+    deps = getattr(request.app.state, "dependencies", None)
+    if deps is None or getattr(deps, "admission_config", None) is None:
+        return None
+    try:
+        body = json.loads(await request.body())
+        request_id = body.get("request_id") if isinstance(body, dict) else None
+        if not request_id:
+            return None
+        return compute_turn_correlation(deps.admission_config, request_id)
+    except Exception:
+        return None
+
+
 def get_current_user(
     request: Request,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    correlation: Optional[str] = Depends(get_turn_correlation),
 ):
     """Authenticate the bearer token against the server-side auth client.
 
     The authenticated identity is resolved per request and never stored in
-    the container or any global. The auth surface is the engine's Supabase
-    client (shared with admission and persistence), and only sanitized codes
-    are logged.
+    the container or any global. The auth surface is ``deps.auth_client``
+    (the injected auth dependency), and only sanitized codes, a monotonic
+    duration, and a non-reversible HMAC user reference are logged.
     """
+    started_at = time.monotonic()
     if not credentials:
+        emit_event(
+            logger,
+            EVENT_AUTH_FAILED,
+            code="missing_credentials",
+            duration_ms=_duration_ms(started_at),
+            correlation=correlation,
+        )
         raise HTTPException(
             status_code=401,
             detail="Not authenticated",
@@ -131,37 +169,90 @@ def get_current_user(
         )
     token = credentials.credentials
     deps = get_dependencies(request)
-    auth_client = deps.conversation_engine.memory_manager.supabase
+    auth_client = deps.auth_client
     try:
         if not auth_client:
-            emit_event(logger, EVENT_AUTH_FAILED, code="service_unavailable")
+            emit_event(
+                logger,
+                EVENT_AUTH_FAILED,
+                code="service_unavailable",
+                duration_ms=_duration_ms(started_at),
+                correlation=correlation,
+            )
             raise HTTPException(status_code=503, detail="Authentication service unavailable")
         auth_response = auth_client.auth.get_user(token)
         if not auth_response.user:
-            emit_event(logger, EVENT_AUTH_FAILED, code="invalid_token")
+            emit_event(
+                logger,
+                EVENT_AUTH_FAILED,
+                code="invalid_token",
+                duration_ms=_duration_ms(started_at),
+                correlation=correlation,
+            )
             raise HTTPException(
                 status_code=401,
                 detail="Authentication failed",
                 headers={"WWW-Authenticate": "Bearer"},
             )
-        emit_event(logger, EVENT_AUTH_COMPLETED, outcome="ok")
+        user_ref = None
+        try:
+            user_ref = compute_user_reference(
+                deps.admission_config, auth_response.user.id
+            )
+        except Exception:
+            # The identity itself is still valid; only the sanitized reference
+            # could not be derived, so the event is emitted without it.
+            user_ref = None
+        emit_event(
+            logger,
+            EVENT_AUTH_COMPLETED,
+            outcome="ok",
+            duration_ms=_duration_ms(started_at),
+            correlation=correlation,
+            user_ref=user_ref,
+        )
         return auth_response.user
     except HTTPException:
         raise
     except AuthApiError as exc:
         if exc.status in (400, 401, 403):
+            emit_event(
+                logger,
+                EVENT_AUTH_FAILED,
+                code="invalid_token",
+                duration_ms=_duration_ms(started_at),
+                correlation=correlation,
+            )
             raise HTTPException(
                 status_code=401,
                 detail="Authentication failed",
                 headers={"WWW-Authenticate": "Bearer"},
             )
-        emit_event(logger, EVENT_AUTH_FAILED, code="upstream_error")
+        emit_event(
+            logger,
+            EVENT_AUTH_FAILED,
+            code="upstream_error",
+            duration_ms=_duration_ms(started_at),
+            correlation=correlation,
+        )
         raise HTTPException(status_code=503, detail="Authentication service unavailable")
     except AuthRetryableError:
-        emit_event(logger, EVENT_AUTH_FAILED, code="transport_error")
+        emit_event(
+            logger,
+            EVENT_AUTH_FAILED,
+            code="transport_error",
+            duration_ms=_duration_ms(started_at),
+            correlation=correlation,
+        )
         raise HTTPException(status_code=503, detail="Authentication service unavailable")
     except Exception:
-        emit_event(logger, EVENT_AUTH_FAILED, code="unexpected")
+        emit_event(
+            logger,
+            EVENT_AUTH_FAILED,
+            code="unexpected",
+            duration_ms=_duration_ms(started_at),
+            correlation=correlation,
+        )
         raise HTTPException(status_code=503, detail="Authentication service unavailable")
 
 
@@ -511,6 +602,11 @@ async def chat_endpoint(
             request.headers.get("x-forwarded-for"),
             admission_config.trusted_proxy_networks,
         )
+        # Sanitized correlation reference for observability: HMAC-SHA256 of
+        # the canonical request id under the dedicated turn-correlation domain
+        # (never the raw request id, user id, message or any secret). Computed
+        # before admission so every event of the turn carries it.
+        correlation = compute_turn_correlation(admission_config, identity.request_id)
         admission_request = build_admission_request(
             user_id=user_id,
             request_identity=identity,
@@ -523,14 +619,10 @@ async def chat_endpoint(
             budget,
             turn_config.supabase_timeout,
             reserve_admission_sync,
-            engine.memory_manager.supabase,
+            deps.persistence_client,
             admission_request,
             allowlist_exceptions=(AdmissionUnavailable,),
         )
-        # Sanitized correlation reference for observability: HMAC-SHA256 of
-        # the canonical request id under the dedicated turn-correlation domain
-        # (never the raw request id, user id, message or any secret).
-        correlation = compute_turn_correlation(admission_config, identity.request_id)
         if admission_result.decision == ADMITTED:
             mode = TurnMode.normal
             logger.info("event=admission_admitted correlation=%s", correlation)
@@ -543,7 +635,12 @@ async def chat_endpoint(
         else:
             logger.info("event=admission_rejected code=%s", admission_result.decision)
             http_exc = _map_admission_rejection(admission_result)
-            emit_event(logger, EVENT_HTTP_RESULT, code=http_exc.status_code)
+            emit_event(
+                logger,
+                EVENT_HTTP_RESULT,
+                code=http_exc.status_code,
+                correlation=correlation,
+            )
             raise http_exc
 
         result = await engine.process_turn(
@@ -563,7 +660,12 @@ async def chat_endpoint(
             mode=mode.value,
             correlation=correlation,
         )
-        emit_event(logger, EVENT_HTTP_RESULT, code=200)
+        emit_event(
+            logger,
+            EVENT_HTTP_RESULT,
+            code=200,
+            correlation=correlation,
+        )
         # The public DTO exposes exactly response + emotion_state; revisions,
         # outbox refs, internal IDs and CommittedTurn are never exposed.
         return ChatResponse(response=result.response, emotion_state=result.emotion_state)
@@ -574,12 +676,22 @@ async def chat_endpoint(
         raise
     except AdmissionUnavailable:
         emit_event(logger, EVENT_TURN_FAILED, code="admission_unavailable")
-        emit_event(logger, EVENT_HTTP_RESULT, code=503)
+        emit_event(
+            logger,
+            EVENT_HTTP_RESULT,
+            code=503,
+            correlation=correlation,
+        )
         raise _admission_unavailable_error()
     except ConflictError as exc:
         emit_event(logger, EVENT_REQUEST_CONFLICT, code=exc.code, correlation=correlation)
         http_exc = _map_process_turn_conflict(exc)
-        emit_event(logger, EVENT_HTTP_RESULT, code=http_exc.status_code)
+        emit_event(
+            logger,
+            EVENT_HTTP_RESULT,
+            code=http_exc.status_code,
+            correlation=correlation,
+        )
         raise http_exc
     except (DeadlineExceeded, TurnExecutionError, GroqPoolExhaustedError,
             GroqRequestError, StatePersistenceError, PersistenceError) as exc:
@@ -593,7 +705,12 @@ async def chat_endpoint(
             code=code,
             correlation=correlation,
         )
-        emit_event(logger, EVENT_HTTP_RESULT, code=http_exc.status_code)
+        emit_event(
+            logger,
+            EVENT_HTTP_RESULT,
+            code=http_exc.status_code,
+            correlation=correlation,
+        )
         raise http_exc
     except Exception:
         # Sanitize logging: avoid logging raw exceptions that might contain
@@ -605,7 +722,12 @@ async def chat_endpoint(
             code=TurnErrorCode.internal_error.value,
             correlation=correlation,
         )
-        emit_event(logger, EVENT_HTTP_RESULT, code=500)
+        emit_event(
+            logger,
+            EVENT_HTTP_RESULT,
+            code=500,
+            correlation=correlation,
+        )
         raise HTTPException(
             status_code=500,
             detail={"code": TurnErrorCode.internal_error.value, "message": "Internal server error."},
@@ -616,7 +738,7 @@ def get_history(request: Request, current_user=Depends(get_current_user)):
     deps = get_dependencies(request)
     user_id = current_user.id
     try:
-        supabase = deps.conversation_engine.memory_manager.supabase
+        supabase = deps.persistence_client
         if not supabase:
             return []
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,20 +1,45 @@
+"""HTTP application factory for the Katherine Bot backend.
+
+Lifecycle
+=========
+
+* Importing this module has no side effects beyond declaring the FastAPI
+  application (``app = create_app()``): no sockets, no Groq/Supabase clients,
+  no embedding models, no threads, no environment reads outside
+  ``Settings.from_env()``.
+* Heavy resources (engine, providers, persistence) are built inside the
+  lifespan by :func:`backend.dependencies.build_default_dependencies` and
+  owned by the application.
+* ``create_app(settings=..., dependencies=...)`` accepts injected doubles so
+  tests run without Groq, Supabase, embeddings, or network.
+
+Health semantics
+================
+
+* ``GET /live``  — process/event-loop vitality only; never touches providers.
+* ``GET /ready`` — real checks over critical dependencies with explicit
+  timeouts; 503 when any critical component is unavailable.
+* ``GET /health`` — legacy alias kept for compatibility; asserts only that
+  the process is alive, never readiness.
+"""
+
+from __future__ import annotations
+
 import asyncio
-from fastapi import FastAPI, HTTPException, Depends, Request
-from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-
 import logging
-from supabase_auth.errors import AuthApiError, AuthRetryableError
-logger = logging.getLogger(__name__)
+import time
+from contextlib import asynccontextmanager
+from typing import Optional
 
-
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, ConfigDict, StrictStr, field_validator
 from pydantic_core import PydanticCustomError
-from typing import Optional
-import uvicorn
-import os
-from dotenv import load_dotenv
+from supabase_auth.errors import AuthApiError, AuthRetryableError
+
 from .admission import (
     ADMITTED,
     APPLICATION_RATE_LIMITED,
@@ -26,7 +51,6 @@ from .admission import (
     USER_DAILY_UNIT_QUOTA_EXCEEDED,
     USER_RATE_LIMITED,
     AdmissionResult,
-    AdmissionRuntimeConfig,
     AdmissionUnavailable,
     build_admission_request,
     compute_turn_correlation,
@@ -35,103 +59,114 @@ from .admission import (
 )
 from .admission_contracts import AdmissionError, RequestIdentity, validate_new_message
 from .atomic_turn_commit import ConflictError, PersistenceError
-from .chat_engine import ChatConversationEngine
-from .memory import StatePersistenceError
+from .dependencies import (
+    ApplicationDependencies,
+    build_default_dependencies,
+    shutdown_dependencies,
+)
 from .emotion_presentation import EmotionStateResponse
+from .groq_manager import GroqPoolExhaustedError, GroqRequestError
+from .health import build_ready_response
+from .memory import StatePersistenceError
+from .observability import (
+    EVENT_APP_STARTUP_FAILED,
+    EVENT_AUTH_COMPLETED,
+    EVENT_AUTH_FAILED,
+    EVENT_HTTP_RESULT,
+    EVENT_REQUEST_CONFLICT,
+    EVENT_TURN_COMPLETED,
+    EVENT_TURN_FAILED,
+    emit_event,
+)
 from .process_turn import TurnMode
+from .runtime_containment import validate_worker_configuration
+from .settings import Settings, SettingsConfigurationError
 from .turn_execution import (
-    TurnExecutionConfig,
-    TurnExecutionError,
-    TurnErrorCode,
     DeadlineExceeded,
+    TurnErrorCode,
+    TurnExecutionError,
     create_budget,
     run_blocking_write,
 )
-from .groq_manager import GroqPoolExhaustedError, GroqRequestError
 
-load_dotenv()
-
-from fastapi.middleware.cors import CORSMiddleware
-
-app = FastAPI(title="SoulMate API", description="Backend for the Emotional Companion Bot")
-
-# Comma-separated origins allowed by CORS. Default preserves the historical
-# development origin; production sets its own public frontend origin(s).
-# Invalid configuration (empty or wildcard) fails fast at startup without
-# logging the raw value.
-from .cors_policy import parse_cors_allowed_origins  # noqa: E402
-
-try:
-    cors_allowed_origins = list(parse_cors_allowed_origins(os.getenv("CORS_ALLOWED_ORIGINS")))
-except ValueError:
-    raise RuntimeError("Invalid CORS_ALLOWED_ORIGINS configuration") from None
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=cors_allowed_origins,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
-# Validate runtime containment before initialising the engine.
-# This runs at module load time, so multi-worker configurations fail early.
-from .runtime_containment import (
-    validate_worker_configuration,
-    parse_archival_extraction_flag,
-)
-
-validate_worker_configuration()
-
-# Parse archival extraction flag from environment (default: disabled)
-_archival_extraction_enabled = parse_archival_extraction_flag(
-    os.environ.get("ARCHIVAL_EXTRACTION_ENABLED")
-)
-
-# Parse turn execution and admission config from environment. Admission has no
-# fallback secret and fails closed during application initialisation.
-_turn_config = TurnExecutionConfig.from_env()
-_admission_config = AdmissionRuntimeConfig.from_env()
-
-# Initialize Engine with containment-aware configuration
-engine = ChatConversationEngine(
-    archival_extraction_enabled=_archival_extraction_enabled,
-    turn_config=_turn_config,
-)
-
+logger = logging.getLogger(__name__)
 
 security = HTTPBearer(auto_error=False)
 
-def get_current_user(credentials: Optional[HTTPAuthorizationCredentials] = Depends(security)):
-    if not credentials:
-        raise HTTPException(status_code=401, detail="Not authenticated", headers={"WWW-Authenticate": "Bearer"})
-    token = credentials.credentials
-    try:
-        if not engine.memory_manager.supabase:
-            raise HTTPException(status_code=503, detail="Authentication service unavailable")
 
-        auth_response = engine.memory_manager.supabase.auth.get_user(token)
+# ─── Dependency access from app.state ───────────────────────────────────────
+
+
+def get_dependencies(request: Request) -> ApplicationDependencies:
+    """Resolve the application dependency container from ``app.state``.
+
+    Returns 503 when the lifespan has not completed startup, so no endpoint
+    can run against a partially initialized application.
+    """
+    deps = getattr(request.app.state, "dependencies", None)
+    if deps is None:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": "service_unavailable", "message": "Service unavailable."},
+        )
+    return deps
+
+
+def get_current_user(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    """Authenticate the bearer token against the server-side auth client.
+
+    The authenticated identity is resolved per request and never stored in
+    the container or any global. The auth surface is the engine's Supabase
+    client (shared with admission and persistence), and only sanitized codes
+    are logged.
+    """
+    if not credentials:
+        raise HTTPException(
+            status_code=401,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    token = credentials.credentials
+    deps = get_dependencies(request)
+    auth_client = deps.conversation_engine.memory_manager.supabase
+    try:
+        if not auth_client:
+            emit_event(logger, EVENT_AUTH_FAILED, code="service_unavailable")
+            raise HTTPException(status_code=503, detail="Authentication service unavailable")
+        auth_response = auth_client.auth.get_user(token)
         if not auth_response.user:
+            emit_event(logger, EVENT_AUTH_FAILED, code="invalid_token")
             raise HTTPException(
                 status_code=401,
                 detail="Authentication failed",
                 headers={"WWW-Authenticate": "Bearer"},
             )
+        emit_event(logger, EVENT_AUTH_COMPLETED, outcome="ok")
         return auth_response.user
     except HTTPException:
         raise
-    except AuthApiError as e:
-        # e.status is present in AuthApiError
-        if e.status in (400, 401, 403):
-            raise HTTPException(status_code=401, detail="Authentication failed", headers={"WWW-Authenticate": "Bearer"})
-        logger.error("Authentication service failure: Upstream AuthApiError")
+    except AuthApiError as exc:
+        if exc.status in (400, 401, 403):
+            raise HTTPException(
+                status_code=401,
+                detail="Authentication failed",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        emit_event(logger, EVENT_AUTH_FAILED, code="upstream_error")
         raise HTTPException(status_code=503, detail="Authentication service unavailable")
     except AuthRetryableError:
-        logger.error("Authentication service failure: Transport/Fetch error")
+        emit_event(logger, EVENT_AUTH_FAILED, code="transport_error")
         raise HTTPException(status_code=503, detail="Authentication service unavailable")
     except Exception:
-        logger.error("Authentication service failure: Unexpected error")
+        emit_event(logger, EVENT_AUTH_FAILED, code="unexpected")
         raise HTTPException(status_code=503, detail="Authentication service unavailable")
+
+
+# ─── Request/response contracts ─────────────────────────────────────────────
+
 
 class ChatInput(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -155,6 +190,7 @@ class ChatInput(BaseModel):
             raise PydanticCustomError(exc.code, exc.code)
         return value
 
+
 class ChatResponse(BaseModel):
     response: str
     emotion_state: EmotionStateResponse
@@ -168,28 +204,8 @@ _VALIDATION_MESSAGES = {
 }
 
 
-@app.exception_handler(RequestValidationError)
-async def _sanitise_request_validation_error(
-    _request: Request,
-    exc: RequestValidationError,
-) -> JSONResponse:
-    error_types = {item.get("type") for item in exc.errors()}
-    code = "invalid_request"
-    for candidate in (
-        "invalid_request_id",
-        "message_too_long",
-        "message_budget_exceeded",
-    ):
-        if candidate in error_types:
-            code = candidate
-            break
-    return JSONResponse(
-        status_code=422,
-        content={"detail": {"code": code, "message": _VALIDATION_MESSAGES[code]}},
-    )
+# ─── Error mapping (public contract preserved) ──────────────────────────────
 
-
-# ─── Error mapping ───────────────────────────────────────────────────────────
 
 def _turn_code_to_http(code: TurnErrorCode) -> int:
     """Map a ``TurnErrorCode`` to an HTTP status code.
@@ -248,8 +264,8 @@ def _map_turn_error(exc: Exception) -> HTTPException:
         )
 
     if isinstance(exc, GroqPoolExhaustedError):
-        # Map the failure code if available
         from .groq_manager import provider_failure_to_turn_code
+
         turn_code = (
             provider_failure_to_turn_code(exc.failure_code) if exc.failure_code
             else TurnErrorCode.provider_unavailable
@@ -262,23 +278,30 @@ def _map_turn_error(exc: Exception) -> HTTPException:
     if isinstance(exc, GroqRequestError):
         return HTTPException(
             status_code=503,
-            detail={"code": TurnErrorCode.provider_unavailable.value, "message": "Provider request failed."},
+            detail={
+                "code": TurnErrorCode.provider_unavailable.value,
+                "message": "Provider request failed.",
+            },
         )
 
     if isinstance(exc, StatePersistenceError):
         return HTTPException(
             status_code=503,
-            detail={"code": TurnErrorCode.persistence_unavailable.value, "message": "Persistence service unavailable."},
+            detail={
+                "code": TurnErrorCode.persistence_unavailable.value,
+                "message": "Persistence service unavailable.",
+            },
         )
 
     if isinstance(exc, PersistenceError):
-        # Unexpected persistence failure: sanitized, never PostgreSQL messages.
         return HTTPException(
             status_code=503,
-            detail={"code": TurnErrorCode.persistence_unavailable.value, "message": "Persistence service unavailable."},
+            detail={
+                "code": TurnErrorCode.persistence_unavailable.value,
+                "message": "Persistence service unavailable.",
+            },
         )
 
-    # Unknown/unexpected — sanitize to generic 500
     return HTTPException(
         status_code=500,
         detail={"code": TurnErrorCode.internal_error.value, "message": "Internal server error."},
@@ -349,33 +372,156 @@ def _admission_unavailable_error() -> HTTPException:
     )
 
 
-@app.post("/chat", response_model=ChatResponse)
+# ─── Lifespan ───────────────────────────────────────────────────────────────
+
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    """Start and stop application resources.
+
+    Startup: build owned resources when none were injected, store the
+    completed container, and only then mark startup as complete.
+    Shutdown: close owned resources, keep going past individual failures,
+    and record shutdown completion (idempotent).
+    """
+    if app.state.dependencies is None:
+        try:
+            dependencies, owned = build_default_dependencies(app.state.settings)
+        except Exception:
+            # Partial startup: drain anything already recorded as owned, then
+            # fail. Resources created inside build_default_dependencies are
+            # cleaned by the builder itself.
+            await shutdown_dependencies(app.state.owned_resources)
+            app.state.owned_resources = ()
+            emit_event(logger, EVENT_APP_STARTUP_FAILED, level=logging.ERROR)
+            raise
+        app.state.dependencies = dependencies
+        app.state.owned_resources = owned
+    app.state.lifespan_started = True
+    try:
+        yield
+    finally:
+        app.state.lifespan_started = False
+        await shutdown_dependencies(app.state.owned_resources)
+        app.state.owned_resources = ()
+        app.state.shutdown_completed = True
+
+
+# ─── Application factory ────────────────────────────────────────────────────
+
+
+def create_app(
+    settings: Optional[Settings] = None,
+    dependencies: Optional[ApplicationDependencies] = None,
+) -> FastAPI:
+    """Build and configure the FastAPI application.
+
+    Args:
+        settings: Validated settings. Defaults to ``Settings.from_env()``.
+        dependencies: Fully composed container. When provided, the caller
+            keeps ownership of every resource inside it; the application
+            performs no startup construction and marks the lifespan as
+            already complete. When omitted, the lifespan builds the default
+            composition from settings (owned by the application).
+
+    The factory never constructs Groq/Supabase/embedding resources: heavy
+    construction happens only inside the lifespan.
+    """
+    if settings is None:
+        try:
+            settings = Settings.from_env()
+        except SettingsConfigurationError:
+            emit_event(logger, EVENT_APP_STARTUP_FAILED, reason="invalid_settings")
+            raise
+
+    # Single-worker containment (fail early for multi-worker configs).
+    validate_worker_configuration()
+
+    app = FastAPI(
+        title="SoulMate API",
+        description="Backend for the Emotional Companion Bot",
+        lifespan=_lifespan,
+    )
+
+    app.state.settings = settings
+    app.state.dependencies = dependencies
+    app.state.lifespan_started = dependencies is not None
+    app.state.owned_resources = ()
+    app.state.shutdown_completed = False
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=list(settings.cors_allowed_origins),
+        allow_credentials=settings.cors_allow_credentials,
+        allow_methods=["GET", "POST", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type"],
+    )
+
+    @app.exception_handler(RequestValidationError)
+    async def _sanitise_request_validation_error(
+        _request: Request,
+        exc: RequestValidationError,
+    ) -> JSONResponse:
+        error_types = {item.get("type") for item in exc.errors()}
+        code = "invalid_request"
+        for candidate in (
+            "invalid_request_id",
+            "message_too_long",
+            "message_budget_exceeded",
+        ):
+            if candidate in error_types:
+                code = candidate
+                break
+        return JSONResponse(
+            status_code=422,
+            content={"detail": {"code": code, "message": _VALIDATION_MESSAGES[code]}},
+        )
+
+    # ─── Routes (module-level handlers registered here) ───────────────────
+    app.post("/chat", response_model=ChatResponse)(chat_endpoint)
+    app.get("/history")(get_history)
+    app.get("/live")(live_endpoint)
+    app.get("/ready")(ready_endpoint)
+    app.get("/health")(health_endpoint)
+
+    return app
+
+
+# ─── Route handlers (module-level for injection and direct testing) ─────────
+
+
 async def chat_endpoint(
     input_data: ChatInput,
     request: Request,
-    current_user = Depends(get_current_user)
+    current_user=Depends(get_current_user),
 ):
+    deps = get_dependencies(request)
+    engine = deps.conversation_engine
+    turn_config = deps.turn_config
+    admission_config = deps.admission_config
+    started_at = time.monotonic()
+    correlation = None
     try:
-        budget = create_budget(_turn_config)
+        budget = create_budget(turn_config)
         user_id = getattr(current_user, "id", None)
         identity = RequestIdentity(input_data.request_id)
         peer_host = request.client.host if request.client is not None else None
         network_identity = resolve_network_identity(
             peer_host,
             request.headers.get("x-forwarded-for"),
-            _admission_config.trusted_proxy_networks,
+            admission_config.trusted_proxy_networks,
         )
         admission_request = build_admission_request(
             user_id=user_id,
             request_identity=identity,
             message=input_data.message,
             network_identity=network_identity,
-            config=_admission_config,
+            config=admission_config,
         )
         admission_result = await run_blocking_write(
             "reserve_admission",
             budget,
-            _turn_config.supabase_timeout,
+            turn_config.supabase_timeout,
             reserve_admission_sync,
             engine.memory_manager.supabase,
             admission_request,
@@ -384,7 +530,7 @@ async def chat_endpoint(
         # Sanitized correlation reference for observability: HMAC-SHA256 of
         # the canonical request id under the dedicated turn-correlation domain
         # (never the raw request id, user id, message or any secret).
-        correlation = compute_turn_correlation(_admission_config, identity.request_id)
+        correlation = compute_turn_correlation(admission_config, identity.request_id)
         if admission_result.decision == ADMITTED:
             mode = TurnMode.normal
             logger.info("event=admission_admitted correlation=%s", correlation)
@@ -396,7 +542,9 @@ async def chat_endpoint(
             logger.info("event=admission_replay correlation=%s", correlation)
         else:
             logger.info("event=admission_rejected code=%s", admission_result.decision)
-            raise _map_admission_rejection(admission_result)
+            http_exc = _map_admission_rejection(admission_result)
+            emit_event(logger, EVENT_HTTP_RESULT, code=http_exc.status_code)
+            raise http_exc
 
         result = await engine.process_turn(
             user_id,
@@ -406,6 +554,16 @@ async def chat_endpoint(
             mode=mode,
             correlation=correlation,
         )
+        duration_ms = (time.monotonic() - started_at) * 1000
+        emit_event(
+            logger,
+            EVENT_TURN_COMPLETED,
+            code="ok",
+            duration_ms=duration_ms,
+            mode=mode.value,
+            correlation=correlation,
+        )
+        emit_event(logger, EVENT_HTTP_RESULT, code=200)
         # The public DTO exposes exactly response + emotion_state; revisions,
         # outbox refs, internal IDs and CommittedTurn are never exposed.
         return ChatResponse(response=result.response, emotion_state=result.emotion_state)
@@ -415,44 +573,112 @@ async def chat_endpoint(
     except HTTPException:
         raise
     except AdmissionUnavailable:
-        logger.error("event=admission_unavailable")
+        emit_event(logger, EVENT_TURN_FAILED, code="admission_unavailable")
+        emit_event(logger, EVENT_HTTP_RESULT, code=503)
         raise _admission_unavailable_error()
     except ConflictError as exc:
-        raise _map_process_turn_conflict(exc)
+        emit_event(logger, EVENT_REQUEST_CONFLICT, code=exc.code, correlation=correlation)
+        http_exc = _map_process_turn_conflict(exc)
+        emit_event(logger, EVENT_HTTP_RESULT, code=http_exc.status_code)
+        raise http_exc
     except (DeadlineExceeded, TurnExecutionError, GroqPoolExhaustedError,
             GroqRequestError, StatePersistenceError, PersistenceError) as exc:
-        raise _map_turn_error(exc)
+        http_exc = _map_turn_error(exc)
+        detail = http_exc.detail
+        code = detail.get("code") if isinstance(detail, dict) else "internal_error"
+        emit_event(
+            logger,
+            EVENT_TURN_FAILED,
+            level=logging.ERROR,
+            code=code,
+            correlation=correlation,
+        )
+        emit_event(logger, EVENT_HTTP_RESULT, code=http_exc.status_code)
+        raise http_exc
     except Exception:
-        # Sanitize logging: avoid logging raw exceptions that might contain secrets or tracebacks
-        logger.error("Event: Chat Turn Failure")
+        # Sanitize logging: avoid logging raw exceptions that might contain
+        # secrets or tracebacks.
+        emit_event(
+            logger,
+            EVENT_TURN_FAILED,
+            level=logging.ERROR,
+            code=TurnErrorCode.internal_error.value,
+            correlation=correlation,
+        )
+        emit_event(logger, EVENT_HTTP_RESULT, code=500)
         raise HTTPException(
             status_code=500,
             detail={"code": TurnErrorCode.internal_error.value, "message": "Internal server error."},
         )
 
-@app.get("/health")
-def health_check():
-    return {"status": "alive", "engine_status": "ready"}
 
-@app.get("/history")
-def get_history(current_user = Depends(get_current_user)):
+def get_history(request: Request, current_user=Depends(get_current_user)):
+    deps = get_dependencies(request)
     user_id = current_user.id
     try:
-        if not engine.memory_manager.supabase:
+        supabase = deps.conversation_engine.memory_manager.supabase
+        if not supabase:
             return []
-            
-        response = engine.memory_manager.supabase.table("chat_logs")\
+
+        response = supabase.table("chat_logs")\
             .select("*")\
             .eq("user_id", user_id)\
             .order("created_at", desc=True)\
             .limit(50)\
             .execute()
-            
+
         return response.data[::-1] if response.data else []
     except Exception:
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
+
+async def live_endpoint():
+    """Liveness: proves the process and event loop can respond.
+
+    Never touches providers, database, embeddings, or readiness state.
+    """
+    return JSONResponse(status_code=200, content={"status": "live"})
+
+
+async def ready_endpoint(request: Request):
+    """Readiness: checks critical dependencies with explicit timeouts.
+
+    Returns 200 only when every critical component for the currently
+    enabled mode is available and the lifespan completed startup;
+    503 otherwise. The response never includes URLs, keys, project
+    names, exception text, counts, or user identifiers.
+    """
+    deps = getattr(request.app.state, "dependencies", None)
+    if deps is None:
+        return JSONResponse(
+            status_code=503,
+            content={"status": "not_ready", "components": {}},
+        )
+    results = await deps.health_checks.run_all()
+    lifespan_started = bool(getattr(request.app.state, "lifespan_started", False))
+    status_code, body = build_ready_response(results, lifespan_started)
+    return JSONResponse(status_code=status_code, content=body)
+
+
+def health_endpoint():
+    """Legacy compatibility endpoint.
+
+    Documented as a process-alive alias: it never asserts readiness
+    (no database/provider checks run here). New consumers must use
+    ``/live`` and ``/ready``.
+    """
+    return {"status": "alive"}
+
+
+# Module-level application for Uvicorn targets (``backend.main:app``).
+# Only configuration and routing are built here; resources are created by
+# the lifespan when the server actually starts.
+app = create_app()
+
+
 if __name__ == "__main__":
     # Development entrypoint — NOT for production use.
     # Use ``python -m backend.serve`` for production.
+    import uvicorn
+
     uvicorn.run("backend.main:app", host="0.0.0.0", port=8000, reload=True)

--- a/backend/memory.py
+++ b/backend/memory.py
@@ -200,6 +200,7 @@ class MemoryManager:
         clock=time.time,
         supabase_factory: Optional[Callable[[], Optional[Client]]] = None,
         supabase_timeout: Optional[float] = None,
+        embeddings_enabled: bool = False,
     ):
         if supabase_factory is not None:
             self.supabase: Optional[Client] = supabase_factory()
@@ -210,9 +211,19 @@ class MemoryManager:
                 factory = lambda: _default_supabase_factory()
             self.supabase: Optional[Client] = factory()
 
-        try:
-            self.embedding_model = SentenceTransformer('all-MiniLM-L6-v2')
-        except Exception:
+        # Embeddings are an explicitly configured mode: the SentenceTransformer
+        # model is only constructed when vector retrieval is enabled. A
+        # disabled mode never loads the heavy resource; an enabled mode whose
+        # model fails to load surfaces as ``embedding_model is None`` and is
+        # reported honestly by the readiness ``embeddings`` check instead of
+        # silently degrading retrieval.
+        self.embeddings_enabled = bool(embeddings_enabled)
+        if self.embeddings_enabled:
+            try:
+                self.embedding_model = SentenceTransformer('all-MiniLM-L6-v2')
+            except Exception:
+                self.embedding_model = None
+        else:
             self.embedding_model = None
         self._clock = clock
 
@@ -553,6 +564,12 @@ class MemoryManager:
         supabase = getattr(self, 'supabase', None)
         embedding_model = getattr(self, 'embedding_model', None)
         if not supabase or not embedding_model:
+            if getattr(self, 'embeddings_enabled', False):
+                # The active mode requires vector retrieval; a missing model or
+                # store is a real failure, never a silent empty result. The
+                # readiness ``embeddings`` check blocks traffic in this state,
+                # and this guard makes the turn path fail honestly too.
+                raise ContextLoadError("Recuperação vetorial indisponível.")
             return []
 
         try:

--- a/backend/memory.py
+++ b/backend/memory.py
@@ -563,8 +563,9 @@ class MemoryManager:
         # Use getattr for resilience when MemoryManager is mocked in tests
         supabase = getattr(self, 'supabase', None)
         embedding_model = getattr(self, 'embedding_model', None)
+        enabled = bool(getattr(self, 'embeddings_enabled', False))
         if not supabase or not embedding_model:
-            if getattr(self, 'embeddings_enabled', False):
+            if enabled:
                 # The active mode requires vector retrieval; a missing model or
                 # store is a real failure, never a silent empty result. The
                 # readiness ``embeddings`` check blocks traffic in this state,
@@ -575,6 +576,11 @@ class MemoryManager:
         try:
             query_embedding = self.embedding_model.encode(query).tolist()
         except Exception:
+            if enabled:
+                # In the active mode an embedding failure is a real failure of
+                # the retrieval function, not "no memories". Never degrade
+                # silently.
+                raise ContextLoadError("Falha na geração do embedding.")
             return []
 
         params = {
@@ -584,24 +590,31 @@ class MemoryManager:
             "filter_user_id": user_id,
         }
 
-        # RPC call and response validation in a single protected block
+        # RPC call and response validation in a single protected block. A
+        # transport/RPC error or a structurally invalid response is a failure
+        # of the active retrieval mode; only a valid ``data=[]`` represents
+        # the real absence of memories.
         try:
             response = (
                 self.supabase
                 .rpc("match_memories", params)
                 .execute()
             )
-
-            if (
-                response is None
-                or not hasattr(response, "data")
-                or not isinstance(response.data, list)
-            ):
-                return []
-
-            documents = response.data
         except Exception:
+            if enabled:
+                raise ContextLoadError("Falha na busca vetorial de memórias.")
             return []
+
+        if (
+            response is None
+            or not hasattr(response, "data")
+            or not isinstance(response.data, list)
+        ):
+            if enabled:
+                raise ContextLoadError("Resposta da busca vetorial inválida.")
+            return []
+
+        documents = response.data
 
         entries: list[RetrievedMemory] = []
         for doc in documents:

--- a/backend/observability.py
+++ b/backend/observability.py
@@ -1,0 +1,181 @@
+"""Minimal, sanitized observability contract for the backend.
+
+This module defines constant event names and a single ``emit_event`` helper
+that renders structured log lines like::
+
+    event=turn_completed code=ok duration_ms=1234 correlation=<hmac>
+
+Guarantees:
+
+* Event names are constants from a closed registry (low cardinality).
+* Field names are allowlisted; forbidden names (``user_id``, ``message``,
+  ``response``, ``prompt``, ``memory``, ``token``, ``secret``, ...) are
+  rejected at the call site, so content can never reach a log by accident.
+* Values are restricted to ``str``/``int``/``float``/``bool``; string values
+  are scrubbed of control characters and collapsed whitespace to prevent log
+  injection.
+* No ``logging.basicConfig`` here and no global state.
+
+Raw user identifiers are never logged. When correlation is needed, the
+admission runtime provides an HMAC-SHA256 reference under a dedicated domain
+(see ``backend.admission.compute_turn_correlation``); this module never
+computes hashes itself and never accepts raw identifiers as fields.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+# ─── Event names (closed registry) ─────────────────────────────────────────
+
+EVENT_APP_STARTUP_FAILED = "app_startup_failed"
+EVENT_APP_SHUTDOWN_FAILED = "app_shutdown_failed"
+EVENT_SUPABASE_CLIENT_CREATION_FAILED = "supabase_client_creation_failed"
+EVENT_READINESS_CHECK_FAILED = "readiness_check_failed"
+EVENT_AUTH_FAILED = "auth_failed"
+EVENT_AUTH_COMPLETED = "auth_completed"
+EVENT_TURN_COMPLETED = "turn_completed"
+EVENT_TURN_FAILED = "turn_failed"
+EVENT_REQUEST_CONFLICT = "request_conflict"
+EVENT_HTTP_RESULT = "http_result"
+
+EVENT_NAMES = frozenset(
+    {
+        EVENT_APP_STARTUP_FAILED,
+        EVENT_APP_SHUTDOWN_FAILED,
+        EVENT_SUPABASE_CLIENT_CREATION_FAILED,
+        EVENT_READINESS_CHECK_FAILED,
+        EVENT_AUTH_FAILED,
+        EVENT_AUTH_COMPLETED,
+        EVENT_TURN_COMPLETED,
+        EVENT_TURN_FAILED,
+        EVENT_REQUEST_CONFLICT,
+        EVENT_HTTP_RESULT,
+    }
+)
+
+# ─── Field contract ─────────────────────────────────────────────────────────
+
+#: Allowed field names for event payloads. Low-cardinality, sanitized values
+#: only (codes, phases, durations, HTTP statuses, HMAC correlations).
+ALLOWED_FIELDS = frozenset(
+    {
+        "correlation",
+        "code",
+        "stage",
+        "outcome",
+        "phase",
+        "duration_ms",
+        "latency_ms",
+        "attempt",
+        "http_status",
+        "component",
+        "mode",
+        "reason",
+        "result",
+        "retry",
+        "conflict",
+        "deadline_ms",
+    }
+)
+
+#: Field names that are never accepted, even if a future caller insists.
+#: Content and identifiers must not reach logs.
+FORBIDDEN_FIELDS = frozenset(
+    {
+        "user_id",
+        "request_id",
+        "message",
+        "response",
+        "prompt",
+        "memory",
+        "appraisal",
+        "snapshot",
+        "token",
+        "secret",
+        "api_key",
+        "apikey",
+        "authorization",
+        "password",
+        "key",
+    }
+)
+
+_WHITESPACE_RE = re.compile(r"\s+")
+_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+class ObservabilityContractError(ValueError):
+    """Raised when an event violates the sanitized observability contract.
+
+    This is a programmer error: it fails fast instead of silently logging
+    content that must never be emitted.
+    """
+
+
+def sanitize_value(value: Any) -> str:
+    """Render an event field value safely.
+
+    Accepts only ``str``, ``int``, ``float`` (finite), and ``bool``. Strings
+    have control characters removed and whitespace runs collapsed, so
+    multi-line or injected payloads cannot break log framing.
+    """
+    if isinstance(value, str):
+        return _CONTROL_RE.sub("", _WHITESPACE_RE.sub(" ", value)).strip()
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):  # NaN / inf
+            raise ObservabilityContractError("event field values must be finite")
+        return f"{value:.0f}"
+    raise ObservabilityContractError(
+        f"event field values must be str/int/float/bool, got {type(value).__name__}"
+    )
+
+
+def emit_event(
+    logger: logging.Logger,
+    event: str,
+    *,
+    level: int = logging.INFO,
+    **fields: Any,
+) -> None:
+    """Emit one sanitized structured event line.
+
+    Args:
+        logger: Logger to emit on.
+        event: One of the constant names in :data:`EVENT_NAMES`.
+        level: Logging level (``logging.INFO`` or ``logging.ERROR``).
+        **fields: Allowlisted, sanitized payload fields.
+
+    Raises:
+        ObservabilityContractError: For unknown events, unknown field names,
+            forbidden field names, or unsupported value types. Failing fast
+            prevents content from ever reaching a log.
+    """
+    if event not in EVENT_NAMES:
+        raise ObservabilityContractError(f"unknown event name: {event!r}")
+
+    parts = [f"event={event}"]
+    for name, value in fields.items():
+        if name in FORBIDDEN_FIELDS:
+            raise ObservabilityContractError(
+                f"field {name!r} is forbidden in event payloads"
+            )
+        if name not in ALLOWED_FIELDS:
+            raise ObservabilityContractError(f"unknown event field: {name!r}")
+        if value is None:
+            # Absent optional fields are simply omitted from the line.
+            continue
+        parts.append(f"{name}={sanitize_value(value)}")
+
+    logger.log(level, " ".join(parts))
+
+
+def emit_error(logger: logging.Logger, event: str, **fields: Any) -> None:
+    """Emit a sanitized event at ERROR level."""
+    emit_event(logger, event, level=logging.ERROR, **fields)

--- a/backend/observability.py
+++ b/backend/observability.py
@@ -59,10 +59,12 @@ EVENT_NAMES = frozenset(
 # ─── Field contract ─────────────────────────────────────────────────────────
 
 #: Allowed field names for event payloads. Low-cardinality, sanitized values
-#: only (codes, phases, durations, HTTP statuses, HMAC correlations).
+#: only (codes, phases, durations, HTTP statuses, HMAC correlations, and the
+#: non-reversible HMAC user reference ``user_ref``).
 ALLOWED_FIELDS = frozenset(
     {
         "correlation",
+        "user_ref",
         "code",
         "stage",
         "outcome",

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -1,0 +1,653 @@
+"""Typed, validated application configuration for the Katherine Bot backend.
+
+This module centralizes every piece of runtime configuration in one frozen,
+strictly validated model. It has no dependency on FastAPI, Groq, Supabase,
+embeddings, or network I/O: importing it never reads the environment, opens
+sockets, or constructs clients.
+
+Rules enforced here:
+
+* Environments are a closed enum: ``local``, ``test``, ``staging``,
+  ``production``.
+* Numeric and boolean values are strict: no permissive string parsing, no
+  bool/float substitution for ints, no silent defaults for secrets.
+* Critical strings are non-empty; URLs are validated; CORS origins are
+  normalized, deduplicated, and rejected when unsafe.
+* Production fails closed: missing critical configuration, localhost CORS
+  origins, wildcard origins, and enabled features without their dependencies
+  are rejected before the application starts serving traffic.
+* Secrets are excluded from ``repr``, ``str``, and sanitized error messages.
+
+Environment variables are read only by :meth:`Settings.from_env`; direct
+construction (``Settings(...)``) never consults the environment, which makes
+tests able to build settings without globals.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping, Optional
+from urllib.parse import urlparse
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+
+from .cors_policy import DEFAULT_ALLOWED_ORIGINS, parse_cors_allowed_origins
+from .turn_execution import TurnExecutionConfig
+
+__all__ = [
+    "AppEnvironment",
+    "Settings",
+    "SettingsConfigurationError",
+    "SettingsIssue",
+]
+
+# ---------------------------------------------------------------------------
+# Environments
+# ---------------------------------------------------------------------------
+
+
+class AppEnvironment(str, Enum):
+    """Closed set of supported deployment environments."""
+
+    local = "local"
+    test = "test"
+    staging = "staging"
+    production = "production"
+
+
+#: Environments that require the Supabase runtime configuration up front.
+_REQUIRE_SUPABASE = frozenset({AppEnvironment.staging, AppEnvironment.production})
+
+#: Environments that require an explicit CORS allowlist.
+_REQUIRE_CORS_ALLOWLIST = frozenset({AppEnvironment.staging, AppEnvironment.production})
+
+#: Hosts that are never acceptable CORS origins in production.
+_LOCALHOST_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0"})
+
+#: Lower bound for the admission HMAC secret, mirroring ``admission.py``.
+ADMISSION_SECRET_MIN_BYTES = 32
+
+#: Timeout ranges for readiness checks (milliseconds).
+READINESS_DATABASE_TIMEOUT_MIN_MS = 100
+READINESS_DATABASE_TIMEOUT_MAX_MS = 30_000
+READINESS_PROVIDER_TIMEOUT_MIN_MS = 100
+READINESS_PROVIDER_TIMEOUT_MAX_MS = 30_000
+
+
+# ---------------------------------------------------------------------------
+# Sanitized configuration errors
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SettingsIssue:
+    """One sanitized configuration issue.
+
+    Only the field name and a stable code are exposed. The raw value is never
+    kept, so secrets and URLs cannot leak through error messages or repr.
+    """
+
+    field: str
+    code: str
+
+
+class SettingsConfigurationError(Exception):
+    """Raised when application configuration is invalid.
+
+    ``str`` and ``repr`` contain only field names and stable codes, never
+    input values. This is the only error type raised by
+    :meth:`Settings.from_env`; direct construction raises ``ValidationError``
+    (whose ``input`` values are never rendered by this module).
+    """
+
+    def __init__(self, issues: tuple[SettingsIssue, ...]) -> None:
+        self.issues = issues
+        super().__init__(self._render(issues))
+
+    @staticmethod
+    def _render(issues: tuple[SettingsIssue, ...]) -> str:
+        if not issues:
+            return "Invalid application configuration."
+        rendered = ", ".join(f"{issue.field}:{issue.code}" for issue in issues)
+        return f"Invalid application configuration: {rendered}"
+
+    def __str__(self) -> str:
+        return self._render(self.issues)
+
+    def __repr__(self) -> str:
+        return f"SettingsConfigurationError({self.issues!r})"
+
+    def sanitized_details(self) -> tuple[SettingsIssue, ...]:
+        """Return the sanitized (field, code) issues, safe for logs."""
+        return self.issues
+
+
+class _SettingsError(ValueError):
+    """Internal validator error carrying a stable code and field name.
+
+    Pydantic v2 keeps the original exception in ``ctx["error"]``; sanitization
+    extracts only ``code`` and ``field``, never the input value.
+    """
+
+    def __init__(self, code: str, field: str) -> None:
+        super().__init__(code)
+        self.code = code
+        self.field = field
+
+
+def _sanitize_validation_error(exc: ValidationError) -> SettingsConfigurationError:
+    """Convert a pydantic ``ValidationError`` into sanitized issues.
+
+    Only field locations and stable codes/types are kept; ``input`` values are
+    deliberately discarded.
+    """
+    issues: list[SettingsIssue] = []
+    for err in exc.errors():
+        ctx_error = (err.get("ctx") or {}).get("error")
+        if isinstance(ctx_error, _SettingsError):
+            field = ctx_error.field or _loc_to_field(err.get("loc", ()))
+            issues.append(SettingsIssue(field=field, code=ctx_error.code))
+        else:
+            issues.append(
+                SettingsIssue(
+                    field=_loc_to_field(err.get("loc", ())),
+                    code=str(err.get("type", "invalid")),
+                )
+            )
+    return SettingsConfigurationError(tuple(issues))
+
+
+def _loc_to_field(loc: tuple[Any, ...]) -> str:
+    parts = [str(part) for part in loc if isinstance(part, (str, int))]
+    return ".".join(parts) if parts else "settings"
+
+
+# ---------------------------------------------------------------------------
+# Strict environment parsing helpers (used only by ``from_env``)
+# ---------------------------------------------------------------------------
+
+
+def _env_bool(key: str, source: Mapping[str, object], default: bool) -> bool:
+    """Parse a boolean environment variable strictly.
+
+    Accepts only ``"true"``/``"false"`` (case-insensitive). Absent values fall
+    back to ``default``. Empty or unrecognized values raise
+    ``SettingsConfigurationError``.
+    """
+    raw = source.get(key)
+    if raw is None:
+        return default
+    if not isinstance(raw, str):
+        raise SettingsConfigurationError((SettingsIssue(key.lower(), "invalid_boolean"),))
+    token = raw.strip()
+    if not token:
+        raise SettingsConfigurationError((SettingsIssue(key.lower(), "invalid_boolean"),))
+    lowered = token.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    raise SettingsConfigurationError((SettingsIssue(key.lower(), "invalid_boolean"),))
+
+
+def _env_int(
+    key: str,
+    source: Mapping[str, object],
+    default: int,
+    minimum: int,
+    maximum: int,
+) -> int:
+    """Parse an integer environment variable strictly."""
+    raw = source.get(key)
+    if raw is None:
+        return default
+    if not isinstance(raw, str):
+        raise SettingsConfigurationError((SettingsIssue(key.lower(), "invalid_integer"),))
+    token = raw.strip()
+    if not token:
+        raise SettingsConfigurationError((SettingsIssue(key.lower(), "invalid_integer"),))
+    if token.lower() in ("true", "false", "yes", "no"):
+        raise SettingsConfigurationError((SettingsIssue(key.lower(), "invalid_integer"),))
+    try:
+        value = int(token)
+    except ValueError:
+        raise SettingsConfigurationError((SettingsIssue(key.lower(), "invalid_integer"),))
+    if value < minimum or value > maximum:
+        raise SettingsConfigurationError((SettingsIssue(key.lower(), "out_of_range"),))
+    return value
+
+
+def _env_secret(key: str, source: Mapping[str, object]) -> Optional[str]:
+    """Return a trimmed secret string, or ``None`` when absent."""
+    raw = source.get(key)
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        raise SettingsConfigurationError((SettingsIssue(key.lower(), "invalid_secret"),))
+    token = raw.strip()
+    if not token:
+        raise SettingsConfigurationError((SettingsIssue(key.lower(), "empty_secret"),))
+    return token
+
+
+def _env_url(key: str, source: Mapping[str, object]) -> Optional[str]:
+    """Return a URL string, or ``None`` when absent. Validation happens later."""
+    raw = source.get(key)
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        raise SettingsConfigurationError((SettingsIssue(key.lower(), "invalid_url"),))
+    token = raw.strip()
+    if not token:
+        raise SettingsConfigurationError((SettingsIssue(key.lower(), "empty_url"),))
+    return token
+
+
+def _env_cidrs(key: str, source: Mapping[str, object]) -> tuple[str, ...]:
+    """Parse a comma-separated CIDR list strictly; absent means empty."""
+    raw = source.get(key)
+    if raw is None:
+        return ()
+    if not isinstance(raw, str):
+        raise SettingsConfigurationError((SettingsIssue(key.lower(), "invalid_cidr"),))
+    entries = [entry.strip() for entry in raw.split(",") if entry.strip()]
+    return tuple(entries)
+
+
+def _env_origins(
+    key: str,
+    source: Mapping[str, object],
+    environment: AppEnvironment,
+) -> tuple[str, ...]:
+    """Parse CORS origins from the environment with per-environment policy.
+
+    * Absent variable: ``local``/``test`` fall back to the documented
+      development default; ``staging``/``production`` fail (explicit
+      allowlist required).
+    * Wildcards are rejected (credentials are enabled).
+    * Full validation (scheme, host, no path/credentials) happens in the
+      pydantic model; parsing here only handles absent/empty input.
+    """
+    raw = source.get(key)
+    if raw is None:
+        if environment in _REQUIRE_CORS_ALLOWLIST:
+            raise SettingsConfigurationError(
+                (SettingsIssue(key.lower(), "required"),)
+            )
+        return DEFAULT_ALLOWED_ORIGINS
+    if not isinstance(raw, str):
+        raise SettingsConfigurationError((SettingsIssue(key.lower(), "invalid_origins"),))
+    if not raw.strip():
+        raise SettingsConfigurationError((SettingsIssue(key.lower(), "invalid_origins"),))
+    try:
+        return parse_cors_allowed_origins(raw)
+    except ValueError:
+        raise SettingsConfigurationError((SettingsIssue(key.lower(), "invalid_origins"),))
+
+
+# ---------------------------------------------------------------------------
+# Settings model
+# ---------------------------------------------------------------------------
+
+
+class Settings(BaseModel):
+    """Frozen, strictly validated application configuration.
+
+    Direct construction never reads the environment; use :meth:`from_env` for
+    environment-driven startup. Secrets are never rendered by ``repr`` or
+    ``str`` and never included in sanitized error messages.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        arbitrary_types_allowed=True,
+        validate_default=True,
+    )
+
+    app_env: AppEnvironment = AppEnvironment.local
+
+    # ── Supabase ────────────────────────────────────────────────────────────
+    supabase_url: Optional[str] = None
+    supabase_service_role_key: Optional[SecretStr] = None
+
+    # ── Provider ────────────────────────────────────────────────────────────
+    groq_api_key: SecretStr = Field(...)
+    groq_api_key_2: Optional[SecretStr] = None
+
+    # ── Admission / ledger ──────────────────────────────────────────────────
+    admission_hmac_secret: SecretStr = Field(...)
+    trusted_proxy_cidrs: tuple[str, ...] = ()
+
+    # ── CORS ────────────────────────────────────────────────────────────────
+    cors_allowed_origins: tuple[str, ...] = ()
+    cors_allow_credentials: bool = True
+
+    # ── Feature flags ───────────────────────────────────────────────────────
+    archival_extraction_enabled: bool = False
+
+    # ── Turn execution (validated by TurnExecutionConfig) ───────────────────
+    turn_config: TurnExecutionConfig = Field(default_factory=TurnExecutionConfig.defaults)
+
+    # ── Readiness ───────────────────────────────────────────────────────────
+    readiness_database_timeout_ms: int = Field(default=3000)
+    readiness_provider_timeout_ms: int = Field(default=1000)
+
+    # ── Validators ──────────────────────────────────────────────────────────
+
+    @field_validator(
+        "groq_api_key",
+        "groq_api_key_2",
+        "supabase_service_role_key",
+        "admission_hmac_secret",
+        mode="before",
+    )
+    @classmethod
+    def _validate_secret(cls, value: object) -> object:
+        if value is None:
+            return None
+        if isinstance(value, SecretStr):
+            value = value.get_secret_value()
+        if not isinstance(value, str):
+            raise _SettingsError("secret_type", "secret")
+        if not value.strip():
+            raise _SettingsError("secret_empty", "secret")
+        return SecretStr(value)
+
+    @field_validator("admission_hmac_secret")
+    @classmethod
+    def _validate_admission_secret_length(cls, value: SecretStr) -> SecretStr:
+        if len(value.get_secret_value().encode("utf-8")) < ADMISSION_SECRET_MIN_BYTES:
+            raise _SettingsError("secret_too_short", "admission_hmac_secret")
+        return value
+
+    @field_validator("supabase_url", mode="before")
+    @classmethod
+    def _validate_url(cls, value: object) -> object:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise _SettingsError("url_type", "supabase_url")
+        token = value.strip()
+        if not token:
+            raise _SettingsError("url_empty", "supabase_url")
+        parsed = urlparse(token)
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            raise _SettingsError("url_invalid", "supabase_url")
+        if parsed.username is not None or parsed.password is not None:
+            raise _SettingsError("url_credentials", "supabase_url")
+        if parsed.path not in ("", "/") or parsed.query or parsed.fragment:
+            raise _SettingsError("url_invalid", "supabase_url")
+        return token.rstrip("/")
+
+    @field_validator("cors_allowed_origins", mode="before")
+    @classmethod
+    def _validate_origins(cls, value: object) -> tuple[str, ...]:
+        if value is None:
+            return ()
+        if isinstance(value, str):
+            raise _SettingsError("origins_type", "cors_allowed_origins")
+        if not isinstance(value, (tuple, list)):
+            raise _SettingsError("origins_type", "cors_allowed_origins")
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for entry in value:
+            if not isinstance(entry, str):
+                raise _SettingsError("origins_type", "cors_allowed_origins")
+            token = entry.strip().rstrip("/")
+            if not token:
+                continue
+            if token == "*":
+                raise _SettingsError("origins_wildcard", "cors_allowed_origins")
+            parsed = urlparse(token)
+            if parsed.scheme not in ("http", "https") or not parsed.netloc:
+                raise _SettingsError("origins_invalid", "cors_allowed_origins")
+            if parsed.username is not None or parsed.password is not None:
+                raise _SettingsError("origins_credentials", "cors_allowed_origins")
+            if parsed.path not in ("", "/") or parsed.query or parsed.fragment:
+                raise _SettingsError("origins_invalid", "cors_allowed_origins")
+            key = token.lower()
+            if key not in seen:
+                seen.add(key)
+                normalized.append(token)
+        return tuple(normalized)
+
+    @field_validator("trusted_proxy_cidrs", mode="before")
+    @classmethod
+    def _validate_cidrs(cls, value: object) -> tuple[str, ...]:
+        if value is None:
+            return ()
+        if isinstance(value, str):
+            value = tuple(entry.strip() for entry in value.split(",") if entry.strip())
+        if not isinstance(value, (tuple, list)):
+            raise _SettingsError("cidr_type", "trusted_proxy_cidrs")
+        result: list[str] = []
+        for entry in value:
+            if not isinstance(entry, str) or not entry.strip():
+                raise _SettingsError("cidr_invalid", "trusted_proxy_cidrs")
+            try:
+                ipaddress.ip_network(entry.strip(), strict=False)
+            except ValueError:
+                raise _SettingsError("cidr_invalid", "trusted_proxy_cidrs")
+            result.append(entry.strip())
+        return tuple(result)
+
+    @field_validator("archival_extraction_enabled", "cors_allow_credentials", mode="before")
+    @classmethod
+    def _validate_strict_bool(cls, value: object) -> object:
+        if not isinstance(value, bool):
+            raise _SettingsError("boolean_type", "boolean")
+        return value
+
+    @field_validator("supabase_url", mode="after")
+    @classmethod
+    def _validate_environment_requires_supabase_url(
+        cls, value: Optional[str], info
+    ) -> Optional[str]:
+        environment = info.data.get("app_env")
+        if environment in _REQUIRE_SUPABASE and not value:
+            raise _SettingsError("required", "supabase_url")
+        return value
+
+    @field_validator("supabase_service_role_key", mode="after")
+    @classmethod
+    def _validate_environment_requires_service_key(
+        cls, value: Optional[SecretStr], info
+    ) -> Optional[SecretStr]:
+        environment = info.data.get("app_env")
+        if environment in _REQUIRE_SUPABASE and value is None:
+            raise _SettingsError("required", "supabase_service_role_key")
+        return value
+
+    @field_validator("cors_allowed_origins", mode="after")
+    @classmethod
+    def _validate_environment_requires_origins(
+        cls, value: tuple[str, ...], info
+    ) -> tuple[str, ...]:
+        environment = info.data.get("app_env")
+        if environment in _REQUIRE_CORS_ALLOWLIST and not value:
+            raise _SettingsError("required", "cors_allowed_origins")
+        return value
+
+    @field_validator("readiness_database_timeout_ms", mode="before")
+    @classmethod
+    def _validate_database_timeout(cls, value: object) -> object:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise _SettingsError("timeout_type", "readiness_database_timeout_ms")
+        if not (
+            READINESS_DATABASE_TIMEOUT_MIN_MS
+            <= value
+            <= READINESS_DATABASE_TIMEOUT_MAX_MS
+        ):
+            raise _SettingsError("timeout_out_of_range", "readiness_database_timeout_ms")
+        return value
+
+    @field_validator("readiness_provider_timeout_ms", mode="before")
+    @classmethod
+    def _validate_provider_timeout(cls, value: object) -> object:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise _SettingsError("timeout_type", "readiness_provider_timeout_ms")
+        if not (
+            READINESS_PROVIDER_TIMEOUT_MIN_MS
+            <= value
+            <= READINESS_PROVIDER_TIMEOUT_MAX_MS
+        ):
+            raise _SettingsError("timeout_out_of_range", "readiness_provider_timeout_ms")
+        return value
+
+    @field_validator("turn_config")
+    @classmethod
+    def _validate_turn_config(cls, value: object) -> TurnExecutionConfig:
+        if not isinstance(value, TurnExecutionConfig):
+            raise _SettingsError("turn_config_type", "turn_config")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_environment_combinations(self) -> "Settings":
+        environment = self.app_env
+
+        if environment is AppEnvironment.production:
+            if self.supabase_url is not None:
+                url_host = (urlparse(self.supabase_url).hostname or "").lower()
+                if url_host in _LOCALHOST_HOSTS or url_host.endswith(".localhost"):
+                    raise _SettingsError(
+                        "url_localhost_production", "supabase_url"
+                    )
+            for origin in self.cors_allowed_origins:
+                hostname = (urlparse(origin).hostname or "").lower()
+                if (
+                    hostname in _LOCALHOST_HOSTS
+                    or hostname.endswith(".localhost")
+                    or hostname.endswith(".local")
+                ):
+                    raise _SettingsError(
+                        "origins_localhost_production", "cors_allowed_origins"
+                    )
+
+        # A feature that is enabled must have its required dependencies.
+        if self.archival_extraction_enabled and not self._has_provider_key():
+            raise _SettingsError("feature_missing_dependency", "archival_extraction_enabled")
+
+        return self
+
+    def _has_provider_key(self) -> bool:
+        for candidate in (self.groq_api_key, self.groq_api_key_2):
+            if candidate is not None and candidate.get_secret_value():
+                return True
+        return False
+
+    # ── Factories ───────────────────────────────────────────────────────────
+
+    @classmethod
+    def from_env(
+        cls,
+        env: Optional[Mapping[str, object]] = None,
+    ) -> "Settings":
+        """Build settings strictly from an environment mapping.
+
+        Fails with :class:`SettingsConfigurationError` (sanitized, no input
+        values) on any invalid, missing, or unsafe configuration. Defaults to
+        ``os.environ``.
+        """
+        source: Mapping[str, object] = os.environ if env is None else env
+
+        raw_env = source.get("APP_ENV")
+        if raw_env is None or not str(raw_env).strip():
+            environment = AppEnvironment.local
+        else:
+            try:
+                environment = AppEnvironment(str(raw_env).strip().lower())
+            except ValueError:
+                raise SettingsConfigurationError(
+                    (SettingsIssue("app_env", "invalid_environment"),)
+                )
+
+        try:
+            turn_config = TurnExecutionConfig.from_env(source)
+        except ValueError:
+            raise SettingsConfigurationError(
+                (SettingsIssue("turn_config", "invalid_turn_configuration"),)
+            )
+
+        data: dict[str, object] = {
+            "app_env": environment,
+            "supabase_url": _env_url("SUPABASE_URL", source),
+            "supabase_service_role_key": _env_secret(
+                "SUPABASE_SERVICE_ROLE_KEY", source
+            ),
+            "groq_api_key": _env_secret("GROQ_API_KEY", source),
+            "groq_api_key_2": _env_secret("GROQ_API_KEY_2", source),
+            "admission_hmac_secret": _env_secret("ADMISSION_HMAC_SECRET", source),
+            "trusted_proxy_cidrs": _env_cidrs("TRUSTED_PROXY_CIDRS", source),
+            "cors_allowed_origins": _env_origins(
+                "CORS_ALLOWED_ORIGINS", source, environment
+            ),
+            "archival_extraction_enabled": _env_bool(
+                "ARCHIVAL_EXTRACTION_ENABLED", source, False
+            ),
+            "turn_config": turn_config,
+            "readiness_database_timeout_ms": _env_int(
+                "READINESS_DATABASE_TIMEOUT_MS",
+                source,
+                3000,
+                READINESS_DATABASE_TIMEOUT_MIN_MS,
+                READINESS_DATABASE_TIMEOUT_MAX_MS,
+            ),
+            "readiness_provider_timeout_ms": _env_int(
+                "READINESS_PROVIDER_TIMEOUT_MS",
+                source,
+                1000,
+                READINESS_PROVIDER_TIMEOUT_MIN_MS,
+                READINESS_PROVIDER_TIMEOUT_MAX_MS,
+            ),
+        }
+
+        try:
+            return cls(**data)
+        except ValidationError as exc:
+            raise _sanitize_validation_error(exc)
+
+    def ensure_valid(self) -> None:
+        """Re-run the cross-field validation (cheap, no I/O).
+
+        Used by the readiness ``configuration`` check to confirm the settings
+        instance the application is running with is still valid.
+        """
+        self._validate_environment_combinations()
+
+    def to_admission_values(self) -> tuple[str, Optional[str]]:
+        """Return ``(admission_secret, trusted_proxy_cidrs_csv)`` for admission."""
+        secret = self.admission_hmac_secret.get_secret_value()
+        cidrs = ",".join(self.trusted_proxy_cidrs) if self.trusted_proxy_cidrs else None
+        return secret, cidrs
+
+    def provider_keys(self) -> tuple[str, ...]:
+        """Return the configured non-empty provider keys (never logged)."""
+        keys: list[str] = []
+        for candidate in (self.groq_api_key, self.groq_api_key_2):
+            if candidate is not None:
+                keys.append(candidate.get_secret_value())
+        return tuple(keys)
+
+    # ── Representation ──────────────────────────────────────────────────────
+
+    def __repr__(self) -> str:
+        visible = self.model_dump(
+            exclude={
+                "groq_api_key",
+                "groq_api_key_2",
+                "admission_hmac_secret",
+                "supabase_service_role_key",
+            }
+        )
+        return f"Settings({visible!r})"

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -8,7 +8,12 @@ sockets, or constructs clients.
 Rules enforced here:
 
 * Environments are a closed enum: ``local``, ``test``, ``staging``,
-  ``production``.
+  ``production``, and ``APP_ENV`` is **required** by :meth:`Settings.from_env`
+  (fail-closed: a deployment that forgets it never silently runs in local
+  mode).
+* The model is frozen and assignment-validated: a constructed instance can
+  never be mutated into an invalid state, so the readiness ``configuration``
+  check can trust the running settings.
 * Numeric and boolean values are strict: no permissive string parsing, no
   bool/float substitution for ints, no silent defaults for secrets.
 * Critical strings are non-empty; URLs are validated; CORS origins are
@@ -17,6 +22,9 @@ Rules enforced here:
   origins, wildcard origins, and enabled features without their dependencies
   are rejected before the application starts serving traffic.
 * Secrets are excluded from ``repr``, ``str``, and sanitized error messages.
+  Direct construction failures raise ``ValidationError`` with
+  ``hide_input_in_errors`` so raw values (URL credentials, keys) never appear
+  in rendered errors.
 
 Environment variables are read only by :meth:`Settings.from_env`; direct
 construction (``Settings(...)``) never consults the environment, which makes
@@ -108,7 +116,8 @@ class SettingsConfigurationError(Exception):
     ``str`` and ``repr`` contain only field names and stable codes, never
     input values. This is the only error type raised by
     :meth:`Settings.from_env`; direct construction raises ``ValidationError``
-    (whose ``input`` values are never rendered by this module).
+    with ``hide_input_in_errors`` enabled, so raw inputs are never rendered
+    by this module either.
     """
 
     def __init__(self, issues: tuple[SettingsIssue, ...]) -> None:
@@ -306,13 +315,18 @@ class Settings(BaseModel):
 
     Direct construction never reads the environment; use :meth:`from_env` for
     environment-driven startup. Secrets are never rendered by ``repr`` or
-    ``str`` and never included in sanitized error messages.
+    ``str`` and never included in sanitized error messages. The model is
+    frozen and assignment-validated, so a running instance can never be
+    mutated into an invalid state.
     """
 
     model_config = ConfigDict(
         extra="forbid",
         arbitrary_types_allowed=True,
         validate_default=True,
+        frozen=True,
+        validate_assignment=True,
+        hide_input_in_errors=True,
     )
 
     app_env: AppEnvironment = AppEnvironment.local
@@ -335,6 +349,12 @@ class Settings(BaseModel):
 
     # ── Feature flags ───────────────────────────────────────────────────────
     archival_extraction_enabled: bool = False
+    #: Explicit mode for vector memory retrieval (SentenceTransformer + RPC).
+    #: When enabled, the embedding model is constructed at startup and the
+    #: ``embeddings`` readiness component must pass before the instance serves
+    #: traffic. When disabled, the model is never constructed and retrieval
+    #: returns no entries by design.
+    embeddings_retrieval_enabled: bool = False
 
     # ── Turn execution (validated by TurnExecutionConfig) ───────────────────
     turn_config: TurnExecutionConfig = Field(default_factory=TurnExecutionConfig.defaults)
@@ -442,7 +462,12 @@ class Settings(BaseModel):
             result.append(entry.strip())
         return tuple(result)
 
-    @field_validator("archival_extraction_enabled", "cors_allow_credentials", mode="before")
+    @field_validator(
+        "archival_extraction_enabled",
+        "embeddings_retrieval_enabled",
+        "cors_allow_credentials",
+        mode="before",
+    )
     @classmethod
     def _validate_strict_bool(cls, value: object) -> object:
         if not isinstance(value, bool):
@@ -558,19 +583,25 @@ class Settings(BaseModel):
         Fails with :class:`SettingsConfigurationError` (sanitized, no input
         values) on any invalid, missing, or unsafe configuration. Defaults to
         ``os.environ``.
+
+        ``APP_ENV`` is **required**: an absent or empty value fails closed
+        instead of silently selecting the least restrictive environment, so a
+        deployment that forgets to declare its mode never runs production
+        traffic under development defaults.
         """
         source: Mapping[str, object] = os.environ if env is None else env
 
         raw_env = source.get("APP_ENV")
         if raw_env is None or not str(raw_env).strip():
-            environment = AppEnvironment.local
-        else:
-            try:
-                environment = AppEnvironment(str(raw_env).strip().lower())
-            except ValueError:
-                raise SettingsConfigurationError(
-                    (SettingsIssue("app_env", "invalid_environment"),)
-                )
+            raise SettingsConfigurationError(
+                (SettingsIssue("app_env", "required"),)
+            )
+        try:
+            environment = AppEnvironment(str(raw_env).strip().lower())
+        except ValueError:
+            raise SettingsConfigurationError(
+                (SettingsIssue("app_env", "invalid_environment"),)
+            )
 
         try:
             turn_config = TurnExecutionConfig.from_env(source)
@@ -595,6 +626,9 @@ class Settings(BaseModel):
             "archival_extraction_enabled": _env_bool(
                 "ARCHIVAL_EXTRACTION_ENABLED", source, False
             ),
+            "embeddings_retrieval_enabled": _env_bool(
+                "EMBEDDINGS_RETRIEVAL_ENABLED", source, False
+            ),
             "turn_config": turn_config,
             "readiness_database_timeout_ms": _env_int(
                 "READINESS_DATABASE_TIMEOUT_MS",
@@ -618,12 +652,19 @@ class Settings(BaseModel):
             raise _sanitize_validation_error(exc)
 
     def ensure_valid(self) -> None:
-        """Re-run the cross-field validation (cheap, no I/O).
+        """Re-validate the complete settings model (cheap, no I/O).
 
-        Used by the readiness ``configuration`` check to confirm the settings
-        instance the application is running with is still valid.
+        Rebuilds the model from the current field values so every field-level,
+        range, and cross-field validator runs again. Because the model is
+        frozen and assignment-validated, a mutated or replaced instance fails
+        here. Used by the readiness ``configuration`` check to confirm the
+        settings instance the application runs with is still valid.
         """
-        self._validate_environment_combinations()
+        values = {
+            name: getattr(self, name)
+            for name in type(self).model_fields
+        }
+        type(self).model_validate(values)
 
     def to_admission_values(self) -> tuple[str, Optional[str]]:
         """Return ``(admission_secret, trusted_proxy_cidrs_csv)`` for admission."""

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -362,6 +362,10 @@ class Settings(BaseModel):
     # ── Readiness ───────────────────────────────────────────────────────────
     readiness_database_timeout_ms: int = Field(default=3000)
     readiness_provider_timeout_ms: int = Field(default=1000)
+    #: Bounded timeout for the Auth service availability probe (/health).
+    #: The probe is a cheap HTTP GET that never depends on a user token and
+    #: never reads user data; the transport timeout is aligned to this value.
+    readiness_auth_timeout_ms: int = Field(default=1000)
 
     # ── Validators ──────────────────────────────────────────────────────────
 
@@ -530,6 +534,19 @@ class Settings(BaseModel):
             raise _SettingsError("timeout_out_of_range", "readiness_provider_timeout_ms")
         return value
 
+    @field_validator("readiness_auth_timeout_ms", mode="before")
+    @classmethod
+    def _validate_auth_timeout(cls, value: object) -> object:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise _SettingsError("timeout_type", "readiness_auth_timeout_ms")
+        if not (
+            READINESS_PROVIDER_TIMEOUT_MIN_MS
+            <= value
+            <= READINESS_PROVIDER_TIMEOUT_MAX_MS
+        ):
+            raise _SettingsError("timeout_out_of_range", "readiness_auth_timeout_ms")
+        return value
+
     @field_validator("turn_config")
     @classmethod
     def _validate_turn_config(cls, value: object) -> TurnExecutionConfig:
@@ -639,6 +656,13 @@ class Settings(BaseModel):
             ),
             "readiness_provider_timeout_ms": _env_int(
                 "READINESS_PROVIDER_TIMEOUT_MS",
+                source,
+                1000,
+                READINESS_PROVIDER_TIMEOUT_MIN_MS,
+                READINESS_PROVIDER_TIMEOUT_MAX_MS,
+            ),
+            "readiness_auth_timeout_ms": _env_int(
+                "READINESS_AUTH_TIMEOUT_MS",
                 source,
                 1000,
                 READINESS_PROVIDER_TIMEOUT_MIN_MS,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 
 # Force mock placeholders for tests to prevent real environment keys from being used.
+os.environ["APP_ENV"] = "test"
 os.environ["GROQ_API_KEY"] = "mock_groq_key_placeholder"
 os.environ["GROQ_API_KEY_2"] = "mock_groq_key_2_placeholder"
 os.environ["ADMISSION_HMAC_SECRET"] = "test-admission-secret-that-is-at-least-32-bytes"

--- a/backend/tests/test_admission_additional_invariants.py
+++ b/backend/tests/test_admission_additional_invariants.py
@@ -77,12 +77,24 @@ def test_endpoint_cancellation_drains_reservation_and_never_calls_engine(monkeyp
             raise AssertionError("engine must not run after cancelled admission")
 
     fake_engine = FakeEngine()
-    monkeypatch.setattr(main, "engine", fake_engine)
-    monkeypatch.setattr(
-        main,
-        "_admission_config",
-        AdmissionRuntimeConfig.from_values("s" * 32),
+    from backend.health import HealthRegistry
+    from backend.settings import AppEnvironment, Settings
+    from backend.turn_execution import TurnExecutionConfig
+
+    settings = Settings(
+        app_env=AppEnvironment.local,
+        groq_api_key="k",
+        admission_hmac_secret="s" * 40,
+        cors_allowed_origins=("http://localhost:3000",),
     )
+    deps = main.ApplicationDependencies(
+        conversation_engine=fake_engine,
+        auth_client=object(),
+        admission_config=AdmissionRuntimeConfig.from_values("s" * 32),
+        turn_config=TurnExecutionConfig.defaults(),
+        health_checks=HealthRegistry(),
+    )
+    app = main.create_app(settings=settings, dependencies=deps)
 
     def blocking_reservation(_client, _request):
         started.set()
@@ -100,6 +112,7 @@ def test_endpoint_cancellation_drains_reservation_and_never_calls_engine(monkeyp
                 "path": "/chat",
                 "headers": [],
                 "client": ("203.0.113.8", 12345),
+                "app": app,
             }
         )
         task = asyncio.create_task(

--- a/backend/tests/test_app_factory.py
+++ b/backend/tests/test_app_factory.py
@@ -243,7 +243,12 @@ def test_injected_routes_refuse_outside_lifespan():
 # ─── Readiness resources enter the lifecycle (review blocker 1) ─────────────
 
 
-class _ProbeOkClient:
+class _FakeSupabase:
+    """Duck-typed Supabase surface: auth + table + rpc."""
+
+    def __init__(self):
+        self.auth = object()
+
     def table(self, name):
         return self
 
@@ -251,6 +256,9 @@ class _ProbeOkClient:
         return self
 
     def limit(self, n):
+        return self
+
+    def rpc(self, name, params):
         return self
 
     def execute(self):
@@ -269,8 +277,13 @@ def test_default_builder_shuts_down_readiness_executor(monkeypatch):
 
     monkeypatch.setattr(
         dependencies_module,
+        "_supabase_factory_from_settings",
+        lambda settings: lambda: _FakeSupabase(),
+    )
+    monkeypatch.setattr(
+        dependencies_module,
         "_build_readiness_probe_client",
-        lambda _settings: _ProbeOkClient(),
+        lambda settings: _FakeSupabase(),
     )
     app = main_module.create_app(settings=_settings())
 
@@ -279,13 +292,100 @@ def test_default_builder_shuts_down_readiness_executor(monkeypatch):
         # Running /ready submits a probe, which creates the executor thread.
         response = client.get("/ready")
         assert response.status_code == 200
-        # The owned tuple now includes the closable registry.
+        # The owned tuple includes the closable registry.
         assert any(
             hasattr(resource, "close") and type(resource).__name__ == "HealthRegistry"
             for resource in app.state.owned_resources
         )
-    # After shutdown the registry's close() shut the executor down; the
+    # After shutdown the registry's aclose() shut the executor down; the
     # (completed) probe thread terminates on its own.
+    deadline = _time.monotonic() + 5.0
+    while any(t.name.startswith("readiness-db") for t in threading.enumerate()):
+        assert _time.monotonic() < deadline, "readiness-db thread alive after shutdown"
+        _time.sleep(0.01)
+
+
+# ─── Real surfaces vs probe client (review blocker 1) ───────────────────────
+
+
+def test_ready_fails_when_real_clients_missing_but_probe_works(monkeypatch):
+    """A healthy dedicated probe cannot substitute for the real auth and
+    persistence surfaces the routes use (review blocker 1)."""
+    import backend.dependencies as dependencies_module
+
+    monkeypatch.setattr(
+        dependencies_module,
+        "_supabase_factory_from_settings",
+        lambda settings: lambda: None,
+    )
+    monkeypatch.setattr(
+        dependencies_module,
+        "_build_readiness_probe_client",
+        lambda settings: _FakeSupabase(),
+    )
+    app = main_module.create_app(settings=_settings())
+    with TestClient(app) as client:
+        response = client.get("/ready")
+        assert response.status_code == 503
+        body = response.json()
+        assert body["status"] == "not_ready"
+        assert body["components"]["configuration"] == "ok"
+        assert body["components"]["auth"] == "unavailable"
+        assert body["components"]["persistence"] == "unavailable"
+        assert body["components"]["database"] == "ok"
+        assert body["components"]["provider"] == "ok"
+        assert body["components"]["lifespan"] == "ok"
+
+
+# ─── Shutdown drains an active probe before closing its client (blocker 2) ──
+
+
+def test_shutdown_drains_active_probe_before_closing_client(monkeypatch):
+    """A probe still in flight when the lifespan shuts down is drained with a
+    bounded wait; the probe client is closed only after the thread is done,
+    and no readiness-db thread survives (review blocker 2)."""
+    import threading
+    import time as _time
+    from types import SimpleNamespace
+
+    import backend.dependencies as dependencies_module
+
+    probe_started = threading.Event()
+    release = threading.Event()
+    events = []
+
+    class BlockingProbeClient(_FakeSupabase):
+        def execute(self):
+            probe_started.set()
+            release.wait(timeout=5.0)
+            events.append("probe_done")
+            return SimpleNamespace(data=[], error=None)
+
+        def close(self):
+            events.append("client_closed")
+
+    monkeypatch.setattr(
+        dependencies_module,
+        "_supabase_factory_from_settings",
+        lambda settings: lambda: _FakeSupabase(),
+    )
+    monkeypatch.setattr(
+        dependencies_module,
+        "_build_readiness_probe_client",
+        lambda settings: BlockingProbeClient(),
+    )
+    app = main_module.create_app(settings=_settings(readiness_database_timeout_ms=100))
+    with TestClient(app) as client:
+        response = client.get("/ready")
+        assert response.status_code == 503  # probe timed out, thread still blocked
+        assert probe_started.is_set()
+        # The probe thread is still alive while we are about to shut down.
+        assert any(t.name.startswith("readiness-db") for t in threading.enumerate())
+        # Release the probe so the shutdown drain can complete it.
+        release.set()
+    # Lifespan teardown drained the probe BEFORE closing the client.
+    assert events == ["probe_done", "client_closed"]
+    # No readiness-db thread survives.
     deadline = _time.monotonic() + 5.0
     while any(t.name.startswith("readiness-db") for t in threading.enumerate()):
         assert _time.monotonic() < deadline, "readiness-db thread alive after shutdown"

--- a/backend/tests/test_app_factory.py
+++ b/backend/tests/test_app_factory.py
@@ -91,11 +91,23 @@ def test_create_app_without_dependencies_defers_construction_to_lifespan():
 
 
 def test_create_app_defaults_settings_from_environment(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "local")
     monkeypatch.setenv("GROQ_API_KEY", "env-key")
     monkeypatch.setenv("ADMISSION_HMAC_SECRET", SECRET)
     app = main_module.create_app()
     assert app.state.settings.app_env is AppEnvironment.local
     assert app.state.dependencies is None
+
+
+def test_create_app_fails_closed_without_app_env(monkeypatch):
+    """A runtime that forgets APP_ENV never starts in an implicit mode."""
+    from backend.settings import SettingsConfigurationError
+
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.setenv("GROQ_API_KEY", "env-key")
+    monkeypatch.setenv("ADMISSION_HMAC_SECRET", SECRET)
+    with pytest.raises(SettingsConfigurationError):
+        main_module.create_app()
 
 
 def test_create_app_with_default_dependencies_builds_owned_resources_once(monkeypatch):
@@ -228,7 +240,7 @@ def test_builder_cleans_partial_resources_when_startup_fails(monkeypatch):
 
     monkeypatch.setattr(dependencies_module, "ChatConversationEngine", FakeEngineWithClose)
 
-    def boom(settings, engine, auth_client):
+    def boom(settings, engine, **kwargs):
         raise RuntimeError("late startup failure")
 
     monkeypatch.setattr(dependencies_module, "build_health_registry", boom)
@@ -311,12 +323,134 @@ def test_no_per_user_state_in_app_state_or_container():
         "turn_config",
         "health_checks",
         "clock",
+        "persistence_client",
     }
     assert set(deps.__dataclass_fields__) == container_fields
     # No attribute of the container may hold a user identity.
     for field_name in container_fields:
         assert "user" not in field_name.lower()
         assert "request" not in field_name.lower()
+
+
+# ─── DI: routes use only the injected dependency surfaces (review blocker 2) ─
+
+
+def test_routes_use_only_the_correct_dependency():
+    """Auth uses only ``auth_client``; history/admission use only
+    ``persistence_client``; routes never navigate engine internals."""
+    from types import SimpleNamespace as NS
+
+    from backend.emotion_presentation import EmotionStateResponse
+    from backend.process_turn import ProcessTurnResult
+
+    auth_calls = []
+    persist_calls = []
+
+    class AuthOnlyClient:
+        """Exposes ONLY the auth surface; any other use fails loudly."""
+
+        @property
+        def auth(self):
+            return self
+
+        def get_user(self, token):
+            auth_calls.append(token)
+            return NS(user=NS(id="user-123"))
+
+    class PersistenceOnlyClient:
+        """Exposes ONLY rpc/table persistence; no auth surface at all."""
+
+        def rpc(self, name, params):
+            persist_calls.append(("rpc", name))
+            return NS(
+                execute=lambda: NS(
+                    data=[{"decision": "admitted", "retry_after_seconds": 0}]
+                )
+            )
+
+        def table(self, name):
+            persist_calls.append(("table", name))
+            return self
+
+        def select(self, cols):
+            return self
+
+        def eq(self, key, value):
+            return self
+
+        def order(self, col, **kwargs):
+            return self
+
+        def limit(self, n):
+            return self
+
+        def execute(self):
+            return NS(data=[{"content": "msg1", "role": "user"}], error=None)
+
+    class GuardedMemoryManager:
+        @property
+        def supabase(self):
+            raise AssertionError("routes must not navigate engine internals")
+
+    class GuardedEngine:
+        def __init__(self):
+            self.memory_manager = GuardedMemoryManager()
+            self.groq_manager = FakeGroqManager()
+            self.turn_calls = []
+
+        async def process_turn(
+            self, user_id, message, request_id, *, budget=None, mode=None, correlation=None
+        ):
+            self.turn_calls.append((user_id, message, request_id))
+            return ProcessTurnResult(
+                committed=object(),
+                response="di response",
+                emotion_state=EmotionStateResponse(
+                    schema_version=1,
+                    mood_label="NEUTRA",
+                    pad={"pleasure": 0.0, "arousal": 0.0, "dominance": 0.0},
+                    dominant_emotions=[],
+                    timestamp=1000.0,
+                ),
+            )
+
+    engine = GuardedEngine()
+    auth_client = AuthOnlyClient()
+    persistence_client = PersistenceOnlyClient()
+    deps = main_module.ApplicationDependencies(
+        conversation_engine=engine,
+        auth_client=auth_client,
+        admission_config=AdmissionRuntimeConfig.from_values(SECRET),
+        turn_config=TurnExecutionConfig.defaults(),
+        health_checks=HealthRegistry(),
+        clock=time.time,
+        persistence_client=persistence_client,
+    )
+    app = main_module.create_app(settings=_settings(), dependencies=deps)
+    client = TestClient(app)
+
+    # History: auth via auth_client, query via persistence_client only.
+    history = client.get("/history", headers={"Authorization": "Bearer t"})
+    assert history.status_code == 200
+    assert history.json() == [{"content": "msg1", "role": "user"}]
+    assert auth_calls == ["t"]
+    assert ("table", "chat_logs") in persist_calls
+
+    # Chat: auth via auth_client, admission RPC via persistence_client only,
+    # and the engine receives the turn.
+    auth_calls.clear()
+    persist_calls.clear()
+    chat = client.post(
+        "/chat",
+        json={"request_id": "550e8400-e29b-41d4-a716-446655440000", "message": "hi"},
+        headers={"Authorization": "Bearer t"},
+    )
+    assert chat.status_code == 200
+    assert chat.json()["response"] == "di response"
+    assert auth_calls == ["t"]
+    assert ("rpc", "reserve_admission") in persist_calls
+    assert len(engine.turn_calls) == 1
+    assert engine.turn_calls[0][0] == "user-123"
 
 
 # ─── CORS (35-38) ───────────────────────────────────────────────────────────

--- a/backend/tests/test_app_factory.py
+++ b/backend/tests/test_app_factory.py
@@ -243,11 +243,18 @@ def test_injected_routes_refuse_outside_lifespan():
 # ─── Readiness resources enter the lifecycle (review blocker 1) ─────────────
 
 
+class _FakeAuth:
+    """Duck-typed auth surface: the exact ``get_user`` path routes call."""
+
+    def get_user(self, token):
+        return None
+
+
 class _FakeSupabase:
     """Duck-typed Supabase surface: auth + table + rpc."""
 
     def __init__(self):
-        self.auth = object()
+        self.auth = _FakeAuth()
 
     def table(self, name):
         return self

--- a/backend/tests/test_app_factory.py
+++ b/backend/tests/test_app_factory.py
@@ -243,6 +243,15 @@ def test_injected_routes_refuse_outside_lifespan():
 # ─── Readiness resources enter the lifecycle (review blocker 1) ─────────────
 
 
+def _ok_async_probe():
+    """A passing async readiness probe (no network)."""
+
+    async def probe():
+        return None
+
+    return probe
+
+
 class _FakeAuth:
     """Duck-typed auth surface: the exact ``get_user`` path routes call."""
 
@@ -274,11 +283,11 @@ class _FakeSupabase:
         return SimpleNamespace(data=[], error=None)
 
 
-def test_default_builder_shuts_down_readiness_executor(monkeypatch):
+def test_default_builder_shuts_down_readiness_resources(monkeypatch):
     """The readiness registry is owned by the application: after leaving the
-    lifespan no readiness-db executor thread stays alive (review blocker 1)."""
+    lifespan no readiness probe task/thread survives and the owned resources
+    are cleared (review blockers 1-3)."""
     import threading
-    import time as _time
 
     import backend.dependencies as dependencies_module
 
@@ -289,19 +298,26 @@ def test_default_builder_shuts_down_readiness_executor(monkeypatch):
     )
     monkeypatch.setattr(
         dependencies_module,
-        "_build_readiness_probe_client",
-        lambda settings: _FakeSupabase(),
+        "_build_database_probe",
+        lambda settings: _ok_async_probe(),
     )
     monkeypatch.setattr(
         dependencies_module,
         "_build_auth_probe",
-        lambda settings: lambda: None,
+        lambda settings: _ok_async_probe(),
     )
     app = main_module.create_app(settings=_settings())
 
-    assert not [t for t in threading.enumerate() if t.name.startswith("readiness-db")]
+    def _readiness_threads():
+        return [
+            t
+            for t in threading.enumerate()
+            if t.name.startswith("readiness-")
+        ]
+
+    assert _readiness_threads() == []
     with TestClient(app) as client:
-        # Running /ready submits a probe, which creates the executor thread.
+        # Running /ready runs the async probes (no threads are created).
         response = client.get("/ready")
         assert response.status_code == 200
         # The owned tuple includes the closable registry.
@@ -309,20 +325,19 @@ def test_default_builder_shuts_down_readiness_executor(monkeypatch):
             hasattr(resource, "close") and type(resource).__name__ == "HealthRegistry"
             for resource in app.state.owned_resources
         )
-    # After shutdown the registry's aclose() shut the executor down; the
-    # (completed) probe thread terminates on its own.
-    deadline = _time.monotonic() + 5.0
-    while any(t.name.startswith("readiness-db") for t in threading.enumerate()):
-        assert _time.monotonic() < deadline, "readiness-db thread alive after shutdown"
-        _time.sleep(0.01)
+        assert _readiness_threads() == []
+    # After shutdown the owned resources are cleared and nothing remains.
+    assert app.state.owned_resources == ()
+    assert app.state.dependencies is None
+    assert _readiness_threads() == []
 
 
-# ─── Real surfaces vs probe client (review blocker 1) ───────────────────────
+# ─── Real surfaces vs probe (review blocker 1) ──────────────────────────────
 
 
 def test_ready_fails_when_real_clients_missing_but_probe_works(monkeypatch):
-    """A healthy dedicated probe cannot substitute for the real auth and
-    persistence surfaces the routes use (review blocker 1)."""
+    """A healthy probe cannot substitute for the real auth and persistence
+    surfaces the routes use (review blocker 1)."""
     import backend.dependencies as dependencies_module
 
     monkeypatch.setattr(
@@ -332,8 +347,13 @@ def test_ready_fails_when_real_clients_missing_but_probe_works(monkeypatch):
     )
     monkeypatch.setattr(
         dependencies_module,
-        "_build_readiness_probe_client",
-        lambda settings: _FakeSupabase(),
+        "_build_database_probe",
+        lambda settings: _ok_async_probe(),
+    )
+    monkeypatch.setattr(
+        dependencies_module,
+        "_build_auth_probe",
+        lambda settings: _ok_async_probe(),
     )
     app = main_module.create_app(settings=_settings())
     with TestClient(app) as client:
@@ -349,32 +369,36 @@ def test_ready_fails_when_real_clients_missing_but_probe_works(monkeypatch):
         assert body["components"]["lifespan"] == "ok"
 
 
-# ─── Shutdown drains an active probe before closing its client (blocker 2) ──
+# ─── Lifecycle: shutdown cancels in-flight probes (review blocker) ──────────
 
 
-def test_shutdown_drains_active_probe_before_closing_client(monkeypatch):
-    """A probe still in flight when the lifespan shuts down is drained with a
-    bounded wait; the probe client is closed only after the thread is done,
-    and no readiness-db thread survives (review blocker 2)."""
+def test_lifecycle_shutdown_cancels_inflight_probes(monkeypatch):
+    """Real lifecycle: a blocked probe at drain time is cancelled by the
+    lifespan shutdown itself. No fire-and-forget cleanup, no orphaned
+    ownership, no readiness thread survives (review blocker)."""
+    import asyncio as _asyncio
     import threading
-    import time as _time
-    from types import SimpleNamespace
 
     import backend.dependencies as dependencies_module
 
-    probe_started = threading.Event()
-    release = threading.Event()
-    events = []
+    cancelled = []
+    started = threading.Event()
 
-    class BlockingProbeClient(_FakeSupabase):
-        def execute(self):
-            probe_started.set()
-            release.wait(timeout=5.0)
-            events.append("probe_done")
-            return SimpleNamespace(data=[], error=None)
+    async def _blocking_auth_probe():
+        started.set()
+        try:
+            await _asyncio.sleep(10)
+        except _asyncio.CancelledError:
+            cancelled.append("auth")
+            raise
 
-        def close(self):
-            events.append("client_closed")
+    async def _blocking_db_probe():
+        started.set()
+        try:
+            await _asyncio.sleep(10)
+        except _asyncio.CancelledError:
+            cancelled.append("database")
+            raise
 
     monkeypatch.setattr(
         dependencies_module,
@@ -383,47 +407,52 @@ def test_shutdown_drains_active_probe_before_closing_client(monkeypatch):
     )
     monkeypatch.setattr(
         dependencies_module,
-        "_build_readiness_probe_client",
-        lambda settings: BlockingProbeClient(),
+        "_build_auth_probe",
+        lambda settings: _blocking_auth_probe,
+    )
+    monkeypatch.setattr(
+        dependencies_module,
+        "_build_database_probe",
+        lambda settings: _blocking_db_probe,
+    )
+    app = main_module.create_app(
+        settings=_settings(
+            readiness_auth_timeout_ms=100,
+            readiness_database_timeout_ms=100,
+        )
+    )
+    with TestClient(app) as client:
+        response = client.get("/ready")
+        assert response.status_code == 503
+        assert response.json()["components"]["auth"] == "unavailable"
+        assert response.json()["components"]["database"] == "unavailable"
+        assert started.is_set()
+    # Leaving the lifespan cancelled the in-flight probes; nothing survived.
+    assert "auth" in cancelled
+    assert "database" in cancelled
+    assert app.state.dependencies is None
+    assert app.state.owned_resources == ()
+    assert not [
+        t for t in threading.enumerate() if t.name.startswith("readiness-")
+    ]
+
+
+def test_default_builder_cleans_readiness_on_partial_startup(monkeypatch):
+    """Partial startup failure closes the registry created before the
+    failure; the async probe builders never leave owned clients behind."""
+    import backend.dependencies as dependencies_module
+
+    probes_built = []
+
+    monkeypatch.setattr(
+        dependencies_module,
+        "_build_database_probe",
+        lambda settings: probes_built.append("database") or _ok_async_probe(),
     )
     monkeypatch.setattr(
         dependencies_module,
         "_build_auth_probe",
-        lambda settings: lambda: None,
-    )
-    app = main_module.create_app(settings=_settings(readiness_database_timeout_ms=100))
-    with TestClient(app) as client:
-        response = client.get("/ready")
-        assert response.status_code == 503  # probe timed out, thread still blocked
-        assert probe_started.is_set()
-        # The probe thread is still alive while we are about to shut down.
-        assert any(t.name.startswith("readiness-db") for t in threading.enumerate())
-        # Release the probe so the shutdown drain can complete it.
-        release.set()
-    # Lifespan teardown drained the probe BEFORE closing the client.
-    assert events == ["probe_done", "client_closed"]
-    # No readiness-db thread survives.
-    deadline = _time.monotonic() + 5.0
-    while any(t.name.startswith("readiness-db") for t in threading.enumerate()):
-        assert _time.monotonic() < deadline, "readiness-db thread alive after shutdown"
-        _time.sleep(0.01)
-
-
-def test_default_builder_cleans_readiness_on_partial_startup(monkeypatch):
-    """Partial startup failure closes the probe client and registry created
-    before the failure (review blocker 1)."""
-    import backend.dependencies as dependencies_module
-
-    closed = []
-
-    class ClosableProbe:
-        def close(self):
-            closed.append(self)
-
-    monkeypatch.setattr(
-        dependencies_module,
-        "_build_readiness_probe_client",
-        lambda _settings: ClosableProbe(),
+        lambda settings: probes_built.append("auth") or _ok_async_probe(),
     )
 
     def boom(settings, engine, **kwargs):
@@ -432,7 +461,11 @@ def test_default_builder_cleans_readiness_on_partial_startup(monkeypatch):
     monkeypatch.setattr(dependencies_module, "build_health_registry", boom)
     with pytest.raises(RuntimeError):
         dependencies_module.build_default_dependencies(_settings())
-    assert len(closed) == 1, "probe client must be closed on partial startup"
+    # The async probe builders were reached before the registry failure; the
+    # probes are plain callables (no client, no thread), and the builder
+    # cleans the resources it created (the engine) on partial startup, so
+    # nothing owned is leaked.
+    assert probes_built == ["auth", "database"]
 
 
 def test_aclose_and_close_contracts_both_supported():

--- a/backend/tests/test_app_factory.py
+++ b/backend/tests/test_app_factory.py
@@ -130,20 +130,27 @@ def test_create_app_with_default_dependencies_builds_owned_resources_once(monkey
     monkeypatch.setattr(main_module, "build_default_dependencies", fake_builder)
     app = main_module.create_app(settings=settings)
     with TestClient(app):
-        pass
-    assert len(built) == 1
-    assert app.state.dependencies is not None
+        assert len(built) == 1
+        assert app.state.dependencies is not None
 
 
 # ─── 18/19. Lifespan ownership and close counts ─────────────────────────────
 
 
-def test_lifespan_closes_each_owned_resource_exactly_once(monkeypatch):
+def test_lifespan_second_cycle_builds_fresh_owned_composition(monkeypatch):
+    """A second lifespan cycle builds a NEW owned composition.
+
+    Shutdown closes and drops the owned composition; the next cycle must not
+    reuse already-closed resources (review blocker 2).
+    """
     settings = _settings()
-    owned_a = RecordingResource("a")
-    owned_b = RecordingResource("b")
+    cycles = []
 
     def fake_builder(settings_arg):
+        idx = len(cycles)
+        owned_a = RecordingResource(f"a-{idx}")
+        owned_b = RecordingResource(f"b-{idx}")
+        cycles.append((owned_a, owned_b))
         engine = FakeEngine(supabase=object())
         deps = main_module.ApplicationDependencies(
             conversation_engine=engine,
@@ -157,17 +164,20 @@ def test_lifespan_closes_each_owned_resource_exactly_once(monkeypatch):
 
     monkeypatch.setattr(main_module, "build_default_dependencies", fake_builder)
     app = main_module.create_app(settings=settings)
+
     with TestClient(app):
-        assert owned_a.close_calls == 0
-        assert owned_b.close_calls == 0
-    assert owned_a.close_calls == 1
-    assert owned_b.close_calls == 1
-    assert owned_a.closed and owned_b.closed
-    # Idempotent shutdown: a second lifespan run closes nothing again.
+        assert len(cycles) == 1
+    a1, b1 = cycles[0]
+    assert a1.close_calls == 1 and b1.close_calls == 1
+    assert app.state.dependencies is None, "owned composition must be dropped"
+
+    # Second lifespan cycle builds fresh resources and closes them again.
     with TestClient(app):
-        pass
-    assert owned_a.close_calls == 1
-    assert owned_b.close_calls == 1
+        assert len(cycles) == 2
+    a2, b2 = cycles[1]
+    assert a2 is not a1 and b2 is not b1
+    assert a2.close_calls == 1 and b2.close_calls == 1
+    assert app.state.dependencies is None
 
 
 def test_injected_dependencies_are_never_closed():
@@ -185,6 +195,127 @@ def test_injected_dependencies_are_never_closed():
     # The caller keeps ownership of injected resources.
     assert calls == []
     assert app.state.owned_resources == ()
+
+
+def test_owned_routes_refuse_after_shutdown(monkeypatch):
+    """After an owned lifespan shutdown, routes return 503 even though the
+    container was dropped (review blocker 2)."""
+    settings = _settings()
+
+    def fake_builder(settings_arg):
+        engine = FakeEngine(supabase=object())
+        deps = main_module.ApplicationDependencies(
+            conversation_engine=engine,
+            auth_client=object(),
+            admission_config=AdmissionRuntimeConfig.from_values(SECRET),
+            turn_config=TurnExecutionConfig.defaults(),
+            health_checks=HealthRegistry(),
+            clock=time.time,
+        )
+        return deps, ()
+
+    monkeypatch.setattr(main_module, "build_default_dependencies", fake_builder)
+    app = main_module.create_app(settings=settings)
+    with TestClient(app):
+        pass
+    assert app.state.dependencies is None
+    client = TestClient(app)
+    response = client.get("/history", headers={"Authorization": "Bearer x"})
+    assert response.status_code == 503
+
+
+def test_injected_routes_refuse_outside_lifespan():
+    """Injected dependencies stay with the caller after shutdown, but routes
+    still refuse to operate outside the lifespan (review blocker 2)."""
+    deps = _fake_dependencies()
+    app = main_module.create_app(settings=_settings(), dependencies=deps)
+    client = TestClient(app)
+    with client:
+        # During the lifespan the injected composition serves requests.
+        response = client.get("/history", headers={"Authorization": "Bearer x"})
+        assert response.status_code == 503  # no persistence client -> 503 body
+    # After the lifespan, routes refuse even though deps remain in app.state.
+    assert app.state.dependencies is deps
+    response = client.get("/history", headers={"Authorization": "Bearer x"})
+    assert response.status_code == 503
+
+
+# ─── Readiness resources enter the lifecycle (review blocker 1) ─────────────
+
+
+class _ProbeOkClient:
+    def table(self, name):
+        return self
+
+    def select(self, cols):
+        return self
+
+    def limit(self, n):
+        return self
+
+    def execute(self):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(data=[], error=None)
+
+
+def test_default_builder_shuts_down_readiness_executor(monkeypatch):
+    """The readiness registry is owned by the application: after leaving the
+    lifespan no readiness-db executor thread stays alive (review blocker 1)."""
+    import threading
+    import time as _time
+
+    import backend.dependencies as dependencies_module
+
+    monkeypatch.setattr(
+        dependencies_module,
+        "_build_readiness_probe_client",
+        lambda _settings: _ProbeOkClient(),
+    )
+    app = main_module.create_app(settings=_settings())
+
+    assert not [t for t in threading.enumerate() if t.name.startswith("readiness-db")]
+    with TestClient(app) as client:
+        # Running /ready submits a probe, which creates the executor thread.
+        response = client.get("/ready")
+        assert response.status_code == 200
+        # The owned tuple now includes the closable registry.
+        assert any(
+            hasattr(resource, "close") and type(resource).__name__ == "HealthRegistry"
+            for resource in app.state.owned_resources
+        )
+    # After shutdown the registry's close() shut the executor down; the
+    # (completed) probe thread terminates on its own.
+    deadline = _time.monotonic() + 5.0
+    while any(t.name.startswith("readiness-db") for t in threading.enumerate()):
+        assert _time.monotonic() < deadline, "readiness-db thread alive after shutdown"
+        _time.sleep(0.01)
+
+
+def test_default_builder_cleans_readiness_on_partial_startup(monkeypatch):
+    """Partial startup failure closes the probe client and registry created
+    before the failure (review blocker 1)."""
+    import backend.dependencies as dependencies_module
+
+    closed = []
+
+    class ClosableProbe:
+        def close(self):
+            closed.append(self)
+
+    monkeypatch.setattr(
+        dependencies_module,
+        "_build_readiness_probe_client",
+        lambda _settings: ClosableProbe(),
+    )
+
+    def boom(settings, engine, **kwargs):
+        raise RuntimeError("late readiness build failure")
+
+    monkeypatch.setattr(dependencies_module, "build_health_registry", boom)
+    with pytest.raises(RuntimeError):
+        dependencies_module.build_default_dependencies(_settings())
+    assert len(closed) == 1, "probe client must be closed on partial startup"
 
 
 def test_aclose_and_close_contracts_both_supported():
@@ -311,6 +442,7 @@ def test_no_per_user_state_in_app_state_or_container():
     assert state_keys <= {
         "settings",
         "dependencies",
+        "dependencies_owned",
         "lifespan_started",
         "owned_resources",
         "shutdown_completed",

--- a/backend/tests/test_app_factory.py
+++ b/backend/tests/test_app_factory.py
@@ -1,0 +1,407 @@
+"""Tests for the application factory, lifespan, and dependency container (#275)."""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+import backend.main as main_module
+from backend.admission import AdmissionRuntimeConfig
+from backend.health import HealthRegistry
+from backend.settings import AppEnvironment, Settings
+from backend.turn_execution import TurnExecutionConfig
+
+SECRET = "s" * 40
+
+
+def _settings(**overrides) -> Settings:
+    kwargs = {
+        "app_env": AppEnvironment.local,
+        "groq_api_key": "groq-key",
+        "admission_hmac_secret": SECRET,
+        "cors_allowed_origins": ("https://allowed.example",),
+    }
+    kwargs.update(overrides)
+    return Settings(**kwargs)
+
+
+class RecordingResource:
+    """Fake owned resource with a close() that records invocations."""
+
+    def __init__(self, label="resource"):
+        self.label = label
+        self.close_calls = 0
+        self.closed = False
+
+    def close(self):
+        self.close_calls += 1
+        self.closed = True
+
+
+class FakeGroqManager:
+    def is_configured(self):
+        return True
+
+
+class FakeEngine:
+    def __init__(self, supabase=None):
+        self.memory_manager = SimpleNamespace(supabase=supabase)
+        self.groq_manager = FakeGroqManager()
+
+
+def _fake_dependencies(**overrides) -> main_module.ApplicationDependencies:
+    settings = _settings()
+    engine = FakeEngine(supabase=object())
+    kwargs = {
+        "conversation_engine": engine,
+        "auth_client": engine.memory_manager.supabase,
+        "admission_config": AdmissionRuntimeConfig.from_values(SECRET),
+        "turn_config": TurnExecutionConfig.defaults(),
+        "health_checks": HealthRegistry(),
+        "clock": time.time,
+    }
+    kwargs.update(overrides)
+    return main_module.ApplicationDependencies(**kwargs)
+
+
+# ─── 17. create_app with settings and injected fakes ────────────────────────
+
+
+def test_create_app_works_with_injected_settings_and_dependencies():
+    settings = _settings()
+    deps = _fake_dependencies()
+    app = main_module.create_app(settings=settings, dependencies=deps)
+    assert app.state.settings is settings
+    assert app.state.dependencies is deps
+    assert app.state.lifespan_started is True
+    assert app.state.owned_resources == ()
+    assert app.state.shutdown_completed is False
+
+
+def test_create_app_without_dependencies_defers_construction_to_lifespan():
+    app = main_module.create_app(settings=_settings())
+    assert app.state.dependencies is None
+    assert app.state.lifespan_started is False
+    # No heavy resources were built by the factory itself.
+    assert app.state.owned_resources == ()
+
+
+def test_create_app_defaults_settings_from_environment(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "env-key")
+    monkeypatch.setenv("ADMISSION_HMAC_SECRET", SECRET)
+    app = main_module.create_app()
+    assert app.state.settings.app_env is AppEnvironment.local
+    assert app.state.dependencies is None
+
+
+def test_create_app_with_default_dependencies_builds_owned_resources_once(monkeypatch):
+    settings = _settings()
+    built = []
+
+    def fake_builder(settings_arg):
+        built.append(settings_arg)
+        engine = FakeEngine(supabase=object())
+        deps = main_module.ApplicationDependencies(
+            conversation_engine=engine,
+            auth_client=object(),
+            admission_config=AdmissionRuntimeConfig.from_values(SECRET),
+            turn_config=TurnExecutionConfig.defaults(),
+            health_checks=HealthRegistry(),
+            clock=time.time,
+        )
+        return deps, (RecordingResource("owned-a"),)
+
+    monkeypatch.setattr(main_module, "build_default_dependencies", fake_builder)
+    app = main_module.create_app(settings=settings)
+    with TestClient(app):
+        pass
+    assert len(built) == 1
+    assert app.state.dependencies is not None
+
+
+# ─── 18/19. Lifespan ownership and close counts ─────────────────────────────
+
+
+def test_lifespan_closes_each_owned_resource_exactly_once(monkeypatch):
+    settings = _settings()
+    owned_a = RecordingResource("a")
+    owned_b = RecordingResource("b")
+
+    def fake_builder(settings_arg):
+        engine = FakeEngine(supabase=object())
+        deps = main_module.ApplicationDependencies(
+            conversation_engine=engine,
+            auth_client=object(),
+            admission_config=AdmissionRuntimeConfig.from_values(SECRET),
+            turn_config=TurnExecutionConfig.defaults(),
+            health_checks=HealthRegistry(),
+            clock=time.time,
+        )
+        return deps, (owned_a, owned_b)
+
+    monkeypatch.setattr(main_module, "build_default_dependencies", fake_builder)
+    app = main_module.create_app(settings=settings)
+    with TestClient(app):
+        assert owned_a.close_calls == 0
+        assert owned_b.close_calls == 0
+    assert owned_a.close_calls == 1
+    assert owned_b.close_calls == 1
+    assert owned_a.closed and owned_b.closed
+    # Idempotent shutdown: a second lifespan run closes nothing again.
+    with TestClient(app):
+        pass
+    assert owned_a.close_calls == 1
+    assert owned_b.close_calls == 1
+
+
+def test_injected_dependencies_are_never_closed():
+    calls = []
+
+    class EngineWithClose(FakeEngine):
+        def close(self):
+            calls.append(self)
+
+    engine = EngineWithClose(supabase=object())
+    deps = _fake_dependencies(conversation_engine=engine)
+    app = main_module.create_app(settings=_settings(), dependencies=deps)
+    with TestClient(app):
+        pass
+    # The caller keeps ownership of injected resources.
+    assert calls == []
+    assert app.state.owned_resources == ()
+
+
+def test_aclose_and_close_contracts_both_supported():
+    from backend.dependencies import close_resource
+
+    class SyncClose:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class AsyncClose:
+        def __init__(self):
+            self.closed = False
+
+        async def aclose(self):
+            self.closed = True
+
+    async def _run():
+        sync_resource = SyncClose()
+        async_resource = AsyncClose()
+        await close_resource(sync_resource)
+        await close_resource(async_resource)
+        assert sync_resource.closed
+        assert async_resource.closed
+        # Idempotent per-resource: closing again is a no-op by contract.
+        await close_resource(sync_resource)
+
+    import asyncio
+
+    asyncio.run(_run())
+
+
+# ─── 21. Partial startup failure ────────────────────────────────────────────
+
+
+def test_builder_cleans_partial_resources_when_startup_fails(monkeypatch):
+    """The real default builder must close resources created before a failure."""
+    import backend.dependencies as dependencies_module
+
+    created = []
+    closed = []
+
+    class FakeEngineWithClose:
+        def __init__(self, *args, **kwargs):
+            self.groq_manager = object()
+            self.memory_manager = SimpleNamespace(supabase=object())
+            created.append(self)
+
+        def close(self):
+            closed.append(self)
+
+    monkeypatch.setattr(dependencies_module, "ChatConversationEngine", FakeEngineWithClose)
+
+    def boom(settings, engine, auth_client):
+        raise RuntimeError("late startup failure")
+
+    monkeypatch.setattr(dependencies_module, "build_health_registry", boom)
+    with pytest.raises(RuntimeError):
+        dependencies_module.build_default_dependencies(_settings())
+    assert len(created) == 1
+    assert closed == created
+
+
+def test_lifespan_startup_failure_leaves_app_not_ready(monkeypatch, caplog):
+    settings = _settings()
+
+    def failing_builder(settings_arg):
+        raise RuntimeError("startup exploded")
+
+    monkeypatch.setattr(main_module, "build_default_dependencies", failing_builder)
+    app = main_module.create_app(settings=settings)
+    with pytest.raises(RuntimeError):
+        with TestClient(app):
+            pass
+    assert app.state.dependencies is None
+    assert app.state.lifespan_started is False
+    # Startup failure is observable through the sanitized event.
+    assert "event=app_startup_failed" in caplog.text
+
+
+# ─── 22. Shutdown continues past individual failures ────────────────────────
+
+
+def test_shutdown_continues_when_one_resource_fails(monkeypatch):
+    settings = _settings()
+
+    class FailingResource(RecordingResource):
+        def close(self):
+            super().close()
+            raise RuntimeError("close exploded")
+
+    failing = FailingResource("failing")
+    ok = RecordingResource("ok")
+
+    def fake_builder(settings_arg):
+        engine = FakeEngine(supabase=object())
+        deps = main_module.ApplicationDependencies(
+            conversation_engine=engine,
+            auth_client=object(),
+            admission_config=AdmissionRuntimeConfig.from_values(SECRET),
+            turn_config=TurnExecutionConfig.defaults(),
+            health_checks=HealthRegistry(),
+            clock=time.time,
+        )
+        return deps, (failing, ok)
+
+    monkeypatch.setattr(main_module, "build_default_dependencies", fake_builder)
+    app = main_module.create_app(settings=settings)
+    with TestClient(app):
+        pass  # shutdown must not raise
+    assert failing.closed
+    assert ok.closed
+    assert ok.close_calls == 1
+
+
+# ─── 23. No per-user state in singletons or app.state ───────────────────────
+
+
+def test_no_per_user_state_in_app_state_or_container():
+    app = main_module.create_app(settings=_settings(), dependencies=_fake_dependencies())
+    state_keys = set(app.state._state)
+    assert state_keys <= {
+        "settings",
+        "dependencies",
+        "lifespan_started",
+        "owned_resources",
+        "shutdown_completed",
+    }
+    deps = app.state.dependencies
+    container_fields = {
+        "conversation_engine",
+        "auth_client",
+        "admission_config",
+        "turn_config",
+        "health_checks",
+        "clock",
+    }
+    assert set(deps.__dataclass_fields__) == container_fields
+    # No attribute of the container may hold a user identity.
+    for field_name in container_fields:
+        assert "user" not in field_name.lower()
+        assert "request" not in field_name.lower()
+
+
+# ─── CORS (35-38) ───────────────────────────────────────────────────────────
+
+
+def _cors_client(settings):
+    app = main_module.create_app(settings=settings, dependencies=_fake_dependencies())
+    return TestClient(app)
+
+
+def test_allowed_origin_receives_expected_headers():
+    client = _cors_client(_settings(cors_allowed_origins=("https://allowed.example",)))
+    response = client.get("/health", headers={"Origin": "https://allowed.example"})
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == "https://allowed.example"
+    assert response.headers.get("access-control-allow-credentials") == "true"
+
+
+def test_disallowed_origin_does_not_receive_authorization():
+    client = _cors_client(_settings(cors_allowed_origins=("https://allowed.example",)))
+    response = client.get("/health", headers={"Origin": "https://denied.example"})
+    assert response.status_code == 200
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_unsafe_configuration_never_starts_in_production():
+    with pytest.raises(ValidationError):
+        _settings(
+            app_env=AppEnvironment.production,
+            supabase_url="https://db.example.com",
+            supabase_service_role_key="sk",
+            cors_allowed_origins=("http://localhost:3000",),
+        )
+    with pytest.raises(ValidationError):
+        _settings(
+            app_env=AppEnvironment.production,
+            supabase_url="https://db.example.com",
+            supabase_service_role_key="sk",
+            cors_allowed_origins=("*",),
+        )
+    with pytest.raises(ValidationError):
+        _settings(
+            app_env=AppEnvironment.production,
+            supabase_url="https://db.example.com",
+            cors_allowed_origins=("https://app.example.com",),
+        )
+
+
+def test_valid_production_configuration_starts():
+    settings = _settings(
+        app_env=AppEnvironment.production,
+        supabase_url="https://db.example.com",
+        supabase_service_role_key="sk",
+        cors_allowed_origins=("https://app.example.com",),
+    )
+    client = _cors_client(settings)
+    response = client.get("/health", headers={"Origin": "https://app.example.com"})
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == "https://app.example.com"
+
+
+def test_local_configuration_continues_working():
+    client = _cors_client(
+        _settings(cors_allowed_origins=("http://localhost:3000",))
+    )
+    response = client.get("/health", headers={"Origin": "http://localhost:3000"})
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+
+def test_cors_methods_and_headers_are_minimal():
+    client = _cors_client(_settings(cors_allowed_origins=("https://allowed.example",)))
+    response = client.options(
+        "/chat",
+        headers={
+            "Origin": "https://allowed.example",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "authorization,content-type",
+        },
+    )
+    assert response.status_code == 200
+    allow_methods = response.headers.get("access-control-allow-methods", "")
+    assert "POST" in allow_methods and "GET" in allow_methods
+    assert "*" not in allow_methods
+    allow_headers = response.headers.get("access-control-allow-headers", "").lower()
+    assert "authorization" in allow_headers
+    assert "content-type" in allow_headers
+    assert "*" not in allow_headers

--- a/backend/tests/test_app_factory.py
+++ b/backend/tests/test_app_factory.py
@@ -292,6 +292,11 @@ def test_default_builder_shuts_down_readiness_executor(monkeypatch):
         "_build_readiness_probe_client",
         lambda settings: _FakeSupabase(),
     )
+    monkeypatch.setattr(
+        dependencies_module,
+        "_build_auth_probe",
+        lambda settings: lambda: None,
+    )
     app = main_module.create_app(settings=_settings())
 
     assert not [t for t in threading.enumerate() if t.name.startswith("readiness-db")]
@@ -380,6 +385,11 @@ def test_shutdown_drains_active_probe_before_closing_client(monkeypatch):
         dependencies_module,
         "_build_readiness_probe_client",
         lambda settings: BlockingProbeClient(),
+    )
+    monkeypatch.setattr(
+        dependencies_module,
+        "_build_auth_probe",
+        lambda settings: lambda: None,
     )
     app = main_module.create_app(settings=_settings(readiness_database_timeout_ms=100))
     with TestClient(app) as client:

--- a/backend/tests/test_archival_memory_integration.py
+++ b/backend/tests/test_archival_memory_integration.py
@@ -112,7 +112,10 @@ def _app_engine(client_app):
 @pytest.fixture
 def mock_supabase(client_app):
     engine = _app_engine(client_app)
-    with patch.object(engine.memory_manager, 'supabase', MagicMock()) as mock_sb:
+    deps = client_app.app.state.dependencies
+    with patch.object(engine.memory_manager, 'supabase', MagicMock()) as mock_sb, \
+         patch.object(deps, 'auth_client', mock_sb), \
+         patch.object(deps, 'persistence_client', mock_sb):
         mock_sb.rpc.return_value.execute.return_value.data = [
             {"decision": "admitted", "retry_after_seconds": 0}
         ]

--- a/backend/tests/test_archival_memory_integration.py
+++ b/backend/tests/test_archival_memory_integration.py
@@ -13,6 +13,8 @@ from unittest.mock import patch, AsyncMock
 from fastapi import BackgroundTasks
 from fastapi.testclient import TestClient
 
+import backend.main as main
+
 REQUEST_ID = "550e8400-e29b-41d4-a716-446655440000"
 
 
@@ -73,15 +75,43 @@ def backend(mock_external_dependencies):
     return h
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def client_app(mock_external_dependencies):
-    from backend.main import app
+    """Real engine composed through the application factory with mocked env."""
+    from backend.admission import AdmissionRuntimeConfig
+    from backend.chat_engine import ChatConversationEngine
+    from backend.dependencies import ApplicationDependencies
+    from backend.health import HealthRegistry
+    from backend.settings import AppEnvironment, Settings
+    from backend.turn_execution import TurnExecutionConfig
+
+    engine = ChatConversationEngine()
+    settings = Settings(
+        app_env=AppEnvironment.local,
+        groq_api_key="mock_key",
+        admission_hmac_secret="test-admission-secret-that-is-at-least-32-bytes",
+        cors_allowed_origins=("http://localhost:3000",),
+    )
+    deps = ApplicationDependencies(
+        conversation_engine=engine,
+        auth_client=engine.memory_manager.supabase,
+        admission_config=AdmissionRuntimeConfig.from_values(
+            "test-admission-secret-that-is-at-least-32-bytes"
+        ),
+        turn_config=TurnExecutionConfig.defaults(),
+        health_checks=HealthRegistry(),
+    )
+    app = main.create_app(settings=settings, dependencies=deps)
     return TestClient(app)
 
 
+def _app_engine(client_app):
+    return client_app.app.state.dependencies.conversation_engine
+
+
 @pytest.fixture
-def mock_supabase():
-    from backend.main import engine
+def mock_supabase(client_app):
+    engine = _app_engine(client_app)
     with patch.object(engine.memory_manager, 'supabase', MagicMock()) as mock_sb:
         mock_sb.rpc.return_value.execute.return_value.data = [
             {"decision": "admitted", "retry_after_seconds": 0}
@@ -371,7 +401,7 @@ async def test_run_archival_extraction_disabled_returns_early(backend):
 
 
 def test_chat_response_format(client_app, mock_supabase, monkeypatch):
-    from backend.main import engine
+    engine = _app_engine(client_app)
     from backend.relationship import RelationshipStateV1
     
     mock_user = MockUser(id="user123")

--- a/backend/tests/test_archival_memory_integration.py
+++ b/backend/tests/test_archival_memory_integration.py
@@ -514,6 +514,94 @@ def test_archival_extraction_explicit_false(backend):
     assert engine.archival_extraction_enabled is False
 
 
+# ─── Retrieval honesty in enabled mode (review blocker 3) ───────────────────
+
+
+def _mm_with_embeddings(enabled, supabase=None, model=None):
+    """Bare MemoryManager with controlled retrieval dependencies."""
+    from backend.memory import MemoryManager
+
+    mm = MemoryManager.__new__(MemoryManager)
+    mm.embeddings_enabled = enabled
+    mm.supabase = supabase
+    mm.embedding_model = model
+    return mm
+
+
+def test_embeddings_disabled_mode_returns_empty_without_embeddings():
+    """Disabled mode returns [] and never touches embeddings or the store."""
+    from backend.memory import MemoryManager
+
+    mm = _mm_with_embeddings(enabled=False, supabase=None, model=None)
+    assert mm._retrieve_relevant_entries("u", "q") == []
+
+
+def test_embeddings_enabled_mode_encode_failure_fails_honestly():
+    """Enabled mode: an encode failure raises a sanitized ContextLoadError
+    instead of silently returning [] (review blocker 3)."""
+    from unittest.mock import MagicMock
+
+    from backend.memory import ContextLoadError
+
+    model = MagicMock()
+    model.encode.side_effect = RuntimeError("embedding backend down")
+    mm = _mm_with_embeddings(enabled=True, supabase=MagicMock(), model=model)
+    with pytest.raises(ContextLoadError):
+        mm._retrieve_relevant_entries("u", "q")
+
+
+def test_embeddings_enabled_mode_rpc_failure_fails_honestly():
+    """Enabled mode: a transport/RPC failure raises ContextLoadError (blocker 3)."""
+    from unittest.mock import MagicMock
+
+    from backend.memory import ContextLoadError
+
+    model = MagicMock()
+    model.encode.return_value.tolist.return_value = [0.1, 0.2]
+    supabase = MagicMock()
+    supabase.rpc.return_value.execute.side_effect = RuntimeError("rpc down")
+    mm = _mm_with_embeddings(enabled=True, supabase=supabase, model=model)
+    with pytest.raises(ContextLoadError):
+        mm._retrieve_relevant_entries("u", "q")
+
+
+def test_embeddings_enabled_mode_invalid_response_fails_honestly():
+    """Enabled mode: a structurally invalid RPC response raises
+    ContextLoadError; only valid data=[] means no memories (review blocker 3)."""
+    from unittest.mock import MagicMock
+
+    from backend.memory import ContextLoadError
+
+    model = MagicMock()
+    model.encode.return_value.tolist.return_value = [0.1, 0.2]
+    supabase = MagicMock()
+    supabase.rpc.return_value.execute.return_value = None
+    mm = _mm_with_embeddings(enabled=True, supabase=supabase, model=model)
+    with pytest.raises(ContextLoadError):
+        mm._retrieve_relevant_entries("u", "q")
+
+    supabase.rpc.return_value.execute.return_value = MagicMock(data=None)
+    with pytest.raises(ContextLoadError):
+        mm._retrieve_relevant_entries("u", "q")
+
+    supabase.rpc.return_value.execute.return_value = MagicMock(data="not-a-list")
+    with pytest.raises(ContextLoadError):
+        mm._retrieve_relevant_entries("u", "q")
+
+
+def test_embeddings_enabled_mode_valid_empty_returns_no_memories():
+    """Enabled mode: a structurally valid response with data=[] is the real
+    absence of memories and returns [] (review blocker 3)."""
+    from unittest.mock import MagicMock
+
+    model = MagicMock()
+    model.encode.return_value.tolist.return_value = [0.1, 0.2]
+    supabase = MagicMock()
+    supabase.rpc.return_value.execute.return_value = MagicMock(data=[])
+    mm = _mm_with_embeddings(enabled=True, supabase=supabase, model=model)
+    assert mm._retrieve_relevant_entries("u", "q") == []
+
+
 def test_no_real_external_dependencies_proof():
     # Programmatic proof that real SentenceTransformer, Supabase or Groq are not used
     # in any test environment instantiation

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -103,7 +103,10 @@ def _app_engine(client_app):
 @pytest.fixture
 def mock_supabase(client_app):
     engine = _app_engine(client_app)
-    with patch.object(engine.memory_manager, 'supabase', MagicMock()) as mock_sb:
+    deps = client_app.app.state.dependencies
+    with patch.object(engine.memory_manager, 'supabase', MagicMock()) as mock_sb, \
+         patch.object(deps, 'auth_client', mock_sb), \
+         patch.object(deps, 'persistence_client', mock_sb):
         mock_sb.rpc.return_value.execute.return_value.data = [
             {"decision": "admitted", "retry_after_seconds": 0}
         ]
@@ -198,8 +201,8 @@ def test_user_is_none(client_app, mock_supabase, mock_engine_process):
 
 
 def test_service_unavailable(client_app, mock_supabase, mock_engine_process):
-    engine = _app_engine(client_app)
-    with patch.object(engine.memory_manager, 'supabase', None):
+    deps = client_app.app.state.dependencies
+    with patch.object(deps, 'auth_client', None):
         response = client_app.post(
             "/chat",
             json=_chat_payload("Hi"),

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -4,6 +4,8 @@ import logging
 import pytest
 from unittest.mock import patch, MagicMock, ANY
 
+import backend.main as main
+
 REQUEST_ID = "550e8400-e29b-41d4-a716-446655440000"
 
 
@@ -57,16 +59,50 @@ def mock_external_dependencies():
     os.environ.update(_original_env)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def client_app(mock_external_dependencies):
+    """Real engine composed through the application factory with mocked env.
+
+    The engine is built once per module (like the historical module-level
+    engine) and composed via ``create_app`` with the validated settings, so
+    the auth dependency runs through the real server-side path.
+    """
     from fastapi.testclient import TestClient
-    from backend.main import app
+    from backend.admission import AdmissionRuntimeConfig
+    from backend.chat_engine import ChatConversationEngine
+    from backend.dependencies import ApplicationDependencies
+    from backend.health import HealthRegistry
+    from backend.settings import AppEnvironment, Settings
+    from backend.turn_execution import TurnExecutionConfig
+
+    engine = ChatConversationEngine()
+    settings = Settings(
+        app_env=AppEnvironment.local,
+        groq_api_key="mock_key",
+        admission_hmac_secret="test-admission-secret-that-is-at-least-32-bytes",
+        cors_allowed_origins=("http://localhost:3000",),
+    )
+    deps = ApplicationDependencies(
+        conversation_engine=engine,
+        auth_client=engine.memory_manager.supabase,
+        admission_config=AdmissionRuntimeConfig.from_values(
+            "test-admission-secret-that-is-at-least-32-bytes"
+        ),
+        turn_config=TurnExecutionConfig.defaults(),
+        health_checks=HealthRegistry(),
+    )
+    app = main.create_app(settings=settings, dependencies=deps)
     return TestClient(app)
 
 
+def _app_engine(client_app):
+    """Resolve the composed engine from the test client's app state."""
+    return client_app.app.state.dependencies.conversation_engine
+
+
 @pytest.fixture
-def mock_supabase():
-    from backend.main import engine
+def mock_supabase(client_app):
+    engine = _app_engine(client_app)
     with patch.object(engine.memory_manager, 'supabase', MagicMock()) as mock_sb:
         mock_sb.rpc.return_value.execute.return_value.data = [
             {"decision": "admitted", "retry_after_seconds": 0}
@@ -75,8 +111,8 @@ def mock_supabase():
 
 
 @pytest.fixture
-def mock_engine_process():
-    from backend.main import engine
+def mock_engine_process(client_app):
+    engine = _app_engine(client_app)
     from backend.emotion_presentation import EmotionStateResponse, PublicPAD
     from backend.process_turn import ProcessTurnResult
     fake_emotion = EmotionStateResponse(
@@ -162,7 +198,7 @@ def test_user_is_none(client_app, mock_supabase, mock_engine_process):
 
 
 def test_service_unavailable(client_app, mock_supabase, mock_engine_process):
-    from backend.main import engine
+    engine = _app_engine(client_app)
     with patch.object(engine.memory_manager, 'supabase', None):
         response = client_app.post(
             "/chat",
@@ -331,7 +367,7 @@ def test_unexpected_error_503(client_app, mock_supabase, mock_engine_process, ca
 
 
 def test_http_chat_load_failure_sanitization(client_app, mock_supabase, caplog):
-    from backend.main import engine
+    engine = _app_engine(client_app)
     mock_supabase.auth.get_user.return_value = MockAuthResponse(user=MockUser("user123"))
 
     # Mock supabase select call to raise a sensitive exception
@@ -361,7 +397,7 @@ def test_http_chat_load_failure_sanitization(client_app, mock_supabase, caplog):
 
 
 def test_http_chat_persistence_failure_sanitization(client_app, mock_supabase, caplog):
-    from backend.main import engine
+    engine = _app_engine(client_app)
     from backend.emotional_core import EmotionalState
     from backend.relationship import RelationshipStateV1
     mock_supabase.auth.get_user.return_value = MockAuthResponse(user=MockUser("user123"))

--- a/backend/tests/test_chat_admission.py
+++ b/backend/tests/test_chat_admission.py
@@ -73,17 +73,37 @@ class FakeEngine:
         return _turn_result()
 
 
+def _build_app(fake_engine, *, override_auth=True):
+    """Build an application with injected fakes (no lifespan needed)."""
+    from backend.health import HealthRegistry
+    from backend.settings import AppEnvironment, Settings
+    from backend.turn_execution import TurnExecutionConfig
+
+    settings = Settings(
+        app_env=AppEnvironment.local,
+        groq_api_key="k",
+        admission_hmac_secret=SECRET,
+        cors_allowed_origins=("http://localhost:3000",),
+    )
+    deps = main.ApplicationDependencies(
+        conversation_engine=fake_engine,
+        auth_client=fake_engine.memory_manager.supabase,
+        admission_config=AdmissionRuntimeConfig.from_values(SECRET),
+        turn_config=TurnExecutionConfig.defaults(),
+        health_checks=HealthRegistry(),
+    )
+    app = main.create_app(settings=settings, dependencies=deps)
+    if override_auth:
+        app.dependency_overrides[main.get_current_user] = lambda: SimpleNamespace(
+            id="user-a"
+        )
+    return app
+
+
 @pytest.fixture
 def endpoint(monkeypatch):
     fake_engine = FakeEngine()
     captured = {}
-
-    monkeypatch.setattr(main, "engine", fake_engine)
-    monkeypatch.setattr(
-        main,
-        "_admission_config",
-        AdmissionRuntimeConfig.from_values("s" * 32),
-    )
 
     async def fake_run_blocking_write(
         stage_label,
@@ -101,14 +121,12 @@ def endpoint(monkeypatch):
         return func(*args, **kwargs)
 
     monkeypatch.setattr(main, "run_blocking_write", fake_run_blocking_write)
-    main.app.dependency_overrides[main.get_current_user] = lambda: SimpleNamespace(
-        id="user-a"
-    )
-    client = TestClient(main.app)
+    app = _build_app(fake_engine)
+    client = TestClient(app)
     try:
         yield client, fake_engine, captured
     finally:
-        main.app.dependency_overrides.clear()
+        app.dependency_overrides.clear()
 
 
 def test_admitted_runs_process_turn_normal_with_request_id_and_one_budget(endpoint, monkeypatch):
@@ -380,8 +398,7 @@ def test_extra_field_and_wrong_types_use_generic_sanitised_validation(endpoint):
 
 def test_missing_authentication_does_not_reserve(monkeypatch):
     fake_engine = FakeEngine()
-    monkeypatch.setattr(main, "engine", fake_engine)
-    main.app.dependency_overrides.clear()
+    app = _build_app(fake_engine, override_auth=False)
     called = False
 
     def reserve(_client, _request):
@@ -390,7 +407,7 @@ def test_missing_authentication_does_not_reserve(monkeypatch):
         return AdmissionResult(ADMITTED, 0)
 
     monkeypatch.setattr(main, "reserve_admission_sync", reserve)
-    client = TestClient(main.app)
+    client = TestClient(app)
     response = client.post(
         "/chat",
         json={"request_id": UUID, "message": "hello"},
@@ -435,12 +452,7 @@ def test_expired_budget_returns_timeout_before_rpc(endpoint, monkeypatch):
 def test_cancellation_is_propagated_not_converted_to_500(monkeypatch):
     """The endpoint must re-raise CancelledError, never map it to HTTP 500."""
     fake_engine = FakeEngine()
-    monkeypatch.setattr(main, "engine", fake_engine)
-    monkeypatch.setattr(
-        main,
-        "_admission_config",
-        AdmissionRuntimeConfig.from_values("s" * 32),
-    )
+    app = _build_app(fake_engine, override_auth=False)
     monkeypatch.setattr(
         main,
         "reserve_admission_sync",
@@ -465,6 +477,7 @@ def test_cancellation_is_propagated_not_converted_to_500(monkeypatch):
         "headers": [],
         "client": ("127.0.0.1", 1234),
         "server": ("test", 80),
+        "app": app,
     }
     request = main.Request(scope)
 

--- a/backend/tests/test_emotional_integration.py
+++ b/backend/tests/test_emotional_integration.py
@@ -816,7 +816,7 @@ class TestNewProfileFirstTurn:
 
             # ── Isolate from real SentenceTransformer (would hang in CI)  ──
             with patch("backend.memory.SentenceTransformer", return_value=MagicMock()) as embedding_cls:
-                engine = ConversationEngine(clock=clock)
+                engine = ConversationEngine(clock=clock, embeddings_enabled=True)
             embedding_cls.assert_called_once()
 
             # ── Mock Supabase: empty select (new user), then insert OK     ──

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -475,6 +475,45 @@ def test_aclose_is_clean_after_expired_ready():
     asyncio.run(scenario())
 
 
+def test_registry_aclose_awaits_async_check_aclose():
+    """HealthRegistry.aclose() must actually await each check's async
+    aclose() to completion. A NameError in the dispatch (e.g. a missing
+    ``inspect`` import) is swallowed by the generic handler and the
+    coroutine is never awaited, silently skipping the cleanup (review
+    blocker)."""
+    from backend.health import HealthRegistry
+
+    awaited = []
+
+    class AsyncCloseCheck:
+        name = "async-close"
+
+        async def aclose(self):
+            # Only reached when the registry actually awaits this coroutine.
+            await asyncio.sleep(0)
+            awaited.append("aclose-ran")
+
+    class SyncCloseCheck:
+        name = "sync-close"
+
+        def close(self):
+            awaited.append("close-ran")
+
+    registry = HealthRegistry(
+        {
+            "async-close": AsyncCloseCheck(),
+            "sync-close": SyncCloseCheck(),
+        }
+    )
+
+    async def scenario():
+        await registry.aclose()
+        # The async aclose ran to completion and the sync close also ran.
+        assert awaited == ["aclose-ran", "close-ran"]
+
+    asyncio.run(scenario())
+
+
 # ─── 32. Sensitive marker sanitization ──────────────────────────────────────
 
 

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -67,8 +67,21 @@ def _ok_auth_client():
 
 
 def _ok_auth_probe():
-    """A passing Auth availability probe (no network)."""
-    return lambda: None
+    """A passing async Auth availability probe (no network)."""
+
+    async def probe():
+        return None
+
+    return probe
+
+
+def _ok_db_probe():
+    """A passing async database availability probe (no network)."""
+
+    async def probe():
+        return None
+
+    return probe
 
 
 def _deps_with_checks(checks):
@@ -262,28 +275,34 @@ class _OkProbeClient:
         return _ProbeResult(data=[])
 
 
-def test_database_check_timeout_bounds_the_real_blocking_probe():
-    """Repeated polls never accumulate threads and recover once the probe's
-    aligned transport releases the worker (review blocker 4)."""
-    import concurrent.futures
-    import threading
-    import time as _time
+def _slow_db_probe(started=None, release=None):
+    """Build an async database probe that blocks until ``release`` is set."""
+    import asyncio as _asyncio
 
-    probe_started = threading.Event()
-    release = threading.Event()
+    async def probe():
+        if started is not None:
+            started.set()
+        if release is not None:
+            await release.wait()
+        return None
+
+    return probe
+
+
+def test_database_check_timeout_cancels_the_slow_probe():
+    """A slow async probe is cancelled at the readiness timeout: no worker
+    thread survives, no duplicate probe is stacked, and the check recovers
+    once the probe can complete (review blocker 4)."""
+    import asyncio as _asyncio
+
     calls = []
+    release = _asyncio.Event()
 
-    class BlockingClient(_OkProbeClient):
-        def execute(self):
-            calls.append(_time.monotonic())
-            probe_started.set()
-            # Simulates the aligned transport timeout: the probe self-terminates
-            # shortly after the registry-level await was cancelled.
-            release.wait(timeout=1.0)
-            return _ProbeResult(data=[])
+    async def _blocking_probe():
+        calls.append(1)
+        await release.wait()
 
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-    check = DatabaseCheck(BlockingClient(), timeout_seconds=0.05, probe_executor=executor)
+    check = DatabaseCheck(_blocking_probe, timeout_seconds=0.05)
 
     async def run_check():
         try:
@@ -292,50 +311,34 @@ def test_database_check_timeout_bounds_the_real_blocking_probe():
         except Exception:
             return "unavailable"
 
-    # First poll times out at the readiness timeout while the thread runs.
-    assert asyncio.run(run_check()) == "unavailable"
-    assert probe_started.is_set()
+    async def scenario():
+        # First poll times out; the probe task was cancelled (no orphaned work).
+        assert await run_check() == "unavailable"
+        assert len(calls) == 1
+        assert check._inflight is None
 
-    # While the probe is still in flight, repeated polls fail fast without
-    # submitting new work: exactly one probe execution has been started.
-    for _ in range(5):
-        assert asyncio.run(run_check()) == "unavailable"
-    assert len(calls) == 1, "no new probe may be submitted while one is in flight"
+        # A fresh probe completes fine once the blocked probe is released.
+        release.set()
+        assert await run_check() == "ok"
+        assert len(calls) == 2
 
-    # The in-flight probe completes on its own (aligned transport timeout).
-    release.set()
-    deadline = _time.monotonic() + 5.0
-    while _time.monotonic() < deadline:
-        if asyncio.run(run_check()) == "ok":
-            break
-        _time.sleep(0.01)
-    assert asyncio.run(run_check()) == "ok"
-
-    # The executor never grew beyond its single worker: no thread accumulation.
-    assert len(executor._threads) <= 1
-    executor.shutdown(wait=False)
+    asyncio.run(scenario())
 
 
 def test_database_check_fails_while_probe_in_flight_and_recovers():
-    """A stuck probe makes readiness fail honestly, and recovery is automatic
-    once the probe terminates (review blocker 4)."""
-    import concurrent.futures
-    import threading
-    import time as _time
+    """A stuck probe makes readiness fail honestly; while a probe is in
+    flight no duplicate is stacked, and once it terminates the next poll
+    runs a fresh one (review blocker 4)."""
+    import asyncio as _asyncio
 
-    release = threading.Event()
-    probe_started = threading.Event()
     calls = []
+    release = _asyncio.Event()
 
-    class StuckClient(_OkProbeClient):
-        def execute(self):
-            calls.append(1)
-            probe_started.set()
-            release.wait(timeout=1.0)
-            return _ProbeResult(data=[])
+    async def _blocking_probe():
+        calls.append(1)
+        await release.wait()
 
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-    check = DatabaseCheck(StuckClient(), timeout_seconds=0.05, probe_executor=executor)
+    check = DatabaseCheck(_blocking_probe, timeout_seconds=0.05)
 
     async def run_check():
         try:
@@ -344,44 +347,51 @@ def test_database_check_fails_while_probe_in_flight_and_recovers():
         except Exception:
             return "unavailable"
 
-    assert asyncio.run(run_check()) == "unavailable"
-    assert probe_started.is_set()
-    # A subsequent poll while in flight does not start a second probe.
-    assert asyncio.run(run_check()) == "unavailable"
-    assert len(calls) == 1
+    async def scenario():
+        # First poll times out and cancels its probe.
+        assert await run_check() == "unavailable"
+        assert len(calls) == 1
+        assert check._inflight is None
 
-    release.set()
-    deadline = _time.monotonic() + 5.0
-    while _time.monotonic() < deadline:
-        if asyncio.run(run_check()) == "ok":
-            break
-        _time.sleep(0.01)
-    assert asyncio.run(run_check()) == "ok"
-    executor.shutdown(wait=False)
+        # A probe left in flight makes further polls fail fast (single-probe
+        # guard) without stacking duplicate work.
+        task = _asyncio.ensure_future(check._probe())
+        check._inflight = task
+        await _asyncio.sleep(0)
+        assert len(calls) == 2  # timed-out probe #1 + the in-flight task #2
+        assert await run_check() == "unavailable"
+        assert await run_check() == "unavailable"
+        assert len(calls) == 2, "no duplicate probe while one is in flight"
+        task.cancel()
+        import contextlib
+
+        with contextlib.suppress(BaseException):
+            await task
+
+        # Once the probe can complete, the next poll recovers.
+        release.set()
+        assert await run_check() == "ok"
+        assert len(calls) == 3
+
+    asyncio.run(scenario())
 
 
-# ─── 31c. Probe guard race between concurrent requests (review blocker 4) ────
+# ─── 31c. Single-probe guard under concurrent polls (review blocker 4) ───────
 
 
 def test_concurrent_polls_submit_single_probe():
     """Concurrent /ready polls while a probe is in flight submit exactly one
     probe; the rest fail fast (review blocker 4)."""
-    import asyncio
-    import concurrent.futures
-    import threading
-    import time as _time
+    import asyncio as _asyncio
 
-    release = threading.Event()
     calls = []
+    release = _asyncio.Event()
 
-    class BlockingClient(_OkProbeClient):
-        def execute(self):
-            calls.append(1)
-            release.wait(timeout=1.0)
-            return _ProbeResult(data=[])
+    async def _blocking_probe():
+        calls.append(1)
+        await release.wait()
 
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-    check = DatabaseCheck(BlockingClient(), timeout_seconds=0.1, probe_executor=executor)
+    check = DatabaseCheck(_blocking_probe, timeout_seconds=0.1)
 
     async def run_check():
         try:
@@ -391,195 +401,78 @@ def test_concurrent_polls_submit_single_probe():
             return "unavailable"
 
     async def hammer():
-        results = await asyncio.gather(*(run_check() for _ in range(12)))
-        return results
+        return await _asyncio.gather(*(run_check() for _ in range(12)))
 
     results = asyncio.run(hammer())
     assert all(r == "unavailable" for r in results)
     assert len(calls) == 1, "concurrent polls must submit a single probe"
 
     release.set()
-    deadline = _time.monotonic() + 5.0
-    while _time.monotonic() < deadline:
-        if asyncio.run(run_check()) == "ok":
-            break
-        _time.sleep(0.01)
     assert asyncio.run(run_check()) == "ok"
-    executor.shutdown(wait=False)
-
-
-def test_probe_guard_preserves_newer_future_on_owner_finish():
-    """The guarded clear only drops the future the calling poll owns.
-
-    Deterministically reproduces the race: poll A's probe completes; before
-    A's finally runs, poll B installs a newer probe future. A's finally must
-    NOT clear B's reference, otherwise a third poll could submit extra work
-    (review blocker 4).
-    """
-    import asyncio
-    import concurrent.futures
-
-    made = []
-
-    class FakeExecutor:
-        def submit(self, fn, *args, **kwargs):
-            fut = concurrent.futures.Future()
-            made.append(fut)
-            return fut
-
-        def shutdown(self, *args, **kwargs):
-            pass
-
-    check = DatabaseCheck(_OkProbeClient(), timeout_seconds=1.0, probe_executor=FakeExecutor())
-
-    async def run_check():
-        try:
-            await check.run()
-            return "ok"
-        except Exception:
-            return "unavailable"
-
-    async def scenario():
-        # Seed an already-completed future (as if a previous probe finished).
-        old = concurrent.futures.Future()
-        old.set_result(_ProbeResult(data=[]))
-        check._probe_future = old
-
-        # Poll A submits a PENDING future and awaits it.
-        task_a = asyncio.create_task(run_check())
-        await asyncio.sleep(0)
-        fut_a = check._probe_future
-        assert fut_a is not old and not fut_a.done()
-
-        # While A is still awaiting, poll B sees fut_a done? No: fut_a is
-        # pending, so B must fail fast (single-probe invariant holds).
-        assert await run_check() == "unavailable"
-        assert check._probe_future is fut_a
-
-        # Complete A's future; A's continuation is queued. Before A resumes,
-        # simulate B observing fut_a done and installing a newer future. The
-        # guard in A's finally must not clear this newer reference.
-        fut_a.set_result(_ProbeResult(data=[]))
-        fut_b = concurrent.futures.Future()
-        fut_b.set_result(_ProbeResult(data=[]))
-        check._probe_future = fut_b
-
-        await task_a  # A's finally runs the guarded clear here
-        assert check._probe_future is fut_b, "A must not clear B's newer future"
-        assert made == [fut_a]
-
-    asyncio.run(scenario())
 
 
 # ─── 31d. aclose cleanup guarantees (review blockers 2 and 3) ───────────────
 
 
-def test_aclose_cleans_up_when_probe_completes_exceptionally():
-    """A probe that terminates with an exception while aclose is draining
-    must not escape the drain and skip executor/client cleanup (review
-    blocker 2)."""
-    import concurrent.futures
-    import time as _time
+def test_aclose_cancels_inflight_probe():
+    """aclose cancels and awaits an in-flight async probe; no fire-and-forget
+    cleanup and no owned work survives (review blocker 3)."""
+    import asyncio as _asyncio
 
-    class DelayedFailingClient(_OkProbeClient):
-        def __init__(self):
-            self.closed = False
+    cancelled = []
 
-        def execute(self):
-            _time.sleep(0.05)
-            raise RuntimeError("probe exploded")
+    async def _slow_probe():
+        try:
+            await _asyncio.sleep(10)
+        except _asyncio.CancelledError:
+            cancelled.append(1)
+            raise
 
-        def close(self):
-            self.closed = True
-
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-    client = DelayedFailingClient()
-    check = DatabaseCheck(
-        client,
-        timeout_seconds=0.01,
-        probe_executor=executor,
-        owns_client=True,
-    )
+    check = DatabaseCheck(_slow_probe, 1.0)
 
     async def scenario():
-        try:
-            await check.run()  # times out at the readiness bound; probe pending
-        except Exception:
-            pass
-        # aclose must not propagate the probe exception and must clean up.
+        # Start the probe directly (simulating an in-flight readiness poll).
+        task = _asyncio.ensure_future(check._probe())
+        check._inflight = task
+        await _asyncio.sleep(0)
         await check.aclose()
-        assert client.closed, "owned client must be closed after an exceptional probe"
-        assert check._probe_future is None
+        assert task.done()
+        assert task.cancelled()
+        assert cancelled == [1]
+        assert check._inflight is None
+        # A second aclose is a no-op.
+        await check.aclose()
 
     asyncio.run(scenario())
-    executor.shutdown(wait=False)
 
 
-def test_aclose_guarantees_cleanup_on_drain_timeout():
-    """aclose never closes the client under a live probe thread: on drain
-    timeout ownership is deferred and released only after the probe
-    terminates (review blocker 3)."""
-    import concurrent.futures
-    import threading
-    import time as _time
+def test_aclose_is_clean_after_expired_ready():
+    """After /ready expires on a slow probe, the probe task was already
+    cancelled by the check itself; aclose stays clean and idempotent."""
+    import asyncio as _asyncio
 
-    release = threading.Event()
-    calls = []
+    cancelled = []
 
-    class StuckClient(_OkProbeClient):
-        def __init__(self):
-            self.closed = False
-            self.active = False
+    async def _slow_probe():
+        try:
+            await _asyncio.sleep(10)
+        except _asyncio.CancelledError:
+            cancelled.append(1)
+            raise
 
-        def execute(self):
-            calls.append(1)
-            self.active = True
-            try:
-                release.wait(timeout=5.0)
-            finally:
-                self.active = False
-            return _ProbeResult(data=[])
-
-        def close(self):
-            # The fake fails loudly if the client is closed while the probe
-            # thread may still be using it.
-            if self.active:
-                raise AssertionError("close() called while execute() still active")
-            self.closed = True
-
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-    client = StuckClient()
-    check = DatabaseCheck(
-        client,
-        timeout_seconds=0.01,
-        probe_executor=executor,
-        owns_client=True,
-    )
+    check = DatabaseCheck(_slow_probe, 0.01)
 
     async def scenario():
         try:
-            await check.run()  # times out; probe still blocked
+            await check.run()
         except Exception:
             pass
-        await check.aclose()  # drain bound (0.01 + 1.0) expires; probe stuck
-        # aclose must NOT have closed the client while the thread is active,
-        # and ownership must remain tracked until the probe completes.
-        assert client.closed is False
-        assert check._client is client
-        assert check._deferred_close is not None
-        # Release the probe; the deferred cleanup closes the client and
-        # clears the future only after the thread terminates.
-        release.set()
-        await check._deferred_close
-        assert client.closed is True
-        assert check._probe_future is None
-        deadline = _time.monotonic() + 5.0
-        while any(t.is_alive() for t in executor._threads):
-            assert _time.monotonic() < deadline, "probe thread alive after close"
-            _time.sleep(0.01)
+        assert cancelled == [1], "expired probe must be cancelled by run()"
+        assert check._inflight is None
+        await check.aclose()
+        assert check._inflight is None
 
     asyncio.run(scenario())
-    executor.shutdown(wait=False)
 
 
 # ─── 32. Sensitive marker sanitization ──────────────────────────────────────
@@ -671,7 +564,7 @@ def test_default_registry_component_set_and_order():
         auth_client=_ok_auth_client(),
         auth_probe=_ok_auth_probe(),
         persistence_client=_OkProbeClient(),
-        database_probe_client=object(),
+        database_probe=_ok_db_probe(),
     )
     assert registry.names() == (
         "configuration",
@@ -694,7 +587,7 @@ def test_default_registry_includes_embeddings_only_when_retrieval_enabled():
         auth_client=_ok_auth_client(),
         auth_probe=_ok_auth_probe(),
         persistence_client=_OkProbeClient(),
-        database_probe_client=object(),
+        database_probe=_ok_db_probe(),
     )
     assert registry.names() == (
         "configuration",
@@ -772,7 +665,7 @@ def test_auth_check_fails_when_availability_probe_fails():
     unavailable (review blocker 1)."""
     from backend.health import AuthClientCheck
 
-    def _failing_probe():
+    async def _failing_probe():
         raise RuntimeError("auth service unreachable")
 
     check = AuthClientCheck(_ok_auth_client(), 1.0, probe=_failing_probe)
@@ -806,7 +699,7 @@ def _auth_ready_client(auth_probe):
         auth_client=_ok_auth_client(),
         auth_probe=auth_probe,
         persistence_client=_OkProbeClient(),
-        database_probe_client=_OkProbeClient(),
+        database_probe=_ok_db_probe(),
     )
     deps = main_module.ApplicationDependencies(
         conversation_engine=engine,
@@ -823,7 +716,7 @@ def _auth_ready_client(auth_probe):
 def test_ready_503_when_auth_service_unavailable():
     """Callable auth surface + healthy database probe + Auth service down
     => /ready 503 with auth=unavailable (review blocker 1)."""
-    def _failing_probe():
+    async def _failing_probe():
         raise RuntimeError("auth service unreachable")
 
     client, registry = _auth_ready_client(_failing_probe)
@@ -880,12 +773,12 @@ def test_auth_health_probe_detects_service_availability():
     try:
         base = f"http://127.0.0.1:{server.server_port}"
         ok_probe = _auth_health_probe(f"{base}/auth/v1", None, 1.0)
-        ok_probe()  # healthy Auth service: no raise
+        asyncio.run(ok_probe())  # healthy Auth service: no raise
 
         # Unreachable Auth service (connection refused): sanitized failure.
         bad_probe = _auth_health_probe("http://127.0.0.1:1/auth/v1", None, 1.0)
         with pytest.raises(CheckFailure):
-            bad_probe()
+            asyncio.run(bad_probe())
     finally:
         server.shutdown()
         server.server_close()
@@ -941,7 +834,7 @@ def test_auth_and_persistence_surfaces_are_independent():
         auth_client=None,
         auth_probe=_ok_auth_probe(),
         persistence_client=persistence,
-        database_probe_client=_OkProbeClient(),
+        database_probe=_ok_db_probe(),
     )
     by_name = asyncio.run(_statuses(registry))
     assert by_name["auth"] == "unavailable"
@@ -955,7 +848,7 @@ def test_auth_and_persistence_surfaces_are_independent():
         auth_client=auth,
         auth_probe=_ok_auth_probe(),
         persistence_client=None,
-        database_probe_client=_OkProbeClient(),
+        database_probe=_ok_db_probe(),
     )
     by_name = asyncio.run(_statuses(registry))
     assert by_name["auth"] == "ok"
@@ -984,7 +877,7 @@ def _embeddings_client(retrieval_enabled: bool, model_available: bool):
         auth_client=_ok_auth_client(),
         auth_probe=_ok_auth_probe(),
         persistence_client=_OkProbeClient(),
-        database_probe_client=_OkProbeClient(),
+        database_probe=_ok_db_probe(),
     )
     deps = main_module.ApplicationDependencies(
         conversation_engine=engine,

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -224,6 +224,129 @@ def test_slow_check_expires_at_approved_timeout():
     assert response.json()["components"]["provider"] == "ok"
 
 
+# ─── 31b. DatabaseCheck bounds the real blocking probe (review blocker 4) ────
+
+
+class _ProbeResult:
+    def __init__(self, data=None, error=None):
+        self.data = data if data is not None else []
+        self.error = error
+
+
+class _OkProbeClient:
+    """Duck-typed probe client that succeeds immediately."""
+
+    def table(self, name):
+        return self
+
+    def select(self, cols):
+        return self
+
+    def limit(self, n):
+        return self
+
+    def execute(self):
+        return _ProbeResult(data=[])
+
+
+def test_database_check_timeout_bounds_the_real_blocking_probe():
+    """Repeated polls never accumulate threads and recover once the probe's
+    aligned transport releases the worker (review blocker 4)."""
+    import concurrent.futures
+    import threading
+    import time as _time
+
+    probe_started = threading.Event()
+    release = threading.Event()
+    calls = []
+
+    class BlockingClient(_OkProbeClient):
+        def execute(self):
+            calls.append(_time.monotonic())
+            probe_started.set()
+            # Simulates the aligned transport timeout: the probe self-terminates
+            # shortly after the registry-level await was cancelled.
+            release.wait(timeout=1.0)
+            return _ProbeResult(data=[])
+
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    check = DatabaseCheck(BlockingClient(), timeout_seconds=0.05, probe_executor=executor)
+
+    async def run_check():
+        try:
+            await check.run()
+            return "ok"
+        except Exception:
+            return "unavailable"
+
+    # First poll times out at the readiness timeout while the thread runs.
+    assert asyncio.run(run_check()) == "unavailable"
+    assert probe_started.is_set()
+
+    # While the probe is still in flight, repeated polls fail fast without
+    # submitting new work: exactly one probe execution has been started.
+    for _ in range(5):
+        assert asyncio.run(run_check()) == "unavailable"
+    assert len(calls) == 1, "no new probe may be submitted while one is in flight"
+
+    # The in-flight probe completes on its own (aligned transport timeout).
+    release.set()
+    deadline = _time.monotonic() + 5.0
+    while _time.monotonic() < deadline:
+        if asyncio.run(run_check()) == "ok":
+            break
+        _time.sleep(0.01)
+    assert asyncio.run(run_check()) == "ok"
+
+    # The executor never grew beyond its single worker: no thread accumulation.
+    assert len(executor._threads) <= 1
+    executor.shutdown(wait=False)
+
+
+def test_database_check_fails_while_probe_in_flight_and_recovers():
+    """A stuck probe makes readiness fail honestly, and recovery is automatic
+    once the probe terminates (review blocker 4)."""
+    import concurrent.futures
+    import threading
+    import time as _time
+
+    release = threading.Event()
+    probe_started = threading.Event()
+    calls = []
+
+    class StuckClient(_OkProbeClient):
+        def execute(self):
+            calls.append(1)
+            probe_started.set()
+            release.wait(timeout=1.0)
+            return _ProbeResult(data=[])
+
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    check = DatabaseCheck(StuckClient(), timeout_seconds=0.05, probe_executor=executor)
+
+    async def run_check():
+        try:
+            await check.run()
+            return "ok"
+        except Exception:
+            return "unavailable"
+
+    assert asyncio.run(run_check()) == "unavailable"
+    assert probe_started.is_set()
+    # A subsequent poll while in flight does not start a second probe.
+    assert asyncio.run(run_check()) == "unavailable"
+    assert len(calls) == 1
+
+    release.set()
+    deadline = _time.monotonic() + 5.0
+    while _time.monotonic() < deadline:
+        if asyncio.run(run_check()) == "ok":
+            break
+        _time.sleep(0.01)
+    assert asyncio.run(run_check()) == "ok"
+    executor.shutdown(wait=False)
+
+
 # ─── 32. Sensitive marker sanitization ──────────────────────────────────────
 
 
@@ -307,17 +430,17 @@ def test_default_registry_component_set_and_order():
         memory_manager=SimpleNamespace(embedding_model=object(), supabase=object()),
         groq_manager=SimpleNamespace(is_configured=lambda: True),
     )
-    registry = build_health_registry(settings, engine, object())
+    registry = build_health_registry(settings, engine, database_probe_client=object())
     assert registry.names() == ("configuration", "database", "provider")
 
 
-def test_default_registry_includes_embeddings_only_when_enabled():
-    settings = _settings(archival_extraction_enabled=True)
+def test_default_registry_includes_embeddings_only_when_retrieval_enabled():
+    settings = _settings(embeddings_retrieval_enabled=True)
     engine = SimpleNamespace(
         memory_manager=SimpleNamespace(embedding_model=object(), supabase=object()),
         groq_manager=SimpleNamespace(is_configured=lambda: True),
     )
-    registry = build_health_registry(settings, engine, object())
+    registry = build_health_registry(settings, engine, database_probe_client=object())
     assert registry.names() == ("configuration", "database", "provider", "embeddings")
 
 
@@ -329,6 +452,110 @@ def test_embeddings_check_fails_when_model_missing():
             await check.run()
 
     asyncio.run(_run())
+
+
+# ─── 34b. Embeddings lifecycle and readiness (review blocker 3) ──────────────
+
+
+def _embeddings_client(retrieval_enabled: bool, model_available: bool):
+    """Build a /ready client for the retrieval-mode × model-availability grid."""
+    from backend.admission import AdmissionRuntimeConfig
+
+    settings = _settings(embeddings_retrieval_enabled=retrieval_enabled)
+    engine = SimpleNamespace(
+        memory_manager=SimpleNamespace(
+            embedding_model=object() if model_available else None,
+            supabase=object(),
+        ),
+        groq_manager=SimpleNamespace(is_configured=lambda: True),
+    )
+    registry = build_health_registry(
+        settings, engine, database_probe_client=_OkProbeClient()
+    )
+    deps = main_module.ApplicationDependencies(
+        conversation_engine=engine,
+        auth_client=object(),
+        admission_config=AdmissionRuntimeConfig.from_values(SECRET),
+        turn_config=TurnExecutionConfig.defaults(),
+        health_checks=registry,
+        clock=__import__("time").time,
+    )
+    app = main_module.create_app(settings=settings, dependencies=deps)
+    return TestClient(app)
+
+
+@pytest.mark.parametrize(
+    ("retrieval_enabled", "model_available", "expected_status", "embeddings_present"),
+    [
+        # Feature off × model would be available → ready, no embeddings component.
+        (False, True, 200, False),
+        # Feature off × model unavailable → ready, no embeddings component.
+        (False, False, 200, False),
+        # Feature on × model available → ready with embeddings ok.
+        (True, True, 200, True),
+        # Feature on × model unavailable → NOT ready, embeddings fails honestly.
+        (True, False, 503, True),
+    ],
+)
+def test_embeddings_lifecycle_four_scenarios(
+    retrieval_enabled,
+    model_available,
+    expected_status,
+    embeddings_present,
+):
+    client = _embeddings_client(retrieval_enabled, model_available)
+    response = client.get("/ready")
+    assert response.status_code == expected_status
+    body = response.json()
+    components = body["components"]
+    assert ("embeddings" in components) is embeddings_present
+    if embeddings_present:
+        expected = "ok" if model_available else "unavailable"
+        assert components["embeddings"] == expected
+        assert body["status"] == ("ready" if model_available else "not_ready")
+
+
+def test_default_builder_never_constructs_embedding_model_when_disabled(monkeypatch):
+    """Startup with retrieval disabled must not construct SentenceTransformer."""
+    import backend.dependencies as dependencies_module
+    import backend.memory as memory_module
+
+    def _no_model(*_args, **_kwargs):
+        raise AssertionError("embedding model must not be constructed when disabled")
+
+    monkeypatch.setattr(memory_module, "SentenceTransformer", _no_model)
+    settings = _settings(embeddings_retrieval_enabled=False)
+    deps, _owned = dependencies_module.build_default_dependencies(settings)
+    assert deps.conversation_engine.memory_manager.embedding_model is None
+
+
+def test_memory_manager_constructs_model_only_when_enabled(monkeypatch):
+    """Startup with retrieval enabled constructs the model; a failure surfaces
+    as embedding_model is None (readiness then blocks traffic)."""
+    import backend.memory as memory_module
+
+    calls = []
+
+    def _fake_model(*_args, **_kwargs):
+        calls.append(1)
+        return object()
+
+    monkeypatch.setattr(memory_module, "SentenceTransformer", _fake_model)
+
+    disabled = memory_module.MemoryManager(embeddings_enabled=False)
+    assert disabled.embedding_model is None
+    assert calls == []
+
+    enabled = memory_module.MemoryManager(embeddings_enabled=True)
+    assert enabled.embedding_model is not None
+    assert calls == [1]
+
+    def _failing_model(*_args, **_kwargs):
+        raise RuntimeError("model download failed")
+
+    monkeypatch.setattr(memory_module, "SentenceTransformer", _failing_model)
+    broken = memory_module.MemoryManager(embeddings_enabled=True)
+    assert broken.embedding_model is None
 
 
 def test_provider_check_fails_when_manager_unconfigured():

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,374 @@
+"""Tests for /live, /ready, /health and the readiness check registry (#275)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+import backend.main as main_module
+from backend.health import (
+    CheckStatus,
+    ConfigurationCheck,
+    DatabaseCheck,
+    EmbeddingsCheck,
+    HealthRegistry,
+    LifespanCheck,
+    ProviderCheck,
+    build_health_registry,
+    build_ready_response,
+)
+from backend.settings import AppEnvironment, Settings
+from backend.turn_execution import TurnExecutionConfig
+
+SECRET = "s" * 40
+
+
+def _settings(**overrides) -> Settings:
+    kwargs = {
+        "app_env": AppEnvironment.local,
+        "groq_api_key": "groq-key",
+        "admission_hmac_secret": SECRET,
+        "cors_allowed_origins": ("https://allowed.example",),
+    }
+    kwargs.update(overrides)
+    return Settings(**kwargs)
+
+
+class OkCheck:
+    def __init__(self, name, timeout_seconds=1.0):
+        self.name = name
+        self.timeout_seconds = timeout_seconds
+        self.runs = 0
+
+    async def run(self):
+        self.runs += 1
+
+
+class FailCheck:
+    def __init__(self, name, timeout_seconds=1.0):
+        self.name = name
+        self.timeout_seconds = timeout_seconds
+        self.runs = 0
+
+    async def run(self):
+        self.runs += 1
+        from backend.health import CheckFailure
+
+        raise CheckFailure()
+
+
+def _deps_with_checks(checks):
+    from backend.admission import AdmissionRuntimeConfig
+
+    engine = SimpleNamespace(
+        memory_manager=SimpleNamespace(supabase=object()),
+        groq_manager=SimpleNamespace(is_configured=lambda: True),
+    )
+    return main_module.ApplicationDependencies(
+        conversation_engine=engine,
+        auth_client=object(),
+        admission_config=AdmissionRuntimeConfig.from_values(SECRET),
+        turn_config=TurnExecutionConfig.defaults(),
+        health_checks=HealthRegistry(checks),
+        clock=__import__("time").time,
+    )
+
+
+def _client(settings=None, checks=None):
+    settings = settings or _settings()
+    checks = checks or {
+        "database": OkCheck("database"),
+        "provider": OkCheck("provider"),
+    }
+    app = main_module.create_app(
+        settings=settings, dependencies=_deps_with_checks(checks)
+    )
+    return TestClient(app), checks
+
+
+# ─── 24/25. /live ───────────────────────────────────────────────────────────
+
+
+def test_live_returns_200_even_when_dependencies_are_down():
+    checks = {
+        "database": FailCheck("database"),
+        "provider": FailCheck("provider"),
+    }
+    client, _ = _client(checks=checks)
+    response = client.get("/live")
+    assert response.status_code == 200
+    assert response.json() == {"status": "live"}
+
+
+def test_live_never_runs_external_checks():
+    checks = {
+        "database": OkCheck("database"),
+        "provider": OkCheck("provider"),
+    }
+    client, checks = _client(checks=checks)
+    response = client.get("/live")
+    assert response.status_code == 200
+    assert checks["database"].runs == 0
+    assert checks["provider"].runs == 0
+
+
+# ─── 26-30. /ready components ───────────────────────────────────────────────
+
+
+def test_ready_returns_200_only_when_all_critical_components_pass():
+    client, _ = _client()
+    response = client.get("/ready")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ready"
+    assert body["components"] == {
+        "database": "ok",
+        "provider": "ok",
+        "lifespan": "ok",
+    }
+
+
+def test_ready_database_unavailable_returns_503_with_sanitized_body():
+    checks = {"database": FailCheck("database"), "provider": OkCheck("provider")}
+    client, _ = _client(checks=checks)
+    response = client.get("/ready")
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "not_ready"
+    assert body["components"]["database"] == "unavailable"
+    assert body["components"]["provider"] == "ok"
+
+
+def test_ready_provider_unavailable_blocks_ready():
+    checks = {"database": OkCheck("database"), "provider": FailCheck("provider")}
+    client, _ = _client(checks=checks)
+    response = client.get("/ready")
+    assert response.status_code == 503
+    assert response.json()["status"] == "not_ready"
+
+
+def test_optional_feature_disabled_does_not_block_readiness():
+    settings = _settings(archival_extraction_enabled=False)
+    client, _ = _client(settings=settings)
+    response = client.get("/ready")
+    assert response.status_code == 200
+    assert "embeddings" not in response.json()["components"]
+
+
+def test_enabled_required_feature_unavailable_blocks_readiness():
+    settings = _settings(archival_extraction_enabled=True)
+    checks = {
+        "database": OkCheck("database"),
+        "provider": OkCheck("provider"),
+        "embeddings": FailCheck("embeddings"),
+    }
+    client, _ = _client(settings=settings, checks=checks)
+    response = client.get("/ready")
+    assert response.status_code == 503
+    assert response.json()["components"]["embeddings"] == "unavailable"
+
+
+def test_enabled_required_feature_available_passes_readiness():
+    settings = _settings(archival_extraction_enabled=True)
+    checks = {
+        "database": OkCheck("database"),
+        "provider": OkCheck("provider"),
+        "embeddings": OkCheck("embeddings"),
+    }
+    client, _ = _client(settings=settings, checks=checks)
+    response = client.get("/ready")
+    assert response.status_code == 200
+    assert response.json()["components"]["embeddings"] == "ok"
+
+
+def test_ready_before_lifespan_returns_503():
+    app = main_module.create_app(
+        settings=_settings(),
+        dependencies=_deps_with_checks(
+            {"database": OkCheck("database"), "provider": OkCheck("provider")}
+        ),
+    )
+    app.state.dependencies = None  # simulate startup not completed
+    app.state.lifespan_started = False
+    client = TestClient(app)
+    response = client.get("/ready")
+    assert response.status_code == 503
+    assert response.json()["status"] == "not_ready"
+
+
+# ─── 31. Timeout ────────────────────────────────────────────────────────────
+
+
+class SlowCheck:
+    def __init__(self, name, timeout_seconds=0.05):
+        self.name = name
+        self.timeout_seconds = timeout_seconds
+
+    async def run(self):
+        await asyncio.sleep(5.0)
+
+
+def test_slow_check_expires_at_approved_timeout():
+    checks = {
+        "database": SlowCheck("database"),
+        "provider": OkCheck("provider"),
+    }
+    client, _ = _client(checks=checks)
+    response = client.get("/ready")
+    assert response.status_code == 503
+    assert response.json()["components"]["database"] == "unavailable"
+    assert response.json()["components"]["provider"] == "ok"
+
+
+# ─── 32. Sensitive marker sanitization ──────────────────────────────────────
+
+
+class LeakyCheck:
+    def __init__(self, name, timeout_seconds=1.0):
+        self.name = name
+        self.timeout_seconds = timeout_seconds
+
+    async def run(self):
+        raise Exception("SENSITIVE_PROVIDER_MARKER_XYZ")
+
+
+def test_sensitive_exception_never_appears_in_response_or_logs(caplog):
+    checks = {"database": LeakyCheck("database"), "provider": OkCheck("provider")}
+    client, _ = _client(checks=checks)
+    with caplog.at_level(logging.ERROR):
+        response = client.get("/ready")
+    assert response.status_code == 503
+    assert "SENSITIVE_PROVIDER_MARKER_XYZ" not in response.text
+    assert "SENSITIVE_PROVIDER_MARKER_XYZ" not in caplog.text
+    # The sanitized failure event carries only the component name.
+    assert "event=readiness_check_failed component=database" in caplog.text
+
+
+# ─── 33. Deterministic schema and order ─────────────────────────────────────
+
+
+def test_ready_response_schema_and_order_are_deterministic():
+    checks = {
+        "configuration": OkCheck("configuration"),
+        "database": OkCheck("database"),
+        "provider": OkCheck("provider"),
+    }
+    client, _ = _client(checks=checks)
+    first = client.get("/ready").json()
+    second = client.get("/ready").json()
+    assert first == second
+    assert list(first["components"].keys()) == ["configuration", "database", "provider", "lifespan"]
+    assert set(first.keys()) == {"status", "components"}
+
+
+def test_build_ready_response_contract():
+    from backend.health import CheckResult
+
+    results = [
+        CheckResult("database", CheckStatus.ok),
+        CheckResult("provider", CheckStatus.unavailable),
+    ]
+    status, body = build_ready_response(results, lifespan_started=True)
+    assert status == 503
+    assert body == {
+        "status": "not_ready",
+        "components": {"database": "ok", "provider": "unavailable", "lifespan": "ok"},
+    }
+    status, body = build_ready_response(results, lifespan_started=False)
+    assert status == 503
+    assert body["components"]["lifespan"] == "unavailable"
+
+
+# ─── 34. /health legacy semantics ───────────────────────────────────────────
+
+
+def test_health_is_process_alive_alias_and_never_asserts_readiness():
+    checks = {"database": FailCheck("database"), "provider": FailCheck("provider")}
+    client, _ = _client(checks=checks)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "alive"}
+    assert "ready" not in response.text
+    # It must not run readiness checks either.
+    assert checks["database"].runs == 0
+    assert checks["provider"].runs == 0
+
+
+# ─── Default registry builder ───────────────────────────────────────────────
+
+
+def test_default_registry_component_set_and_order():
+    settings = _settings()
+    engine = SimpleNamespace(
+        memory_manager=SimpleNamespace(embedding_model=object(), supabase=object()),
+        groq_manager=SimpleNamespace(is_configured=lambda: True),
+    )
+    registry = build_health_registry(settings, engine, object())
+    assert registry.names() == ("configuration", "database", "provider")
+
+
+def test_default_registry_includes_embeddings_only_when_enabled():
+    settings = _settings(archival_extraction_enabled=True)
+    engine = SimpleNamespace(
+        memory_manager=SimpleNamespace(embedding_model=object(), supabase=object()),
+        groq_manager=SimpleNamespace(is_configured=lambda: True),
+    )
+    registry = build_health_registry(settings, engine, object())
+    assert registry.names() == ("configuration", "database", "provider", "embeddings")
+
+
+def test_embeddings_check_fails_when_model_missing():
+    check = EmbeddingsCheck(SimpleNamespace(embedding_model=None))
+
+    async def _run():
+        with pytest.raises(Exception):
+            await check.run()
+
+    asyncio.run(_run())
+
+
+def test_provider_check_fails_when_manager_unconfigured():
+    check = ProviderCheck(SimpleNamespace(is_configured=lambda: False), 1.0)
+
+    async def _run():
+        with pytest.raises(Exception):
+            await check.run()
+
+    asyncio.run(_run())
+
+
+def test_database_check_fails_without_client():
+    check = DatabaseCheck(None, 1.0)
+
+    async def _run():
+        with pytest.raises(Exception):
+            await check.run()
+
+    asyncio.run(_run())
+
+
+def test_configuration_check_fails_without_settings():
+    check = ConfigurationCheck(None)
+
+    async def _run():
+        with pytest.raises(Exception):
+            await check.run()
+
+    asyncio.run(_run())
+
+
+def test_lifespan_check_reflects_state():
+    state = {"started": True}
+    check = LifespanCheck(lambda: state["started"])
+
+    async def _run():
+        await check.run()
+        state["started"] = False
+        with pytest.raises(Exception):
+            await check.run()
+
+    asyncio.run(_run())

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -347,6 +347,117 @@ def test_database_check_fails_while_probe_in_flight_and_recovers():
     executor.shutdown(wait=False)
 
 
+# ─── 31c. Probe guard race between concurrent requests (review blocker 4) ────
+
+
+def test_concurrent_polls_submit_single_probe():
+    """Concurrent /ready polls while a probe is in flight submit exactly one
+    probe; the rest fail fast (review blocker 4)."""
+    import asyncio
+    import concurrent.futures
+    import threading
+    import time as _time
+
+    release = threading.Event()
+    calls = []
+
+    class BlockingClient(_OkProbeClient):
+        def execute(self):
+            calls.append(1)
+            release.wait(timeout=1.0)
+            return _ProbeResult(data=[])
+
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    check = DatabaseCheck(BlockingClient(), timeout_seconds=0.1, probe_executor=executor)
+
+    async def run_check():
+        try:
+            await check.run()
+            return "ok"
+        except Exception:
+            return "unavailable"
+
+    async def hammer():
+        results = await asyncio.gather(*(run_check() for _ in range(12)))
+        return results
+
+    results = asyncio.run(hammer())
+    assert all(r == "unavailable" for r in results)
+    assert len(calls) == 1, "concurrent polls must submit a single probe"
+
+    release.set()
+    deadline = _time.monotonic() + 5.0
+    while _time.monotonic() < deadline:
+        if asyncio.run(run_check()) == "ok":
+            break
+        _time.sleep(0.01)
+    assert asyncio.run(run_check()) == "ok"
+    executor.shutdown(wait=False)
+
+
+def test_probe_guard_preserves_newer_future_on_owner_finish():
+    """The guarded clear only drops the future the calling poll owns.
+
+    Deterministically reproduces the race: poll A's probe completes; before
+    A's finally runs, poll B installs a newer probe future. A's finally must
+    NOT clear B's reference, otherwise a third poll could submit extra work
+    (review blocker 4).
+    """
+    import asyncio
+    import concurrent.futures
+
+    made = []
+
+    class FakeExecutor:
+        def submit(self, fn, *args, **kwargs):
+            fut = concurrent.futures.Future()
+            made.append(fut)
+            return fut
+
+        def shutdown(self, *args, **kwargs):
+            pass
+
+    check = DatabaseCheck(_OkProbeClient(), timeout_seconds=1.0, probe_executor=FakeExecutor())
+
+    async def run_check():
+        try:
+            await check.run()
+            return "ok"
+        except Exception:
+            return "unavailable"
+
+    async def scenario():
+        # Seed an already-completed future (as if a previous probe finished).
+        old = concurrent.futures.Future()
+        old.set_result(_ProbeResult(data=[]))
+        check._probe_future = old
+
+        # Poll A submits a PENDING future and awaits it.
+        task_a = asyncio.create_task(run_check())
+        await asyncio.sleep(0)
+        fut_a = check._probe_future
+        assert fut_a is not old and not fut_a.done()
+
+        # While A is still awaiting, poll B sees fut_a done? No: fut_a is
+        # pending, so B must fail fast (single-probe invariant holds).
+        assert await run_check() == "unavailable"
+        assert check._probe_future is fut_a
+
+        # Complete A's future; A's continuation is queued. Before A resumes,
+        # simulate B observing fut_a done and installing a newer future. The
+        # guard in A's finally must not clear this newer reference.
+        fut_a.set_result(_ProbeResult(data=[]))
+        fut_b = concurrent.futures.Future()
+        fut_b.set_result(_ProbeResult(data=[]))
+        check._probe_future = fut_b
+
+        await task_a  # A's finally runs the guarded clear here
+        assert check._probe_future is fut_b, "A must not clear B's newer future"
+        assert made == [fut_a]
+
+    asyncio.run(scenario())
+
+
 # ─── 32. Sensitive marker sanitization ──────────────────────────────────────
 
 

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -66,6 +66,11 @@ def _ok_auth_client():
     return SimpleNamespace(auth=SimpleNamespace(get_user=lambda token: None))
 
 
+def _ok_auth_probe():
+    """A passing Auth availability probe (no network)."""
+    return lambda: None
+
+
 def _deps_with_checks(checks):
     from backend.admission import AdmissionRuntimeConfig
 
@@ -511,9 +516,9 @@ def test_aclose_cleans_up_when_probe_completes_exceptionally():
 
 
 def test_aclose_guarantees_cleanup_on_drain_timeout():
-    """When the drain bound expires, aclose still clears the future and
-    closes the owned client so no owned resource survives the lifespan
-    (review blocker 3)."""
+    """aclose never closes the client under a live probe thread: on drain
+    timeout ownership is deferred and released only after the probe
+    terminates (review blocker 3)."""
     import concurrent.futures
     import threading
     import time as _time
@@ -524,13 +529,22 @@ def test_aclose_guarantees_cleanup_on_drain_timeout():
     class StuckClient(_OkProbeClient):
         def __init__(self):
             self.closed = False
+            self.active = False
 
         def execute(self):
             calls.append(1)
-            release.wait(timeout=5.0)
+            self.active = True
+            try:
+                release.wait(timeout=5.0)
+            finally:
+                self.active = False
             return _ProbeResult(data=[])
 
         def close(self):
+            # The fake fails loudly if the client is closed while the probe
+            # thread may still be using it.
+            if self.active:
+                raise AssertionError("close() called while execute() still active")
             self.closed = True
 
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
@@ -548,17 +562,23 @@ def test_aclose_guarantees_cleanup_on_drain_timeout():
         except Exception:
             pass
         await check.aclose()  # drain bound (0.01 + 1.0) expires; probe stuck
-        assert client.closed, "owned client must be closed even on drain timeout"
+        # aclose must NOT have closed the client while the thread is active,
+        # and ownership must remain tracked until the probe completes.
+        assert client.closed is False
+        assert check._client is client
+        assert check._deferred_close is not None
+        # Release the probe; the deferred cleanup closes the client and
+        # clears the future only after the thread terminates.
+        release.set()
+        await check._deferred_close
+        assert client.closed is True
         assert check._probe_future is None
+        deadline = _time.monotonic() + 5.0
+        while any(t.is_alive() for t in executor._threads):
+            assert _time.monotonic() < deadline, "probe thread alive after close"
+            _time.sleep(0.01)
 
     asyncio.run(scenario())
-    assert calls == [1]
-    # Release the stuck probe so its worker thread terminates on its own.
-    release.set()
-    deadline = _time.monotonic() + 5.0
-    while any(t.is_alive() for t in executor._threads):
-        assert _time.monotonic() < deadline, "probe thread alive after close"
-        _time.sleep(0.01)
     executor.shutdown(wait=False)
 
 
@@ -649,6 +669,7 @@ def test_default_registry_component_set_and_order():
         settings,
         engine,
         auth_client=_ok_auth_client(),
+        auth_probe=_ok_auth_probe(),
         persistence_client=_OkProbeClient(),
         database_probe_client=object(),
     )
@@ -671,6 +692,7 @@ def test_default_registry_includes_embeddings_only_when_retrieval_enabled():
         settings,
         engine,
         auth_client=_ok_auth_client(),
+        auth_probe=_ok_auth_probe(),
         persistence_client=_OkProbeClient(),
         database_probe_client=object(),
     )
@@ -698,8 +720,9 @@ def test_embeddings_check_fails_when_model_missing():
 
 
 def test_auth_check_fails_when_surface_missing():
-    """The auth check verifies the callable route path ``auth.get_user``,
-    not mere attribute existence (review blocker 1)."""
+    """The auth check verifies the callable route path ``auth.get_user``
+    AND an Auth availability probe; either missing is unavailable
+    (review blocker 1)."""
     from backend.health import AuthClientCheck
 
     async def _run(check):
@@ -709,22 +732,164 @@ def test_auth_check_fails_when_surface_missing():
         except Exception:
             return "unavailable"
 
-    assert asyncio.run(_run(AuthClientCheck(None))) == "unavailable"
-    assert asyncio.run(_run(AuthClientCheck(object()))) == "unavailable"
-    # False positive fixed: an ``auth`` object without a callable get_user
-    # (or with get_user=None) is unavailable.
-    assert (
-        asyncio.run(_run(AuthClientCheck(SimpleNamespace(auth=object()))))
-        == "unavailable"
+    cases = [
+        # Broken surfaces, even with a working probe.
+        (AuthClientCheck(None, 1.0, probe=_ok_auth_probe()), "unavailable"),
+        (AuthClientCheck(object(), 1.0, probe=_ok_auth_probe()), "unavailable"),
+        (
+            AuthClientCheck(
+                SimpleNamespace(auth=object()), 1.0, probe=_ok_auth_probe()
+            ),
+            "unavailable",
+        ),
+        (
+            AuthClientCheck(
+                SimpleNamespace(auth=SimpleNamespace(get_user=None)),
+                1.0,
+                probe=_ok_auth_probe(),
+            ),
+            "unavailable",
+        ),
+        # Callable surface but no probe configured: unavailable (an instance
+        # whose Auth cannot be probed must not report ready).
+        (AuthClientCheck(_ok_auth_client(), 1.0, probe=None), "unavailable"),
+        # Surface ok + probe ok: available.
+        (
+            AuthClientCheck(_ok_auth_client(), 1.0, probe=_ok_auth_probe()),
+            "ok",
+        ),
+    ]
+    try:
+        for check, expected in cases:
+            assert asyncio.run(_run(check)) == expected
+    finally:
+        for check, _ in cases:
+            check.close()
+
+
+def test_auth_check_fails_when_availability_probe_fails():
+    """A callable auth surface with a failing Auth service probe is
+    unavailable (review blocker 1)."""
+    from backend.health import AuthClientCheck
+
+    def _failing_probe():
+        raise RuntimeError("auth service unreachable")
+
+    check = AuthClientCheck(_ok_auth_client(), 1.0, probe=_failing_probe)
+
+    async def _run():
+        try:
+            await check.run()
+            return "ok"
+        except Exception:
+            return "unavailable"
+
+    try:
+        assert asyncio.run(_run()) == "unavailable"
+    finally:
+        check.close()
+
+
+def _auth_ready_client(auth_probe):
+    """/ready client: callable auth surface, healthy DB/persistence probes,
+    configurable Auth availability probe."""
+    from backend.admission import AdmissionRuntimeConfig
+
+    settings = _settings()
+    engine = SimpleNamespace(
+        memory_manager=SimpleNamespace(embedding_model=object(), supabase=object()),
+        groq_manager=SimpleNamespace(is_configured=lambda: True),
     )
-    assert (
-        asyncio.run(
-            _run(AuthClientCheck(SimpleNamespace(auth=SimpleNamespace(get_user=None))))
-        )
-        == "unavailable"
+    registry = build_health_registry(
+        settings,
+        engine,
+        auth_client=_ok_auth_client(),
+        auth_probe=auth_probe,
+        persistence_client=_OkProbeClient(),
+        database_probe_client=_OkProbeClient(),
     )
-    # The exact path routes call exists and is callable.
-    assert asyncio.run(_run(AuthClientCheck(_ok_auth_client()))) == "ok"
+    deps = main_module.ApplicationDependencies(
+        conversation_engine=engine,
+        auth_client=_ok_auth_client(),
+        admission_config=AdmissionRuntimeConfig.from_values(SECRET),
+        turn_config=TurnExecutionConfig.defaults(),
+        health_checks=registry,
+        clock=__import__("time").time,
+    )
+    app = main_module.create_app(settings=settings, dependencies=deps)
+    return TestClient(app), registry
+
+
+def test_ready_503_when_auth_service_unavailable():
+    """Callable auth surface + healthy database probe + Auth service down
+    => /ready 503 with auth=unavailable (review blocker 1)."""
+    def _failing_probe():
+        raise RuntimeError("auth service unreachable")
+
+    client, registry = _auth_ready_client(_failing_probe)
+    try:
+        response = client.get("/ready")
+        assert response.status_code == 503
+        body = response.json()
+        assert body["status"] == "not_ready"
+        assert body["components"]["auth"] == "unavailable"
+        assert body["components"]["database"] == "ok"
+        assert body["components"]["persistence"] == "ok"
+    finally:
+        registry.close()
+
+
+def test_ready_200_when_auth_service_available():
+    """Callable auth surface + healthy database probe + Auth service up
+    => /ready 200 with auth=ok (review blocker 1)."""
+    client, registry = _auth_ready_client(_ok_auth_probe())
+    try:
+        response = client.get("/ready")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "ready"
+        assert body["components"]["auth"] == "ok"
+    finally:
+        registry.close()
+
+
+def test_auth_health_probe_detects_service_availability():
+    """The default probe performs a bounded GET /health and detects an
+    unreachable Auth service without external network (review blocker 1)."""
+    import http.server
+    import threading
+
+    from backend.health import CheckFailure, _auth_health_probe
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/auth/v1/health":
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b'{"version":"v2.0.0"}')
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+        def log_message(self, *args):
+            pass
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        base = f"http://127.0.0.1:{server.server_port}"
+        ok_probe = _auth_health_probe(f"{base}/auth/v1", None, 1.0)
+        ok_probe()  # healthy Auth service: no raise
+
+        # Unreachable Auth service (connection refused): sanitized failure.
+        bad_probe = _auth_health_probe("http://127.0.0.1:1/auth/v1", None, 1.0)
+        with pytest.raises(CheckFailure):
+            bad_probe()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
 
 
 def test_persistence_check_fails_when_surface_missing():
@@ -774,6 +939,7 @@ def test_auth_and_persistence_surfaces_are_independent():
         settings,
         engine,
         auth_client=None,
+        auth_probe=_ok_auth_probe(),
         persistence_client=persistence,
         database_probe_client=_OkProbeClient(),
     )
@@ -787,6 +953,7 @@ def test_auth_and_persistence_surfaces_are_independent():
         settings,
         engine,
         auth_client=auth,
+        auth_probe=_ok_auth_probe(),
         persistence_client=None,
         database_probe_client=_OkProbeClient(),
     )
@@ -815,6 +982,7 @@ def _embeddings_client(retrieval_enabled: bool, model_available: bool):
         settings,
         engine,
         auth_client=_ok_auth_client(),
+        auth_probe=_ok_auth_probe(),
         persistence_client=_OkProbeClient(),
         database_probe_client=_OkProbeClient(),
     )

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -245,6 +245,9 @@ class _OkProbeClient:
     def limit(self, n):
         return self
 
+    def rpc(self, name, params):
+        return self
+
     def execute(self):
         return _ProbeResult(data=[])
 
@@ -541,8 +544,20 @@ def test_default_registry_component_set_and_order():
         memory_manager=SimpleNamespace(embedding_model=object(), supabase=object()),
         groq_manager=SimpleNamespace(is_configured=lambda: True),
     )
-    registry = build_health_registry(settings, engine, database_probe_client=object())
-    assert registry.names() == ("configuration", "database", "provider")
+    registry = build_health_registry(
+        settings,
+        engine,
+        auth_client=SimpleNamespace(auth=object()),
+        persistence_client=_OkProbeClient(),
+        database_probe_client=object(),
+    )
+    assert registry.names() == (
+        "configuration",
+        "auth",
+        "database",
+        "persistence",
+        "provider",
+    )
 
 
 def test_default_registry_includes_embeddings_only_when_retrieval_enabled():
@@ -551,8 +566,21 @@ def test_default_registry_includes_embeddings_only_when_retrieval_enabled():
         memory_manager=SimpleNamespace(embedding_model=object(), supabase=object()),
         groq_manager=SimpleNamespace(is_configured=lambda: True),
     )
-    registry = build_health_registry(settings, engine, database_probe_client=object())
-    assert registry.names() == ("configuration", "database", "provider", "embeddings")
+    registry = build_health_registry(
+        settings,
+        engine,
+        auth_client=SimpleNamespace(auth=object()),
+        persistence_client=_OkProbeClient(),
+        database_probe_client=object(),
+    )
+    assert registry.names() == (
+        "configuration",
+        "auth",
+        "database",
+        "persistence",
+        "provider",
+        "embeddings",
+    )
 
 
 def test_embeddings_check_fails_when_model_missing():
@@ -563,6 +591,85 @@ def test_embeddings_check_fails_when_model_missing():
             await check.run()
 
     asyncio.run(_run())
+
+
+# ─── 34c. Real auth/persistence surfaces are readiness-critical (blocker 1) ──
+
+
+def test_auth_check_fails_when_surface_missing():
+    from backend.health import AuthClientCheck
+
+    async def _run(check):
+        try:
+            await check.run()
+            return "ok"
+        except Exception:
+            return "unavailable"
+
+    assert asyncio.run(_run(AuthClientCheck(None))) == "unavailable"
+    assert asyncio.run(_run(AuthClientCheck(object()))) == "unavailable"
+    assert asyncio.run(_run(AuthClientCheck(SimpleNamespace(auth=object())))) == "ok"
+
+
+def test_persistence_check_fails_when_surface_missing():
+    from backend.health import PersistenceClientCheck
+
+    async def _run(check):
+        try:
+            await check.run()
+            return "ok"
+        except Exception:
+            return "unavailable"
+
+    assert asyncio.run(_run(PersistenceClientCheck(None))) == "unavailable"
+    assert asyncio.run(_run(PersistenceClientCheck(object()))) == "unavailable"
+    assert (
+        asyncio.run(_run(PersistenceClientCheck(SimpleNamespace(table=None, rpc=None))))
+        == "ok"
+    )
+
+
+def test_auth_and_persistence_surfaces_are_independent():
+    """With distinct injected surfaces, readiness fails when either the auth
+    or the persistence surface is missing even if the probe client works
+    (review blocker 1)."""
+    settings = _settings()
+    engine = SimpleNamespace(
+        memory_manager=SimpleNamespace(embedding_model=object(), supabase=object()),
+        groq_manager=SimpleNamespace(is_configured=lambda: True),
+    )
+    auth = SimpleNamespace(auth=object())
+    persistence = _OkProbeClient()
+
+    async def _statuses(registry):
+        results = await registry.run_all()
+        return {result.name: result.status.value for result in results}
+
+    # Auth missing, persistence + probe present.
+    registry = build_health_registry(
+        settings,
+        engine,
+        auth_client=None,
+        persistence_client=persistence,
+        database_probe_client=_OkProbeClient(),
+    )
+    by_name = asyncio.run(_statuses(registry))
+    assert by_name["auth"] == "unavailable"
+    assert by_name["persistence"] == "ok"
+    assert by_name["database"] == "ok"
+
+    # Persistence missing, auth + probe present.
+    registry = build_health_registry(
+        settings,
+        engine,
+        auth_client=auth,
+        persistence_client=None,
+        database_probe_client=_OkProbeClient(),
+    )
+    by_name = asyncio.run(_statuses(registry))
+    assert by_name["auth"] == "ok"
+    assert by_name["persistence"] == "unavailable"
+    assert by_name["database"] == "ok"
 
 
 # ─── 34b. Embeddings lifecycle and readiness (review blocker 3) ──────────────
@@ -581,7 +688,11 @@ def _embeddings_client(retrieval_enabled: bool, model_available: bool):
         groq_manager=SimpleNamespace(is_configured=lambda: True),
     )
     registry = build_health_registry(
-        settings, engine, database_probe_client=_OkProbeClient()
+        settings,
+        engine,
+        auth_client=SimpleNamespace(auth=object()),
+        persistence_client=_OkProbeClient(),
+        database_probe_client=_OkProbeClient(),
     )
     deps = main_module.ApplicationDependencies(
         conversation_engine=engine,

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -61,6 +61,11 @@ class FailCheck:
         raise CheckFailure()
 
 
+def _ok_auth_client():
+    """Duck-typed auth surface whose exact route path (get_user) is callable."""
+    return SimpleNamespace(auth=SimpleNamespace(get_user=lambda token: None))
+
+
 def _deps_with_checks(checks):
     from backend.admission import AdmissionRuntimeConfig
 
@@ -461,6 +466,102 @@ def test_probe_guard_preserves_newer_future_on_owner_finish():
     asyncio.run(scenario())
 
 
+# ─── 31d. aclose cleanup guarantees (review blockers 2 and 3) ───────────────
+
+
+def test_aclose_cleans_up_when_probe_completes_exceptionally():
+    """A probe that terminates with an exception while aclose is draining
+    must not escape the drain and skip executor/client cleanup (review
+    blocker 2)."""
+    import concurrent.futures
+    import time as _time
+
+    class DelayedFailingClient(_OkProbeClient):
+        def __init__(self):
+            self.closed = False
+
+        def execute(self):
+            _time.sleep(0.05)
+            raise RuntimeError("probe exploded")
+
+        def close(self):
+            self.closed = True
+
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    client = DelayedFailingClient()
+    check = DatabaseCheck(
+        client,
+        timeout_seconds=0.01,
+        probe_executor=executor,
+        owns_client=True,
+    )
+
+    async def scenario():
+        try:
+            await check.run()  # times out at the readiness bound; probe pending
+        except Exception:
+            pass
+        # aclose must not propagate the probe exception and must clean up.
+        await check.aclose()
+        assert client.closed, "owned client must be closed after an exceptional probe"
+        assert check._probe_future is None
+
+    asyncio.run(scenario())
+    executor.shutdown(wait=False)
+
+
+def test_aclose_guarantees_cleanup_on_drain_timeout():
+    """When the drain bound expires, aclose still clears the future and
+    closes the owned client so no owned resource survives the lifespan
+    (review blocker 3)."""
+    import concurrent.futures
+    import threading
+    import time as _time
+
+    release = threading.Event()
+    calls = []
+
+    class StuckClient(_OkProbeClient):
+        def __init__(self):
+            self.closed = False
+
+        def execute(self):
+            calls.append(1)
+            release.wait(timeout=5.0)
+            return _ProbeResult(data=[])
+
+        def close(self):
+            self.closed = True
+
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    client = StuckClient()
+    check = DatabaseCheck(
+        client,
+        timeout_seconds=0.01,
+        probe_executor=executor,
+        owns_client=True,
+    )
+
+    async def scenario():
+        try:
+            await check.run()  # times out; probe still blocked
+        except Exception:
+            pass
+        await check.aclose()  # drain bound (0.01 + 1.0) expires; probe stuck
+        assert client.closed, "owned client must be closed even on drain timeout"
+        assert check._probe_future is None
+
+    asyncio.run(scenario())
+    assert calls == [1]
+    # Release the stuck probe so its worker thread terminates on its own.
+    release.set()
+    deadline = _time.monotonic() + 5.0
+    while any(t.is_alive() for t in executor._threads):
+        assert _time.monotonic() < deadline, "probe thread alive after close"
+        _time.sleep(0.01)
+    executor.shutdown(wait=False)
+
+
 # ─── 32. Sensitive marker sanitization ──────────────────────────────────────
 
 
@@ -547,7 +648,7 @@ def test_default_registry_component_set_and_order():
     registry = build_health_registry(
         settings,
         engine,
-        auth_client=SimpleNamespace(auth=object()),
+        auth_client=_ok_auth_client(),
         persistence_client=_OkProbeClient(),
         database_probe_client=object(),
     )
@@ -569,7 +670,7 @@ def test_default_registry_includes_embeddings_only_when_retrieval_enabled():
     registry = build_health_registry(
         settings,
         engine,
-        auth_client=SimpleNamespace(auth=object()),
+        auth_client=_ok_auth_client(),
         persistence_client=_OkProbeClient(),
         database_probe_client=object(),
     )
@@ -597,6 +698,8 @@ def test_embeddings_check_fails_when_model_missing():
 
 
 def test_auth_check_fails_when_surface_missing():
+    """The auth check verifies the callable route path ``auth.get_user``,
+    not mere attribute existence (review blocker 1)."""
     from backend.health import AuthClientCheck
 
     async def _run(check):
@@ -608,10 +711,25 @@ def test_auth_check_fails_when_surface_missing():
 
     assert asyncio.run(_run(AuthClientCheck(None))) == "unavailable"
     assert asyncio.run(_run(AuthClientCheck(object()))) == "unavailable"
-    assert asyncio.run(_run(AuthClientCheck(SimpleNamespace(auth=object())))) == "ok"
+    # False positive fixed: an ``auth`` object without a callable get_user
+    # (or with get_user=None) is unavailable.
+    assert (
+        asyncio.run(_run(AuthClientCheck(SimpleNamespace(auth=object()))))
+        == "unavailable"
+    )
+    assert (
+        asyncio.run(
+            _run(AuthClientCheck(SimpleNamespace(auth=SimpleNamespace(get_user=None))))
+        )
+        == "unavailable"
+    )
+    # The exact path routes call exists and is callable.
+    assert asyncio.run(_run(AuthClientCheck(_ok_auth_client()))) == "ok"
 
 
 def test_persistence_check_fails_when_surface_missing():
+    """The persistence check verifies callable, invocable ``table``/``rpc``
+    surfaces, not mere attribute existence (review blocker 1)."""
     from backend.health import PersistenceClientCheck
 
     async def _run(check):
@@ -623,10 +741,16 @@ def test_persistence_check_fails_when_surface_missing():
 
     assert asyncio.run(_run(PersistenceClientCheck(None))) == "unavailable"
     assert asyncio.run(_run(PersistenceClientCheck(object()))) == "unavailable"
+    # False positive fixed: table=None/rpc=None passes hasattr but cannot be
+    # called by the routes.
     assert (
-        asyncio.run(_run(PersistenceClientCheck(SimpleNamespace(table=None, rpc=None))))
-        == "ok"
+        asyncio.run(
+            _run(PersistenceClientCheck(SimpleNamespace(table=None, rpc=None)))
+        )
+        == "unavailable"
     )
+    # Invocation must not raise and must return a usable builder.
+    assert asyncio.run(_run(PersistenceClientCheck(_OkProbeClient()))) == "ok"
 
 
 def test_auth_and_persistence_surfaces_are_independent():
@@ -638,7 +762,7 @@ def test_auth_and_persistence_surfaces_are_independent():
         memory_manager=SimpleNamespace(embedding_model=object(), supabase=object()),
         groq_manager=SimpleNamespace(is_configured=lambda: True),
     )
-    auth = SimpleNamespace(auth=object())
+    auth = _ok_auth_client()
     persistence = _OkProbeClient()
 
     async def _statuses(registry):
@@ -690,7 +814,7 @@ def _embeddings_client(retrieval_enabled: bool, model_available: bool):
     registry = build_health_registry(
         settings,
         engine,
-        auth_client=SimpleNamespace(auth=object()),
+        auth_client=_ok_auth_client(),
         persistence_client=_OkProbeClient(),
         database_probe_client=_OkProbeClient(),
     )

--- a/backend/tests/test_import_safety.py
+++ b/backend/tests/test_import_safety.py
@@ -94,6 +94,7 @@ def _run_guard_script() -> subprocess.CompletedProcess:
             "PYTHONPATH": ".",
             "HF_HUB_OFFLINE": "1",
             "TRANSFORMERS_OFFLINE": "1",
+            "APP_ENV": "test",
             "GROQ_API_KEY": "mock-groq-key",
             "GROQ_API_KEY_2": "mock-groq-key-2",
             "ADMISSION_HMAC_SECRET": "mock-admission-secret-at-least-32-bytes-xxxx",
@@ -160,6 +161,7 @@ def test_import_blocks_installed_before_import_are_effective():
             "PYTHONPATH": ".",
             "HF_HUB_OFFLINE": "1",
             "TRANSFORMERS_OFFLINE": "1",
+            "APP_ENV": "test",
             "GROQ_API_KEY": "mock-groq-key",
             "ADMISSION_HMAC_SECRET": "mock-admission-secret-at-least-32-bytes-xxxx",
         }

--- a/backend/tests/test_import_safety.py
+++ b/backend/tests/test_import_safety.py
@@ -1,0 +1,196 @@
+"""Import-safety tests: importing backend modules must have no side effects.
+
+These tests run in isolated subprocesses so they never contaminate the
+``sys.modules`` of the main suite, and blockers (socket, client factories,
+model construction) are installed BEFORE the import under test.
+
+Covered properties (#275):
+* imports never open sockets;
+* imports never construct real Groq or Supabase clients;
+* imports never instantiate ``SentenceTransformer``;
+* imports never start threads;
+* the test suite's own module registry stays untouched.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+GUARD_SCRIPT = textwrap.dedent(
+    """
+    import sys
+    import threading
+
+    # ── Blockers installed BEFORE any backend import ────────────────────────
+    import socket as _socket
+
+    def _forbid(*args, **kwargs):
+        raise AssertionError("network socket usage during import")
+
+    _socket.socket.connect = _forbid
+    _socket.socket.connect_ex = _forbid
+    _socket.create_connection = _forbid
+
+    import groq as _groq
+
+    class _NoGroqClient:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("real Groq client constructed during import")
+
+    _groq.Groq = _NoGroqClient
+    _groq.AsyncGroq = _NoGroqClient
+
+    import supabase as _supabase
+
+    def _no_supabase_client(*args, **kwargs):
+        raise AssertionError("real Supabase client constructed during import")
+
+    _supabase.create_client = _no_supabase_client
+
+    import sentence_transformers as _st
+
+    class _NoEmbeddingModel:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("SentenceTransformer constructed during import")
+
+    _st.SentenceTransformer = _NoEmbeddingModel
+
+    threads_before = len(threading.enumerate())
+
+    # ── Import the modules under test ───────────────────────────────────────
+    import backend.main
+    import backend.engine
+    import backend.memory
+    import backend.groq_manager
+    import backend.dependencies
+    import backend.settings
+    import backend.health
+    import backend.observability
+    import backend.process_turn
+
+    threads_after = len(threading.enumerate())
+
+    assert backend.main.app is not None, "module-level app must exist"
+    assert backend.main.app.state.dependencies is None, (
+        "import must not build the dependency container"
+    )
+    assert backend.main.app.state.lifespan_started is False
+    assert threads_after == threads_before, "import started a thread"
+
+    print("IMPORT_SAFETY_OK")
+    """
+)
+
+
+def _run_guard_script() -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.update(
+        {
+            "PYTHONPATH": ".",
+            "HF_HUB_OFFLINE": "1",
+            "TRANSFORMERS_OFFLINE": "1",
+            "GROQ_API_KEY": "mock-groq-key",
+            "GROQ_API_KEY_2": "mock-groq-key-2",
+            "ADMISSION_HMAC_SECRET": "mock-admission-secret-at-least-32-bytes-xxxx",
+            "SUPABASE_URL": "http://127.0.0.1:54321",
+            "SUPABASE_SERVICE_ROLE_KEY": "mock-service-key",
+            "CORS_ALLOWED_ORIGINS": "http://localhost:3000",
+            "ARCHIVAL_EXTRACTION_ENABLED": "false",
+        }
+    )
+    return subprocess.run(
+        [sys.executable, "-c", GUARD_SCRIPT],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+
+# ─── 10-15. Isolated subprocess guards ──────────────────────────────────────
+
+
+def test_import_opens_no_socket_and_constructs_no_clients():
+    result = _run_guard_script()
+    assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+    assert "IMPORT_SAFETY_OK" in result.stdout
+
+
+def test_import_does_not_start_threads():
+    result = _run_guard_script()
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "IMPORT_SAFETY_OK" in result.stdout
+
+
+def test_import_blocks_installed_before_import_are_effective():
+    """The guard script itself proves the blockers run before the import.
+
+    The blockers are installed first, then a deliberate socket attempt must
+    fail with the blocker's marker: if the import under test had tried to
+    open any connection, it would have hit the same blocker.
+    """
+    script = textwrap.dedent(
+        """
+        import socket as _socket
+
+        def _forbid(*args, **kwargs):
+            raise AssertionError("BLOCKER_MARKER")
+
+        _socket.socket.connect = _forbid
+        _socket.create_connection = _forbid
+
+        try:
+            _socket.create_connection(("127.0.0.1", 1), timeout=0.1)
+            print("BLOCKER_INACTIVE")
+            raise SystemExit(1)
+        except AssertionError as exc:
+            assert "BLOCKER_MARKER" in str(exc)
+            print("BLOCKER_ACTIVE")
+        """
+    )
+    env = dict(os.environ)
+    env.update(
+        {
+            "PYTHONPATH": ".",
+            "HF_HUB_OFFLINE": "1",
+            "TRANSFORMERS_OFFLINE": "1",
+            "GROQ_API_KEY": "mock-groq-key",
+            "ADMISSION_HMAC_SECRET": "mock-admission-secret-at-least-32-bytes-xxxx",
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "BLOCKER_ACTIVE" in result.stdout
+
+
+# ─── 16. Main suite registry is not contaminated ────────────────────────────
+
+
+def test_subprocess_isolation_does_not_pollute_suite_modules():
+    """The subprocess runs in a fresh interpreter; nothing leaks back."""
+    import backend.main as main_module
+
+    assert main_module.app is not None
+    # The module object is the suite's own (no duplicate reload happened).
+    assert sys.modules["backend.main"] is main_module
+
+
+def test_importing_main_again_is_idempotent():
+    import importlib
+
+    import backend.main as main_module
+
+    assert importlib.import_module("backend.main") is main_module

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -1,0 +1,311 @@
+"""Tests for the sanitized observability contract and turn events (#275)."""
+
+from __future__ import annotations
+
+import logging
+import re
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+import backend.main as main_module
+from backend.admission import (
+    ADMITTED,
+    REQUEST_REPLAY_UNAVAILABLE,
+    AdmissionResult,
+    AdmissionRuntimeConfig,
+)
+from backend.atomic_turn_commit import ConflictError
+from backend.emotion_presentation import EmotionStateResponse
+from backend.health import HealthRegistry
+from backend.process_turn import ProcessTurnResult, TurnMode
+from backend.settings import AppEnvironment, Settings
+from backend.turn_execution import (
+    DeadlineExceeded,
+    TurnErrorCode,
+    TurnExecutionConfig,
+    TurnExecutionError,
+)
+
+SECRET = "s" * 40
+REQUEST_ID = "550e8400-e29b-41d4-a716-446655440000"
+UUID = REQUEST_ID
+CORRELATION_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _settings() -> Settings:
+    return Settings(
+        app_env=AppEnvironment.local,
+        groq_api_key="groq-key",
+        admission_hmac_secret=SECRET,
+        cors_allowed_origins=("https://allowed.example",),
+    )
+
+
+def _emotion() -> EmotionStateResponse:
+    return EmotionStateResponse(
+        schema_version=1,
+        mood_label="NEUTRA",
+        pad={"pleasure": 0.0, "arousal": 0.0, "dominance": 0.0},
+        dominant_emotions=[],
+        timestamp=1000.0,
+    )
+
+
+def _turn_result(mode: str = "normal") -> ProcessTurnResult:
+    return ProcessTurnResult(
+        committed=object(),
+        response="response text",
+        emotion_state=_emotion(),
+    )
+
+
+class FakeAuthClient:
+    """Minimal auth surface used by the real get_current_user dependency."""
+
+    def __init__(self):
+        self.tokens = []
+
+    @property
+    def auth(self):
+        return self
+
+    def get_user(self, token):
+        self.tokens.append(token)
+        return SimpleNamespace(user=SimpleNamespace(id="user-a"))
+
+
+class FakeEngine:
+    def __init__(self, supabase=None):
+        self.memory_manager = SimpleNamespace(supabase=supabase or object())
+        self.calls = []
+        self.error = None
+        self.result = _turn_result()
+
+    async def process_turn(
+        self, user_id, message, request_id, *, budget=None, mode=None, correlation=None
+    ):
+        self.calls.append(
+            {
+                "user_id": user_id,
+                "message": message,
+                "request_id": request_id,
+                "mode": mode,
+                "correlation": correlation,
+            }
+        )
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+@pytest.fixture
+def endpoint(monkeypatch):
+    fake_auth = FakeAuthClient()
+    fake_engine = FakeEngine(supabase=fake_auth)
+    captured = {}
+
+    monkeypatch.setattr(
+        main_module,
+        "reserve_admission_sync",
+        lambda client, request: captured.get(
+            "admission_result", AdmissionResult(ADMITTED, 0)
+        ),
+    )
+
+    async def fake_run_blocking_write(
+        stage_label,
+        budget,
+        supabase_timeout,
+        func,
+        *args,
+        allowlist_exceptions=(),
+        **kwargs,
+    ):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(main_module, "run_blocking_write", fake_run_blocking_write)
+
+    deps = main_module.ApplicationDependencies(
+        conversation_engine=fake_engine,
+        auth_client=fake_auth,
+        admission_config=AdmissionRuntimeConfig.from_values(SECRET),
+        turn_config=TurnExecutionConfig.defaults(),
+        health_checks=HealthRegistry(),
+        clock=__import__("time").time,
+    )
+    app = main_module.create_app(settings=_settings(), dependencies=deps)
+    client = TestClient(app)
+    try:
+        yield client, fake_engine, captured, fake_auth
+    finally:
+        app.dependency_overrides.clear()
+
+
+def _payload(request_id=REQUEST_ID, message="Hello"):
+    return {"request_id": request_id, "message": message}
+
+
+def _post(client, payload, **kwargs):
+    return client.post(
+        "/chat", json=payload, headers={"Authorization": "Bearer valid-token"}, **kwargs
+    )
+
+
+def _correlation_from(log_lines: str) -> str | None:
+    match = re.search(r"correlation=([0-9a-f]{64})", log_lines)
+    return match.group(1) if match else None
+
+
+# ─── 39. Nominal turn events correlatable by request ID ─────────────────────
+
+
+def test_nominal_turn_emits_correlatable_events(endpoint, caplog):
+    client, fake_engine, captured, fake_auth = endpoint
+    with caplog.at_level(logging.INFO, logger="backend.main"):
+        response = _post(client, _payload(message="Hello there"))
+
+    assert response.status_code == 200
+    assert response.json()["response"] == "response text"
+
+    correlation = _correlation_from(caplog.text)
+    assert correlation is not None
+    assert "event=auth_completed outcome=ok" in caplog.text
+    assert "event=admission_admitted" in caplog.text
+    assert "event=turn_completed code=ok" in caplog.text
+    assert "event=http_result code=200" in caplog.text
+    # The turn_completed line carries the same sanitized correlation.
+    turn_line = next(
+        line
+        for line in caplog.text.splitlines()
+        if "event=turn_completed code=ok" in line
+    )
+    assert f"correlation={correlation}" in turn_line
+
+    # The engine received the same sanitized correlation the logs carry.
+    assert fake_engine.calls[0]["correlation"] == correlation
+
+
+def test_same_request_id_produces_same_correlation(endpoint, caplog):
+    client, _, _, _ = endpoint
+    correlations = set()
+    for _ in range(2):
+        with caplog.at_level(logging.INFO, logger="backend.main"):
+            response = _post(client, _payload())
+            assert response.status_code == 200
+        correlations.add(_correlation_from(caplog.text))
+    assert len(correlations) == 1
+
+
+# ─── 40. Replay and conflict are distinct events ────────────────────────────
+
+
+def test_replay_attempt_is_a_distinct_event(endpoint, caplog):
+    client, fake_engine, captured, fake_auth = endpoint
+    captured["admission_result"] = AdmissionResult(REQUEST_REPLAY_UNAVAILABLE, 0)
+
+    with caplog.at_level(logging.INFO, logger="backend.main"):
+        response = _post(client, _payload())
+
+    assert response.status_code == 200
+    assert "event=admission_replay" in caplog.text
+    assert fake_engine.calls[0]["mode"] is TurnMode.replay_attempt
+
+
+def test_revision_conflict_is_a_distinct_event(endpoint, caplog):
+    client, fake_engine, captured, fake_auth = endpoint
+    fake_engine.error = ConflictError("revision_mismatch", "conflict", expected_revision=1)
+
+    with caplog.at_level(logging.INFO, logger="backend.main"):
+        response = _post(client, _payload())
+
+    assert response.status_code == 409
+    assert "event=request_conflict code=revision_mismatch" in caplog.text
+    assert "event=admission_replay" not in caplog.text
+
+
+# ─── 41. Failure codes remain distinct ──────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "error,expected_code,expected_status",
+    [
+        (DeadlineExceeded(), "turn_timeout", 504),
+        (
+            TurnExecutionError(TurnErrorCode.upstream_rate_limited, "rate"),
+            "upstream_rate_limited",
+            429,
+        ),
+        (
+            TurnExecutionError(TurnErrorCode.provider_unavailable, "down"),
+            "provider_unavailable",
+            503,
+        ),
+        (
+            TurnExecutionError(TurnErrorCode.persistence_unavailable, "db"),
+            "persistence_unavailable",
+            503,
+        ),
+    ],
+)
+def test_failure_codes_remain_distinct(endpoint, caplog, error, expected_code, expected_status):
+    client, fake_engine, _, _ = endpoint
+    fake_engine.error = error
+    with caplog.at_level(logging.INFO, logger="backend.main"):
+        response = _post(client, _payload())
+    assert response.status_code == expected_status
+    assert f"event=turn_failed code={expected_code}" in caplog.text
+    assert f"event=http_result code={expected_status}" in caplog.text
+
+
+# ─── 42/43/44. Logs never contain content or identifiers ────────────────────
+
+
+def test_logs_never_contain_message_response_or_secrets(endpoint, caplog):
+    client, _, _, _ = endpoint
+    with caplog.at_level(logging.INFO, logger="backend.main"):
+        response = _post(client, _payload(message="TOP_SECRET_USER_MESSAGE"))
+    assert response.status_code == 200
+    assert "TOP_SECRET_USER_MESSAGE" not in caplog.text
+    assert "response text" not in caplog.text
+    assert SECRET not in caplog.text
+    assert "groq-key" not in caplog.text
+
+
+def test_logs_never_contain_raw_user_id(endpoint, caplog):
+    client, fake_engine, _, _ = endpoint
+    with caplog.at_level(logging.INFO, logger="backend.main"):
+        response = _post(client, _payload())
+    assert response.status_code == 200
+    assert "user-a" not in caplog.text
+    assert fake_engine.calls[0]["user_id"] == "user-a"  # used internally, never logged
+
+
+def test_sensitive_fake_exception_remains_sanitized(endpoint, caplog):
+    client, fake_engine, _, _ = endpoint
+    fake_engine.error = Exception("SENSITIVE_TURN_MARKER_XYZ")
+    with caplog.at_level(logging.INFO, logger="backend.main"):
+        response = _post(client, _payload())
+    assert response.status_code == 500
+    assert "SENSITIVE_TURN_MARKER_XYZ" not in response.text
+    assert "SENSITIVE_TURN_MARKER_XYZ" not in caplog.text
+    assert "event=turn_failed code=internal_error" in caplog.text
+
+
+# ─── 45. Events never alter the turn result ─────────────────────────────────
+
+
+def test_events_do_not_change_turn_result(endpoint, caplog):
+    client, fake_engine, _, _ = endpoint
+    with caplog.at_level(logging.INFO, logger="backend.main"):
+        response = _post(client, _payload(message="Hello"))
+    assert response.status_code == 200
+    assert len(fake_engine.calls) == 1
+    call = fake_engine.calls[0]
+    assert call["message"] == "Hello"
+    assert call["mode"] is TurnMode.normal
+    assert call["request_id"] == REQUEST_ID
+    assert response.json() == {"response": "response text", "emotion_state": _emotion().model_dump()}
+    # Observability must not introduce extra provider/persistence calls.
+    assert "event=turn_completed code=ok" in caplog.text

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -309,3 +309,96 @@ def test_events_do_not_change_turn_result(endpoint, caplog):
     assert response.json() == {"response": "response text", "emotion_state": _emotion().model_dump()}
     # Observability must not introduce extra provider/persistence calls.
     assert "event=turn_completed code=ok" in caplog.text
+
+
+# ─── 46. Auth observability: duration, correlation, user hash (blocker 5) ───
+
+
+def _auth_completed_line(caplog_text: str) -> str:
+    return next(
+        line
+        for line in caplog_text.splitlines()
+        if "event=auth_completed" in line
+    )
+
+
+def test_auth_completed_carries_duration_correlation_and_user_hash(endpoint, caplog):
+    client, _, _, _ = endpoint
+    with caplog.at_level(logging.INFO, logger="backend.main"):
+        response = _post(client, _payload())
+    assert response.status_code == 200
+
+    correlation = _correlation_from(caplog.text)
+    assert correlation is not None
+    line = _auth_completed_line(caplog.text)
+    assert "event=auth_completed outcome=ok" in line
+    assert "duration_ms=" in line
+    assert f"correlation={correlation}" in line
+    # The user reference is the non-reversible HMAC, never the raw user id.
+    match = re.search(r"user_ref=([0-9a-f]{64})", line)
+    assert match is not None
+    from backend.admission import AdmissionRuntimeConfig, compute_user_reference
+
+    expected = compute_user_reference(
+        AdmissionRuntimeConfig.from_values(SECRET), "user-a"
+    )
+    assert match.group(1) == expected
+    assert "user-a" not in line
+
+
+def test_auth_failure_401_emits_event_with_duration_and_correlation(endpoint, caplog):
+    from unittest.mock import patch
+
+    from supabase_auth.errors import AuthApiError
+
+    client, _, _, fake_auth = endpoint
+    fake_auth.get_user = lambda _token: (_ for _ in ()).throw(
+        AuthApiError("SENSITIVE_AUTH_MARKER", 400, "error_code")
+    )
+    with caplog.at_level(logging.INFO, logger="backend.main"):
+        response = _post(client, _payload())
+    assert response.status_code == 401
+    correlation = _correlation_from(caplog.text)
+    assert correlation is not None
+    assert "event=auth_failed code=invalid_token" in caplog.text
+    assert "duration_ms=" in caplog.text
+    assert f"correlation={correlation}" in caplog.text
+    assert "SENSITIVE_AUTH_MARKER" not in caplog.text
+
+
+def test_auth_missing_credentials_emits_failure_event(endpoint, caplog):
+    client, _, _, _ = endpoint
+    with caplog.at_level(logging.INFO, logger="backend.main"):
+        response = client.post("/chat", json=_payload())
+    assert response.status_code == 401
+    assert "event=auth_failed code=missing_credentials" in caplog.text
+    assert "duration_ms=" in caplog.text
+
+
+def test_auth_unavailable_503_emits_failure_event(endpoint, caplog):
+    from unittest.mock import patch
+
+    client, _, _, _ = endpoint
+    deps = client.app.state.dependencies
+    with patch.object(deps, "auth_client", None), caplog.at_level(
+        logging.INFO, logger="backend.main"
+    ):
+        response = _post(client, _payload())
+    assert response.status_code == 503
+    assert "event=auth_failed code=service_unavailable" in caplog.text
+    assert "duration_ms=" in caplog.text
+
+
+def test_http_result_carries_turn_correlation(endpoint, caplog):
+    client, _, _, _ = endpoint
+    with caplog.at_level(logging.INFO, logger="backend.main"):
+        response = _post(client, _payload())
+    assert response.status_code == 200
+    correlation = _correlation_from(caplog.text)
+    assert correlation is not None
+    http_line = next(
+        line
+        for line in caplog.text.splitlines()
+        if "event=http_result code=200" in line
+    )
+    assert f"correlation={correlation}" in http_line

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,0 +1,407 @@
+"""Tests for the validated application settings model (#275)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from backend.settings import (
+    ADMISSION_SECRET_MIN_BYTES,
+    AppEnvironment,
+    Settings,
+    SettingsConfigurationError,
+    SettingsIssue,
+)
+from backend.turn_execution import TurnExecutionConfig
+
+SECRET = "s" * ADMISSION_SECRET_MIN_BYTES
+
+
+def _valid_kwargs(**overrides):
+    kwargs = {
+        "groq_api_key": "groq-key",
+        "admission_hmac_secret": SECRET,
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def _production_kwargs(**overrides):
+    kwargs = _valid_kwargs(
+        app_env=AppEnvironment.production,
+        supabase_url="https://db.example.com",
+        supabase_service_role_key="service-key",
+        cors_allowed_origins=("https://app.example.com",),
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+# ─── 1. Valid settings per environment ──────────────────────────────────────
+
+
+def test_valid_settings_accepted_for_every_environment():
+    for environment in AppEnvironment:
+        if environment in (AppEnvironment.staging, AppEnvironment.production):
+            settings = _production_kwargs(app_env=environment)
+        else:
+            settings = _valid_kwargs(app_env=environment)
+        assert Settings(**settings).app_env is environment
+
+
+def test_valid_settings_from_env_for_local_environment(monkeypatch):
+    env = {
+        "APP_ENV": "local",
+        "GROQ_API_KEY": "k",
+        "GROQ_API_KEY_2": "k2",
+        "ADMISSION_HMAC_SECRET": SECRET,
+        "TRUSTED_PROXY_CIDRS": "10.0.0.0/8, 192.168.0.0/16",
+        "CORS_ALLOWED_ORIGINS": "https://a.example, https://a.example, http://localhost:3000",
+        "ARCHIVAL_EXTRACTION_ENABLED": "false",
+    }
+    settings = Settings.from_env(env)
+    assert settings.app_env is AppEnvironment.local
+    assert settings.provider_keys() == ("k", "k2")
+    assert settings.cors_allowed_origins == (
+        "https://a.example",
+        "http://localhost:3000",
+    )  # normalized + deduplicated
+    assert settings.trusted_proxy_cidrs == ("10.0.0.0/8", "192.168.0.0/16")
+    assert settings.archival_extraction_enabled is False
+    assert isinstance(settings.turn_config, TurnExecutionConfig)
+
+
+def test_default_environment_is_local_when_app_env_absent():
+    env = {
+        "GROQ_API_KEY": "k",
+        "ADMISSION_HMAC_SECRET": SECRET,
+    }
+    assert Settings.from_env(env).app_env is AppEnvironment.local
+
+
+def test_invalid_environment_is_rejected():
+    env = {
+        "APP_ENV": "preview",
+        "GROQ_API_KEY": "k",
+        "ADMISSION_HMAC_SECRET": SECRET,
+    }
+    with pytest.raises(SettingsConfigurationError) as exc_info:
+        Settings.from_env(env)
+    assert SettingsIssue("app_env", "invalid_environment") in exc_info.value.issues
+
+
+# ─── 2. Production fails early with missing critical config ─────────────────
+
+
+def test_production_missing_supabase_url_fails_early():
+    with pytest.raises(ValidationError):
+        Settings(**_production_kwargs(supabase_url=None))
+
+
+def test_production_missing_service_role_key_fails_early():
+    with pytest.raises(ValidationError):
+        Settings(**_production_kwargs(supabase_service_role_key=None))
+
+
+def test_production_missing_cors_allowlist_fails_early():
+    with pytest.raises(ValidationError):
+        Settings(**_production_kwargs(cors_allowed_origins=()))
+
+
+def test_production_from_env_missing_critical_config_fails_sanitized():
+    env = {
+        "APP_ENV": "production",
+        "GROQ_API_KEY": "k",
+        "ADMISSION_HMAC_SECRET": SECRET,
+        "CORS_ALLOWED_ORIGINS": "https://app.example.com",
+    }
+    with pytest.raises(SettingsConfigurationError) as exc_info:
+        Settings.from_env(env)
+    fields = {issue.field for issue in exc_info.value.issues}
+    assert "supabase_url" in fields
+    assert "supabase_service_role_key" in fields
+
+
+# ─── 3. URL validation ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "not-a-url",
+        "ftp://db.example.com",
+        "http://",
+        "https://user:pass@db.example.com",
+        "https://db.example.com/path",
+        "https://db.example.com?x=1",
+        "",
+        "   ",
+        "https://db.example.com:8000/",
+    ],
+)
+def test_invalid_urls_rejected(url):
+    if url == "https://db.example.com:8000/":
+        # Trailing slash is normalized, not rejected.
+        settings = Settings(**_valid_kwargs(supabase_url=url))
+        assert settings.supabase_url == "https://db.example.com:8000"
+        return
+    with pytest.raises(ValidationError):
+        Settings(**_valid_kwargs(supabase_url=url))
+
+
+def test_valid_urls_accepted():
+    for url in (
+        "https://db.example.com",
+        "http://127.0.0.1:54321",
+        "https://project.supabase.co",
+    ):
+        settings = Settings(**_valid_kwargs(supabase_url=url))
+        assert settings.supabase_url == url
+
+
+# ─── 4/5. CORS policy ───────────────────────────────────────────────────────
+
+
+def test_localhost_origin_rejected_in_production():
+    for origin in (
+        "http://localhost:3000",
+        "https://127.0.0.1",
+        "http://app.localhost",
+    ):
+        with pytest.raises(ValidationError):
+            Settings(**_production_kwargs(cors_allowed_origins=(origin,)))
+
+
+def test_localhost_origin_allowed_outside_production():
+    settings = Settings(
+        **_valid_kwargs(
+            app_env=AppEnvironment.local,
+            cors_allowed_origins=("http://localhost:3000",),
+        )
+    )
+    assert settings.cors_allowed_origins == ("http://localhost:3000",)
+
+
+def test_wildcard_origin_rejected_in_all_environments():
+    for environment in AppEnvironment:
+        kwargs = _production_kwargs(app_env=environment)
+        with pytest.raises(ValidationError):
+            Settings(**{**kwargs, "cors_allowed_origins": ("*",)})
+
+
+def test_localhost_supabase_url_rejected_in_production():
+    with pytest.raises(ValidationError):
+        Settings(
+            **_production_kwargs(
+                supabase_url="http://127.0.0.1:54321",
+            )
+        )
+
+
+def test_cors_origins_normalized_and_deduplicated():
+    settings = Settings(
+        **_valid_kwargs(
+            cors_allowed_origins=(
+                " https://a.example/ ",
+                "https://a.example",
+                "https://a.example/",
+                "https://b.example",
+            ),
+        )
+    )
+    assert settings.cors_allowed_origins == (
+        "https://a.example",
+        "https://b.example",
+    )
+
+
+def test_origin_with_path_or_credentials_rejected():
+    for origin in (
+        "https://a.example/path",
+        "https://a.example?q=1",
+        "https://user@a.example",
+    ):
+        with pytest.raises(ValidationError):
+            Settings(**_valid_kwargs(cors_allowed_origins=(origin,)))
+
+
+# ─── 6. Strict types and ranges ─────────────────────────────────────────────
+
+
+def test_numeric_timeouts_reject_out_of_range():
+    with pytest.raises(ValidationError):
+        Settings(**_valid_kwargs(readiness_database_timeout_ms=0))
+    with pytest.raises(ValidationError):
+        Settings(**_valid_kwargs(readiness_database_timeout_ms=100_000))
+    with pytest.raises(ValidationError):
+        Settings(**_valid_kwargs(readiness_provider_timeout_ms=-1))
+
+
+def test_numeric_timeouts_reject_none_bool_and_numeric_strings():
+    for value in (None, True, False, "3000", 3.5):
+        with pytest.raises(ValidationError):
+            Settings(**_valid_kwargs(readiness_database_timeout_ms=value))
+
+
+def test_boolean_fields_reject_non_bool_values():
+    for value in ("true", 1, 0, "false", None, 1.0):
+        with pytest.raises(ValidationError):
+            Settings(**_valid_kwargs(archival_extraction_enabled=value))
+        with pytest.raises(ValidationError):
+            Settings(**_valid_kwargs(cors_allow_credentials=value))
+
+
+def test_boolean_fields_accept_only_bool():
+    settings = Settings(**_valid_kwargs(archival_extraction_enabled=True))
+    assert settings.archival_extraction_enabled is True
+
+
+def test_from_env_rejects_permissive_boolean_parsing():
+    env = {
+        "GROQ_API_KEY": "k",
+        "ADMISSION_HMAC_SECRET": SECRET,
+        "ARCHIVAL_EXTRACTION_ENABLED": "1",
+    }
+    with pytest.raises(SettingsConfigurationError):
+        Settings.from_env(env)
+
+    env["ARCHIVAL_EXTRACTION_ENABLED"] = "yes"
+    with pytest.raises(SettingsConfigurationError):
+        Settings.from_env(env)
+
+
+def test_from_env_rejects_empty_critical_values():
+    env = {
+        "GROQ_API_KEY": "k",
+        "ADMISSION_HMAC_SECRET": SECRET,
+        "CORS_ALLOWED_ORIGINS": "   ",
+    }
+    with pytest.raises(SettingsConfigurationError):
+        Settings.from_env(env)
+
+    env = {"GROQ_API_KEY": "", "ADMISSION_HMAC_SECRET": SECRET}
+    with pytest.raises(SettingsConfigurationError) as exc_info:
+        Settings.from_env(env)
+    assert SettingsIssue("groq_api_key", "empty_secret") in exc_info.value.issues
+
+
+def test_from_env_rejects_invalid_turn_configuration():
+    env = {
+        "GROQ_API_KEY": "k",
+        "ADMISSION_HMAC_SECRET": SECRET,
+        "TURN_MAX_ATTEMPTS": "not-a-number",
+    }
+    with pytest.raises(SettingsConfigurationError) as exc_info:
+        Settings.from_env(env)
+    assert SettingsIssue("turn_config", "invalid_turn_configuration") in exc_info.value.issues
+
+
+def test_secret_too_short_rejected():
+    with pytest.raises(ValidationError):
+        Settings(groq_api_key="k", admission_hmac_secret="short")
+
+
+def test_empty_secrets_rejected():
+    with pytest.raises(ValidationError):
+        Settings(groq_api_key="", admission_hmac_secret=SECRET)
+    with pytest.raises(ValidationError):
+        Settings(groq_api_key="k", admission_hmac_secret="   ")
+
+
+def test_invalid_proxy_cidr_rejected():
+    with pytest.raises(ValidationError):
+        Settings(**_valid_kwargs(trusted_proxy_cidrs=("not-a-cidr",)))
+
+
+def test_extra_fields_forbidden():
+    with pytest.raises(ValidationError):
+        Settings(**_valid_kwargs(unexpected_field="x"))
+
+
+# ─── 7. Secrets never appear in repr ────────────────────────────────────────
+
+
+def test_repr_does_not_contain_secrets():
+    settings = Settings(
+        groq_api_key="groq-secret-value",
+        groq_api_key_2="second-secret-value",
+        admission_hmac_secret=SECRET,
+        supabase_service_role_key="service-secret-value",
+    )
+    rendered = repr(settings)
+    for secret in ("groq-secret-value", "second-secret-value", SECRET, "service-secret-value"):
+        assert secret not in rendered
+
+
+def test_str_does_not_contain_secrets():
+    settings = Settings(groq_api_key="groq-secret-value", admission_hmac_secret=SECRET)
+    assert "groq-secret-value" not in str(settings)
+    assert SECRET not in str(settings)
+
+
+# ─── 8. Sanitized validation errors ─────────────────────────────────────────
+
+
+def test_from_env_errors_never_contain_input_values():
+    secret_marker = "super-secret-marker-value-12345"
+    env = {
+        "APP_ENV": "production",
+        "GROQ_API_KEY": "k",
+        "ADMISSION_HMAC_SECRET": SECRET,
+        "CORS_ALLOWED_ORIGINS": "https://app.example.com",
+        "SUPABASE_URL": "http://localhost:9",
+        "SUPABASE_SERVICE_ROLE_KEY": secret_marker,
+    }
+    with pytest.raises(SettingsConfigurationError) as exc_info:
+        Settings.from_env(env)
+    rendered = str(exc_info.value)
+    assert secret_marker not in rendered
+    assert SECRET not in rendered
+    assert "localhost:9" not in rendered
+
+
+def test_from_env_errors_expose_only_field_and_code():
+    env = {
+        "APP_ENV": "production",
+        "GROQ_API_KEY": "k",
+        "ADMISSION_HMAC_SECRET": SECRET,
+        "CORS_ALLOWED_ORIGINS": "http://localhost:3000",
+        "SUPABASE_URL": "https://db.example.com",
+        "SUPABASE_SERVICE_ROLE_KEY": "sk",
+    }
+    with pytest.raises(SettingsConfigurationError) as exc_info:
+        Settings.from_env(env)
+    assert SettingsIssue("cors_allowed_origins", "origins_localhost_production") in exc_info.value.issues
+    assert exc_info.value.sanitized_details() == exc_info.value.issues
+
+
+def test_settings_configuration_error_repr_never_contains_values():
+    error = SettingsConfigurationError(
+        (SettingsIssue("supabase_url", "url_invalid"),)
+    )
+    assert "http://" not in repr(error)
+    assert "url_invalid" in repr(error)
+
+
+# ─── 9. Direct construction never reads the environment ─────────────────────
+
+
+def test_direct_construction_does_not_consult_environment(monkeypatch):
+    def _fail_read(*_args, **_kwargs):
+        raise AssertionError("environment must not be read during direct construction")
+
+    monkeypatch.setattr("backend.settings.os.environ", {})
+    monkeypatch.setattr("backend.settings.os.getenv", _fail_read)
+    settings = Settings(groq_api_key="k", admission_hmac_secret=SECRET)
+    assert settings.groq_api_key.get_secret_value() == "k"
+
+
+def test_from_env_uses_provided_mapping_without_global_environment(monkeypatch):
+    def _fail_read(*_args, **_kwargs):
+        raise AssertionError("environment must not be read when a mapping is provided")
+
+    monkeypatch.setattr("backend.settings.os.getenv", _fail_read)
+    settings = Settings.from_env(
+        {"GROQ_API_KEY": "k", "ADMISSION_HMAC_SECRET": SECRET}
+    )
+    assert settings.app_env is AppEnvironment.local

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -262,12 +262,18 @@ def test_numeric_timeouts_reject_out_of_range():
         Settings(**_valid_kwargs(readiness_database_timeout_ms=100_000))
     with pytest.raises(ValidationError):
         Settings(**_valid_kwargs(readiness_provider_timeout_ms=-1))
+    with pytest.raises(ValidationError):
+        Settings(**_valid_kwargs(readiness_auth_timeout_ms=0))
+    with pytest.raises(ValidationError):
+        Settings(**_valid_kwargs(readiness_auth_timeout_ms=50_000))
 
 
 def test_numeric_timeouts_reject_none_bool_and_numeric_strings():
     for value in (None, True, False, "3000", 3.5):
         with pytest.raises(ValidationError):
             Settings(**_valid_kwargs(readiness_database_timeout_ms=value))
+        with pytest.raises(ValidationError):
+            Settings(**_valid_kwargs(readiness_auth_timeout_ms=value))
 
 
 def test_boolean_fields_reject_non_bool_values():

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -71,12 +71,39 @@ def test_valid_settings_from_env_for_local_environment(monkeypatch):
     assert isinstance(settings.turn_config, TurnExecutionConfig)
 
 
-def test_default_environment_is_local_when_app_env_absent():
+def test_missing_app_env_fails_closed():
+    """A deployment that forgets APP_ENV never silently runs in local mode."""
     env = {
         "GROQ_API_KEY": "k",
         "ADMISSION_HMAC_SECRET": SECRET,
     }
-    assert Settings.from_env(env).app_env is AppEnvironment.local
+    with pytest.raises(SettingsConfigurationError) as exc_info:
+        Settings.from_env(env)
+    assert SettingsIssue("app_env", "required") in exc_info.value.issues
+
+    env["APP_ENV"] = "   "
+    with pytest.raises(SettingsConfigurationError) as exc_info:
+        Settings.from_env(env)
+    assert SettingsIssue("app_env", "required") in exc_info.value.issues
+
+
+def test_explicit_environment_modes_are_accepted():
+    """Explicit APP_ENV values work for every supported mode."""
+    for environment in AppEnvironment:
+        env = {
+            "APP_ENV": environment.value,
+            "GROQ_API_KEY": "k",
+            "ADMISSION_HMAC_SECRET": SECRET,
+        }
+        if environment in (AppEnvironment.staging, AppEnvironment.production):
+            env.update(
+                {
+                    "SUPABASE_URL": "https://db.example.com",
+                    "SUPABASE_SERVICE_ROLE_KEY": "sk",
+                    "CORS_ALLOWED_ORIGINS": "https://app.example.com",
+                }
+            )
+        assert Settings.from_env(env).app_env is environment
 
 
 def test_invalid_environment_is_rejected():
@@ -258,6 +285,7 @@ def test_boolean_fields_accept_only_bool():
 
 def test_from_env_rejects_permissive_boolean_parsing():
     env = {
+        "APP_ENV": "local",
         "GROQ_API_KEY": "k",
         "ADMISSION_HMAC_SECRET": SECRET,
         "ARCHIVAL_EXTRACTION_ENABLED": "1",
@@ -272,6 +300,7 @@ def test_from_env_rejects_permissive_boolean_parsing():
 
 def test_from_env_rejects_empty_critical_values():
     env = {
+        "APP_ENV": "local",
         "GROQ_API_KEY": "k",
         "ADMISSION_HMAC_SECRET": SECRET,
         "CORS_ALLOWED_ORIGINS": "   ",
@@ -279,7 +308,11 @@ def test_from_env_rejects_empty_critical_values():
     with pytest.raises(SettingsConfigurationError):
         Settings.from_env(env)
 
-    env = {"GROQ_API_KEY": "", "ADMISSION_HMAC_SECRET": SECRET}
+    env = {
+        "APP_ENV": "local",
+        "GROQ_API_KEY": "",
+        "ADMISSION_HMAC_SECRET": SECRET,
+    }
     with pytest.raises(SettingsConfigurationError) as exc_info:
         Settings.from_env(env)
     assert SettingsIssue("groq_api_key", "empty_secret") in exc_info.value.issues
@@ -287,6 +320,7 @@ def test_from_env_rejects_empty_critical_values():
 
 def test_from_env_rejects_invalid_turn_configuration():
     env = {
+        "APP_ENV": "local",
         "GROQ_API_KEY": "k",
         "ADMISSION_HMAC_SECRET": SECRET,
         "TURN_MAX_ATTEMPTS": "not-a-number",
@@ -294,6 +328,22 @@ def test_from_env_rejects_invalid_turn_configuration():
     with pytest.raises(SettingsConfigurationError) as exc_info:
         Settings.from_env(env)
     assert SettingsIssue("turn_config", "invalid_turn_configuration") in exc_info.value.issues
+
+
+def test_from_env_parses_embeddings_retrieval_flag():
+    env = {
+        "APP_ENV": "local",
+        "GROQ_API_KEY": "k",
+        "ADMISSION_HMAC_SECRET": SECRET,
+        "EMBEDDINGS_RETRIEVAL_ENABLED": "true",
+    }
+    assert Settings.from_env(env).embeddings_retrieval_enabled is True
+
+    env["EMBEDDINGS_RETRIEVAL_ENABLED"] = "false"
+    assert Settings.from_env(env).embeddings_retrieval_enabled is False
+
+    del env["EMBEDDINGS_RETRIEVAL_ENABLED"]
+    assert Settings.from_env(env).embeddings_retrieval_enabled is False
 
 
 def test_secret_too_short_rejected():
@@ -402,6 +452,60 @@ def test_from_env_uses_provided_mapping_without_global_environment(monkeypatch):
 
     monkeypatch.setattr("backend.settings.os.getenv", _fail_read)
     settings = Settings.from_env(
-        {"GROQ_API_KEY": "k", "ADMISSION_HMAC_SECRET": SECRET}
+        {"APP_ENV": "local", "GROQ_API_KEY": "k", "ADMISSION_HMAC_SECRET": SECRET}
     )
     assert settings.app_env is AppEnvironment.local
+
+
+# ─── 10. Immutability (frozen + assignment-validated) ───────────────────────
+
+
+def test_settings_instance_is_immutable():
+    """A constructed Settings can never be mutated into an invalid state."""
+    settings = Settings(**_valid_kwargs())
+    for mutate in (
+        lambda s: setattr(s, "app_env", AppEnvironment.production),
+        lambda s: setattr(s, "cors_allowed_origins", ("https://evil.example",)),
+        lambda s: setattr(s, "readiness_database_timeout_ms", 999_999),
+        lambda s: setattr(s, "groq_api_key", "mutated-secret"),
+    ):
+        with pytest.raises(ValidationError):
+            mutate(settings)
+    # The instance is still the original, valid one.
+    settings.ensure_valid()
+    assert settings.app_env is AppEnvironment.local
+
+
+def test_ensure_valid_revalidates_the_complete_model():
+    """ensure_valid() rebuilds and revalidates the full model, not just the
+    cross-field validator."""
+    settings = Settings(**_valid_kwargs())
+    settings.ensure_valid()  # no-op for a valid frozen instance
+
+    # A replaced settings reference on app.state is caught by the
+    # configuration check because ensure_valid() revalidates everything.
+    from backend.health import ConfigurationCheck
+
+    async def _run():
+        await ConfigurationCheck(settings).run()
+        with pytest.raises(Exception):
+            await ConfigurationCheck("not-a-settings").run()
+
+    import asyncio
+
+    asyncio.run(_run())
+
+
+def test_direct_construction_errors_never_contain_sensitive_values():
+    """hide_input_in_errors: a ValidationError from direct construction never
+    renders URL credentials, keys, or other raw values."""
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(
+            groq_api_key="SUPER-SECRET-KEY-MARKER-12345",
+            admission_hmac_secret="short",
+            supabase_url="https://user:pass@db.example.com",
+        )
+    rendered = str(exc_info.value)
+    assert "SUPER-SECRET-KEY-MARKER-12345" not in rendered
+    assert "user:pass" not in rendered
+    assert "db.example.com" not in rendered

--- a/backend/tests/test_smoke.py
+++ b/backend/tests/test_smoke.py
@@ -13,8 +13,10 @@ def test_imports():
 
         # Mock environment variables
         os.environ['GROQ_API_KEY'] = 'mock'
-        os.environ['SUPABASE_URL'] = 'mock'
+        os.environ['SUPABASE_URL'] = 'http://mock.example'
         os.environ['SUPABASE_SERVICE_ROLE_KEY'] = 'mock'
+        os.environ['ADMISSION_HMAC_SECRET'] = 'mock-admission-secret-that-is-at-least-32-bytes'
+        os.environ['CORS_ALLOWED_ORIGINS'] = 'http://localhost:3000'
 
         # Attempt to import main
         import backend.main

--- a/backend/tests/test_smoke.py
+++ b/backend/tests/test_smoke.py
@@ -12,6 +12,7 @@ def test_imports():
         sys.modules['supabase'] = MagicMock()
 
         # Mock environment variables
+        os.environ['APP_ENV'] = 'test'
         os.environ['GROQ_API_KEY'] = 'mock'
         os.environ['SUPABASE_URL'] = 'http://mock.example'
         os.environ['SUPABASE_SERVICE_ROLE_KEY'] = 'mock'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@ services:
   backend:
     build:
       context: ./backend
+    # The .env file must declare APP_ENV (local/test/staging/production):
+    # Settings.from_env() fails closed when it is missing, so the backend
+    # never silently runs in an implicit mode.
     env_file: .env
     ports:
       - "8000:8000"

--- a/docs/architecture/application-lifecycle.md
+++ b/docs/architecture/application-lifecycle.md
@@ -109,28 +109,50 @@ class ApplicationDependencies:
 ## Ordem de shutdown (lifespan)
 
 ```text
-1. Marcar lifespan como não iniciado (impede readiness durante shutdown).
+1. Marcar lifespan como não iniciado (impede readiness durante shutdown e
+   faz get_dependencies() recusar novas requisições).
 2. Fechar cada recurso owned:
    a. contrato: aclose() → close() (o primeiro disponível)
    b. falha em um recurso não interrompe os demais
    c. apenas `event=app_shutdown_failed` é registrado (código sanitizado)
-3. Limpar app.state.owned_resources → shutdown idempotente
-4. Recursos injetados externamente NUNCA são fechados pela aplicação
+3. Limpar app.state.owned_resources.
+4. Se a composição era owned (construída pela aplicação), limpar
+   app.state.dependencies: o próximo ciclo de lifespan constrói uma
+   composição nova com recursos novos, nunca reutiliza recursos já fechados.
+5. Recursos injetados externamente NUNCA são fechados pela aplicação e
+   permanecem em app.state para o chamador; as rotas ainda recusam operar
+   fora do lifespan (get_dependencies() exige lifespan_started).
 ```
+
+## Ciclos de lifespan
+
+- Composição **owned**: cada entrada no lifespan executa
+  `build_default_dependencies()`; o shutdown fecha e descarta a composição.
+  Um segundo ciclo constrói recursos novos (testado com fakes e com o builder
+  padrão).
+- Composição **injetada**: o chamador mantém ownership; o shutdown não fecha
+  nem descarta, mas as rotas continuam recusando operar fora do lifespan.
 
 ## Ownership
 
 | Recurso | Criado por | Fechado por |
 | --- | --- | --- |
-| Engine/managers (default) | `build_default_dependencies` | aplicação (shutdown) |
+| Engine/managers (default) | `build_default_dependencies` | aplicação (shutdown; hoje sem contrato close/aclose no grafo) |
+| Registry de readiness (checks + executor do probe) | `build_default_dependencies` | aplicação (shutdown e startup parcial) |
+| Cliente de probe do banco | `build_default_dependencies` | aplicação (quando o SDK expuser close/aclose) |
 | Cliente Supabase (default) | `build_default_dependencies` via factory dos settings | aplicação (se expuser close/aclose) |
 | Container injetado | chamador (teste/deploy) | chamador |
 | Clientes Groq por request | `GroqClientManager` | request-scoped (fechados por call) |
 
-A versão atual do SDK Supabase pinado não expõe `close()`/`aclose()` no
-cliente, e os clientes Groq são request-scoped; portanto o mecanismo de
-shutdown existe e é testado com recursos falsos, mas a lista owned do builder
-padrão é vazia hoje.
+O builder padrão retorna `owned = (health_checks, probe_client)`: o registry
+fecha cada check fechável (o executor dedicado do probe de banco, com
+`wait=False`, sem abandonar um probe em voo — o transporte alinhado o
+encerra) e o cliente de probe é fechado quando o SDK expuser contrato
+compatível. A versão atual do SDK Supabase pinado não expõe
+`close()`/`aclose()`, e os clientes Groq são request-scoped, então o grafo do
+engine não entra na tupla owned hoje. Em falha parcial de startup, os
+recursos já criados (engine, probe client, registry) são fechados antes da
+exceção propagar.
 
 ## Importabilidade
 

--- a/docs/architecture/application-lifecycle.md
+++ b/docs/architecture/application-lifecycle.md
@@ -1,0 +1,153 @@
+# Application Lifecycle
+
+Status: implementado na issue #275.
+
+Este documento descreve como o backend é composto, iniciado e encerrado:
+settings validados, container de dependências, app factory, lifespan e
+ownership dos recursos.
+
+## Problema e causa raiz
+
+O backend anterior construía dependências no carregamento dos módulos:
+
+```text
+import backend.main
+→ cria engine (cliente Groq + MemoryManager + SentenceTransformer + Supabase)
+→ lê CORS, archival flag e timeouts de ambiente no import
+→ registra /health sem checar dependências
+```
+
+Consequências:
+
+- efeitos colaterais durante import (rede, modelos, clientes);
+- testes dependentes de monkeypatch em `sys.modules` e de globais de módulo;
+- impossibilidade de fechar clientes no shutdown;
+- configuração de produção baseada em defaults de desenvolvimento;
+- health check incapaz de distinguir processo vivo de instância apta;
+- baixa capacidade de injetar doubles nos testes.
+
+## Solução
+
+A composição foi separada da lógica de negócio em quatro camadas:
+
+1. `backend/settings.py` — configuração tipada e validada (ver
+   [Configuration](operations/configuration.md)).
+2. `backend/dependencies.py` — container explícito
+   `ApplicationDependencies` + builder padrão + ownership.
+3. `backend/main.py` — `create_app(settings, dependencies)` + lifespan.
+4. `backend/health.py` — checks de readiness (ver
+   [Health and Readiness](operations/health-and-readiness.md)).
+
+## Contrato da app factory
+
+```python
+def create_app(
+    settings: Settings | None = None,
+    dependencies: ApplicationDependencies | None = None,
+) -> FastAPI: ...
+```
+
+- `settings=None` → `Settings.from_env()` (validação estrita, falha cedo).
+- `dependencies=None` → o lifespan constrói a composição padrão
+  (`build_default_dependencies(settings)`) e a aplicação é dona dos recursos.
+- `dependencies=<container>` → o chamador mantém ownership; a aplicação não
+  constrói nada no startup e marca o ciclo como concluído imediatamente.
+- A factory **nunca** constrói cliente Groq, cliente Supabase, modelo de
+  embeddings, threads ou tarefas em background. Importar `backend.main` é
+  seguro e sem efeitos colaterais.
+- O container fica em `app.state.dependencies`; endpoints o recuperam por
+  dependency functions pequenas (`get_dependencies(request)`), nunca por
+  globais.
+
+## Container de dependências
+
+```python
+@dataclass
+class ApplicationDependencies:
+    conversation_engine: ConversationEngine  # ProcessTurn + provider + persistência
+    auth_client: object                      # superfície de auth (cliente Supabase)
+    admission_config: AdmissionRuntimeConfig # ledger de admissão + HMAC
+    turn_config: TurnExecutionConfig         # budget/deadline do turno
+    health_checks: HealthRegistry            # checks de readiness
+    clock: Callable[[], float]               # relógio de parede
+```
+
+- Nenhum estado por usuário vive no container ou em singleton: identidade
+  autenticada é resolvida por request (`get_current_user`), e snapshots
+  emocionais/relacionais permanecem no domínio/persistência.
+- `UserLockManager` permanece process-wide porque já é thread-safe por
+  construção e é um recurso de infraestrutura, não estado de usuário.
+- Para adicionar uma dependência nova, ver “Procedimento para adicionar uma
+  dependência” abaixo.
+
+## Ordem de startup (lifespan)
+
+```text
+1. Validar configuração final (Settings já validado; re-validação barata).
+2. Se não injetado: build_default_dependencies(settings)
+   a. engine (GroqClientManager + MemoryManager + lock manager)
+   b. admission_config a partir dos settings
+   c. health registry (configuration, database, provider[, embeddings])
+   d. container concluído
+3. Falha em qualquer passo:
+   a. recursos já criados pelo builder são fechados (cleanup parcial)
+   b. app.state.owned_resources é drenado
+   c. evento sanitizado `event=app_startup_failed`
+   d. a exceção propaga: a aplicação não começa a servir tráfego
+4. Somente após sucesso: `app.state.lifespan_started = True`
+```
+
+## Ordem de shutdown (lifespan)
+
+```text
+1. Marcar lifespan como não iniciado (impede readiness durante shutdown).
+2. Fechar cada recurso owned:
+   a. contrato: aclose() → close() (o primeiro disponível)
+   b. falha em um recurso não interrompe os demais
+   c. apenas `event=app_shutdown_failed` é registrado (código sanitizado)
+3. Limpar app.state.owned_resources → shutdown idempotente
+4. Recursos injetados externamente NUNCA são fechados pela aplicação
+```
+
+## Ownership
+
+| Recurso | Criado por | Fechado por |
+| --- | --- | --- |
+| Engine/managers (default) | `build_default_dependencies` | aplicação (shutdown) |
+| Cliente Supabase (default) | `build_default_dependencies` via factory dos settings | aplicação (se expuser close/aclose) |
+| Container injetado | chamador (teste/deploy) | chamador |
+| Clientes Groq por request | `GroqClientManager` | request-scoped (fechados por call) |
+
+A versão atual do SDK Supabase pinado não expõe `close()`/`aclose()` no
+cliente, e os clientes Groq são request-scoped; portanto o mecanismo de
+shutdown existe e é testado com recursos falsos, mas a lista owned do builder
+padrão é vazia hoje.
+
+## Importabilidade
+
+Importar `backend.main`, `backend.engine`, `backend.memory`,
+`backend.groq_manager`, `backend.dependencies`, `backend.settings`,
+`backend.health`, `backend.observability` e `backend.process_turn`:
+
+- não abre socket;
+- não constrói cliente Groq ou Supabase;
+- não instancia `SentenceTransformer`;
+- não inicia thread nem background task;
+- não lê arquivos de runtime nem executa migration;
+- não imprime nada.
+
+O único acesso a ambiente no import é `Settings.from_env()` na construção do
+app de módulo (`app = create_app()`), que é validação pura.
+
+## Procedimento para adicionar uma dependência nova
+
+1. Adicione o campo ao container `ApplicationDependencies` (sem estado por
+   usuário).
+2. Construa o recurso em `build_default_dependencies` e, se a aplicação deve
+   fechá-lo, inclua-o na tupla de `owned_resources` e implemente
+   `close()`/`aclose()`.
+3. Se for crítico para tráfego nominal, adicione um check em `health.py` com
+   timeout explícito e registre-o em `build_health_registry`.
+4. Se exigir configuração, adicione o campo em `Settings` com validação
+   estrita e documente a variável em `docs/operations/configuration.md`.
+5. Teste: factory com fakes injetados, lifespan, ownership, readiness.

--- a/docs/architecture/application-lifecycle.md
+++ b/docs/architecture/application-lifecycle.md
@@ -140,7 +140,7 @@ class ApplicationDependencies:
 | --- | --- | --- |
 | Engine/managers (default) | `build_default_dependencies` | aplicação (shutdown; hoje sem contrato close/aclose no grafo) |
 | Registry de readiness (checks + executor do probe) | `build_default_dependencies` | aplicação (shutdown e startup parcial) |
-| Cliente de probe do banco | `build_default_dependencies` (dono: `DatabaseCheck`) | `DatabaseCheck.aclose()` após drenar o probe em voo; `_close_sync` em startup parcial |
+| Cliente de probe do banco | `build_default_dependencies` (dono: `DatabaseCheck`) | `DatabaseCheck.aclose()` após drenar o probe em voo (mesmo se a drenagem estourar o limite, o cliente é fechado e a future descartada); `_close_sync` em startup parcial |
 | Cliente Supabase (default) | `build_default_dependencies` via factory dos settings | aplicação (se expuser close/aclose) |
 | Container injetado | chamador (teste/deploy) | chamador |
 | Clientes Groq por request | `GroqClientManager` | request-scoped (fechados por call) |

--- a/docs/architecture/application-lifecycle.md
+++ b/docs/architecture/application-lifecycle.md
@@ -70,11 +70,17 @@ class ApplicationDependencies:
     turn_config: TurnExecutionConfig         # budget/deadline do turno
     health_checks: HealthRegistry            # checks de readiness
     clock: Callable[[], float]               # relógio de parede
+    persistence_client: object               # superfície de persistência (history/admission)
 ```
 
 - Nenhum estado por usuário vive no container ou em singleton: identidade
   autenticada é resolvida por request (`get_current_user`), e snapshots
   emocionais/relacionais permanecem no domínio/persistência.
+- `auth_client` e `persistence_client` são superfícies explícitas: as rotas
+  usam somente a dependência correta (`auth_client` para autenticação,
+  `persistence_client` para history/admission) e nunca navegam por
+  `conversation_engine.memory_manager`. Fakes distintos podem ser injetados
+  para provar o isolamento.
 - `UserLockManager` permanece process-wide porque já é thread-safe por
   construção e é um recurso de infraestrutura, não estado de usuário.
 - Para adicionar uma dependência nova, ver “Procedimento para adicionar uma
@@ -83,12 +89,15 @@ class ApplicationDependencies:
 ## Ordem de startup (lifespan)
 
 ```text
-1. Validar configuração final (Settings já validado; re-validação barata).
+1. Validar configuração final (Settings congelado; re-validação completa).
 2. Se não injetado: build_default_dependencies(settings)
-   a. engine (GroqClientManager + MemoryManager + lock manager)
+   a. engine (GroqClientManager + MemoryManager + lock manager); o modelo de
+      embeddings só é construído quando EMBEDDINGS_RETRIEVAL_ENABLED=true
    b. admission_config a partir dos settings
-   c. health registry (configuration, database, provider[, embeddings])
-   d. container concluído
+   c. cliente de probe de banco dedicado (timeout de transporte alinhado ao
+      READINESS_DATABASE_TIMEOUT_MS)
+   d. health registry (configuration, database, provider[, embeddings])
+   e. container concluído
 3. Falha em qualquer passo:
    a. recursos já criados pelo builder são fechados (cleanup parcial)
    b. app.state.owned_resources é drenado
@@ -137,7 +146,10 @@ Importar `backend.main`, `backend.engine`, `backend.memory`,
 - não imprime nada.
 
 O único acesso a ambiente no import é `Settings.from_env()` na construção do
-app de módulo (`app = create_app()`), que é validação pura.
+app de módulo (`app = create_app()`), que é validação pura. Como `APP_ENV` é
+obrigatório (fail-closed), o runtime (Docker/CI/process manager) precisa
+declará-lo; sem ele, `create_app()` falha com erro sanitizado em vez de rodar
+em modo implícito.
 
 ## Procedimento para adicionar uma dependência nova
 

--- a/docs/architecture/application-lifecycle.md
+++ b/docs/architecture/application-lifecycle.md
@@ -94,8 +94,8 @@ class ApplicationDependencies:
    a. engine (GroqClientManager + MemoryManager + lock manager); o modelo de
       embeddings só é construído quando EMBEDDINGS_RETRIEVAL_ENABLED=true
    b. admission_config a partir dos settings
-   c. cliente de probe de banco dedicado (timeout de transporte alinhado ao
-      READINESS_DATABASE_TIMEOUT_MS)
+   c. probes de readiness (auth e database) construídos a partir dos settings:
+      I/O HTTP assíncrono bounded (httpx), sem threads, sem cliente owned
    d. health registry (configuration, auth, database, persistence,
       provider[, embeddings])
    e. container concluído
@@ -139,30 +139,29 @@ class ApplicationDependencies:
 | Recurso | Criado por | Fechado por |
 | --- | --- | --- |
 | Engine/managers (default) | `build_default_dependencies` | aplicação (shutdown; hoje sem contrato close/aclose no grafo) |
-| Registry de readiness (checks + executor do probe) | `build_default_dependencies` | aplicação (shutdown e startup parcial) |
-| Cliente de probe do banco | `build_default_dependencies` (dono: `DatabaseCheck`) | `DatabaseCheck.aclose()` após drenar o probe em voo (mesmo se a drenagem estourar o limite, o cliente é fechado e a future descartada); `_close_sync` em startup parcial |
+| Registry de readiness (checks) | `build_default_dependencies` | aplicação (shutdown e startup parcial) |
+| Probes de readiness (auth/database) | `build_default_dependencies` (callables async) | sem recurso owned (I/O HTTP assíncrono; `aclose()` cancela probes em voo) |
 | Cliente Supabase (default) | `build_default_dependencies` via factory dos settings | aplicação (se expuser close/aclose) |
 | Container injetado | chamador (teste/deploy) | chamador |
 | Clientes Groq por request | `GroqClientManager` | request-scoped (fechados por call) |
 
 O builder padrão retorna `owned = (health_checks,)`. O registry de readiness é
 o único recurso owned: `HealthRegistry.aclose()` prefere o `aclose` de cada
-check; `DatabaseCheck.aclose()` impede novos probes, drena o probe ativo com
-espera limitada (timeout de transporte alinhado + margem) e só então fecha o
-executor e o cliente de probe do qual é dono — o cliente nunca é invalidado
-por baixo de uma thread viva (em caso patológico, o cliente é mantido aberto).
-`HealthRegistry.close()` (síncrono, usado em falha parcial de startup) encerra
-o executor sem tocar no cliente. A versão atual do SDK Supabase pinado não
-expõe `close()`/`aclose()`, e os clientes Groq são request-scoped, então o
-grafo do engine não entra na tupla owned hoje. Em falha parcial de startup, os
-recursos já criados (engine, probe client, registry) são fechados antes da
-exceção propagar.
+check; `AuthClientCheck.aclose()` e `DatabaseCheck.aclose()` **cancelam
+qualquer probe em voo e aguardam sua terminação antes de retornar** — os
+probes são I/O HTTP assíncrono (httpx), então o cancelamento realmente para a
+operação. Não há threads, executors nem clientes de probe owned; nenhum
+trabalho de readiness sobrevive ao lifespan e nenhum cleanup fire-and-forget
+é necessário. `HealthRegistry.close()` (síncrono, usado em falha parcial de
+startup) apenas rejeita novos probes. A versão atual do SDK Supabase pinado
+não expõe `close()`/`aclose()`, e os clientes Groq são request-scoped, então o
+grafo do engine não entra na tupla owned hoje.
 
 O readiness também valida as **superfícies reais** usadas pelas rotas: os
 checks `auth` e `persistence` verificam `auth_client` e `persistence_client`
-(criados com o engine). Um cliente de probe dedicado e saudável nunca
-substitui essas superfícies: se a criação do cliente real falhar, `/ready`
-responde 503 mesmo com o probe funcionando.
+(criados com o engine). Um probe saudável nunca substitui essas superfícies:
+se a criação do cliente real falhar, `/ready` responde 503 mesmo com o probe
+funcionando.
 
 ## Importabilidade
 

--- a/docs/architecture/application-lifecycle.md
+++ b/docs/architecture/application-lifecycle.md
@@ -96,7 +96,8 @@ class ApplicationDependencies:
    b. admission_config a partir dos settings
    c. cliente de probe de banco dedicado (timeout de transporte alinhado ao
       READINESS_DATABASE_TIMEOUT_MS)
-   d. health registry (configuration, database, provider[, embeddings])
+   d. health registry (configuration, auth, database, persistence,
+      provider[, embeddings])
    e. container concluído
 3. Falha em qualquer passo:
    a. recursos já criados pelo builder são fechados (cleanup parcial)
@@ -139,20 +140,29 @@ class ApplicationDependencies:
 | --- | --- | --- |
 | Engine/managers (default) | `build_default_dependencies` | aplicação (shutdown; hoje sem contrato close/aclose no grafo) |
 | Registry de readiness (checks + executor do probe) | `build_default_dependencies` | aplicação (shutdown e startup parcial) |
-| Cliente de probe do banco | `build_default_dependencies` | aplicação (quando o SDK expuser close/aclose) |
+| Cliente de probe do banco | `build_default_dependencies` (dono: `DatabaseCheck`) | `DatabaseCheck.aclose()` após drenar o probe em voo; `_close_sync` em startup parcial |
 | Cliente Supabase (default) | `build_default_dependencies` via factory dos settings | aplicação (se expuser close/aclose) |
 | Container injetado | chamador (teste/deploy) | chamador |
 | Clientes Groq por request | `GroqClientManager` | request-scoped (fechados por call) |
 
-O builder padrão retorna `owned = (health_checks, probe_client)`: o registry
-fecha cada check fechável (o executor dedicado do probe de banco, com
-`wait=False`, sem abandonar um probe em voo — o transporte alinhado o
-encerra) e o cliente de probe é fechado quando o SDK expuser contrato
-compatível. A versão atual do SDK Supabase pinado não expõe
-`close()`/`aclose()`, e os clientes Groq são request-scoped, então o grafo do
-engine não entra na tupla owned hoje. Em falha parcial de startup, os
+O builder padrão retorna `owned = (health_checks,)`. O registry de readiness é
+o único recurso owned: `HealthRegistry.aclose()` prefere o `aclose` de cada
+check; `DatabaseCheck.aclose()` impede novos probes, drena o probe ativo com
+espera limitada (timeout de transporte alinhado + margem) e só então fecha o
+executor e o cliente de probe do qual é dono — o cliente nunca é invalidado
+por baixo de uma thread viva (em caso patológico, o cliente é mantido aberto).
+`HealthRegistry.close()` (síncrono, usado em falha parcial de startup) encerra
+o executor sem tocar no cliente. A versão atual do SDK Supabase pinado não
+expõe `close()`/`aclose()`, e os clientes Groq são request-scoped, então o
+grafo do engine não entra na tupla owned hoje. Em falha parcial de startup, os
 recursos já criados (engine, probe client, registry) são fechados antes da
 exceção propagar.
+
+O readiness também valida as **superfícies reais** usadas pelas rotas: os
+checks `auth` e `persistence` verificam `auth_client` e `persistence_client`
+(criados com o engine). Um cliente de probe dedicado e saudável nunca
+substitui essas superfícies: se a criação do cliente real falhar, `/ready`
+responde 503 mesmo com o probe funcionando.
 
 ## Importabilidade
 

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -9,7 +9,8 @@ eventos de observabilidade permitidos.
 ## Modelo central
 
 Toda configuração de runtime vive em `backend/settings.py` (pydantic v2
-estrito, sem nova dependência). O modelo é congelado e validado:
+estrito, sem nova dependência). O modelo é congelado (`frozen=True`) e
+validado também em atribuição:
 
 - tipos e faixas explícitos (bool não aceita `"true"`/`1`; int não aceita
   `True`/`"5"`/`1.0`; números fora da faixa rejeitados);
@@ -20,6 +21,11 @@ estrito, sem nova dependência). O modelo é congelado e validado:
   produção, feature habilitada sem dependência);
 - campos secretos excluídos de `repr`, `str` e de erros de validação
   sanitizados (`SettingsConfigurationError` expõe apenas `campo:código`);
+- construção direta inválida também não renderiza valores brutos
+  (`hide_input_in_errors=True` no modelo);
+- instância congelada nunca pode ser mutada para um estado inválido, e
+  `ensure_valid()` reconstroi/revalida o modelo completo (usado pelo check
+  `configuration` do readiness);
 - configuração inválida falha antes de a aplicação servir tráfego.
 
 Construção direta (`Settings(...)`) não lê o ambiente; `Settings.from_env()`
@@ -27,8 +33,10 @@ Construção direta (`Settings(...)`) não lê o ambiente; `Settings.from_env()`
 
 ## Ambientes
 
-`APP_ENV` é um enum fechado: `local` (default), `test`, `staging`,
-`production`. Qualquer outro valor falha o startup.
+`APP_ENV` é um enum fechado: `local`, `test`, `staging`, `production`.
+Qualquer outro valor falha o startup, e **`APP_ENV` ausente ou vazio também
+falha (fail-closed)**: um deploy que esqueça a variável nunca roda em modo
+`local` por engano.
 
 | Ambiente | Supabase obrigatório | CORS explícito obrigatório | localhost rejeitado |
 | --- | --- | --- | --- |
@@ -37,8 +45,8 @@ Construção direta (`Settings(...)`) não lê o ambiente; `Settings.from_env()`
 | `staging` | sim | sim | não |
 | `production` | sim | sim | sim (origens e URL do Supabase) |
 
-**Produção exige `APP_ENV=production`.** Sem a variável, o default é `local`:
-deployments reais devem sempre setá-la explicitamente.
+Docker/CI devem declarar `APP_ENV` explicitamente (o job `docker` da CI usa
+`APP_ENV=test`). Produção usa `APP_ENV=production`.
 
 ## Variáveis de ambiente
 
@@ -46,6 +54,7 @@ deployments reais devem sempre setá-la explicitamente.
 
 | Variável | Descrição |
 | --- | --- |
+| `APP_ENV` | Ambiente (`local`, `test`, `staging`, `production`) — obrigatória |
 | `GROQ_API_KEY` | Chave do provider (não vazia) |
 | `ADMISSION_HMAC_SECRET` | Segredo do ledger de admissão (>= 32 bytes UTF-8) |
 
@@ -61,10 +70,10 @@ deployments reais devem sempre setá-la explicitamente.
 
 | Variável | Default | Descrição |
 | --- | --- | --- |
-| `APP_ENV` | `local` | Ambiente (`local`, `test`, `staging`, `production`) |
 | `GROQ_API_KEY_2` | ausente | Segunda chave do provider (pool) |
 | `TRUSTED_PROXY_CIDRS` | vazio | CIDRs de proxies confiáveis (admissão) |
 | `ARCHIVAL_EXTRACTION_ENABLED` | `false` | Habilita extração arquivística (`true`/`false` estritos) |
+| `EMBEDDINGS_RETRIEVAL_ENABLED` | `false` | Habilita recuperação vetorial de memória (SentenceTransformer + RPC). Quando ligado, o modelo é construído no startup e o componente `embeddings` do `/ready` precisa passar; quando desligado, o modelo nunca é construído e a recuperação retorna vazio por design |
 | `READINESS_DATABASE_TIMEOUT_MS` | `3000` | Timeout do check de banco (100–30000) |
 | `READINESS_PROVIDER_TIMEOUT_MS` | `1000` | Timeout do check de provider (100–30000) |
 | `TURN_TOTAL_DEADLINE` | `45.0` | Deadline do turno (validado por `TurnExecutionConfig`) |
@@ -106,13 +115,20 @@ Nomes constantes em `backend/observability.py` (registry fechado):
 event=app_startup_failed
 event=app_shutdown_failed
 event=readiness_check_failed component=<nome>
-event=auth_failed code=<código>
-event=auth_completed outcome=ok
+event=auth_failed code=<código> duration_ms=<ms> correlation=<hmac>
+event=auth_completed outcome=ok duration_ms=<ms> correlation=<hmac> user_ref=<hmac>
 event=turn_completed code=ok duration_ms=<ms> mode=<normal|replay_attempt> correlation=<hmac>
 event=turn_failed code=<código> correlation=<hmac>
 event=request_conflict code=<código> correlation=<hmac>
-event=http_result code=<status>
+event=http_result code=<status> correlation=<hmac>
 ```
+
+Eventos de autenticação são medidos com relógio monotônico (`duration_ms`),
+carregam a correlação sanitizada do request (derivada do request ID sob o
+domínio dedicado) e, no sucesso, uma referência HMAC do usuário autenticado
+(`user_ref`, domínio separado, não reversível). Ausência de credencial,
+token inválido (4xx), 503 e erros inesperados emitem `auth_failed` de forma
+consistente, sem token nem texto bruto do erro.
 
 O fluxo transacional (#272) já emite eventos de fase no engine
 (`event=turn_stage_completed stage=... outcome=...`, `process_turn_attempt`,
@@ -123,9 +139,9 @@ correlação HMAC.
 
 ### Campos permitidos
 
-`correlation`, `code`, `stage`, `outcome`, `phase`, `duration_ms`,
-`latency_ms`, `attempt`, `http_status`, `component`, `mode`, `reason`,
-`result`, `retry`, `conflict`, `deadline_ms`.
+`correlation`, `user_ref`, `code`, `stage`, `outcome`, `phase`,
+`duration_ms`, `latency_ms`, `attempt`, `http_status`, `component`, `mode`,
+`reason`, `result`, `retry`, `conflict`, `deadline_ms`.
 
 ### Dados proibidos em logs e erros
 
@@ -133,9 +149,11 @@ Nunca registre: mensagem, resposta, prompt, memória, appraisal bruto,
 snapshot completo, token, segredo, exceção upstream bruta, URL com
 credenciais, headers de autenticação, `user_id` bruto ou request ID bruto.
 
-Correlação de usuário/request, quando necessária, usa o HMAC-SHA256 do
-request ID sob domínio dedicado (`compute_turn_correlation`), com segredo
-server-side; nunca SHA simples de identificador previsível.
+Correlação de request/turn usa o HMAC-SHA256 do request ID sob domínio
+dedicado (`compute_turn_correlation`), e o usuário autenticado usa referência
+HMAC sob domínio separado (`compute_user_reference`, `user_ref`), ambos com
+segredo server-side; nunca SHA simples de identificador previsível e nunca o
+`user_id`/request ID brutos.
 
 `emit_event` rejeita (falha cedo) nomes de campo fora da allowlist ou
 pertencentes à lista proibida. Nenhum módulo usa `logging.basicConfig()`.

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -76,6 +76,7 @@ Docker/CI devem declarar `APP_ENV` explicitamente (o job `docker` da CI usa
 | `EMBEDDINGS_RETRIEVAL_ENABLED` | `false` | Habilita recuperação vetorial de memória (SentenceTransformer + RPC). Quando ligado, o modelo é construído no startup e o componente `embeddings` do `/ready` precisa passar; quando desligado, o modelo nunca é construído e a recuperação retorna vazio por design |
 | `READINESS_DATABASE_TIMEOUT_MS` | `3000` | Timeout do check de banco (100–30000) |
 | `READINESS_PROVIDER_TIMEOUT_MS` | `1000` | Timeout do check de provider (100–30000) |
+| `READINESS_AUTH_TIMEOUT_MS` | `1000` | Timeout do probe de disponibilidade do serviço de Auth (`/health`, 100–30000). O probe é um GET bounded que nunca depende de token de usuário nem lê dados de usuário |
 | `TURN_TOTAL_DEADLINE` | `45.0` | Deadline do turno (validado por `TurnExecutionConfig`) |
 | `TURN_CONNECT_TIMEOUT` | `3.0` | Timeout de conexão do provider |
 | `TURN_PROVIDER_ATTEMPT_TIMEOUT` | `15.0` | Timeout de uma tentativa de geração |

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -1,0 +1,141 @@
+# Configuration
+
+Status: implementado na issue #275.
+
+Este documento descreve os settings do backend: ambientes, variáveis
+obrigatórias e opcionais, política de CORS, dados proibidos em logs e os
+eventos de observabilidade permitidos.
+
+## Modelo central
+
+Toda configuração de runtime vive em `backend/settings.py` (pydantic v2
+estrito, sem nova dependência). O modelo é congelado e validado:
+
+- tipos e faixas explícitos (bool não aceita `"true"`/`1`; int não aceita
+  `True`/`"5"`/`1.0`; números fora da faixa rejeitados);
+- strings críticas não vazias; URLs validadas (http/https, sem credenciais,
+  sem path/query);
+- listas de origens CORS normalizadas (trim, sem `/` final, sem duplicatas);
+- combinações inseguras rejeitadas (wildcard com credenciais, localhost em
+  produção, feature habilitada sem dependência);
+- campos secretos excluídos de `repr`, `str` e de erros de validação
+  sanitizados (`SettingsConfigurationError` expõe apenas `campo:código`);
+- configuração inválida falha antes de a aplicação servir tráfego.
+
+Construção direta (`Settings(...)`) não lê o ambiente; `Settings.from_env()`
+é o único ponto de leitura de variáveis de ambiente.
+
+## Ambientes
+
+`APP_ENV` é um enum fechado: `local` (default), `test`, `staging`,
+`production`. Qualquer outro valor falha o startup.
+
+| Ambiente | Supabase obrigatório | CORS explícito obrigatório | localhost rejeitado |
+| --- | --- | --- | --- |
+| `local` | não (degrada com 503) | não (default `http://localhost:3000`) | não |
+| `test` | não | não | não |
+| `staging` | sim | sim | não |
+| `production` | sim | sim | sim (origens e URL do Supabase) |
+
+**Produção exige `APP_ENV=production`.** Sem a variável, o default é `local`:
+deployments reais devem sempre setá-la explicitamente.
+
+## Variáveis de ambiente
+
+### Obrigatórias (todos os ambientes)
+
+| Variável | Descrição |
+| --- | --- |
+| `GROQ_API_KEY` | Chave do provider (não vazia) |
+| `ADMISSION_HMAC_SECRET` | Segredo do ledger de admissão (>= 32 bytes UTF-8) |
+
+### Obrigatórias em `staging`/`production`
+
+| Variável | Descrição |
+| --- | --- |
+| `SUPABASE_URL` | URL http(s) do Supabase |
+| `SUPABASE_SERVICE_ROLE_KEY` | Service role key (não vazia) |
+| `CORS_ALLOWED_ORIGINS` | Lista de origens separada por vírgulas (sem wildcard) |
+
+### Opcionais
+
+| Variável | Default | Descrição |
+| --- | --- | --- |
+| `APP_ENV` | `local` | Ambiente (`local`, `test`, `staging`, `production`) |
+| `GROQ_API_KEY_2` | ausente | Segunda chave do provider (pool) |
+| `TRUSTED_PROXY_CIDRS` | vazio | CIDRs de proxies confiáveis (admissão) |
+| `ARCHIVAL_EXTRACTION_ENABLED` | `false` | Habilita extração arquivística (`true`/`false` estritos) |
+| `READINESS_DATABASE_TIMEOUT_MS` | `3000` | Timeout do check de banco (100–30000) |
+| `READINESS_PROVIDER_TIMEOUT_MS` | `1000` | Timeout do check de provider (100–30000) |
+| `TURN_TOTAL_DEADLINE` | `45.0` | Deadline do turno (validado por `TurnExecutionConfig`) |
+| `TURN_CONNECT_TIMEOUT` | `3.0` | Timeout de conexão do provider |
+| `TURN_PROVIDER_ATTEMPT_TIMEOUT` | `15.0` | Timeout de uma tentativa de geração |
+| `TURN_SUPABASE_TIMEOUT` | `5.0` | Timeout por chamada PostgREST |
+| `TURN_COMMIT_RESERVE` | `10.0` | Reserva do commit atômico |
+| `TURN_MAX_ATTEMPTS` | `2` | Máx. tentativas do provider (1–5) |
+| `TURN_BASE_BACKOFF` | `0.25` | Backoff base |
+| `TURN_MAX_BACKOFF` | `0.75` | Backoff máximo |
+| `TURN_MAX_JITTER` | `0.10` | Jitter (0–1) |
+| `TURN_FRONTEND_TIMEOUT_MS` | `50000` | Sugestão de timeout do frontend (1000–300000) |
+
+Não há chaves fictícias nem defaults silenciosos para segredos: ausência ou
+valor vazio falha o startup.
+
+## Política de CORS
+
+- Origem permitida vem exclusivamente da allowlist validada dos settings.
+- `*` com credenciais é rejeitado em todos os ambientes.
+- Produção exige allowlist explícita e rejeita origens localhost
+  (`localhost`, `127.0.0.1`, `::1`, `0.0.0.0`, sufixos `.localhost`/`.local`)
+  e URL do Supabase em localhost.
+- Nenhuma origem derivada de header do usuário é adicionada dinamicamente.
+- Métodos permitidos: `GET`, `POST`, `OPTIONS` (o mínimo da aplicação).
+- Headers permitidos: `Authorization`, `Content-Type` (o middleware do
+  Starlette também anuncia os headers safelisted do CORS, comportamento
+  padrão).
+- Configurações `local` e `test` são explícitas nos settings (default
+  documentado `http://localhost:3000`).
+
+## Observabilidade
+
+### Eventos
+
+Nomes constantes em `backend/observability.py` (registry fechado):
+
+```text
+event=app_startup_failed
+event=app_shutdown_failed
+event=readiness_check_failed component=<nome>
+event=auth_failed code=<código>
+event=auth_completed outcome=ok
+event=turn_completed code=ok duration_ms=<ms> mode=<normal|replay_attempt> correlation=<hmac>
+event=turn_failed code=<código> correlation=<hmac>
+event=request_conflict code=<código> correlation=<hmac>
+event=http_result code=<status>
+```
+
+O fluxo transacional (#272) já emite eventos de fase no engine
+(`event=turn_stage_completed stage=... outcome=...`, `process_turn_attempt`,
+`process_turn_revision_conflict`, `process_turn_replay`,
+`process_turn_commit_completed`) e de admissão (`admission_admitted`,
+`admission_rejected`, `admission_replay`, `admission_unavailable`), todos com
+correlação HMAC.
+
+### Campos permitidos
+
+`correlation`, `code`, `stage`, `outcome`, `phase`, `duration_ms`,
+`latency_ms`, `attempt`, `http_status`, `component`, `mode`, `reason`,
+`result`, `retry`, `conflict`, `deadline_ms`.
+
+### Dados proibidos em logs e erros
+
+Nunca registre: mensagem, resposta, prompt, memória, appraisal bruto,
+snapshot completo, token, segredo, exceção upstream bruta, URL com
+credenciais, headers de autenticação, `user_id` bruto ou request ID bruto.
+
+Correlação de usuário/request, quando necessária, usa o HMAC-SHA256 do
+request ID sob domínio dedicado (`compute_turn_correlation`), com segredo
+server-side; nunca SHA simples de identificador previsível.
+
+`emit_event` rejeita (falha cedo) nomes de campo fora da allowlist ou
+pertencentes à lista proibida. Nenhum módulo usa `logging.basicConfig()`.

--- a/docs/operations/health-and-readiness.md
+++ b/docs/operations/health-and-readiness.md
@@ -56,13 +56,21 @@ Ordem determinística registrada em `backend/health.py`:
 | Componente | Crítico | O que verifica | Timeout padrão |
 | --- | --- | --- | --- |
 | `configuration` | Sim | Settings ainda válidos (re-validação completa do modelo congelado, sem I/O) | 1s |
+| `auth` | Sim | A superfície real de autenticação usada pelas rotas (`auth_client`) existe | 1s |
 | `database` | Sim | Acesso mínimo ao Supabase: leitura `limit 1` em `profiles` com um cliente de probe dedicado, cujo timeout de transporte é alinhado a `READINESS_DATABASE_TIMEOUT_MS` | `READINESS_DATABASE_TIMEOUT_MS` (3000) |
+| `persistence` | Sim | A superfície real de persistência usada por admissão/histórico (`persistence_client`, com `rpc`/`table`) existe | 1s |
 | `provider` | Sim | Caminho do provider configurado: `GroqClientManager.is_configured()` (chaves válidas, sem geração) | `READINESS_PROVIDER_TIMEOUT_MS` (1000) |
 | `embeddings` | Somente com `EMBEDDINGS_RETRIEVAL_ENABLED=true` | Modelo de embeddings carregado no startup (atributo, sem carregar modelo) | 1s |
 | `lifespan` | Sim | `app.state.lifespan_started` (startup concluído) | 1s |
 
 Políticas:
 
+- **O cliente de probe nunca substitui as superfícies reais.** Os checks `auth`
+  e `persistence` validam os clientes que as rotas realmente usam
+  (`auth_client`/`persistence_client`); se a criação do cliente do engine
+  falhar (ou retornar `None`) enquanto o probe dedicado funciona, `/ready`
+  responde 503: uma instância incapaz de autenticar ou persistir não é ready,
+  por mais saudável que o probe esteja.
 - **O check de provider nunca executa geração real.** É barato, limitado e
   verifica configuração do caminho. Deployments que quiserem um probe real de
   rede devem injetar um check próprio com timeout documentado.
@@ -73,11 +81,16 @@ Políticas:
   `READINESS_DATABASE_TIMEOUT_MS`) libera o worker. Polling repetido não
   acumula threads nem esgota o executor.
 - **O registry de readiness é owned pela aplicação.** O builder padrão inclui
-  `health_checks` (que fecha cada check fechável, incluindo o executor do
-  probe com `wait=False`, sem abandonar um probe em voo) e o cliente de probe
-  na tupla de `owned_resources`: são fechados no shutdown e em falha parcial
-  de startup, e nenhuma thread `readiness-db` permanece viva após sair do
-  lifespan.
+  `health_checks` na tupla de `owned_resources`; `DatabaseCheck` é dono do
+  cliente de probe e o fecha apenas após drenar o probe em voo. No shutdown
+  assíncrono, `HealthRegistry.aclose()` chama `DatabaseCheck.aclose()`, que
+  impede novos probes, drena o probe ativo com espera limitada (timeout de
+  transporte alinhado + margem) e só então fecha o executor e o cliente —
+  o cliente nunca é invalidado por baixo de uma thread viva. Em caso
+  patológico (probe ainda ativo após o limite), o cliente é deliberadamente
+  mantido aberto. Em falha parcial de startup, `close()` síncrono encerra o
+  executor sem tocar no cliente. Nenhuma thread `readiness-db` permanece viva
+  após sair do lifespan no fluxo normal.
 - **A guarda de probe é atômica no event loop.** O clear do estado só
   acontece quando a future observada é a que o poll dono aguarda; uma future
   mais nova instalada por um poll concorrente nunca é limpa por engano, então
@@ -111,12 +124,17 @@ Políticas:
 2. **`configuration` unavailable** — settings inválidos em runtime (improvável,
    pois falha cedo; verifique se o processo foi iniciado com configuração
    válida).
-3. **`database` unavailable** — verifique conectividade com o Supabase
+3. **`auth` unavailable** — o cliente real de autenticação não está disponível
+   (a factory do engine falhou ou retornou `None`); autenticação em `/chat`
+   e `/history` também falharia.
+4. **`persistence` unavailable** — o cliente real de persistência não está
+   disponível; admissão e histórico falhariam mesmo com o probe saudável.
+5. **`database` unavailable** — verifique conectividade com o Supabase
    (URL, service role key, rede) e se a tabela `profiles` está acessível com
    o role da aplicação. Timeout curto sugere rede/slow query.
-4. **`provider` unavailable** — chaves do provider ausentes ou inválidas na
+6. **`provider` unavailable** — chaves do provider ausentes ou inválidas na
    configuração da instância.
-5. **`embeddings` unavailable** (só com `EMBEDDINGS_RETRIEVAL_ENABLED=true`) —
+7. **`embeddings` unavailable** (só com `EMBEDDINGS_RETRIEVAL_ENABLED=true`) —
    o modelo não carregou no startup (ex.: `HF_HUB_OFFLINE=1` sem cache local)
    ou o processo foi iniciado sem o modelo necessário para o modo ativo.
 

--- a/docs/operations/health-and-readiness.md
+++ b/docs/operations/health-and-readiness.md
@@ -56,8 +56,8 @@ Ordem determinística registrada em `backend/health.py`:
 | Componente | Crítico | O que verifica | Timeout padrão |
 | --- | --- | --- | --- |
 | `configuration` | Sim | Settings ainda válidos (re-validação completa do modelo congelado, sem I/O) | 1s |
-| `auth` | Sim | A superfície real de autenticação usada pelas rotas é efetivamente chamável (`auth_client.auth.get_user`, nunca invocada) **e** o serviço de Auth está disponível: probe GET bounded de `{supabase_url}/auth/v1/health` (GoTrue), com timeout de transporte alinhado a `READINESS_AUTH_TIMEOUT_MS`, sem token de usuário e sem ler dados de usuário (só o status HTTP é observado; o corpo é descartado) | `READINESS_AUTH_TIMEOUT_MS` (1000) |
-| `database` | Sim | Acesso mínimo ao Supabase: leitura `limit 1` em `profiles` com um cliente de probe dedicado, cujo timeout de transporte é alinhado a `READINESS_DATABASE_TIMEOUT_MS` | `READINESS_DATABASE_TIMEOUT_MS` (3000) |
+| `auth` | Sim | A superfície real de autenticação usada pelas rotas é efetivamente chamável (`auth_client.auth.get_user`, nunca invocada) **e** o serviço de Auth está disponível: probe HTTP assíncrono bounded de `{supabase_url}/auth/v1/health` (GoTrue), com timeout de transporte alinhado a `READINESS_AUTH_TIMEOUT_MS`, sem token de usuário e sem ler dados de usuário (só o status HTTP é observado; o corpo é descartado). Sendo I/O assíncrono, o timeout de readiness realmente cancela o probe | `READINESS_AUTH_TIMEOUT_MS` (1000) |
+| `database` | Sim | Acesso mínimo ao Supabase: probe HTTP assíncrono bounded de `{supabase_url}/rest/v1/profiles?select=user_id&limit=1` (PostgREST), com timeout de transporte alinhado a `READINESS_DATABASE_TIMEOUT_MS`. Sendo I/O assíncrono, o timeout de readiness realmente cancela o probe | `READINESS_DATABASE_TIMEOUT_MS` (3000) |
 | `persistence` | Sim | A superfície real de persistência usada por admissão/histórico (`persistence_client`) é efetivamente chamável: `table(...)` e `rpc(...)` existem, são callable e são invocadas com argumentos benignos (construção pura de request, sem rede) | 1s |
 | `provider` | Sim | Caminho do provider configurado: `GroqClientManager.is_configured()` (chaves válidas, sem geração) | `READINESS_PROVIDER_TIMEOUT_MS` (1000) |
 | `embeddings` | Somente com `EMBEDDINGS_RETRIEVAL_ENABLED=true` | Modelo de embeddings carregado no startup (atributo, sem carregar modelo) | 1s |
@@ -80,29 +80,10 @@ Políticas:
 - **O check de provider nunca executa geração real.** É barato, limitado e
   verifica configuração do caminho. Deployments que quiserem um probe real de
   rede devem injetar um check próprio com timeout documentado.
-- **O check de banco não abandona workers.** A operação bloqueante roda em um
-  executor dedicado de 1 worker; enquanto um probe está em voo (inclusive após
-  o timeout do registry), novos polls falham rápido em vez de enfileirar
-  trabalho, e o timeout de transporte do cliente de probe (alinhado ao
-  `READINESS_DATABASE_TIMEOUT_MS`) libera o worker. Polling repetido não
-  acumula threads nem esgota o executor.
-- **O registry de readiness é owned pela aplicação.** O builder padrão inclui
-  `health_checks` na tupla de `owned_resources`; `DatabaseCheck` é dono do
-  cliente de probe. No shutdown assíncrono, `HealthRegistry.aclose()` chama
-  `DatabaseCheck.aclose()`, que impede novos probes e drena o probe ativo com
-  espera limitada (timeout de transporte alinhado + margem). O cliente nunca
-  é fechado por baixo de uma thread viva: se o probe terminar (sucesso ou
-  exceção), a thread terminou e o cliente é fechado; se a drenagem estourar o
-  limite (probe patológico que ignora o timeout de transporte), o cliente não
-  é fechado e o ownership é mantido rastreável — uma task de cleanup diferido
-  (`_deferred_close`) fecha executor e cliente somente após o probe terminar,
-  e uma segunda chamada a `aclose()` faz join nessa task. No fluxo normal
-  (transporte alinhado), nada sobrevive ao lifespan; no caminho patológico o
-  ownership permanece rastreável até a conclusão. Em falha parcial de
-  startup, `close()` síncrono encerra o executor (cancelando probes
-  pendentes) sem tocar no cliente.
+- **O check de banco não abandona trabalho.** O probe é I/O HTTP assíncrono (httpx) com timeout de transporte alinhado ao `READINESS_DATABASE_TIMEOUT_MS`; o `asyncio.wait_for` do registry realmente cancela a operação, então não existem threads de worker, acumulação de polling nem trabalho órfão após timeout. Enquanto um probe está em voo, novos polls falham rápido (guarda de probe único), sem duplicar requests.
+- **O registry de readiness é owned pela aplicação.** O builder padrão inclui `health_checks` na tupla de `owned_resources`. No shutdown assíncrono, `HealthRegistry.aclose()` chama o `aclose()` de cada check, que **cancela qualquer probe em voo e aguarda sua terminação antes de retornar** — nenhum trabalho owned sobrevive ao lifespan, sem cleanup fire-and-forget e sem ownership perdido. Em falha parcial de startup, `close()` síncrono apenas rejeita novos probes (não há threads nem clientes owned a liberar).
 - **A guarda de probe é atômica no event loop.** O clear do estado só
-  acontece quando a future observada é a que o poll dono aguarda; uma future
+  acontece quando a task observada é a que o poll dono aguarda; uma task
   mais nova instalada por um poll concorrente nunca é limpa por engano, então
   no máximo um probe fica em voo (testado com concorrência determinística).
 - **Feature opcional desligada não bloqueia readiness** (`embeddings` só

--- a/docs/operations/health-and-readiness.md
+++ b/docs/operations/health-and-readiness.md
@@ -56,9 +56,9 @@ Ordem determinística registrada em `backend/health.py`:
 | Componente | Crítico | O que verifica | Timeout padrão |
 | --- | --- | --- | --- |
 | `configuration` | Sim | Settings ainda válidos (re-validação completa do modelo congelado, sem I/O) | 1s |
-| `auth` | Sim | A superfície real de autenticação usada pelas rotas (`auth_client`) existe | 1s |
+| `auth` | Sim | A superfície real de autenticação usada pelas rotas (`auth_client`) é efetivamente chamável: `auth_client.auth.get_user` existe e é callable (nunca é invocada) | 1s |
 | `database` | Sim | Acesso mínimo ao Supabase: leitura `limit 1` em `profiles` com um cliente de probe dedicado, cujo timeout de transporte é alinhado a `READINESS_DATABASE_TIMEOUT_MS` | `READINESS_DATABASE_TIMEOUT_MS` (3000) |
-| `persistence` | Sim | A superfície real de persistência usada por admissão/histórico (`persistence_client`, com `rpc`/`table`) existe | 1s |
+| `persistence` | Sim | A superfície real de persistência usada por admissão/histórico (`persistence_client`) é efetivamente chamável: `table(...)` e `rpc(...)` existem, são callable e são invocadas com argumentos benignos (construção pura de request, sem rede) | 1s |
 | `provider` | Sim | Caminho do provider configurado: `GroqClientManager.is_configured()` (chaves válidas, sem geração) | `READINESS_PROVIDER_TIMEOUT_MS` (1000) |
 | `embeddings` | Somente com `EMBEDDINGS_RETRIEVAL_ENABLED=true` | Modelo de embeddings carregado no startup (atributo, sem carregar modelo) | 1s |
 | `lifespan` | Sim | `app.state.lifespan_started` (startup concluído) | 1s |
@@ -82,15 +82,19 @@ Políticas:
   acumula threads nem esgota o executor.
 - **O registry de readiness é owned pela aplicação.** O builder padrão inclui
   `health_checks` na tupla de `owned_resources`; `DatabaseCheck` é dono do
-  cliente de probe e o fecha apenas após drenar o probe em voo. No shutdown
+  cliente de probe e o fecha após drenar o probe em voo. No shutdown
   assíncrono, `HealthRegistry.aclose()` chama `DatabaseCheck.aclose()`, que
-  impede novos probes, drena o probe ativo com espera limitada (timeout de
-  transporte alinhado + margem) e só então fecha o executor e o cliente —
-  o cliente nunca é invalidado por baixo de uma thread viva. Em caso
-  patológico (probe ainda ativo após o limite), o cliente é deliberadamente
-  mantido aberto. Em falha parcial de startup, `close()` síncrono encerra o
-  executor sem tocar no cliente. Nenhuma thread `readiness-db` permanece viva
-  após sair do lifespan no fluxo normal.
+  impede novos probes e drena o probe ativo com espera limitada (timeout de
+  transporte alinhado + margem). O cleanup é incondicional: se o probe
+  terminar com exceção, a exceção é absorvida e executor/cliente são
+  encerrados; se a drenagem estourar o limite (probe patológico que ignora o
+  timeout de transporte), o executor é encerrado, a future é descartada e o
+  cliente owned é fechado mesmo assim — fechar o transporte falha a chamada
+  em voo e a thread do worker termina, então nenhum recurso owned sobrevive
+  ao lifespan. Em falha parcial de startup, `close()` síncrono encerra o
+  executor (com cancelamento de probes pendentes) sem tocar no cliente.
+  Nenhuma thread `readiness-db` permanece viva após sair do lifespan no fluxo
+  normal.
 - **A guarda de probe é atômica no event loop.** O clear do estado só
   acontece quando a future observada é a que o poll dono aguarda; uma future
   mais nova instalada por um poll concorrente nunca é limpa por engano, então

--- a/docs/operations/health-and-readiness.md
+++ b/docs/operations/health-and-readiness.md
@@ -1,0 +1,100 @@
+# Health and Readiness
+
+Status: implementado na issue #275.
+
+Este documento define a semântica de `/live`, `/ready` e `/health`, os checks
+críticos e opcionais, os timeouts e o procedimento de diagnóstico.
+
+## Diferença entre `/live`, `/ready` e `/health`
+
+| Endpoint | Semântica | Falha de dependência? | Uso |
+| --- | --- | --- | --- |
+| `GET /live` | Processo e event loop respondem | Ignorada | Liveness de orquestradores |
+| `GET /ready` | Instância apta a receber tráfego nominal | 503 | Readiness de orquestradores |
+| `GET /health` | Alias legado de processo vivo | Ignorada | Compatibilidade (consumidores antigos) |
+
+### `GET /live`
+
+Resposta fixa e estável:
+
+```json
+{"status": "live"}
+```
+
+Nunca chama provider, banco, embeddings ou checks. Não inclui versões,
+hostname, configuração ou detalhes internos. Retorna 200 enquanto o processo
+responder.
+
+### `GET /ready`
+
+Executa os checks críticos com timeout explícito por check. Resposta:
+
+```json
+{"status": "ready", "components": {"configuration": "ok", "database": "ok", "provider": "ok", "lifespan": "ok"}}
+```
+
+Quando qualquer componente crítico falha:
+
+```json
+{"status": "not_ready", "components": {"configuration": "ok", "database": "unavailable", "provider": "ok", "lifespan": "ok"}}
+```
+
+com HTTP 503. A resposta nunca inclui URLs, chaves, nomes de projeto, texto
+de exceção, contagens ou IDs de usuário. A ordem dos componentes é
+determinística.
+
+### `GET /health`
+
+Mantido por compatibilidade (consumidores legados e CI de deploy). Retorna
+exatamente `{"status": "alive"}` e **não afirma readiness**: nenhum check de
+banco/provider é executado. Consumidores novos devem usar `/live` e `/ready`.
+
+## Checks críticos e opcionais
+
+Ordem determinística registrada em `backend/health.py`:
+
+| Componente | Crítico | O que verifica | Timeout padrão |
+| --- | --- | --- | --- |
+| `configuration` | Sim | Settings ainda válidos (re-validação barata, sem I/O) | 1s |
+| `database` | Sim | Acesso mínimo ao Supabase: leitura `limit 1` em `profiles` com o cliente da aplicação | `READINESS_DATABASE_TIMEOUT_MS` (3000) |
+| `provider` | Sim | Caminho do provider configurado: `GroqClientManager.is_configured()` (chaves válidas, sem geração) | `READINESS_PROVIDER_TIMEOUT_MS` (1000) |
+| `embeddings` | Somente com `ARCHIVAL_EXTRACTION_ENABLED=true` | Modelo de embeddings carregado no startup (atributo, sem carregar modelo) | 1s |
+| `lifespan` | Sim | `app.state.lifespan_started` (startup concluído) | 1s |
+
+Políticas:
+
+- **O check de provider nunca executa geração real.** É barato, limitado e
+  verifica configuração do caminho. Deployments que quiserem um probe real de
+  rede devem injetar um check próprio com timeout documentado.
+- **Feature opcional desligada não bloqueia readiness** (`embeddings` só
+  existe quando habilitado).
+- **Feature obrigatória habilitada e indisponível bloqueia readiness.**
+- Check lento é interrompido pelo timeout aprovado (nunca fica pendurado).
+- Exceções com conteúdo sensível nunca aparecem na resposta nem nos logs:
+  o registry emite apenas `event=readiness_check_failed component=<nome>`.
+
+## Timeouts de readiness
+
+- `READINESS_DATABASE_TIMEOUT_MS`: faixa 100–30000, default 3000.
+- `READINESS_PROVIDER_TIMEOUT_MS`: faixa 100–30000, default 1000.
+- Checks internos (configuration, embeddings, lifespan): 1s fixo.
+- Valores inválidos são rejeitados pelos settings (falha cedo).
+
+## Diagnóstico quando `/ready` falhar
+
+1. **`lifespan` unavailable** — a aplicação não completou o startup: procure
+   `event=app_startup_failed` nos logs e valide a configuração (ver
+   `docs/operations/configuration.md`).
+2. **`configuration` unavailable** — settings inválidos em runtime (improvável,
+   pois falha cedo; verifique se o processo foi iniciado com configuração
+   válida).
+3. **`database` unavailable** — verifique conectividade com o Supabase
+   (URL, service role key, rede) e se a tabela `profiles` está acessível com
+   o role da aplicação. Timeout curto sugere rede/slow query.
+4. **`provider` unavailable** — chaves do provider ausentes ou inválidas na
+   configuração da instância.
+5. **`embeddings` unavailable** (só com archival habilitado) — o modelo não
+   carregou no startup (ex.: `HF_HUB_OFFLINE=1` sem cache local).
+
+Cada falha aparece nos logs como `event=readiness_check_failed
+component=<nome>`; nenhum detalhe de exceção é registrado.

--- a/docs/operations/health-and-readiness.md
+++ b/docs/operations/health-and-readiness.md
@@ -56,7 +56,7 @@ Ordem determinística registrada em `backend/health.py`:
 | Componente | Crítico | O que verifica | Timeout padrão |
 | --- | --- | --- | --- |
 | `configuration` | Sim | Settings ainda válidos (re-validação completa do modelo congelado, sem I/O) | 1s |
-| `auth` | Sim | A superfície real de autenticação usada pelas rotas (`auth_client`) é efetivamente chamável: `auth_client.auth.get_user` existe e é callable (nunca é invocada) | 1s |
+| `auth` | Sim | A superfície real de autenticação usada pelas rotas é efetivamente chamável (`auth_client.auth.get_user`, nunca invocada) **e** o serviço de Auth está disponível: probe GET bounded de `{supabase_url}/auth/v1/health` (GoTrue), com timeout de transporte alinhado a `READINESS_AUTH_TIMEOUT_MS`, sem token de usuário e sem ler dados de usuário (só o status HTTP é observado; o corpo é descartado) | `READINESS_AUTH_TIMEOUT_MS` (1000) |
 | `database` | Sim | Acesso mínimo ao Supabase: leitura `limit 1` em `profiles` com um cliente de probe dedicado, cujo timeout de transporte é alinhado a `READINESS_DATABASE_TIMEOUT_MS` | `READINESS_DATABASE_TIMEOUT_MS` (3000) |
 | `persistence` | Sim | A superfície real de persistência usada por admissão/histórico (`persistence_client`) é efetivamente chamável: `table(...)` e `rpc(...)` existem, são callable e são invocadas com argumentos benignos (construção pura de request, sem rede) | 1s |
 | `provider` | Sim | Caminho do provider configurado: `GroqClientManager.is_configured()` (chaves válidas, sem geração) | `READINESS_PROVIDER_TIMEOUT_MS` (1000) |
@@ -71,6 +71,12 @@ Políticas:
   falhar (ou retornar `None`) enquanto o probe dedicado funciona, `/ready`
   responde 503: uma instância incapaz de autenticar ou persistir não é ready,
   por mais saudável que o probe esteja.
+- **O componente `auth` prova disponibilidade real, não só contrato local.**
+  Além da superfície chamável, um probe de rede bounded consulta o `/health`
+  do GoTrue: PostgREST saudável não mascara uma queda do serviço de Auth.
+  Uma instância cuja autenticação em `/chat`/`/history` falharia responde
+  `auth=unavailable` no `/ready` (testado com serviço Auth indisponível + banco
+  saudável → 503).
 - **O check de provider nunca executa geração real.** É barato, limitado e
   verifica configuração do caminho. Deployments que quiserem um probe real de
   rede devem injetar um check próprio com timeout documentado.
@@ -82,19 +88,19 @@ Políticas:
   acumula threads nem esgota o executor.
 - **O registry de readiness é owned pela aplicação.** O builder padrão inclui
   `health_checks` na tupla de `owned_resources`; `DatabaseCheck` é dono do
-  cliente de probe e o fecha após drenar o probe em voo. No shutdown
-  assíncrono, `HealthRegistry.aclose()` chama `DatabaseCheck.aclose()`, que
-  impede novos probes e drena o probe ativo com espera limitada (timeout de
-  transporte alinhado + margem). O cleanup é incondicional: se o probe
-  terminar com exceção, a exceção é absorvida e executor/cliente são
-  encerrados; se a drenagem estourar o limite (probe patológico que ignora o
-  timeout de transporte), o executor é encerrado, a future é descartada e o
-  cliente owned é fechado mesmo assim — fechar o transporte falha a chamada
-  em voo e a thread do worker termina, então nenhum recurso owned sobrevive
-  ao lifespan. Em falha parcial de startup, `close()` síncrono encerra o
-  executor (com cancelamento de probes pendentes) sem tocar no cliente.
-  Nenhuma thread `readiness-db` permanece viva após sair do lifespan no fluxo
-  normal.
+  cliente de probe. No shutdown assíncrono, `HealthRegistry.aclose()` chama
+  `DatabaseCheck.aclose()`, que impede novos probes e drena o probe ativo com
+  espera limitada (timeout de transporte alinhado + margem). O cliente nunca
+  é fechado por baixo de uma thread viva: se o probe terminar (sucesso ou
+  exceção), a thread terminou e o cliente é fechado; se a drenagem estourar o
+  limite (probe patológico que ignora o timeout de transporte), o cliente não
+  é fechado e o ownership é mantido rastreável — uma task de cleanup diferido
+  (`_deferred_close`) fecha executor e cliente somente após o probe terminar,
+  e uma segunda chamada a `aclose()` faz join nessa task. No fluxo normal
+  (transporte alinhado), nada sobrevive ao lifespan; no caminho patológico o
+  ownership permanece rastreável até a conclusão. Em falha parcial de
+  startup, `close()` síncrono encerra o executor (cancelando probes
+  pendentes) sem tocar no cliente.
 - **A guarda de probe é atômica no event loop.** O clear do estado só
   acontece quando a future observada é a que o poll dono aguarda; uma future
   mais nova instalada por um poll concorrente nunca é limpa por engano, então
@@ -117,6 +123,7 @@ Políticas:
 
 - `READINESS_DATABASE_TIMEOUT_MS`: faixa 100–30000, default 3000.
 - `READINESS_PROVIDER_TIMEOUT_MS`: faixa 100–30000, default 1000.
+- `READINESS_AUTH_TIMEOUT_MS`: faixa 100–30000, default 1000 (probe `/health`).
 - Checks internos (configuration, embeddings, lifespan): 1s fixo.
 - Valores inválidos são rejeitados pelos settings (falha cedo).
 

--- a/docs/operations/health-and-readiness.md
+++ b/docs/operations/health-and-readiness.md
@@ -55,10 +55,10 @@ Ordem determinística registrada em `backend/health.py`:
 
 | Componente | Crítico | O que verifica | Timeout padrão |
 | --- | --- | --- | --- |
-| `configuration` | Sim | Settings ainda válidos (re-validação barata, sem I/O) | 1s |
-| `database` | Sim | Acesso mínimo ao Supabase: leitura `limit 1` em `profiles` com o cliente da aplicação | `READINESS_DATABASE_TIMEOUT_MS` (3000) |
+| `configuration` | Sim | Settings ainda válidos (re-validação completa do modelo congelado, sem I/O) | 1s |
+| `database` | Sim | Acesso mínimo ao Supabase: leitura `limit 1` em `profiles` com um cliente de probe dedicado, cujo timeout de transporte é alinhado a `READINESS_DATABASE_TIMEOUT_MS` | `READINESS_DATABASE_TIMEOUT_MS` (3000) |
 | `provider` | Sim | Caminho do provider configurado: `GroqClientManager.is_configured()` (chaves válidas, sem geração) | `READINESS_PROVIDER_TIMEOUT_MS` (1000) |
-| `embeddings` | Somente com `ARCHIVAL_EXTRACTION_ENABLED=true` | Modelo de embeddings carregado no startup (atributo, sem carregar modelo) | 1s |
+| `embeddings` | Somente com `EMBEDDINGS_RETRIEVAL_ENABLED=true` | Modelo de embeddings carregado no startup (atributo, sem carregar modelo) | 1s |
 | `lifespan` | Sim | `app.state.lifespan_started` (startup concluído) | 1s |
 
 Políticas:
@@ -66,9 +66,19 @@ Políticas:
 - **O check de provider nunca executa geração real.** É barato, limitado e
   verifica configuração do caminho. Deployments que quiserem um probe real de
   rede devem injetar um check próprio com timeout documentado.
+- **O check de banco não abandona workers.** A operação bloqueante roda em um
+  executor dedicado de 1 worker; enquanto um probe está em voo (inclusive após
+  o timeout do registry), novos polls falham rápido em vez de enfileirar
+  trabalho, e o timeout de transporte do cliente de probe (alinhado ao
+  `READINESS_DATABASE_TIMEOUT_MS`) libera o worker. Polling repetido não
+  acumula threads nem esgota o executor.
 - **Feature opcional desligada não bloqueia readiness** (`embeddings` só
-  existe quando habilitado).
-- **Feature obrigatória habilitada e indisponível bloqueia readiness.**
+  existe quando `EMBEDDINGS_RETRIEVAL_ENABLED=true`), e o modelo nunca é
+  construído quando a feature está desligada.
+- **Feature obrigatória habilitada e indisponível bloqueia readiness.** Com
+  a recuperação vetorial habilitada, um modelo ausente torna a instância
+  `not_ready` (o caminho do turno também falha de forma honesta, nunca retorna
+  vazio silenciosamente).
 - Check lento é interrompido pelo timeout aprovado (nunca fica pendurado).
 - Exceções com conteúdo sensível nunca aparecem na resposta nem nos logs:
   o registry emite apenas `event=readiness_check_failed component=<nome>`.
@@ -93,8 +103,9 @@ Políticas:
    o role da aplicação. Timeout curto sugere rede/slow query.
 4. **`provider` unavailable** — chaves do provider ausentes ou inválidas na
    configuração da instância.
-5. **`embeddings` unavailable** (só com archival habilitado) — o modelo não
-   carregou no startup (ex.: `HF_HUB_OFFLINE=1` sem cache local).
+5. **`embeddings` unavailable** (só com `EMBEDDINGS_RETRIEVAL_ENABLED=true`) —
+   o modelo não carregou no startup (ex.: `HF_HUB_OFFLINE=1` sem cache local)
+   ou o processo foi iniciado sem o modelo necessário para o modo ativo.
 
 Cada falha aparece nos logs como `event=readiness_check_failed
 component=<nome>`; nenhum detalhe de exceção é registrado.

--- a/docs/operations/health-and-readiness.md
+++ b/docs/operations/health-and-readiness.md
@@ -72,13 +72,26 @@ Políticas:
   trabalho, e o timeout de transporte do cliente de probe (alinhado ao
   `READINESS_DATABASE_TIMEOUT_MS`) libera o worker. Polling repetido não
   acumula threads nem esgota o executor.
+- **O registry de readiness é owned pela aplicação.** O builder padrão inclui
+  `health_checks` (que fecha cada check fechável, incluindo o executor do
+  probe com `wait=False`, sem abandonar um probe em voo) e o cliente de probe
+  na tupla de `owned_resources`: são fechados no shutdown e em falha parcial
+  de startup, e nenhuma thread `readiness-db` permanece viva após sair do
+  lifespan.
+- **A guarda de probe é atômica no event loop.** O clear do estado só
+  acontece quando a future observada é a que o poll dono aguarda; uma future
+  mais nova instalada por um poll concorrente nunca é limpa por engano, então
+  no máximo um probe fica em voo (testado com concorrência determinística).
 - **Feature opcional desligada não bloqueia readiness** (`embeddings` só
   existe quando `EMBEDDINGS_RETRIEVAL_ENABLED=true`), e o modelo nunca é
   construído quando a feature está desligada.
 - **Feature obrigatória habilitada e indisponível bloqueia readiness.** Com
   a recuperação vetorial habilitada, um modelo ausente torna a instância
   `not_ready` (o caminho do turno também falha de forma honesta, nunca retorna
-  vazio silenciosamente).
+  vazio silenciosamente). No modo habilitado, falha de encode, transporte/RPC
+  ou resposta estruturalmente inválida produz `ContextLoadError` sanitizado;
+  somente uma resposta válida com `data=[]` representa ausência real de
+  memórias.
 - Check lento é interrompido pelo timeout aprovado (nunca fica pendurado).
 - Exceções com conteúdo sensível nunca aparecem na resposta nem nos logs:
   o registry emite apenas `event=readiness_check_failed component=<nome>`.


### PR DESCRIPTION
# refactor(ops): add explicit lifecycle and readiness

Closes #275.

## Resultado final

Esta PR torna startup, shutdown, configuração, readiness e observabilidade do backend explícitos e testáveis, removendo inicialização pesada do import e separando liveness de readiness real.

### Settings e ambientes

- `Settings` tipado, validado e congelado; `APP_ENV` é obrigatório no runtime.
- Produção falha cedo para configuração crítica ausente/insegura.
- CORS é allowlist explícita e não aceita wildcard com credenciais.
- Segredos não são expostos em repr/log/erros de validação.

### App factory e lifecycle

- `create_app(settings=None, dependencies=None)` permite DI real e import sem rede/modelos pesados.
- Recursos construídos pela aplicação ficam sob ownership do lifespan e são encerrados no shutdown/falha parcial.
- Dependências injected pertencem ao chamador.
- Composição owned é descartada no shutdown e reconstruída em novo ciclo.
- Rotas recusam uso fora do lifespan ativo.

### Readiness

- `/live` prova apenas que o processo/event loop responde.
- `/ready` verifica configuração, Auth, banco, persistência, provider, embeddings quando habilitados e lifespan.
- Auth e banco usam probes HTTP assíncronos, bounded e canceláveis; não há threads/executors ou cleanup fire-and-forget.
- `HealthRegistry.aclose()` aguarda closers assíncronos; há regressão específica que falha se esse dispatch deixar de aguardar `aclose()`.
- Instância sem capacidade real de autenticar/persistir retorna 503.
- Exceções e respostas de readiness são sanitizadas.

### Embeddings

- `EMBEDDINGS_RETRIEVAL_ENABLED` controla explicitamente recuperação vetorial.
- Desabilitada: o modelo não é construído.
- Habilitada: ausência/falha de encode/RPC/resposta inválida falha de modo explícito e sanitizado; somente resposta válida vazia representa ausência real de memória.

### Observabilidade e DI

- Eventos estruturados incluem correlação e latências operacionais sem prompt, mensagem, memória, token ou `user_id` bruto.
- Referência de usuário é HMAC não reversível e separada por domínio.
- Auth usa `deps.auth_client`; histórico/admissão usam `deps.persistence_client`; rotas não navegam por internals do engine.

## Validação final

HEAD auditado: `60ae27ee974997b817a305d2888c87412e60e9ea`

Base: `main` em `7578cc09e492fc5e8053793ae122f1b7b40f6f5f`, incluindo o unblocker #310 que corrigiu `js-yaml` sem relaxar o audit.

CI #207 (`31213069031`) no HEAD final: **success**.

- backend: verde;
- database: verde, incluindo pgTAP, autorização, atomic turn commit e ProcessTurn multi-worker;
- Docker: verde;
- frontend: verde, incluindo `npm audit`, testes, lint e build.

A suíte backend permanece com 2.307 testes passando no caminho não dependente do Supabase local, e a integração de database é exercitada no job dedicado da CI.

## Riscos residuais

- `APP_ENV` é obrigatório e processo sem a variável falha fechado no startup.
- O provider check valida configuração, não faz geração real; indisponibilidade de rede do Groq aparece no primeiro turno.
- `/ready` faz probes HTTP baratos de Auth/PostgREST e portanto gera carga mínima sob polling.
- Deployments que dependem de recuperação vetorial precisam habilitar `EMBEDDINGS_RETRIEVAL_ENABLED` explicitamente.

## Fora de escopo

- #279 completa (lint/types/SAST/SBOM/supply-chain ampliada);
- retenção/reset, outbox, candidate memory, safety policy e Emotional Core v2;
- mudanças de prompts, personalidade ou contrato público do `/chat`;
- deploy.

`.Jules/palette.md` não foi editado.