### PR TITLE
fix(frontend): make clear-screen action honest

### DIFF
--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -1,16 +1,16 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Trash2, Check, X } from 'lucide-react';
+import { Eraser, Check, X } from 'lucide-react';
 
-const ChatHeader = ({ clearHistory }) => {
+const ChatHeader = ({ clearScreen }) => {
     const [showConfirm, setShowConfirm] = useState(false);
-    const trashRef = useRef(null);
+    const clearButtonRef = useRef(null);
     const prevShowConfirm = useRef(showConfirm);
-    const [shouldFocusTrash, setShouldFocusTrash] = useState(false);
+    const [shouldFocusClearButton, setShouldFocusClearButton] = useState(false);
 
     useEffect(() => {
         // Focus restoration when confirmation closes
-        if (prevShowConfirm.current && !showConfirm && trashRef.current) {
-            trashRef.current.focus();
+        if (prevShowConfirm.current && !showConfirm && clearButtonRef.current) {
+            clearButtonRef.current.focus();
         }
         prevShowConfirm.current = showConfirm;
     }, [showConfirm]);
@@ -30,12 +30,12 @@ const ChatHeader = ({ clearHistory }) => {
     }, [showConfirm]);
 
     const handleClear = () => {
-        clearHistory();
+        clearScreen();
         setShowConfirm(false);
     };
 
-    const handleTrashClick = () => {
-        setShouldFocusTrash(true);
+    const handleClearClick = () => {
+        setShouldFocusClearButton(true);
         setShowConfirm(true);
     };
 
@@ -49,19 +49,19 @@ const ChatHeader = ({ clearHistory }) => {
                 <div
                     className="flex items-center gap-2"
                     role="group"
-                    aria-label="Confirmar limpeza do histórico"
+                    aria-label="Confirmar limpeza da tela"
                 >
                     <span
                         className="text-sm text-gray-400 animate-in fade-in duration-200"
                         id="confirm-text"
                     >
-                        Limpar histórico?
+                        Limpar a tela? O histórico salvo permanece.
                     </span>
                     <button
                         onClick={handleClear}
-                        className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-red-400 focus:outline-none"
-                        title="Confirmar limpeza"
-                        aria-label="Confirmar limpeza"
+                        className="text-gray-400 hover:text-gray-200 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-gray-400 focus:outline-none"
+                        title="Confirmar limpeza da tela"
+                        aria-label="Confirmar limpeza da tela"
                         aria-describedby="confirm-text"
                     >
                         <Check size={20} />
@@ -78,14 +78,14 @@ const ChatHeader = ({ clearHistory }) => {
                 </div>
             ) : (
                 <button
-                    onClick={handleTrashClick}
-                    ref={trashRef}
-                    autoFocus={shouldFocusTrash}
-                    className="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-red-400 focus:outline-none"
-                    title="Limpar conversa"
-                    aria-label="Limpar conversa"
+                    onClick={handleClearClick}
+                    ref={clearButtonRef}
+                    autoFocus={shouldFocusClearButton}
+                    className="text-gray-500 hover:text-gray-300 transition-colors p-2 rounded-md hover:bg-gray-800 focus-visible:ring-2 focus-visible:ring-gray-400 focus:outline-none"
+                    title="Limpar tela"
+                    aria-label="Limpar tela"
                 >
-                    <Trash2 size={20} />
+                    <Eraser size={20} />
                 </button>
             )}
         </header>

--- a/frontend/src/features/chat/components/ChatWindow.jsx
+++ b/frontend/src/features/chat/components/ChatWindow.jsx
@@ -15,13 +15,13 @@ const ChatWindow = () => {
         messagesEndRef,
         inputRef,
         handleSend,
-        clearHistory
+        clearScreen
     } = useChat();
 
     return (
         <div className="flex flex-col h-screen max-w-6xl mx-auto relative">
             {/* Header */}
-            <ChatHeader clearHistory={clearHistory} />
+            <ChatHeader clearScreen={clearScreen} />
 
             {/* Main Content Area */}
             <div className="flex-1 flex flex-col md:flex-row overflow-hidden">

--- a/frontend/src/features/chat/hooks/useChat.js
+++ b/frontend/src/features/chat/hooks/useChat.js
@@ -198,7 +198,14 @@ export const useChat = () => {
         }
     }, [input, isLoading, cleanupRequest, cleanupFocusTimer]);
 
-    const clearHistory = useCallback(() => {
+    /**
+     * Clears the local chat screen only.
+     *
+     * This removes the in-memory `messages` and `emotionState` from the React
+     * state. It never touches persisted data: the server-side history remains
+     * intact and is reloaded on the next mount.
+     */
+    const clearScreen = useCallback(() => {
         localMessagesVersionRef.current += 1;
         setMessages([]);
         setEmotionState(null);
@@ -213,6 +220,6 @@ export const useChat = () => {
         messagesEndRef,
         inputRef,
         handleSend,
-        clearHistory
+        clearScreen
     };
 };

--- a/frontend/tests/chatHeader.test.jsx
+++ b/frontend/tests/chatHeader.test.jsx
@@ -1,0 +1,104 @@
+/**
+ * Behavioral tests for ``ChatHeader`` clear-screen action — issue #313.
+ *
+ * The action must be presented as a local "Limpar tela" (clear screen) with
+ * no persistent-deletion semantics:
+ * - Label is "Limpar tela" (no "Limpar histórico" / "Limpar conversa")
+ * - Neutral representation (no trash/delete icon)
+ * - Confirmation states that the screen is cleared and saved history stays
+ * - Confirm calls ``clearScreen``; cancel and Escape do not
+ * - Escape handling, focus restoration and keyboard navigation are preserved
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ChatHeader from '../src/features/chat/components/ChatHeader';
+
+function renderHeader(clearScreen = vi.fn()) {
+    return render(<ChatHeader clearScreen={clearScreen} />);
+}
+
+describe('ChatHeader clear screen action', () => {
+    it('presents the action as "Limpar tela"', () => {
+        renderHeader();
+
+        const clearButton = screen.getByRole('button', { name: 'Limpar tela' });
+        expect(clearButton).toBeInTheDocument();
+        expect(clearButton).toHaveAttribute('title', 'Limpar tela');
+        expect(clearButton).toHaveAccessibleName('Limpar tela');
+    });
+
+    it('does not present "Limpar histórico" or "Limpar conversa" for the action', () => {
+        const { container } = renderHeader();
+
+        expect(container).not.toHaveTextContent('Limpar histórico');
+        expect(container).not.toHaveTextContent('Limpar conversa');
+        expect(screen.queryByRole('button', { name: /Limpar histórico/ })).toBeNull();
+        expect(screen.queryByRole('button', { name: /Limpar conversa/ })).toBeNull();
+    });
+
+    it('uses a neutral eraser representation, not a trash/delete icon', () => {
+        const { container } = renderHeader();
+
+        // The action is represented by the eraser icon (lucide-eraser), which
+        // means clearing the visible surface, not deleting persisted data.
+        expect(container.querySelector('svg.lucide-eraser')).not.toBeNull();
+        expect(container.querySelector('svg.lucide-trash2')).toBeNull();
+        expect(container.querySelector('svg.lucide-trash')).toBeNull();
+    });
+
+    it('confirmation informs that the screen is cleared and saved history remains', () => {
+        renderHeader();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Limpar tela' }));
+
+        expect(screen.getByText(/Limpar a tela\?/)).toBeInTheDocument();
+        expect(screen.getByText(/hist[oó]rico salvo permanece/i)).toBeInTheDocument();
+    });
+
+    it('confirming clears the screen and closes the confirmation', () => {
+        const clearScreen = vi.fn();
+        renderHeader(clearScreen);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Limpar tela' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Confirmar limpeza da tela' }));
+
+        expect(clearScreen).toHaveBeenCalledTimes(1);
+        expect(screen.queryByRole('button', { name: 'Confirmar limpeza da tela' })).toBeNull();
+        expect(screen.getByRole('button', { name: 'Limpar tela' })).toBeInTheDocument();
+    });
+
+    it('canceling closes the confirmation without clearing', () => {
+        const clearScreen = vi.fn();
+        renderHeader(clearScreen);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Limpar tela' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Cancelar' }));
+
+        expect(clearScreen).not.toHaveBeenCalled();
+        expect(screen.getByRole('button', { name: 'Limpar tela' })).toBeInTheDocument();
+    });
+
+    it('Escape closes the confirmation without clearing', () => {
+        const clearScreen = vi.fn();
+        renderHeader(clearScreen);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Limpar tela' }));
+        fireEvent.keyDown(document, { key: 'Escape' });
+
+        expect(clearScreen).not.toHaveBeenCalled();
+        expect(screen.getByRole('button', { name: 'Limpar tela' })).toBeInTheDocument();
+    });
+
+    it('restores focus to the clear button after the confirmation closes', () => {
+        renderHeader();
+
+        const clearButton = screen.getByRole('button', { name: 'Limpar tela' });
+        fireEvent.click(clearButton);
+        expect(screen.getByRole('button', { name: 'Cancelar' })).toHaveFocus();
+
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(screen.getByRole('button', { name: 'Limpar tela' })).toHaveFocus();
+    });
+});

--- a/frontend/tests/useChat.test.jsx
+++ b/frontend/tests/useChat.test.jsx
@@ -10,7 +10,7 @@
  * - No React act() warnings
  * - History lifecycle: deferred response after unmount does not update state
  * - Late history does not overwrite sent messages
- * - Late history does not undo clearHistory()
+ * - Late history does not undo clearScreen()
  * - Normal history loading still works
  * - Abort of history fetch on unmount is silent
  */
@@ -21,6 +21,8 @@ import { useChat } from '../src/features/chat/hooks/useChat';
 
 // Export a configurable mock for api.get so tests can defer / control its resolution.
 const mockApiGet = vi.hoisted(() => vi.fn().mockResolvedValue({ data: [] }));
+const mockApiPost = vi.hoisted(() => vi.fn());
+const mockApiDelete = vi.hoisted(() => vi.fn());
 
 const mockSendMessage = vi.fn();
 
@@ -38,7 +40,8 @@ vi.mock('../src/features/chat/services/chatService', () => ({
 vi.mock('../src/shared/services/apiClient', () => ({
     default: {
         get: (...args) => mockApiGet(...args),
-        post: vi.fn(),
+        post: (...args) => mockApiPost(...args),
+        delete: (...args) => mockApiDelete(...args),
     },
 }));
 
@@ -69,6 +72,8 @@ describe('useChat', () => {
         mockSendMessage.mockReset();
         mockApiGet.mockReset();
         mockApiGet.mockResolvedValue({ data: [] });
+        mockApiPost.mockReset();
+        mockApiDelete.mockReset();
     });
 
     afterEach(() => {
@@ -356,7 +361,7 @@ describe('useChat', () => {
         expect(result.current.messages[1].content).toBe('Bot reply');
     });
 
-    it('late history does not undo clearHistory', async () => {
+    it('late history does not undo clearScreen', async () => {
         let resolveHistory;
         mockApiGet.mockReturnValue(new Promise(r => { resolveHistory = r; }));
 
@@ -364,9 +369,9 @@ describe('useChat', () => {
 
         expect(mockApiGet).toHaveBeenCalled();
 
-        // Clear history while /history is pending
+        // Clear the screen while /history is pending
         await act(async () => {
-            result.current.clearHistory();
+            result.current.clearScreen();
         });
 
         // Resolve history with old data
@@ -433,5 +438,66 @@ describe('useChat', () => {
 
         consoleErrorSpy.mockRestore();
         consoleWarnSpy.mockRestore();
+    });
+
+    it('clearScreen clears local messages and emotionState without HTTP delete', async () => {
+        mockSendMessage.mockResolvedValue(validEmotionResponse('Bot reply'));
+
+        const { result } = renderHook(() => useChat());
+
+        // Build local state: one user message plus an assistant reply and emotion.
+        await act(async () => { result.current.setInput('Hello'); });
+        let sendPromise;
+        await act(async () => { sendPromise = result.current.handleSend(); });
+        await act(async () => { await sendPromise; });
+
+        expect(result.current.messages).toHaveLength(2);
+        expect(result.current.emotionState).not.toBeNull();
+
+        // Clear the screen
+        await act(async () => {
+            result.current.clearScreen();
+        });
+
+        expect(result.current.messages).toEqual([]);
+        expect(result.current.emotionState).toBeNull();
+
+        // No deletion or privacy write is issued: only the /history GET happened.
+        expect(mockApiDelete).not.toHaveBeenCalled();
+        expect(mockApiPost).not.toHaveBeenCalled();
+        expect(mockApiGet).toHaveBeenCalledTimes(1);
+    });
+
+    it('persisted history still loads after clearScreen and remount', async () => {
+        const historyData = [
+            { role: 'user', content: 'stored question' },
+            { role: 'assistant', content: 'stored answer' },
+        ];
+        mockApiGet.mockResolvedValue({ data: historyData });
+
+        const first = renderHook(() => useChat());
+        await waitFor(() => {
+            expect(first.result.current.messages).toEqual(historyData);
+        });
+
+        // Clear the screen: local view is emptied, nothing is deleted server-side.
+        await act(async () => {
+            first.result.current.clearScreen();
+        });
+        expect(first.result.current.messages).toEqual([]);
+
+        // Simulate a reload: unmount and mount a fresh chat.
+        first.unmount();
+        expect(mockApiGet).toHaveBeenCalledTimes(1);
+
+        const second = renderHook(() => useChat());
+        await waitFor(() => {
+            expect(second.result.current.messages).toEqual(historyData);
+        });
+
+        // The persisted history was never removed: /history returns it again.
+        expect(mockApiGet).toHaveBeenCalledTimes(2);
+        expect(mockApiDelete).not.toHaveBeenCalled();
+        expect(mockApiPost).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Closes #313

## Problema e causa raiz

`useChat.clearHistory()` apenas limpa `messages` e `emotionState` no estado React local. Nenhum dado persistido é removido. Porém o `ChatHeader` apresentava a ação com ícone de lixeira e textos como "Limpar histórico?", "Confirmar limpeza" e "Limpar conversa", sugerindo que o histórico persistido seria apagado.

## Solução e decisões

A ação agora significa somente **Limpar tela** (local):

- Ação renomeada para "Limpar tela" (title, aria-label e confirmação).
- Ícone de lixeira (`Trash2`) substituído por representação neutra de limpar (`Eraser`); removida a affordance vermelha de destrutividade do botão de confirmar.
- Confirmação curta informa: "Limpar a tela? O histórico salvo permanece."
- Identificadores internos renomeados de `clearHistory` para `clearScreen` em `useChat`, `ChatWindow` e `ChatHeader`.
- Comportamento preservado: limpa `messages` e `emotionState`, somente após confirmação; Escape cancela; foco restaurado após fechar; navegação por teclado e ARIA mantidos.
- Nenhuma API, rota (`/chat`, `/history`) ou persistência foi modificada.

## Arquivos/áreas afetadas

- `frontend/src/features/chat/components/ChatHeader.jsx`
- `frontend/src/features/chat/components/ChatWindow.jsx`
- `frontend/src/features/chat/hooks/useChat.js`
- `frontend/tests/chatHeader.test.jsx` (novo)
- `frontend/tests/useChat.test.jsx`

## Testes executados e resultado

No diretório `frontend/`:

- `npm test`: 89 testes node + 56 testes de componente, todos passando.
- `npm run lint`: sem erros.
- `npm run build`: build de produção OK.
- `npm audit` + `scripts/audit-validator.js`: auditoria passou.
- `docker build -f frontend/Dockerfile frontend` com os `VITE_*` obrigatórios: imagem construída com sucesso.

Os testes cobrem: UI usa "Limpar tela"; ausência de "Limpar histórico"/"Limpar conversa"; ausência de lixeira/delete (usa `lucide-eraser`); confirmação informa que o histórico salvo permanece; confirmar limpa mensagens e emotionState locais; cancelar não altera estado; Escape fecha sem limpar; nenhuma chamada HTTP de exclusão/privacidade; após remount simulado, `/history` continua carregando o histórico persistido.

## Riscos, migração e rollback

- Sem migração: nenhum dado persistido ou contrato público é alterado.
- Rollback: reverter o commit da PR restaura o comportamento anterior sem impacto em dados.
- CI de database/backend não é afetada (mudança exclusivamente em arquivos do frontend).

## Fora de escopo

- Sem DELETE/POST de privacidade, exclusão de `chat_logs`/`turn_requests`/`outbox_events`/`memories`, reset emocional/relacional server-side, exclusão de conta, retenção, exportação.
- Sem alterações em `/chat`, `/history`, Emotional Core ou redesign geral do chat.
- Sem atualização de dependências.

## Summary by Sourcery

Esclarecer que a ação de limpar o chat apenas limpa o estado local da tela enquanto preserva o histórico persistido, e alinhar a nomenclatura da UI e dos hooks com esse comportamento.

Correções de bugs:
- Garantir que a ação de limpar a tela não sugira mais a exclusão do histórico persistido e afete apenas o estado local do chat.

Melhorias:
- Renomear a ação de limpar em hooks e componentes de limpeza de histórico para limpeza de tela, atualizando rótulos, texto aria e ícone para uma borracha neutra.
- Documentar e reforçar por meio de testes que `clearScreen` apenas reinicia mensagens em memória e `emotionState`, sem HTTP delete ou gravações de privacidade.

Testes:
- Adicionar testes de componente para `ChatHeader` para validar a rotulagem de limpeza de tela, uso de ícone, texto de confirmação, tratamento de teclado e restauração de foco.
- Estender os testes de `useChat` para cobrir o comportamento de `clearScreen`, expectativas de chamadas à API e recarregamento de histórico após remontagem.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify that the chat clear action only clears the local screen state while preserving persisted history, and align UI and hook naming with this behavior.

Bug Fixes:
- Ensure the clear-screen action no longer suggests deletion of persisted history and only affects local chat state.

Enhancements:
- Rename the clear action across hooks and components from history clearing to screen clearing, updating labels, aria text, and icon to a neutral eraser.
- Document and enforce through tests that clearScreen only resets in-memory messages and emotionState without HTTP delete or privacy writes.

Tests:
- Add component tests for ChatHeader to validate clear-screen labeling, icon usage, confirmation text, keyboard handling, and focus restoration.
- Extend useChat tests to cover clearScreen behavior, API call expectations, and history reloading after remount.

</details>