### PR TITLE
chore(frontend): fix js-yaml audit blocker

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4443,9 +4443,9 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
             "funding": [
                 {
@@ -4457,6 +4457,7 @@
                     "url": "https://github.com/sponsors/nodeca"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
             },


### PR DESCRIPTION
Closes #310

## Problema e causa raiz

O job `frontend / Audit dependencies` falhava com `1 high severity vulnerability` (advisory `GHSA-5p4m-2wfm-xmqj`, CVE-2026-59870), bloqueando a PR #309 / issue #275.

## Cadeia de dependência encontrada

```
katherine-chat-frontend@0.0.0
└─┬ eslint@8.57.1
  ├─┬ @eslint/eslintrc@2.1.4
  │ └── js-yaml@4.3.0 deduped
  └── js-yaml@4.3.0
```

`js-yaml` é transitivo de `eslint@8.57.1` (devDependency direta do frontend), que declara `js-yaml: ^4.1.0` via `@eslint/eslintrc@2.1.4`.

## Versões

- Anterior: `js-yaml@4.3.0` (vulnerável: `>= 4.0.0, < 4.3.1`)
- Corrigida: `js-yaml@4.3.1` (primeira versão patched da advisory)

## Mecanismo usado para corrigir

Bump natural via `npm update js-yaml` dentro do range semver já declarado (`^4.1.0`). Nenhum `overrides` foi necessário e nenhuma dependência direta foi alterada.

## Resultado de `npm ls js-yaml`

```
katherine-chat-frontend@0.0.0
└─┬ eslint@8.57.1
  ├─┬ @eslint/eslintrc@2.1.4
  │ └── js-yaml@4.3.1 deduped
  └── js-yaml@4.3.1
```

## Resultado do audit

- `npm audit`: `found 0 vulnerabilities`
- Processo exato da CI (`npm audit --json` + `node scripts/audit-validator.js`): exit code 0, `Auditoria passou com sucesso!`

## Testes executados

- `npm ci` (2x, incluindo a partir de árvore limpa): ok, lockfile reproduzível
- `npm test`: 89 testes node + 46 testes component, todos passando
- `npm run lint`: ok
- `npm run build`: ok (apenas warning pré-existente de chunk size)

## CI

- Frontend: aguardando execução na PR (audit, tests, lint, build devem ficar verdes)
- Backend (2.307 testes), database e Docker: não foram tocados, permanecem verdes

## Riscos / migração / rollback

- Nenhuma migração. Rollback: reverter o commit restaura o lockfile anterior.
- Nenhuma política de audit foi relaxada: `audit-level`, `audit-validator.js`, `ci.yml` e `npm audit` permanecem intactos.

## Fora de escopo

- Escopo amplo da #279 (lint/types/SAST Python, hashes de requirements, SBOM, migrations adicionais, rulesets, coverage) não foi implementado.

## Summary by Sourcery

Atualizar o lockfile do frontend para resolver uma vulnerabilidade de alta gravidade no `js-yaml` detectada pela auditoria de dependências.

Correções de bug:
- Tratar o aviso de segurança do `js-yaml` atualizando a versão resolvida na árvore de dependências do frontend.

Tarefas de rotina:
- Atualizar o `package-lock.json` do frontend para refletir as versões atualizadas de dependências transitivas sem alterar as dependências diretas.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update frontend lockfile to resolve a high-severity js-yaml vulnerability detected by dependency audit.

Bug Fixes:
- Address security advisory for js-yaml by updating the resolved version in the frontend dependency tree.

Chores:
- Refresh frontend package-lock.json to reflect updated transitive dependency versions without changing direct dependencies.

</details>