### PR TITLE
feat(privacy): add atomic user data operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,24 @@ jobs:
           bash scripts/hide-migrations-after.sh 20240101000006 \
             python -m pytest -q -ra backend/tests/test_privacy_operations_legacy.py
 
+      - name: Reset database for privacy operations preflight tests
+        run: |
+          set -euo pipefail
+          supabase db reset
+
+      - name: Run Privacy Operations Preflight Test (missing dependency -> 23514)
+        env:
+          SUPABASE_URL: "http://127.0.0.1:54321"
+          PYTHONPATH: "."
+        run: |
+          set -euo pipefail
+          # The preflight gate must be exercised by CI, not just exist: each
+          # case hides the new migration, resets the pre-privacy baseline,
+          # drops exactly one mandatory table and requires the migration to
+          # fail with 23514 before installing any object.
+          bash scripts/hide-migrations-after.sh 20240101000006 \
+            python -m pytest -q -ra backend/tests/test_privacy_operations_preflight.py
+
       - name: Stop Supabase
         if: always()
         run: supabase stop
@@ -316,6 +334,7 @@ jobs:
               --ignore=backend/tests/test_rls_auto_enable_legacy.py \
               --ignore=backend/tests/test_privacy_operations_integration.py \
               --ignore=backend/tests/test_privacy_operations_legacy.py \
+              --ignore=backend/tests/test_privacy_operations_preflight.py \
               -ra
 
   frontend:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,38 @@ jobs:
           bash scripts/hide-migrations-after.sh 20240101000006 \
             python -m pytest -q -ra backend/tests/test_rls_auto_enable_legacy.py
 
+      - name: Reset database for privacy operations integration tests
+        run: |
+          set -euo pipefail
+          supabase db reset
+
+      - name: Run Privacy Operations Integration Tests
+        env:
+          SUPABASE_URL: "http://127.0.0.1:54321"
+          SUPABASE_ANON_KEY: "${{ env.SUPABASE_ANON_KEY }}"
+          SUPABASE_SERVICE_ROLE_KEY: "${{ env.SUPABASE_SERVICE_ROLE_KEY }}"
+          PYTHONPATH: "."
+        run: |
+          set -euo pipefail
+          python -m pytest -q -ra backend/tests/test_privacy_operations_integration.py
+
+      - name: Reset database for privacy operations legacy tests
+        run: |
+          set -euo pipefail
+          supabase db reset
+
+      - name: Run Privacy Operations Legacy Test
+        env:
+          SUPABASE_URL: "http://127.0.0.1:54321"
+          PYTHONPATH: "."
+        run: |
+          set -euo pipefail
+          # Hide every migration AFTER the replay migration (06) so the legacy
+          # scenario starts from a true pre-privacy database; the new
+          # migration is restored inside the test before applying it.
+          bash scripts/hide-migrations-after.sh 20240101000006 \
+            python -m pytest -q -ra backend/tests/test_privacy_operations_legacy.py
+
       - name: Stop Supabase
         if: always()
         run: supabase stop
@@ -282,6 +314,8 @@ jobs:
               --ignore=backend/tests/test_atomic_turn_commit_integration.py \
               --ignore=backend/tests/test_process_turn_integration.py \
               --ignore=backend/tests/test_rls_auto_enable_legacy.py \
+              --ignore=backend/tests/test_privacy_operations_integration.py \
+              --ignore=backend/tests/test_privacy_operations_legacy.py \
               -ra
 
   frontend:

--- a/backend/privacy_operations.py
+++ b/backend/privacy_operations.py
@@ -9,15 +9,24 @@ primitives exposed by the PostgreSQL RPC layer (migration
   turn_requests, derived outbox_events and archival_extractions).
 - ``delete_memories``: atomically removes memories and archival/candidate
   material that may still represent ungoverned memory.
-- ``reset_emotional_state``: replaces ONLY the emotional snapshot with a
-  validated v1 neutral snapshot produced by the domain.
-- ``reset_relationship_state``: replaces ONLY the relationship snapshot with a
-  validated v1 neutral snapshot produced by the domain.
+- ``reset_emotional_state``: replaces ONLY the emotional snapshot with the
+  canonical neutral v1 snapshot produced by the domain
+  (``EmotionalStateV1.neutral``).
+- ``reset_relationship_state``: replaces ONLY the relationship snapshot with
+  the canonical neutral v1 snapshot produced by the domain
+  (``RelationshipStateV1.neutral``).
 
 Design guarantees (implemented and enforced by the database):
 
 - Identity comes ONLY from ``authenticated_user_id`` (server-side boundary).
-  No ``user_id`` inside a payload/snapshot is ever trusted.
+  No ``user_id`` inside a payload/snapshot is ever trusted, and the identity
+  is validated exactly as received (1-128 chars, not whitespace-only) so it
+  matches the persistent ledger contract. RPC results whose ``user_id`` does
+  not equal the expected authenticated identity fail closed in the adapter.
+- Resets ONLY accept the canonical NEUTRAL snapshot: a structurally valid v1
+  snapshot with non-neutral values is rejected both in Python (by
+  reconstructing the neutral state through the domain constructors) and at
+  the privileged SQL boundary (``privacy_is_neutral_snapshot``).
 - Every applied operation records a durable ledger row keyed by
   (user_id, operation_id) storing the sanitized public result and the
   fingerprint of the operation payload. Replay of the same operation_id with
@@ -166,9 +175,56 @@ def _validate_operation_id(operation_id: Any) -> None:
 
 
 def _validate_user_id(user_id: Any) -> None:
-    if not isinstance(user_id, str) or not user_id:
+    """Validate the authenticated identity exactly as received.
+
+    Mirrors the persistent ledger contract
+    (``char_length(user_id) BETWEEN 1 AND 128 AND btrim(user_id) <> ''``):
+    rejects None, non-strings, empty strings, whitespace-only strings and
+    strings longer than 128 characters BEFORE the RPC, so invalid identities
+    never reach the database as generic persistence errors. The value is
+    validated exactly as received from the trusted boundary; it is never
+    normalized or altered.
+    """
+    if not isinstance(user_id, str):
         raise ValidationError(
-            "invalid_user_id", "authenticated_user_id must be a non-empty string"
+            "invalid_user_id", "authenticated_user_id must be a string"
+        )
+    if not user_id or user_id.isspace() or len(user_id) > 128:
+        raise ValidationError(
+            "invalid_user_id",
+            "authenticated_user_id must be 1-128 characters and not whitespace-only",
+        )
+
+
+def _validate_reset_neutral(payload: Mapping[str, Any], field_name: str) -> None:
+    """Verify that a reset payload is the canonical neutral v1 snapshot.
+
+    Neutrality is PRODUCED by the domain constructors
+    (``EmotionalStateV1.neutral`` / ``RelationshipStateV1.neutral``): this
+    helper reconstructs the canonical neutral snapshot through those
+    constructors using the payload's own timestamp and requires an exact
+    match, so a structurally valid v1 snapshot with non-neutral values
+    (for example pleasure = 0.9 or coping_mode = 'MANIC') is rejected.
+    """
+    timestamp = payload.get("timestamp")
+    if isinstance(timestamp, bool) or not isinstance(timestamp, (int, float)):
+        raise ValidationError(
+            "invalid_operation_payload", "reset snapshot must be the canonical neutral state"
+        )
+    try:
+        if field_name == "emotional_state":
+            expected = EmotionalStateV1.neutral(timestamp=float(timestamp)).to_dict()
+        else:
+            expected = RelationshipStateV1.neutral(timestamp=float(timestamp)).to_dict()
+    except Exception:
+        # The domain rejects the timestamp; the payload is not canonical.
+        raise ValidationError(
+            "invalid_operation_payload", "reset snapshot must be the canonical neutral state"
+        ) from None
+
+    if payload != expected:
+        raise ValidationError(
+            "invalid_operation_payload", "reset snapshot must be the canonical neutral state"
         )
 
 
@@ -200,11 +256,19 @@ def validate_privacy_operation_input(
 
     field_name = _RESET_SNAPSHOT_FIELD.get(operation)
     if field_name is not None:
-        # Resets REQUIRE a valid v1 snapshot produced by the domain. The
-        # shared snapshot validator enforces the exact v1 contract used by
-        # commit_turn (schema_version == 1, exact field set, ranges, no
-        # identity/internal keys, size bound).
+        # Resets REQUIRE the CANONICAL NEUTRAL v1 snapshot produced by the
+        # domain. The shared snapshot validator first enforces the exact v1
+        # contract used by commit_turn (schema_version == 1, exact field set,
+        # ranges, no identity/internal keys, size bound); the neutrality check
+        # then reconstructs the canonical neutral snapshot through the domain
+        # constructors using the payload's own timestamp and compares, so a
+        # structurally valid but semantically non-neutral v1 snapshot is
+        # rejected. The single canonical definition of the neutral values is
+        # the domain (EmotionalStateV1.neutral / RelationshipStateV1.neutral);
+        # the SQL boundary verifies the same contract independently
+        # (privacy_is_neutral_snapshot) and cross-boundary tests pin both.
         _validate_snapshot_payload(payload, field_name)
+        _validate_reset_neutral(payload, field_name)
 
 
 def build_privacy_operation_rpc_payload(
@@ -261,17 +325,21 @@ def parse_privacy_operation_result(
     result: Mapping[str, Any],
     expected_operation: str,
     expected_operation_id: str,
+    expected_user_id: str,
 ) -> PrivacyOperationResult:
     """Parse the RPC result into a PrivacyOperationResult.
 
     The success envelope is validated strictly: exactly the expected fields
     must be present (missing/extra fields indicate contract corruption), the
-    operation and operation_id must match the request, and revision and every
-    count must be non-negative integers.
+    operation, operation_id AND user_id must match the request, and revision
+    and every count must be non-negative integers. A result whose user_id does
+    not equal the expected authenticated identity fails closed with a constant
+    sanitized message: the divergent identity is NEVER echoed (it may be a
+    sensitive value controlled by an attacker).
 
     Raises:
         ConflictError: If the result indicates an operation conflict.
-        ValidationError: If the result is malformed.
+        ValidationError: If the result is malformed or belongs to another user.
         PersistenceError: If the result indicates an unexpected database error.
     """
     if not isinstance(result, Mapping):
@@ -309,6 +377,13 @@ def parse_privacy_operation_result(
         raise ValidationError("invalid_rpc_result", "status must be applied")
     if not isinstance(user_id, str) or not user_id:
         raise ValidationError("invalid_rpc_result", "user_id must be a non-empty string")
+    if user_id != expected_user_id:
+        # Fail closed: a privileged privacy result belonging to another user
+        # must never be accepted or normalized. The message is constant and
+        # never carries the divergent identity.
+        raise ValidationError(
+            "invalid_rpc_result", "result user_id does not match the authenticated user"
+        )
     if isinstance(revision, bool) or not isinstance(revision, int):
         raise ValidationError("invalid_rpc_result", "revision must be an integer")
     if revision < 0:
@@ -406,4 +481,6 @@ async def run_privacy_operation(
     except Exception as exc:  # noqa: BLE001 - sanitize any RPC-level failure
         raise PersistenceError("database_error", "persistence error") from None
 
-    return parse_privacy_operation_result(result, operation, operation_id)
+    return parse_privacy_operation_result(
+        result, operation, operation_id, authenticated_user_id
+    )

--- a/backend/privacy_operations.py
+++ b/backend/privacy_operations.py
@@ -1,0 +1,409 @@
+"""
+Transactional, idempotent privacy data operations (#314).
+
+This module provides the server-side Python contract for the four privacy
+primitives exposed by the PostgreSQL RPC layer (migration
+``20260808220000_privacy_data_operations``):
+
+- ``delete_history``: atomically removes turn history (chat_logs,
+  turn_requests, derived outbox_events and archival_extractions).
+- ``delete_memories``: atomically removes memories and archival/candidate
+  material that may still represent ungoverned memory.
+- ``reset_emotional_state``: replaces ONLY the emotional snapshot with a
+  validated v1 neutral snapshot produced by the domain.
+- ``reset_relationship_state``: replaces ONLY the relationship snapshot with a
+  validated v1 neutral snapshot produced by the domain.
+
+Design guarantees (implemented and enforced by the database):
+
+- Identity comes ONLY from ``authenticated_user_id`` (server-side boundary).
+  No ``user_id`` inside a payload/snapshot is ever trusted.
+- Every applied operation records a durable ledger row keyed by
+  (user_id, operation_id) storing the sanitized public result and the
+  fingerprint of the operation payload. Replay of the same operation_id with
+  the same operation and payload returns the stored result WITHOUT repeating
+  the mutation or incrementing ``profiles.revision``.
+- The same operation_id with a different operation or payload fails with a
+  sanitized ``operation_conflict``.
+- Concurrency uses the SAME per-user advisory transaction lock as
+  ``commit_turn``; concurrent operations of one user are serialized, distinct
+  users never contend on a global lock.
+- Results and errors are sanitized: only status/operation/operation_id/
+  user_id/revision and aggregate safe counts are returned.
+
+This module is pure Python (no network, no client construction at import) and
+mirrors ``backend.atomic_turn_commit``: validation runs BEFORE the RPC, and
+unexpected persistence failures surface as ``PersistenceError`` with a
+sanitized constant message.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid as _uuid
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from backend.atomic_turn_commit import (
+    PersistenceError,
+    ValidationError,
+    ConflictError,
+    _validate_snapshot_payload,
+)
+from backend.emotional_domain import EmotionalStateV1
+from backend.relationship import RelationshipStateV1
+
+# Canonical operation names (must match the database CHECK constraint).
+OPERATION_DELETE_HISTORY = "delete_history"
+OPERATION_DELETE_MEMORIES = "delete_memories"
+OPERATION_RESET_EMOTIONAL_STATE = "reset_emotional_state"
+OPERATION_RESET_RELATIONSHIP_STATE = "reset_relationship_state"
+
+PRIVACY_OPERATIONS = frozenset(
+    {
+        OPERATION_DELETE_HISTORY,
+        OPERATION_DELETE_MEMORIES,
+        OPERATION_RESET_EMOTIONAL_STATE,
+        OPERATION_RESET_RELATIONSHIP_STATE,
+    }
+)
+
+# Snapshot kind used for payload validation of each reset operation.
+_RESET_SNAPSHOT_FIELD = {
+    OPERATION_RESET_EMOTIONAL_STATE: "emotional_state",
+    OPERATION_RESET_RELATIONSHIP_STATE: "relationship_state",
+}
+
+# UUID regex (same as the database: lowercase hex, canonical form).
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+# RPC function name per operation.
+_RPC_NAME = {
+    OPERATION_DELETE_HISTORY: "delete_history",
+    OPERATION_DELETE_MEMORIES: "delete_memories",
+    OPERATION_RESET_EMOTIONAL_STATE: "reset_emotional_state",
+    OPERATION_RESET_RELATIONSHIP_STATE: "reset_relationship_state",
+}
+
+# Expected field set of a SUCCESS envelope (strict contract validation).
+_SUCCESS_FIELDS = frozenset(
+    {
+        "status",
+        "operation",
+        "operation_id",
+        "user_id",
+        "revision",
+        "counts",
+    }
+)
+
+# Aggregate safe counts returned by every operation (all keys always present).
+_COUNT_FIELDS = frozenset(
+    {
+        "chat_logs",
+        "turn_requests",
+        "outbox_events",
+        "archival_extractions",
+        "memories",
+        "profiles",
+    }
+)
+
+
+class PrivacyOperationError(Exception):
+    """Base class for privacy operation domain failures."""
+
+
+@dataclass(frozen=True)
+class PrivacyOperationResult:
+    """Sanitized public result of an applied privacy operation.
+
+    Mirrors the database output of the four RPC primitives. Contains only
+    status/operation/operation_id/user_id/revision and aggregate safe counts.
+    Never contains message or memory content, internal IDs, prompts or HMACs.
+    """
+
+    operation: str
+    operation_id: str
+    user_id: str
+    revision: int
+    counts: Mapping[str, int]
+
+    def to_db_row(self) -> dict[str, Any]:
+        """Serialize for database result consumption (public contract only)."""
+        return {
+            "status": "applied",
+            "operation": self.operation,
+            "operation_id": self.operation_id,
+            "user_id": self.user_id,
+            "revision": self.revision,
+            "counts": dict(self.counts),
+        }
+
+
+def new_operation_id() -> str:
+    """Return a fresh server-side UUID operation id (lowercase canonical)."""
+    return str(_uuid.uuid4())
+
+
+def neutral_emotional_snapshot(timestamp: float) -> dict[str, Any]:
+    """Return the validated domain neutral emotional snapshot (v1)."""
+    return EmotionalStateV1.neutral(timestamp=timestamp).to_dict()
+
+
+def neutral_relationship_snapshot(timestamp: float) -> dict[str, Any]:
+    """Return the validated domain neutral relationship snapshot (v1)."""
+    return RelationshipStateV1.neutral(timestamp=timestamp).to_dict()
+
+
+def _validate_operation_id(operation_id: Any) -> None:
+    if not isinstance(operation_id, str) or _UUID_RE.match(operation_id) is None:
+        raise ValidationError(
+            "invalid_operation_id", "operation_id must be a valid lowercase UUID"
+        )
+
+
+def _validate_user_id(user_id: Any) -> None:
+    if not isinstance(user_id, str) or not user_id:
+        raise ValidationError(
+            "invalid_user_id", "authenticated_user_id must be a non-empty string"
+        )
+
+
+def validate_privacy_operation_input(
+    operation: str,
+    authenticated_user_id: str,
+    operation_id: str,
+    payload: Optional[Mapping[str, Any]],
+) -> None:
+    """Validate all inputs before attempting the operation.
+
+    Defense-in-depth: the database enforces the true contract, but early
+    validation prevents accidental information leaks and provides clearer
+    error messages.
+
+    Raises:
+        ValidationError: If any input fails validation.
+    """
+    if not isinstance(operation, str) or operation not in PRIVACY_OPERATIONS:
+        raise ValidationError("invalid_operation", "operation is invalid")
+
+    _validate_user_id(authenticated_user_id)
+    _validate_operation_id(operation_id)
+
+    if payload is None or not isinstance(payload, Mapping):
+        raise ValidationError(
+            "invalid_operation_payload", "operation_payload must be a mapping"
+        )
+
+    field_name = _RESET_SNAPSHOT_FIELD.get(operation)
+    if field_name is not None:
+        # Resets REQUIRE a valid v1 snapshot produced by the domain. The
+        # shared snapshot validator enforces the exact v1 contract used by
+        # commit_turn (schema_version == 1, exact field set, ranges, no
+        # identity/internal keys, size bound).
+        _validate_snapshot_payload(payload, field_name)
+
+
+def build_privacy_operation_rpc_payload(
+    operation: str,
+    authenticated_user_id: str,
+    operation_id: str,
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build the payload for the privacy operation PostgreSQL RPC function."""
+    return {
+        "p_authenticated_user_id": authenticated_user_id,
+        "p_operation_id": operation_id,
+        "p_operation_payload": dict(payload),
+    }
+
+
+def _parse_error_envelope(error_info: Any) -> None:
+    """Parse an error envelope and raise the matching exception.
+
+    ``operation_conflict`` raises ConflictError; validation failures raise
+    ValidationError; unexpected/unknown failures raise PersistenceError with a
+    sanitized constant message (fail closed).
+    """
+    if not isinstance(error_info, Mapping):
+        raise ValidationError("invalid_error_format", "error field must be a mapping")
+
+    code = error_info.get("code")
+    if not isinstance(code, str) or not code:
+        raise ValidationError(
+            "invalid_error_format", "error code must be a non-empty string"
+        )
+
+    message = error_info.get("message")
+    if not isinstance(message, str):
+        message = "internal error"
+
+    if code == "operation_conflict":
+        raise ConflictError(
+            code=code,
+            message=message,
+            expected_revision=0,
+            actual_revision=None,
+            request_id=None,
+        )
+
+    if code == "validation_failed":
+        raise ValidationError(code, message)
+
+    # Unknown/other code: fail closed, sanitized.
+    raise PersistenceError("database_error", "persistence error")
+
+
+def parse_privacy_operation_result(
+    result: Mapping[str, Any],
+    expected_operation: str,
+    expected_operation_id: str,
+) -> PrivacyOperationResult:
+    """Parse the RPC result into a PrivacyOperationResult.
+
+    The success envelope is validated strictly: exactly the expected fields
+    must be present (missing/extra fields indicate contract corruption), the
+    operation and operation_id must match the request, and revision and every
+    count must be non-negative integers.
+
+    Raises:
+        ConflictError: If the result indicates an operation conflict.
+        ValidationError: If the result is malformed.
+        PersistenceError: If the result indicates an unexpected database error.
+    """
+    if not isinstance(result, Mapping):
+        raise ValidationError("invalid_rpc_result", "result must be a mapping")
+
+    if "error" in result:
+        _parse_error_envelope(result["error"])
+
+    missing = _SUCCESS_FIELDS - set(result.keys())
+    if missing:
+        raise ValidationError(
+            "invalid_rpc_result", f"missing field: {sorted(missing)[0]}"
+        )
+    extra = set(result.keys()) - _SUCCESS_FIELDS
+    if extra:
+        raise ValidationError(
+            "invalid_rpc_result", f"unexpected field: {sorted(extra)[0]}"
+        )
+
+    operation = result["operation"]
+    operation_id = result["operation_id"]
+    user_id = result["user_id"]
+    revision = result["revision"]
+    counts_raw = result["counts"]
+
+    if not isinstance(operation, str) or operation != expected_operation:
+        raise ValidationError(
+            "invalid_rpc_result", "operation does not match the request"
+        )
+    if not isinstance(operation_id, str) or operation_id != expected_operation_id:
+        raise ValidationError(
+            "invalid_rpc_result", "operation_id does not match the request"
+        )
+    if result["status"] != "applied":
+        raise ValidationError("invalid_rpc_result", "status must be applied")
+    if not isinstance(user_id, str) or not user_id:
+        raise ValidationError("invalid_rpc_result", "user_id must be a non-empty string")
+    if isinstance(revision, bool) or not isinstance(revision, int):
+        raise ValidationError("invalid_rpc_result", "revision must be an integer")
+    if revision < 0:
+        raise ValidationError(
+            "invalid_rpc_result", "revision must be non-negative"
+        )
+    if not isinstance(counts_raw, Mapping):
+        raise ValidationError("invalid_rpc_result", "counts must be a mapping")
+
+    counts: dict[str, int] = {}
+    count_keys = set(counts_raw.keys())
+    if count_keys != _COUNT_FIELDS:
+        missing_count = sorted(_COUNT_FIELDS - count_keys)
+        extra_count = sorted(count_keys - _COUNT_FIELDS)
+        detail = ""
+        if missing_count:
+            detail += f" missing: {', '.join(missing_count)}"
+        if extra_count:
+            detail += f" unexpected: {', '.join(extra_count)}"
+        raise ValidationError(
+            "invalid_rpc_result", f"counts field set mismatch{detail}"
+        )
+    for key, value in counts_raw.items():
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValidationError(
+                "invalid_rpc_result", f"counts.{key} must be a non-negative integer"
+            )
+        counts[key] = value
+
+    return PrivacyOperationResult(
+        operation=operation,
+        operation_id=operation_id,
+        user_id=user_id,
+        revision=revision,
+        counts=counts,
+    )
+
+
+# Type alias for the RPC function callable (same contract as
+# backend.atomic_turn_commit.RpcCallable).
+RpcCallable = Any
+
+
+async def run_privacy_operation(
+    rpc_client: RpcCallable,
+    operation: str,
+    authenticated_user_id: str,
+    operation_id: str,
+    payload: Optional[Mapping[str, Any]] = None,
+) -> PrivacyOperationResult:
+    """Execute one privacy operation via the PostgreSQL RPC function.
+
+    Validation runs BEFORE the RPC is invoked, so invalid input never reaches
+    the database. The RPC is awaited exactly once. Unexpected persistence
+    failures raised by the RPC client are converted to PersistenceError with a
+    sanitized constant message.
+
+    Args:
+        rpc_client: An awaitable callable ``rpc_client(name, params) -> Mapping``.
+        operation: One of the four canonical privacy operation names.
+        authenticated_user_id: Server-side authenticated identity. Never
+            trusted from a payload.
+        operation_id: Server-side UUID binding this operation attempt.
+        payload: Operation payload. For resets this MUST be the validated
+            neutral v1 snapshot produced by the domain; for deletions it is
+            the (optional) request context and defaults to ``{}``.
+
+    Returns:
+        A PrivacyOperationResult with the sanitized public outcome.
+
+    Raises:
+        ValidationError: If input validation fails (RPC is NOT called).
+        ConflictError: If the operation_id was already used with a different
+            operation or payload.
+        PersistenceError: If an unexpected persistence failure occurs.
+    """
+    effective_payload: Mapping[str, Any] = payload if payload is not None else {}
+
+    validate_privacy_operation_input(
+        operation=operation,
+        authenticated_user_id=authenticated_user_id,
+        operation_id=operation_id,
+        payload=effective_payload,
+    )
+
+    rpc_payload = build_privacy_operation_rpc_payload(
+        operation=operation,
+        authenticated_user_id=authenticated_user_id,
+        operation_id=operation_id,
+        payload=effective_payload,
+    )
+
+    try:
+        result = await rpc_client(_RPC_NAME[operation], rpc_payload)
+    except Exception as exc:  # noqa: BLE001 - sanitize any RPC-level failure
+        raise PersistenceError("database_error", "persistence error") from None
+
+    return parse_privacy_operation_result(result, operation, operation_id)

--- a/backend/supabase_cli.py
+++ b/backend/supabase_cli.py
@@ -21,6 +21,9 @@ ALLOWED_OPS = frozenset({
     "rls_auto_enable_reset",
     "rls_auto_enable_upgrade",
     "rls_auto_enable_query",
+    "privacy_legacy_reset",
+    "privacy_legacy_upgrade",
+    "privacy_legacy_query",
 })
 
 

--- a/backend/tests/test_privacy_operations.py
+++ b/backend/tests/test_privacy_operations.py
@@ -1,0 +1,498 @@
+"""
+Tests for ``backend.privacy_operations`` (#314).
+
+Covers:
+ 1. Pure importability from subprocess (no heavy deps, no env/socket/clock/
+    randomness/filesystem at import)
+ 2. Neutral snapshot helpers produce valid v1 domain snapshots
+ 3. Input validation: operation, user id, operation id, payload shape,
+    reset payloads requiring a valid v1 snapshot
+ 4. RPC payload building
+ 5. Result parsing: strict success contract, replay equality, error
+    classification (conflict / validation / persistence)
+ 6. Async run_privacy_operation entry point (validation, single RPC call,
+    success/conflict/malformed/persistence)
+ 7. Defense-in-depth validation before RPC (invalid input never calls RPC)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from backend.atomic_turn_commit import (
+    ConflictError,
+    PersistenceError,
+    ValidationError,
+)
+from backend.privacy_operations import (
+    OPERATION_DELETE_HISTORY,
+    OPERATION_DELETE_MEMORIES,
+    OPERATION_RESET_EMOTIONAL_STATE,
+    OPERATION_RESET_RELATIONSHIP_STATE,
+    PrivacyOperationResult,
+    build_privacy_operation_rpc_payload,
+    neutral_emotional_snapshot,
+    neutral_relationship_snapshot,
+    new_operation_id,
+    parse_privacy_operation_result,
+    run_privacy_operation,
+    validate_privacy_operation_input,
+)
+
+VALID_OP_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def _payload(op_id: str = VALID_OP_ID) -> dict:
+    return {"p_authenticated_user_id": "user-a", "p_operation_id": op_id, "p_operation_payload": {}}
+
+
+def _success_result(
+    op: str = OPERATION_DELETE_HISTORY,
+    op_id: str = VALID_OP_ID,
+    revision: int = 1,
+    counts: dict | None = None,
+) -> dict:
+    return {
+        "status": "applied",
+        "operation": op,
+        "operation_id": op_id,
+        "user_id": "user-a",
+        "revision": revision,
+        "counts": counts
+        if counts is not None
+        else {
+            "chat_logs": 2,
+            "turn_requests": 1,
+            "outbox_events": 1,
+            "archival_extractions": 1,
+            "memories": 0,
+            "profiles": 0,
+        },
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 1. Pure importability (isolated subprocess, no side effects)
+# ═══════════════════════════════════════════════════════════════════════
+
+_PURITY_SCRIPT = textwrap.dedent(
+    """
+    import sys
+    import threading
+
+    import socket as _socket
+
+    def _forbid(*args, **kwargs):
+        raise AssertionError("network socket usage during import")
+
+    _socket.socket.connect = _forbid
+    _socket.socket.connect_ex = _forbid
+    _socket.create_connection = _forbid
+
+    import supabase as _supabase
+
+    def _no_supabase_client(*args, **kwargs):
+        raise AssertionError("real Supabase client constructed during import")
+
+    _supabase.create_client = _no_supabase_client
+
+    threads_before = len(threading.enumerate())
+
+    import backend.privacy_operations
+
+    threads_after = len(threading.enumerate())
+
+    assert threads_after == threads_before, "import started a thread"
+    print("PRIVACY_PURITY_OK")
+    """
+)
+
+
+def test_privacy_operations_import_is_pure():
+    result = subprocess.run(
+        [sys.executable, "-c", _PURITY_SCRIPT],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={"PYTHONPATH": ".", "PATH": "/usr/bin:/bin"},
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+    assert "PRIVACY_PURITY_OK" in result.stdout
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 2. Neutral snapshot helpers
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def test_neutral_emotional_snapshot_is_valid_v1():
+    snapshot = neutral_emotional_snapshot(1700000000.0)
+    assert snapshot["schema_version"] == 1
+    assert snapshot["coping_mode"] == "HEALTHY"
+    assert snapshot["pleasure"] == 0.0
+    assert snapshot["connection"] == 0.5
+    assert snapshot["timestamp"] == 1700000000.0
+    assert set(snapshot) == {
+        "schema_version", "pleasure", "arousal", "dominance", "libido",
+        "aggression", "connection", "energy", "tension", "coping_mode",
+        "timestamp",
+    }
+
+
+def test_neutral_relationship_snapshot_is_valid_v1():
+    snapshot = neutral_relationship_snapshot(1700000000.0)
+    assert snapshot["schema_version"] == 1
+    assert snapshot["trust"] == 0.5
+    assert snapshot["affection"] == 0.3
+    assert snapshot["triggers"] == []
+    assert set(snapshot) == {
+        "schema_version", "trust", "affection", "tension", "triggers", "timestamp",
+    }
+
+
+def test_new_operation_id_is_canonical_uuid():
+    import re
+
+    op_id = new_operation_id()
+    assert re.fullmatch(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", op_id
+    )
+    assert new_operation_id() != op_id
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 3. Input validation
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def test_validate_rejects_unknown_operation():
+    with pytest.raises(ValidationError) as exc:
+        validate_privacy_operation_input("drop_database", "user-a", VALID_OP_ID, {})
+    assert exc.value.code == "invalid_operation"
+
+
+@pytest.mark.parametrize(
+    ("operation", "payload"),
+    [
+        (OPERATION_DELETE_HISTORY, None),
+        (OPERATION_DELETE_MEMORIES, "not-a-mapping"),
+        (OPERATION_RESET_EMOTIONAL_STATE, None),
+        (OPERATION_RESET_RELATIONSHIP_STATE, []),
+    ],
+)
+def test_validate_rejects_bad_payload(operation, payload):
+    with pytest.raises(ValidationError) as exc:
+        validate_privacy_operation_input(operation, "user-a", VALID_OP_ID, payload)
+    assert exc.value.code == "invalid_operation_payload"
+
+
+@pytest.mark.parametrize(
+    "bad_user_id",
+    [None, "", 123],
+)
+def test_validate_rejects_bad_user_id(bad_user_id):
+    with pytest.raises(ValidationError) as exc:
+        validate_privacy_operation_input(
+            OPERATION_DELETE_HISTORY, bad_user_id, VALID_OP_ID, {}
+        )
+    assert exc.value.code == "invalid_user_id"
+
+
+@pytest.mark.parametrize(
+    "bad_op_id",
+    [None, "", "not-a-uuid", "11111111-1111-1111-1111-11111111111G", "ABCDEFAB-..."],
+)
+def test_validate_rejects_bad_operation_id(bad_op_id):
+    with pytest.raises(ValidationError) as exc:
+        validate_privacy_operation_input(
+            OPERATION_DELETE_HISTORY, "user-a", bad_op_id, {}
+        )
+    assert exc.value.code == "invalid_operation_id"
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda snapshot: snapshot.update({"coping_mode": "INVALID"}),
+        lambda snapshot: snapshot.pop("energy"),
+        lambda snapshot: snapshot.update({"pleasure": 2.0}),
+        lambda snapshot: snapshot.update({"user_id": "attacker"}),
+        lambda snapshot: snapshot.update({"schema_version": 2}),
+    ],
+)
+def test_validate_rejects_forged_emotional_reset_snapshot(mutate):
+    snapshot = neutral_emotional_snapshot(1700000000.0)
+    mutate(snapshot)
+    with pytest.raises(ValidationError):
+        validate_privacy_operation_input(
+            OPERATION_RESET_EMOTIONAL_STATE, "user-a", VALID_OP_ID, snapshot
+        )
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda snapshot: snapshot.update({"triggers": ["x" * 129]}),
+        lambda snapshot: snapshot.update({"trust": -0.1}),
+        lambda snapshot: snapshot.pop("affection"),
+        lambda snapshot: snapshot.update({"bond_label": "hidden"}),
+    ],
+)
+def test_validate_rejects_forged_relationship_reset_snapshot(mutate):
+    snapshot = neutral_relationship_snapshot(1700000000.0)
+    mutate(snapshot)
+    with pytest.raises(ValidationError):
+        validate_privacy_operation_input(
+            OPERATION_RESET_RELATIONSHIP_STATE, "user-a", VALID_OP_ID, snapshot
+        )
+
+
+def test_validate_accepts_valid_inputs():
+    validate_privacy_operation_input(
+        OPERATION_DELETE_HISTORY, "user-a", VALID_OP_ID, {}
+    )
+    validate_privacy_operation_input(
+        OPERATION_RESET_EMOTIONAL_STATE,
+        "user-a",
+        VALID_OP_ID,
+        neutral_emotional_snapshot(1700000000.0),
+    )
+    validate_privacy_operation_input(
+        OPERATION_RESET_RELATIONSHIP_STATE,
+        "user-a",
+        VALID_OP_ID,
+        neutral_relationship_snapshot(1700000000.0),
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 4. RPC payload building
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def test_build_rpc_payload():
+    payload = build_privacy_operation_rpc_payload(
+        OPERATION_DELETE_HISTORY, "user-a", VALID_OP_ID, {"reason": "x"}
+    )
+    assert payload == {
+        "p_authenticated_user_id": "user-a",
+        "p_operation_id": VALID_OP_ID,
+        "p_operation_payload": {"reason": "x"},
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 5. Result parsing
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def test_parse_success_result():
+    parsed = parse_privacy_operation_result(
+        _success_result(), OPERATION_DELETE_HISTORY, VALID_OP_ID
+    )
+    assert isinstance(parsed, PrivacyOperationResult)
+    assert parsed.operation == OPERATION_DELETE_HISTORY
+    assert parsed.operation_id == VALID_OP_ID
+    assert parsed.user_id == "user-a"
+    assert parsed.revision == 1
+    assert parsed.counts["chat_logs"] == 2
+    assert parsed.to_db_row()["status"] == "applied"
+
+
+def test_parse_replay_result_is_identical():
+    first = parse_privacy_operation_result(
+        _success_result(), OPERATION_DELETE_HISTORY, VALID_OP_ID
+    )
+    second = parse_privacy_operation_result(
+        _success_result(), OPERATION_DELETE_HISTORY, VALID_OP_ID
+    )
+    assert second.to_db_row() == first.to_db_row()
+
+
+def test_parse_conflict_result():
+    with pytest.raises(ConflictError) as exc:
+        parse_privacy_operation_result(
+            {
+                "error": {
+                    "code": "operation_conflict",
+                    "message": "operation_id already used with a different operation or payload",
+                }
+            },
+            OPERATION_DELETE_HISTORY,
+            VALID_OP_ID,
+        )
+    assert exc.value.code == "operation_conflict"
+
+
+def test_parse_validation_error_result():
+    with pytest.raises(ValidationError) as exc:
+        parse_privacy_operation_result(
+            {
+                "error": {
+                    "code": "validation_failed",
+                    "message": "authenticated_user_id is required",
+                }
+            },
+            OPERATION_DELETE_HISTORY,
+            VALID_OP_ID,
+        )
+    assert exc.value.code == "validation_failed"
+
+
+def test_parse_unknown_error_is_sanitized_persistence():
+    with pytest.raises(PersistenceError) as exc:
+        parse_privacy_operation_result(
+            {"error": {"code": "database_error", "message": "SECRET_LEAK"}},
+            OPERATION_DELETE_HISTORY,
+            VALID_OP_ID,
+        )
+    assert "SECRET_LEAK" not in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda result: result.pop("status"),
+        lambda result: result.update({"extra": 1}),
+        lambda result: result.update({"operation": OPERATION_DELETE_MEMORIES}),
+        lambda result: result.update({"operation_id": "22222222-2222-2222-2222-222222222222"}),
+        lambda result: result.update({"revision": -1}),
+        lambda result: result.update({"revision": True}),
+        lambda result: result.update({"counts": {"memories": 1}}),
+        lambda result: result.update({"counts": {"chat_logs": -1, "turn_requests": 0,
+                                                  "outbox_events": 0, "archival_extractions": 0,
+                                                  "memories": 0, "profiles": 0}}),
+    ],
+)
+def test_parse_rejects_malformed_success(mutate):
+    result = _success_result()
+    mutate(result)
+    with pytest.raises(ValidationError):
+        parse_privacy_operation_result(result, OPERATION_DELETE_HISTORY, VALID_OP_ID)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 6/7. Async entry point: validation before RPC, single call, classification
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def test_run_validates_before_rpc():
+    calls = []
+
+    async def rpc_client(name: str, params: dict) -> dict:
+        calls.append((name, params))
+        return _success_result()
+
+    with pytest.raises(ValidationError):
+        asyncio.run(
+            run_privacy_operation(
+                rpc_client=rpc_client,
+                operation="bogus",
+                authenticated_user_id="user-a",
+                operation_id=VALID_OP_ID,
+                payload={},
+            )
+        )
+    assert calls == [], "RPC must never be called for invalid input"
+
+
+def test_run_success_single_call():
+    calls = []
+
+    async def rpc_client(name: str, params: dict) -> dict:
+        calls.append((name, params))
+        return _success_result()
+
+    result = asyncio.run(
+        run_privacy_operation(
+            rpc_client=rpc_client,
+            operation=OPERATION_DELETE_HISTORY,
+            authenticated_user_id="user-a",
+            operation_id=VALID_OP_ID,
+            payload={},
+        )
+    )
+    assert len(calls) == 1
+    assert calls[0][0] == "delete_history"
+    assert calls[0][1]["p_authenticated_user_id"] == "user-a"
+    assert calls[0][1]["p_operation_id"] == VALID_OP_ID
+    assert result.to_db_row() == _success_result()
+
+
+def test_run_uses_correct_rpc_name_per_operation():
+    expected = {
+        OPERATION_DELETE_HISTORY: "delete_history",
+        OPERATION_DELETE_MEMORIES: "delete_memories",
+        OPERATION_RESET_EMOTIONAL_STATE: "reset_emotional_state",
+        OPERATION_RESET_RELATIONSHIP_STATE: "reset_relationship_state",
+    }
+    for operation, rpc_name in expected.items():
+        seen = {}
+        payload = (
+            neutral_emotional_snapshot(1700000000.0)
+            if operation == OPERATION_RESET_EMOTIONAL_STATE
+            else neutral_relationship_snapshot(1700000000.0)
+            if operation == OPERATION_RESET_RELATIONSHIP_STATE
+            else {}
+        )
+
+        async def rpc_client(name: str, params: dict) -> dict:
+            seen["name"] = name
+            return _success_result(op=operation, op_id=VALID_OP_ID)
+
+        result = asyncio.run(
+            run_privacy_operation(
+                rpc_client=rpc_client,
+                operation=operation,
+                authenticated_user_id="user-a",
+                operation_id=VALID_OP_ID,
+                payload=payload,
+            )
+        )
+        assert seen["name"] == rpc_name
+        assert result.operation == operation
+
+
+def test_run_conflict_propagates():
+    async def rpc_client(name: str, params: dict) -> dict:
+        return {
+            "error": {
+                "code": "operation_conflict",
+                "message": "operation_id already used with a different operation or payload",
+            }
+        }
+
+    with pytest.raises(ConflictError) as exc:
+        asyncio.run(
+            run_privacy_operation(
+                rpc_client=rpc_client,
+                operation=OPERATION_DELETE_HISTORY,
+                authenticated_user_id="user-a",
+                operation_id=VALID_OP_ID,
+                payload={},
+            )
+        )
+    assert exc.value.code == "operation_conflict"
+
+
+def test_run_rpc_exception_is_sanitized_persistence():
+    async def rpc_client(name: str, params: dict) -> dict:
+        raise RuntimeError("SECRET_CONNECTION_LEAK")
+
+    with pytest.raises(PersistenceError) as exc:
+        asyncio.run(
+            run_privacy_operation(
+                rpc_client=rpc_client,
+                operation=OPERATION_DELETE_HISTORY,
+                authenticated_user_id="user-a",
+                operation_id=VALID_OP_ID,
+                payload={},
+            )
+        )
+    assert "SECRET_CONNECTION_LEAK" not in str(exc.value)
+    assert "persistence error" in str(exc.value)

--- a/backend/tests/test_privacy_operations.py
+++ b/backend/tests/test_privacy_operations.py
@@ -193,12 +193,27 @@ def test_validate_rejects_bad_payload(operation, payload):
 
 @pytest.mark.parametrize(
     "bad_user_id",
-    [None, "", 123],
+    [None, "", 123, "   ", "\t\n", "x" * 129],
 )
 def test_validate_rejects_bad_user_id(bad_user_id):
     with pytest.raises(ValidationError) as exc:
         validate_privacy_operation_input(
             OPERATION_DELETE_HISTORY, bad_user_id, VALID_OP_ID, {}
+        )
+    assert exc.value.code == "invalid_user_id"
+
+
+@pytest.mark.parametrize("good_user_id", ["a", "x" * 128])
+def test_validate_accepts_user_id_boundaries(good_user_id):
+    validate_privacy_operation_input(
+        OPERATION_DELETE_HISTORY, good_user_id, VALID_OP_ID, {}
+    )
+
+
+def test_validate_rejects_oversized_user_id():
+    with pytest.raises(ValidationError) as exc:
+        validate_privacy_operation_input(
+            OPERATION_DELETE_HISTORY, "x" * 129, VALID_OP_ID, {}
         )
     assert exc.value.code == "invalid_user_id"
 
@@ -270,6 +285,62 @@ def test_validate_accepts_valid_inputs():
     )
 
 
+def test_validate_rejects_valid_but_non_neutral_emotional_snapshot():
+    """A structurally valid v1 snapshot with non-neutral values must be
+    rejected by a reset (issue #314 review)."""
+    snapshot = neutral_emotional_snapshot(1700000000.0)
+    snapshot["pleasure"] = 0.9
+    snapshot["arousal"] = 0.8
+    snapshot["dominance"] = 0.7
+    snapshot["coping_mode"] = "MANIC"
+    with pytest.raises(ValidationError) as exc:
+        validate_privacy_operation_input(
+            OPERATION_RESET_EMOTIONAL_STATE, "user-a", VALID_OP_ID, snapshot
+        )
+    assert exc.value.code == "invalid_operation_payload"
+    assert "neutral" in str(exc.value)
+
+
+def test_validate_rejects_valid_but_non_neutral_relationship_snapshot():
+    snapshot = neutral_relationship_snapshot(1700000000.0)
+    snapshot["trust"] = 0.9
+    snapshot["affection"] = 0.8
+    snapshot["tension"] = 0.1
+    with pytest.raises(ValidationError) as exc:
+        validate_privacy_operation_input(
+            OPERATION_RESET_RELATIONSHIP_STATE, "user-a", VALID_OP_ID, snapshot
+        )
+    assert exc.value.code == "invalid_operation_payload"
+    assert "neutral" in str(exc.value)
+
+
+def test_neutral_snapshots_are_accepted_for_resets():
+    validate_privacy_operation_input(
+        OPERATION_RESET_EMOTIONAL_STATE,
+        "user-a",
+        VALID_OP_ID,
+        neutral_emotional_snapshot(1700000000.0),
+    )
+    validate_privacy_operation_input(
+        OPERATION_RESET_RELATIONSHIP_STATE,
+        "user-a",
+        VALID_OP_ID,
+        neutral_relationship_snapshot(1700000000.0),
+    )
+
+
+def test_reset_neutrality_uses_domain_constructors_only():
+    """The neutrality contract is derived from the domain constructors; no
+    independent second model is created by the adapter."""
+    from backend.emotional_domain import EmotionalStateV1
+    from backend.relationship import RelationshipStateV1
+
+    emotional = neutral_emotional_snapshot(1700000000.0)
+    assert emotional == EmotionalStateV1.neutral(timestamp=1700000000.0).to_dict()
+    relationship = neutral_relationship_snapshot(1700000000.0)
+    assert relationship == RelationshipStateV1.neutral(timestamp=1700000000.0).to_dict()
+
+
 # ═══════════════════════════════════════════════════════════════════════
 # 4. RPC payload building
 # ═══════════════════════════════════════════════════════════════════════
@@ -293,7 +364,7 @@ def test_build_rpc_payload():
 
 def test_parse_success_result():
     parsed = parse_privacy_operation_result(
-        _success_result(), OPERATION_DELETE_HISTORY, VALID_OP_ID
+        _success_result(), OPERATION_DELETE_HISTORY, VALID_OP_ID, "user-a"
     )
     assert isinstance(parsed, PrivacyOperationResult)
     assert parsed.operation == OPERATION_DELETE_HISTORY
@@ -306,10 +377,10 @@ def test_parse_success_result():
 
 def test_parse_replay_result_is_identical():
     first = parse_privacy_operation_result(
-        _success_result(), OPERATION_DELETE_HISTORY, VALID_OP_ID
+        _success_result(), OPERATION_DELETE_HISTORY, VALID_OP_ID, "user-a"
     )
     second = parse_privacy_operation_result(
-        _success_result(), OPERATION_DELETE_HISTORY, VALID_OP_ID
+        _success_result(), OPERATION_DELETE_HISTORY, VALID_OP_ID, "user-a"
     )
     assert second.to_db_row() == first.to_db_row()
 
@@ -325,6 +396,7 @@ def test_parse_conflict_result():
             },
             OPERATION_DELETE_HISTORY,
             VALID_OP_ID,
+            "user-a",
         )
     assert exc.value.code == "operation_conflict"
 
@@ -340,6 +412,7 @@ def test_parse_validation_error_result():
             },
             OPERATION_DELETE_HISTORY,
             VALID_OP_ID,
+            "user-a",
         )
     assert exc.value.code == "validation_failed"
 
@@ -350,6 +423,7 @@ def test_parse_unknown_error_is_sanitized_persistence():
             {"error": {"code": "database_error", "message": "SECRET_LEAK"}},
             OPERATION_DELETE_HISTORY,
             VALID_OP_ID,
+            "user-a",
         )
     assert "SECRET_LEAK" not in str(exc.value)
 
@@ -373,7 +447,31 @@ def test_parse_rejects_malformed_success(mutate):
     result = _success_result()
     mutate(result)
     with pytest.raises(ValidationError):
-        parse_privacy_operation_result(result, OPERATION_DELETE_HISTORY, VALID_OP_ID)
+        parse_privacy_operation_result(
+            result, OPERATION_DELETE_HISTORY, VALID_OP_ID, "user-a"
+        )
+
+
+def test_parse_accepts_correct_user():
+    parsed = parse_privacy_operation_result(
+        _success_result(), OPERATION_DELETE_HISTORY, VALID_OP_ID, "user-a"
+    )
+    assert parsed.user_id == "user-a"
+
+
+def test_parse_rejects_divergent_user_sanitized():
+    """A result belonging to another user fails closed; the divergent identity
+    (which may be a sensitive attacker-controlled value) is never echoed."""
+    divergent = "SUPER-SECRET-DIVERGENT-USER-MARKER"
+    result = _success_result()
+    result["user_id"] = divergent
+    with pytest.raises(ValidationError) as exc:
+        parse_privacy_operation_result(
+            result, OPERATION_DELETE_HISTORY, VALID_OP_ID, "user-a"
+        )
+    assert exc.value.code == "invalid_rpc_result"
+    assert divergent not in str(exc.value)
+    assert "does not match" in str(exc.value)
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -401,6 +499,29 @@ def test_run_validates_before_rpc():
     assert calls == [], "RPC must never be called for invalid input"
 
 
+def test_run_validates_user_id_before_rpc():
+    """Invalid identities (whitespace-only, oversized) never reach the RPC."""
+    calls = []
+
+    async def rpc_client(name: str, params: dict) -> dict:
+        calls.append((name, params))
+        return _success_result()
+
+    for bad_user in ("   ", "x" * 129):
+        with pytest.raises(ValidationError) as exc:
+            asyncio.run(
+                run_privacy_operation(
+                    rpc_client=rpc_client,
+                    operation=OPERATION_DELETE_HISTORY,
+                    authenticated_user_id=bad_user,
+                    operation_id=VALID_OP_ID,
+                    payload={},
+                )
+            )
+        assert exc.value.code == "invalid_user_id"
+    assert calls == [], "RPC must never be called for an invalid identity"
+
+
 def test_run_success_single_call():
     calls = []
 
@@ -422,6 +543,29 @@ def test_run_success_single_call():
     assert calls[0][1]["p_authenticated_user_id"] == "user-a"
     assert calls[0][1]["p_operation_id"] == VALID_OP_ID
     assert result.to_db_row() == _success_result()
+
+
+def test_run_rejects_result_of_another_user():
+    """run_privacy_operation forwards the expected identity to the parser: a
+    result whose user_id diverges fails closed and never echoes the value."""
+    divergent = "SECRET-OTHER-USER-MARKER"
+
+    async def rpc_client(name: str, params: dict) -> dict:
+        result = _success_result()
+        result["user_id"] = divergent
+        return result
+
+    with pytest.raises(ValidationError) as exc:
+        asyncio.run(
+            run_privacy_operation(
+                rpc_client=rpc_client,
+                operation=OPERATION_DELETE_HISTORY,
+                authenticated_user_id="user-a",
+                operation_id=VALID_OP_ID,
+                payload={},
+            )
+        )
+    assert divergent not in str(exc.value)
 
 
 def test_run_uses_correct_rpc_name_per_operation():

--- a/backend/tests/test_privacy_operations_integration.py
+++ b/backend/tests/test_privacy_operations_integration.py
@@ -1,0 +1,1077 @@
+"""Real Supabase integration tests for the privacy data operations (#314).
+
+This file is executed ONLY by the database CI job against a freshly reset
+local Supabase instance (no mocks: real PostgreSQL transactions, locks, FKs
+and rollbacks). It must never be collected by the ordinary backend unit job.
+
+Covers the 16 mandatory scenarios from issue #314:
+
+ 1.  delete_history removes chat_logs, turn_requests, derived outbox_events
+     and archival_extractions, preserving memories and snapshots
+ 2.  delete_memories removes memories/candidates, preserving chat and
+     snapshots
+ 3.  reset_emotional_state produces a valid v1 neutral snapshot and preserves
+     relationship/history/memories
+ 4.  reset_relationship_state produces a valid v1 neutral snapshot and
+     preserves emotional/history/memories
+ 5.  each operation increments profiles.revision exactly once
+ 6.  retry of the same operation_id returns the stored replay without a new
+     mutation or revision increment
+ 7.  divergent operation/payload on the same operation_id is a sanitized
+     conflict
+ 8.  an injected mid-operation failure causes total rollback
+ 9.  two concurrent operations of the same user never interleave partial
+     state (same per-user advisory lock as commit_turn)
+10.  users A and B remain fully isolated (no global lock)
+11.  admission_reservations survive delete_history (no quota bypass)
+12.  PUBLIC/anon/authenticated cannot execute the RPCs
+13.  service_role holds only the minimal necessary grants
+14.  errors and results are sanitized (no user_id/content/prompt/memory/HMAC/
+     raw SQL leakage)
+15.  migration applies on a clean reset (this suite) and on a legacy upgrade
+     (backend/tests/test_privacy_operations_legacy.py)
+16.  pgTAP + database integration + existing backend/frontend stay green (CI)
+
+Concurrency tests use deterministic barrier coordination, never sleeps.
+Failure injection uses disposable triggers created only in the local test
+database (never public RPC failpoints).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+import threading
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+
+import pytest
+from postgrest.exceptions import APIError
+from supabase import Client, create_client
+
+from backend.atomic_turn_commit import ConflictError, PersistenceError
+from backend.privacy_operations import (
+    OPERATION_DELETE_HISTORY,
+    OPERATION_DELETE_MEMORIES,
+    neutral_emotional_snapshot,
+    neutral_relationship_snapshot,
+    new_operation_id,
+    run_privacy_operation,
+)
+
+_SUPABASE_CLI = ["supabase"] if shutil.which("supabase") else ["npx", "supabase"]
+
+# ---------------------------------------------------------------------------
+# Environment / clients
+# ---------------------------------------------------------------------------
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name)
+    assert value, f"{name} is required for privacy operations integration tests"
+    return value
+
+
+@pytest.fixture(scope="module")
+def supabase_url() -> str:
+    return _required_env("SUPABASE_URL")
+
+
+@pytest.fixture(scope="module")
+def anon_key() -> str:
+    return _required_env("SUPABASE_ANON_KEY")
+
+
+@pytest.fixture(scope="module")
+def service_role_key() -> str:
+    return _required_env("SUPABASE_SERVICE_ROLE_KEY")
+
+
+def _close_http_transports(client: Client) -> None:
+    if client is None:
+        return
+    for attr, session_attr in (
+        ("_postgrest", "session"),
+        ("_storage", "session"),
+        ("_functions", "_client"),
+    ):
+        transport = getattr(client, attr, None)
+        if transport is None:
+            continue
+        session = getattr(transport, session_attr, None)
+        if session is not None and hasattr(session, "close"):
+            session.close()
+
+
+def _close_client(client: Client) -> None:
+    if client is None:
+        return
+    _close_http_transports(client)
+    auth = getattr(client, "auth", None)
+    if auth is not None and hasattr(auth, "close"):
+        auth.close()
+
+
+@pytest.fixture(scope="module")
+def service_client(supabase_url: str, service_role_key: str) -> Client:
+    client = create_client(supabase_url, service_role_key)
+    yield client
+    _close_client(client)
+
+
+@pytest.fixture(scope="module")
+def anon_client(supabase_url: str, anon_key: str) -> Client:
+    client = create_client(supabase_url, anon_key)
+    yield client
+    _close_client(client)
+
+
+@pytest.fixture(scope="module")
+def auth_client(supabase_url: str, anon_key: str, service_client: Client) -> tuple[Client, str]:
+    """A real authenticated user (client, user_id)."""
+    email = "privacy-ops-auth@test.local"
+    password = "password123"
+    client = create_client(supabase_url, anon_key)
+
+    for user in service_client.auth.admin.list_users():
+        if user.email == email:
+            service_client.auth.admin.delete_user(user.id)
+
+    client.auth.sign_up({"email": email, "password": password})
+    response = client.auth.sign_in_with_password({"email": email, "password": password})
+    assert response is not None and response.user is not None
+    assert response.session is not None and response.session.access_token is not None
+    yield client, response.user.id
+
+    _close_http_transports(client)
+    client.auth.sign_out()
+    for user in service_client.auth.admin.list_users():
+        if user.email == email:
+            service_client.auth.admin.delete_user(user.id)
+    _close_client(client)
+
+
+# ---------------------------------------------------------------------------
+# SQL helpers (pinned local Supabase CLI, sanitized)
+# ---------------------------------------------------------------------------
+
+
+def _run_sql(sql: str) -> list[dict]:
+    """Execute trusted test SQL through the pinned local Supabase CLI."""
+    child_env = dict(os.environ)
+    child_env["SUPABASE_TELEMETRY_DISABLED"] = "1"
+    child_env["SUPABASE_ANALYTICS_ENABLED"] = "false"
+    result = subprocess.run(
+        [
+            *_SUPABASE_CLI,
+            "db",
+            "query",
+            "--agent=no",
+            "--output",
+            "json",
+            sql,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=child_env,
+    )
+    assert result.returncode == 0, "sanitized privacy test SQL operation failed"
+    output = result.stdout.strip()
+    if not output or output[0] not in "[{":
+        return []
+    parsed = json.loads(output)
+    assert isinstance(parsed, list)
+    return parsed
+
+
+def _count(table: str, user_id: str) -> int:
+    rows = _run_sql(
+        f"SELECT count(*)::integer AS count FROM public.{table} "
+        f"WHERE user_id = '{user_id}'"
+    )
+    return rows[0]["count"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _uid(label: str) -> str:
+    return f"prv_{label}_{uuid.uuid4().hex[:12]}"
+
+
+def _emotional_state() -> dict:
+    return {
+        "schema_version": 1, "pleasure": 0.9, "arousal": 0.8, "dominance": 0.7,
+        "libido": 0.1, "aggression": 0.1, "connection": 0.5, "energy": 0.8,
+        "tension": 0.1, "coping_mode": "MANIC", "timestamp": 1700000000.0,
+    }
+
+
+def _relationship_state() -> dict:
+    return {
+        "schema_version": 1, "trust": 0.9, "affection": 0.8, "tension": 0.1,
+        "triggers": [], "timestamp": 1700000000.0,
+    }
+
+
+def _seed_user(
+    user_id: str,
+    *,
+    revision: int = 2,
+    with_turn: bool = True,
+    with_memory: bool = True,
+    with_admission: bool = True,
+) -> None:
+    """Seed a realistic user with history, memory, snapshots and ledger rows."""
+    _run_sql(
+        "INSERT INTO public.profiles (user_id, persona_config, user_profile, "
+        "relationship_state, emotional_state, revision) VALUES "
+        f"('{user_id}', 'persona-config', '{{}}'::jsonb, "
+        f"'{json.dumps(_relationship_state())}'::jsonb, "
+        f"'{json.dumps(_emotional_state())}'::jsonb, {revision})"
+    )
+    _run_sql(
+        "INSERT INTO public.chat_logs (user_id, role, content) VALUES "
+        f"('{user_id}', 'user', 'hello'), ('{user_id}', 'assistant', 'hi there')"
+    )
+    if with_turn:
+        turn_id = str(uuid.uuid4())
+        _run_sql(
+            "INSERT INTO public.turn_requests ("
+            "id, user_id, request_id, payload_hash_sha256, status, expected_revision, "
+            "committed_revision, replay_payload, created_at, updated_at, completed_at) "
+            "VALUES "
+            f"('{turn_id}', '{user_id}', '{uuid.uuid4()}', "
+            f"'{'a' * 64}', 'completed', 0, {revision}, "
+            f"'{{\"response\":\"hi there\",\"message_id\":\"{uuid.uuid4()}\"}}'::jsonb, "
+            "now(), now(), now())"
+        )
+        _run_sql(
+            "INSERT INTO public.outbox_events ("
+            "event_type, contract_version, user_id, turn_request_id, payload, status, "
+            "attempts, next_attempt_at, idempotency_key, created_at, updated_at) VALUES "
+            f"('turn_completed', 1, '{user_id}', '{turn_id}', "
+            f"'{{\"ref\":\"t1\"}}'::jsonb, 'pending', 0, now() + interval '1 second', "
+            f"'{user_id}-k1', now(), now())"
+        )
+    if with_memory:
+        _run_sql(
+            "INSERT INTO public.memories (user_id, content, metadata) VALUES "
+            f"('{user_id}', 'a durable memory', '{{\"tags\":[\"x\"]}}'::jsonb)"
+        )
+    _run_sql(
+        "INSERT INTO public.archival_extractions ("
+        "user_id, source_chat_log_id, extractor_version, schema_version, "
+        "idempotency_key, facts) "
+        "SELECT '{user_id}', id, 1, 1, '{user_id}-arch-1', '{{\"facts\":[]}}'::jsonb "
+        "FROM public.chat_logs WHERE user_id = '{user_id}' AND role = 'user'".format(
+            user_id=user_id
+        )
+    )
+    if with_admission:
+        _run_sql(
+            "INSERT INTO public.admission_reservations ("
+            "user_id, request_id, message_hmac_sha256, network_hmac_sha256, "
+            "estimated_units) VALUES "
+            f"('{user_id}', '{uuid.uuid4()}', repeat('a', 64), repeat('b', 64), 10)"
+        )
+
+
+def _cleanup_user(user_id: str) -> None:
+    for table in (
+        "privacy_operations",
+        "admission_reservations",
+        "archival_extractions",
+        "memories",
+        "chat_logs",
+        "turn_requests",
+        "outbox_events",
+        "profiles",
+    ):
+        _run_sql(f"DELETE FROM public.{table} WHERE user_id = '{user_id}'")
+
+
+def _call_rpc(client: Client, name: str, params: dict) -> dict:
+    """Invoke a privacy RPC and return the parsed result object."""
+    response = client.rpc(name, params).execute()
+    data = response.data
+    if isinstance(data, list):
+        assert len(data) == 1
+        data = data[0]
+    assert isinstance(data, dict), f"unexpected RPC response shape: {type(data).__name__}"
+    return data
+
+
+def _rpc_params(user_id: str, operation_id: str, payload: dict | None = None) -> dict:
+    return {
+        "p_authenticated_user_id": user_id,
+        "p_operation_id": operation_id,
+        "p_operation_payload": payload if payload is not None else {},
+    }
+
+
+@dataclass(frozen=True)
+class _ConcurrentOp:
+    user_id: str
+    rpc_name: str
+    operation_id: str
+    payload: dict
+
+
+def _run_concurrent(
+    *,
+    url: str,
+    key: str,
+    barrier: threading.Barrier,
+    calls: list[_ConcurrentOp],
+    timeout: int = 30,
+) -> list[dict]:
+    """Run privacy RPCs concurrently and return each call's parsed result."""
+
+    def _one(call: _ConcurrentOp) -> dict:
+        client = create_client(url, key)
+        try:
+            barrier.wait(timeout=timeout)
+            return _call_rpc(
+                client,
+                call.rpc_name,
+                _rpc_params(call.user_id, call.operation_id, call.payload),
+            )
+        finally:
+            _close_client(client)
+
+    with ThreadPoolExecutor(max_workers=len(calls)) as pool:
+        futures = [pool.submit(_one, call) for call in calls]
+        return [f.result(timeout=timeout) for f in futures]
+
+
+# ---------------------------------------------------------------------------
+# Failpoint triggers (created only in the local test DB)
+# ---------------------------------------------------------------------------
+
+
+def _install_delete_trigger(name: str, target: str, message: str) -> None:
+    trigger_fn = f"prv_{name}_fn"
+    _run_sql(
+        f"CREATE OR REPLACE FUNCTION public.{trigger_fn}() RETURNS trigger "
+        "LANGUAGE plpgsql AS $$ BEGIN "
+        f"RAISE EXCEPTION '{message}'; END $$;"
+    )
+    _run_sql(
+        f"CREATE TRIGGER prv_{name}_trg AFTER DELETE ON public.{target} "
+        "FOR EACH ROW EXECUTE FUNCTION public.{fn}()".format(fn=trigger_fn)
+    )
+
+
+def _install_update_trigger(name: str, target: str, message: str) -> None:
+    trigger_fn = f"prv_{name}_fn"
+    _run_sql(
+        f"CREATE OR REPLACE FUNCTION public.{trigger_fn}() RETURNS trigger "
+        "LANGUAGE plpgsql AS $$ BEGIN "
+        f"RAISE EXCEPTION '{message}'; END $$;"
+    )
+    _run_sql(
+        f"CREATE TRIGGER prv_{name}_trg AFTER UPDATE ON public.{target} "
+        "FOR EACH ROW EXECUTE FUNCTION public.{fn}()".format(fn=trigger_fn)
+    )
+
+
+def _drop_trigger(name: str, target: str) -> None:
+    _run_sql(f"DROP TRIGGER IF EXISTS prv_{name}_trg ON public.{target}")
+    _run_sql(f"DROP FUNCTION IF EXISTS public.prv_{name}_fn()")
+
+
+# ---------------------------------------------------------------------------
+# 1. delete_history semantics
+# ---------------------------------------------------------------------------
+
+
+def test_delete_history_removes_history_derivatives_preserves_rest(service_client: Client):
+    user_id = _uid("dh")
+    _seed_user(user_id, revision=2)
+    try:
+        result = _call_rpc(
+            service_client, "delete_history", _rpc_params(user_id, new_operation_id())
+        )
+        assert "error" not in result
+        assert result["status"] == "applied"
+        assert result["operation"] == "delete_history"
+        assert result["revision"] == 3
+        assert result["counts"]["chat_logs"] == 2
+        assert result["counts"]["turn_requests"] == 1
+        assert result["counts"]["outbox_events"] == 1
+        assert result["counts"]["archival_extractions"] == 1
+        assert result["counts"]["memories"] == 0
+
+        assert _count("chat_logs", user_id) == 0
+        assert _count("turn_requests", user_id) == 0
+        assert _count("outbox_events", user_id) == 0
+        assert _count("archival_extractions", user_id) == 0
+        # preserved
+        assert _count("memories", user_id) == 1
+        assert _count("profiles", user_id) == 1
+        rows = _run_sql(
+            f"SELECT revision, persona_config, emotional_state, relationship_state "
+            f"FROM public.profiles WHERE user_id = '{user_id}'"
+        )
+        assert rows[0]["revision"] == 3
+        assert rows[0]["persona_config"] == "persona-config"
+        assert rows[0]["emotional_state"]["coping_mode"] == "MANIC"
+        assert rows[0]["relationship_state"]["trust"] == 0.9
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_delete_history_preserves_admission_reservations(service_client: Client):
+    user_id = _uid("dh_adm")
+    _seed_user(user_id, revision=2, with_admission=True)
+    try:
+        assert _count("admission_reservations", user_id) == 1
+        result = _call_rpc(
+            service_client, "delete_history", _rpc_params(user_id, new_operation_id())
+        )
+        assert "error" not in result
+        assert _count("admission_reservations", user_id) == 1
+        assert _count("chat_logs", user_id) == 0
+    finally:
+        _cleanup_user(user_id)
+
+
+# ---------------------------------------------------------------------------
+# 2. delete_memories semantics
+# ---------------------------------------------------------------------------
+
+
+def test_delete_memories_removes_memories_preserves_chat_and_snapshots(service_client: Client):
+    user_id = _uid("dm")
+    _seed_user(user_id, revision=4)
+    try:
+        result = _call_rpc(
+            service_client, "delete_memories", _rpc_params(user_id, new_operation_id())
+        )
+        assert "error" not in result
+        assert result["operation"] == "delete_memories"
+        assert result["counts"]["memories"] == 1
+        assert result["counts"]["archival_extractions"] == 1
+        assert result["revision"] == 5
+
+        assert _count("memories", user_id) == 0
+        assert _count("archival_extractions", user_id) == 0
+        # preserved
+        assert _count("chat_logs", user_id) == 2
+        rows = _run_sql(
+            f"SELECT revision, emotional_state, relationship_state "
+            f"FROM public.profiles WHERE user_id = '{user_id}'"
+        )
+        assert rows[0]["revision"] == 5
+        assert rows[0]["emotional_state"]["coping_mode"] == "MANIC"
+        assert rows[0]["relationship_state"]["trust"] == 0.9
+    finally:
+        _cleanup_user(user_id)
+
+
+# ---------------------------------------------------------------------------
+# 3/4. Reset semantics
+# ---------------------------------------------------------------------------
+
+
+def test_reset_emotional_state_produces_valid_neutral_v1(service_client: Client):
+    user_id = _uid("re")
+    _seed_user(user_id, revision=6)
+    neutral = neutral_emotional_snapshot(1700000000.0)
+    try:
+        result = _call_rpc(
+            service_client,
+            "reset_emotional_state",
+            _rpc_params(user_id, new_operation_id(), neutral),
+        )
+        assert "error" not in result
+        assert result["operation"] == "reset_emotional_state"
+        assert result["revision"] == 7
+        assert result["counts"]["profiles"] == 1
+
+        rows = _run_sql(
+            f"SELECT revision, emotional_state, relationship_state FROM public.profiles "
+            f"WHERE user_id = '{user_id}'"
+        )
+        assert rows[0]["revision"] == 7
+        assert rows[0]["emotional_state"] == neutral
+        assert rows[0]["emotional_state"]["schema_version"] == 1
+        assert rows[0]["emotional_state"]["coping_mode"] == "HEALTHY"
+        assert rows[0]["relationship_state"]["trust"] == 0.9
+        # history and memories untouched
+        assert _count("chat_logs", user_id) == 2
+        assert _count("memories", user_id) == 1
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_reset_relationship_state_produces_valid_neutral_v1(service_client: Client):
+    user_id = _uid("rr")
+    _seed_user(user_id, revision=8)
+    neutral = neutral_relationship_snapshot(1700000000.0)
+    try:
+        result = _call_rpc(
+            service_client,
+            "reset_relationship_state",
+            _rpc_params(user_id, new_operation_id(), neutral),
+        )
+        assert "error" not in result
+        assert result["operation"] == "reset_relationship_state"
+        assert result["revision"] == 9
+
+        rows = _run_sql(
+            f"SELECT revision, emotional_state, relationship_state FROM public.profiles "
+            f"WHERE user_id = '{user_id}'"
+        )
+        assert rows[0]["revision"] == 9
+        assert rows[0]["relationship_state"] == neutral
+        assert rows[0]["relationship_state"]["schema_version"] == 1
+        assert rows[0]["emotional_state"]["coping_mode"] == "MANIC"
+        assert _count("chat_logs", user_id) == 2
+        assert _count("memories", user_id) == 1
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_reset_rejects_malformed_snapshot_atomically(service_client: Client):
+    user_id = _uid("re_bad")
+    _seed_user(user_id, revision=3)
+    bad = neutral_emotional_snapshot(1700000000.0)
+    bad["coping_mode"] = "BOGUS"
+    try:
+        result = _call_rpc(
+            service_client,
+            "reset_emotional_state",
+            _rpc_params(user_id, new_operation_id(), bad),
+        )
+        assert result["error"]["code"] == "validation_failed"
+        rows = _run_sql(f"SELECT revision FROM public.profiles WHERE user_id = '{user_id}'")
+        assert rows[0]["revision"] == 3
+        assert _count("privacy_operations", user_id) == 0
+    finally:
+        _cleanup_user(user_id)
+
+
+# ---------------------------------------------------------------------------
+# 5/6. Revision exactly once + durable idempotent replay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("rpc_name", "payload_factory", "revision_before", "revision_after"),
+    [
+        ("delete_history", lambda: {}, 2, 3),
+        ("delete_memories", lambda: {}, 4, 5),
+        ("reset_emotional_state", lambda: neutral_emotional_snapshot(1700000000.0), 6, 7),
+        ("reset_relationship_state", lambda: neutral_relationship_snapshot(1700000000.0), 8, 9),
+    ],
+)
+def test_revision_increments_exactly_once_and_replay_is_durable(
+    service_client: Client,
+    rpc_name: str,
+    payload_factory,
+    revision_before: int,
+    revision_after: int,
+):
+    user_id = _uid(f"rev_{rpc_name}")
+    _seed_user(user_id, revision=revision_before)
+    operation_id = new_operation_id()
+    payload = payload_factory()
+    try:
+        first = _call_rpc(
+            service_client, rpc_name, _rpc_params(user_id, operation_id, payload)
+        )
+        assert "error" not in first
+        assert first["revision"] == revision_after
+        rows = _run_sql(f"SELECT revision FROM public.profiles WHERE user_id = '{user_id}'")
+        assert rows[0]["revision"] == revision_after
+
+        # Exact retry: identical stored result, no mutation, no revision bump
+        replay = _call_rpc(
+            service_client, rpc_name, _rpc_params(user_id, operation_id, payload)
+        )
+        assert replay == first
+        rows = _run_sql(f"SELECT revision FROM public.profiles WHERE user_id = '{user_id}'")
+        assert rows[0]["revision"] == revision_after
+        # Durable ledger: exactly one row, replay survives "restart" (new RPC call)
+        ledger = _run_sql(
+            f"SELECT operation, operation_payload_sha256, result "
+            f"FROM public.privacy_operations "
+            f"WHERE user_id = '{user_id}' AND operation_id = '{operation_id}'"
+        )
+        assert len(ledger) == 1
+        assert ledger[0]["operation"] == rpc_name
+        assert ledger[0]["result"] == first
+    finally:
+        _cleanup_user(user_id)
+
+
+# ---------------------------------------------------------------------------
+# 7. Divergent operation/payload on the same operation_id -> conflict
+# ---------------------------------------------------------------------------
+
+
+def test_same_operation_id_divergent_payload_conflicts(service_client: Client):
+    user_id = _uid("conf_payload")
+    _seed_user(user_id, revision=2)
+    operation_id = new_operation_id()
+    try:
+        first = _call_rpc(
+            service_client, "delete_history", _rpc_params(user_id, operation_id, {})
+        )
+        assert "error" not in first
+
+        conflict = _call_rpc(
+            service_client,
+            "delete_history",
+            _rpc_params(user_id, operation_id, {"reason": "different"}),
+        )
+        assert conflict["error"]["code"] == "operation_conflict"
+        assert conflict["error"]["message"] == (
+            "operation_id already used with a different operation or payload"
+        )
+        # nothing changed
+        assert _count("chat_logs", user_id) == 0
+        rows = _run_sql(f"SELECT revision FROM public.profiles WHERE user_id = '{user_id}'")
+        assert rows[0]["revision"] == 3
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_same_operation_id_divergent_operation_conflicts(service_client: Client):
+    user_id = _uid("conf_op")
+    _seed_user(user_id, revision=2)
+    operation_id = new_operation_id()
+    try:
+        first = _call_rpc(
+            service_client, "delete_history", _rpc_params(user_id, operation_id, {})
+        )
+        assert "error" not in first
+
+        conflict = _call_rpc(
+            service_client, "delete_memories", _rpc_params(user_id, operation_id, {})
+        )
+        assert conflict["error"]["code"] == "operation_conflict"
+        assert _count("memories", user_id) == 1
+        rows = _run_sql(f"SELECT revision FROM public.profiles WHERE user_id = '{user_id}'")
+        assert rows[0]["revision"] == 3
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_same_operation_id_divergent_reset_snapshot_conflicts(service_client: Client):
+    user_id = _uid("conf_reset")
+    _seed_user(user_id, revision=4)
+    operation_id = new_operation_id()
+    neutral_a = neutral_emotional_snapshot(1700000000.0)
+    neutral_b = neutral_emotional_snapshot(1700000000.5)
+    try:
+        first = _call_rpc(
+            service_client,
+            "reset_emotional_state",
+            _rpc_params(user_id, operation_id, neutral_a),
+        )
+        assert "error" not in first
+
+        conflict = _call_rpc(
+            service_client,
+            "reset_emotional_state",
+            _rpc_params(user_id, operation_id, neutral_b),
+        )
+        assert conflict["error"]["code"] == "operation_conflict"
+    finally:
+        _cleanup_user(user_id)
+
+
+# ---------------------------------------------------------------------------
+# 8. Injected mid-operation failure -> total rollback
+# ---------------------------------------------------------------------------
+
+
+def test_delete_history_failure_rolls_back_everything(service_client: Client):
+    user_id = _uid("rb_dh")
+    _seed_user(user_id, revision=2)
+    try:
+        # Fail on the chat_logs DELETE: by then outbox/turn_requests/archival
+        # deletes already ran inside the transaction; everything must roll back.
+        _install_delete_trigger("rb_dh", "chat_logs", "injected fail during history delete")
+        with pytest.raises(APIError) as exc:
+            _call_rpc(service_client, "delete_history", _rpc_params(user_id, new_operation_id()))
+        assert exc.value.code == "P0001"
+
+        assert _count("chat_logs", user_id) == 2
+        assert _count("turn_requests", user_id) == 1
+        assert _count("outbox_events", user_id) == 1
+        assert _count("archival_extractions", user_id) == 1
+        assert _count("memories", user_id) == 1
+        assert _count("privacy_operations", user_id) == 0
+        rows = _run_sql(f"SELECT revision FROM public.profiles WHERE user_id = '{user_id}'")
+        assert rows[0]["revision"] == 2
+    finally:
+        _drop_trigger("rb_dh", "chat_logs")
+        _cleanup_user(user_id)
+
+
+def test_delete_memories_failure_rolls_back_everything(service_client: Client):
+    user_id = _uid("rb_dm")
+    _seed_user(user_id, revision=2)
+    try:
+        _install_delete_trigger("rb_dm", "memories", "injected fail during memory delete")
+        with pytest.raises(APIError) as exc:
+            _call_rpc(service_client, "delete_memories", _rpc_params(user_id, new_operation_id()))
+        assert exc.value.code == "P0001"
+
+        assert _count("memories", user_id) == 1
+        assert _count("archival_extractions", user_id) == 1
+        assert _count("chat_logs", user_id) == 2
+        assert _count("privacy_operations", user_id) == 0
+        rows = _run_sql(f"SELECT revision FROM public.profiles WHERE user_id = '{user_id}'")
+        assert rows[0]["revision"] == 2
+    finally:
+        _drop_trigger("rb_dm", "memories")
+        _cleanup_user(user_id)
+
+
+def test_reset_failure_rolls_back_snapshot_and_revision(service_client: Client):
+    user_id = _uid("rb_re")
+    _seed_user(user_id, revision=3)
+    neutral = neutral_emotional_snapshot(1700000000.0)
+    try:
+        # Fail on the profiles UPDATE: the snapshot replacement and the
+        # revision bump must both roll back.
+        _install_update_trigger("rb_re", "profiles", "injected fail during reset")
+        with pytest.raises(APIError) as exc:
+            _call_rpc(
+                service_client,
+                "reset_emotional_state",
+                _rpc_params(user_id, new_operation_id(), neutral),
+            )
+        assert exc.value.code == "P0001"
+
+        rows = _run_sql(
+            f"SELECT revision, emotional_state FROM public.profiles "
+            f"WHERE user_id = '{user_id}'"
+        )
+        assert rows[0]["revision"] == 3
+        assert rows[0]["emotional_state"]["coping_mode"] == "MANIC"
+        assert _count("privacy_operations", user_id) == 0
+    finally:
+        _drop_trigger("rb_re", "profiles")
+        _cleanup_user(user_id)
+
+
+# ---------------------------------------------------------------------------
+# 9. Concurrent operations of the same user never interleave partial state
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_same_user_operations_are_serialized(supabase_url, service_role_key):
+    user_id = _uid("conc_same")
+    _seed_user(user_id, revision=2)
+    neutral = neutral_emotional_snapshot(1700000000.0)
+    barrier = threading.Barrier(2)
+    calls = [
+        _ConcurrentOp(user_id, "delete_history", new_operation_id(), {}),
+        _ConcurrentOp(user_id, "reset_emotional_state", new_operation_id(), neutral),
+    ]
+    try:
+        results = _run_concurrent(url=supabase_url, key=service_role_key, barrier=barrier, calls=calls)
+        assert all("error" not in r for r in results)
+        # Serialized: both applied, revision bumped exactly twice, and the
+        # final state is fully consistent (no partial interleaving).
+        rows = _run_sql(f"SELECT revision FROM public.profiles WHERE user_id = '{user_id}'")
+        assert rows[0]["revision"] == 4
+        assert _count("chat_logs", user_id) == 0
+        assert _count("memories", user_id) == 1
+        assert _count("admission_reservations", user_id) == 1
+        state = _run_sql(
+            f"SELECT emotional_state->>'coping_mode' AS coping FROM public.profiles "
+            f"WHERE user_id = '{user_id}'"
+        )
+        assert state[0]["coping"] == "HEALTHY"
+        assert _count("privacy_operations", user_id) == 2
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_concurrent_same_operation_id_only_one_applies(supabase_url, service_role_key):
+    """Two simultaneous identical operations: one applies, the other replays."""
+    user_id = _uid("conc_same_id")
+    _seed_user(user_id, revision=2)
+    operation_id = new_operation_id()
+    barrier = threading.Barrier(2)
+    calls = [
+        _ConcurrentOp(user_id, "delete_history", operation_id, {}),
+        _ConcurrentOp(user_id, "delete_history", operation_id, {}),
+    ]
+    try:
+        results = _run_concurrent(url=supabase_url, key=service_role_key, barrier=barrier, calls=calls)
+        assert all("error" not in r for r in results)
+        assert results[0] == results[1]
+        rows = _run_sql(f"SELECT revision FROM public.profiles WHERE user_id = '{user_id}'")
+        assert rows[0]["revision"] == 3
+        assert _count("privacy_operations", user_id) == 1
+        assert _count("chat_logs", user_id) == 0
+    finally:
+        _cleanup_user(user_id)
+
+
+# ---------------------------------------------------------------------------
+# 10. Users A/B remain fully isolated (no global lock)
+# ---------------------------------------------------------------------------
+
+
+def test_different_users_progress_in_parallel(supabase_url, service_role_key):
+    user_a = _uid("iso_a")
+    user_b = _uid("iso_b")
+    _seed_user(user_a, revision=2)
+    _seed_user(user_b, revision=4)
+    barrier = threading.Barrier(2)
+    calls = [
+        _ConcurrentOp(user_a, "delete_history", new_operation_id(), {}),
+        _ConcurrentOp(user_b, "delete_memories", new_operation_id(), {}),
+    ]
+    try:
+        results = _run_concurrent(url=supabase_url, key=service_role_key, barrier=barrier, calls=calls)
+        assert all("error" not in r for r in results)
+        assert results[0]["revision"] == 3
+        assert results[1]["revision"] == 5
+
+        # A: history gone, memories preserved
+        assert _count("chat_logs", user_a) == 0
+        assert _count("memories", user_a) == 1
+        # B: memories gone, history preserved
+        assert _count("memories", user_b) == 0
+        assert _count("chat_logs", user_b) == 2
+    finally:
+        _cleanup_user(user_a)
+        _cleanup_user(user_b)
+
+
+# ---------------------------------------------------------------------------
+# 12/13. Authorization: only service_role executes; grants are minimal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "rpc_name",
+    ["delete_history", "delete_memories", "reset_emotional_state", "reset_relationship_state"],
+)
+def test_anon_cannot_execute_any_privacy_rpc(anon_client: Client, rpc_name: str):
+    params = _rpc_params("anon-target", new_operation_id())
+    with pytest.raises(APIError) as exc:
+        anon_client.rpc(rpc_name, params).execute()
+    assert getattr(exc.value, "code", None) == "42501"
+
+
+@pytest.mark.parametrize(
+    "rpc_name",
+    ["delete_history", "delete_memories", "reset_emotional_state", "reset_relationship_state"],
+)
+def test_authenticated_cannot_execute_any_privacy_rpc(
+    auth_client: tuple[Client, str], rpc_name: str
+):
+    client, user_id = auth_client
+    params = _rpc_params(user_id, new_operation_id())
+    with pytest.raises(APIError) as exc:
+        client.rpc(rpc_name, params).execute()
+    assert getattr(exc.value, "code", None) == "42501"
+
+
+def test_service_role_can_execute_all_privacy_rpcs(service_client: Client):
+    user_id = _uid("svc")
+    _seed_user(user_id, revision=2)
+    try:
+        results = [
+            _call_rpc(
+                service_client,
+                rpc_name,
+                _rpc_params(user_id, new_operation_id(), payload),
+            )
+            for rpc_name, payload in (
+                ("delete_history", {}),
+                ("delete_memories", {}),
+                ("reset_emotional_state", neutral_emotional_snapshot(1700000000.0)),
+                ("reset_relationship_state", neutral_relationship_snapshot(1700000000.0)),
+            )
+        ]
+        assert all("error" not in r for r in results)
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_grants_are_minimal():
+    # service_role has EXECUTE ONLY on the four public RPCs.
+    for rpc_name in (
+        "delete_history", "delete_memories",
+        "reset_emotional_state", "reset_relationship_state",
+    ):
+        assert _run_sql(
+            f"SELECT has_function_privilege('service_role', "
+            f"'public.{rpc_name}(text, uuid, jsonb)', 'EXECUTE') AS result"
+        )[0]["result"] is True
+    # ... and NO table privileges on the ledger (RPCs are the only path).
+    assert _run_sql(
+        "SELECT has_table_privilege('service_role', 'public.privacy_operations', "
+        "'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER') AS result"
+    )[0]["result"] is False
+    # anon / authenticated / PUBLIC: no EXECUTE on the RPCs, no table access.
+    for role in ("anon", "authenticated", "public"):
+        for rpc_name in (
+            "delete_history", "delete_memories",
+            "reset_emotional_state", "reset_relationship_state",
+        ):
+            assert _run_sql(
+                f"SELECT has_function_privilege('{role}', "
+                f"'public.{rpc_name}(text, uuid, jsonb)', 'EXECUTE') AS result"
+            )[0]["result"] is False
+
+
+# ---------------------------------------------------------------------------
+# 14. Sanitized errors and results
+# ---------------------------------------------------------------------------
+
+
+def test_failure_errors_are_sanitized(service_client: Client):
+    user_id = _uid("sanitize")
+    _seed_user(user_id, revision=2)
+    try:
+        _install_delete_trigger(
+            "sanitize", "chat_logs", "SECRET_CONSTRAINT_LEAK user_content=LEAK HMAC=LEAK"
+        )
+        with pytest.raises(APIError) as exc:
+            _call_rpc(service_client, "delete_history", _rpc_params(user_id, new_operation_id()))
+        message = str(exc.value)
+        assert "SECRET_CONSTRAINT_LEAK" not in message
+        assert "user_content=LEAK" not in message
+        assert "HMAC=LEAK" not in message
+        assert "P0001" in message or "persistence error" in message
+        assert "injected" not in message
+    finally:
+        _drop_trigger("sanitize", "chat_logs")
+        _cleanup_user(user_id)
+
+
+def test_results_never_contain_sensitive_content(service_client: Client):
+    user_id = _uid("no_leak")
+    _seed_user(user_id, revision=2)
+    try:
+        for rpc_name, payload in (
+            ("delete_history", {}),
+            ("delete_memories", {}),
+            ("reset_emotional_state", neutral_emotional_snapshot(1700000000.0)),
+            ("reset_relationship_state", neutral_relationship_snapshot(1700000000.0)),
+        ):
+            result = _call_rpc(
+                service_client, rpc_name, _rpc_params(user_id, new_operation_id(), payload)
+            )
+            assert "error" not in result
+            serialized = json.dumps(result)
+            for marker in ("hello", "hi there", "a durable memory", "persona-config"):
+                assert marker not in serialized
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_validation_errors_do_not_echo_payload(service_client: Client):
+    user_id = _uid("no_echo")
+    _seed_user(user_id, revision=2)
+    bad = neutral_emotional_snapshot(1700000000.0)
+    bad["user_id"] = "attacker-hidden-user"
+    try:
+        result = _call_rpc(
+            service_client,
+            "reset_emotional_state",
+            _rpc_params(user_id, new_operation_id(), bad),
+        )
+        assert result["error"]["code"] == "validation_failed"
+        serialized = json.dumps(result)
+        assert "attacker-hidden-user" not in serialized
+        assert _count("profiles", "attacker-hidden-user") == 0
+    finally:
+        _cleanup_user(user_id)
+
+
+# ---------------------------------------------------------------------------
+# Backend adapter against the real database
+# ---------------------------------------------------------------------------
+
+
+def test_backend_adapter_real_client_full_flow(service_client: Client):
+    user_id = _uid("adapter")
+    _seed_user(user_id, revision=2)
+
+    async def rpc_client(name: str, params: dict) -> dict:
+        return _call_rpc(service_client, name, params)
+
+    try:
+        result = asyncio.run(
+            run_privacy_operation(
+                rpc_client=rpc_client,
+                operation=OPERATION_DELETE_HISTORY,
+                authenticated_user_id=user_id,
+                operation_id=new_operation_id(),
+                payload={},
+            )
+        )
+        assert result.to_db_row()["revision"] == 3
+        assert result.counts["chat_logs"] == 2
+
+        # Replay via the adapter: identical, no extra increment
+        replay = asyncio.run(
+            run_privacy_operation(
+                rpc_client=rpc_client,
+                operation=OPERATION_DELETE_HISTORY,
+                authenticated_user_id=user_id,
+                operation_id=result.operation_id,
+                payload={},
+            )
+        )
+        assert replay.to_db_row() == result.to_db_row()
+
+        # Divergent payload via the adapter: sanitized ConflictError
+        with pytest.raises(ConflictError) as exc:
+            asyncio.run(
+                run_privacy_operation(
+                    rpc_client=rpc_client,
+                    operation=OPERATION_DELETE_HISTORY,
+                    authenticated_user_id=user_id,
+                    operation_id=result.operation_id,
+                    payload={"reason": "different"},
+                )
+            )
+        assert exc.value.code == "operation_conflict"
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_backend_adapter_rpc_failure_is_sanitized_persistence(service_client: Client):
+    user_id = _uid("adapter_fail")
+    _seed_user(user_id, revision=2)
+
+    async def rpc_client(name: str, params: dict) -> dict:
+        return _call_rpc(service_client, name, params)
+
+    try:
+        _install_delete_trigger("adapter_fail", "chat_logs", "boom")
+        with pytest.raises(PersistenceError):
+            asyncio.run(
+                run_privacy_operation(
+                    rpc_client=rpc_client,
+                    operation=OPERATION_DELETE_HISTORY,
+                    authenticated_user_id=user_id,
+                    operation_id=new_operation_id(),
+                    payload={},
+                )
+            )
+    finally:
+        _drop_trigger("adapter_fail", "chat_logs")
+        _cleanup_user(user_id)

--- a/backend/tests/test_privacy_operations_integration.py
+++ b/backend/tests/test_privacy_operations_integration.py
@@ -53,7 +53,7 @@ import pytest
 from postgrest.exceptions import APIError
 from supabase import Client, create_client
 
-from backend.atomic_turn_commit import ConflictError, PersistenceError
+from backend.atomic_turn_commit import ConflictError, PersistenceError, ValidationError
 from backend.privacy_operations import (
     OPERATION_DELETE_HISTORY,
     OPERATION_DELETE_MEMORIES,
@@ -560,6 +560,61 @@ def test_reset_rejects_malformed_snapshot_atomically(service_client: Client):
         _cleanup_user(user_id)
 
 
+def test_reset_rejects_valid_but_non_neutral_emotional_snapshot(service_client: Client):
+    """A structurally valid v1 emotional snapshot with non-neutral values must
+    be rejected by reset_emotional_state without touching snapshot, revision
+    or the ledger (issue #314 review)."""
+    user_id = _uid("re_non_neutral")
+    _seed_user(user_id, revision=3)
+    non_neutral = neutral_emotional_snapshot(1700000000.0)
+    non_neutral["pleasure"] = 0.9
+    non_neutral["arousal"] = 0.8
+    non_neutral["dominance"] = 0.7
+    non_neutral["libido"] = 0.1
+    non_neutral["aggression"] = 0.1
+    non_neutral["tension"] = 0.1
+    non_neutral["coping_mode"] = "MANIC"
+    try:
+        result = _call_rpc(
+            service_client,
+            "reset_emotional_state",
+            _rpc_params(user_id, new_operation_id(), non_neutral),
+        )
+        assert result["error"]["code"] == "validation_failed"
+        rows = _run_sql(
+            f"SELECT revision, emotional_state FROM public.profiles WHERE user_id = '{user_id}'"
+        )
+        assert rows[0]["revision"] == 3
+        assert rows[0]["emotional_state"]["coping_mode"] == "MANIC"
+        assert _count("privacy_operations", user_id) == 0
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_reset_rejects_valid_but_non_neutral_relationship_snapshot(service_client: Client):
+    user_id = _uid("rr_non_neutral")
+    _seed_user(user_id, revision=4)
+    non_neutral = neutral_relationship_snapshot(1700000000.0)
+    non_neutral["trust"] = 0.9
+    non_neutral["affection"] = 0.8
+    non_neutral["tension"] = 0.1
+    try:
+        result = _call_rpc(
+            service_client,
+            "reset_relationship_state",
+            _rpc_params(user_id, new_operation_id(), non_neutral),
+        )
+        assert result["error"]["code"] == "validation_failed"
+        rows = _run_sql(
+            f"SELECT revision, relationship_state FROM public.profiles WHERE user_id = '{user_id}'"
+        )
+        assert rows[0]["revision"] == 4
+        assert rows[0]["relationship_state"]["trust"] == 0.9
+        assert _count("privacy_operations", user_id) == 0
+    finally:
+        _cleanup_user(user_id)
+
+
 # ---------------------------------------------------------------------------
 # 5/6. Revision exactly once + durable idempotent replay
 # ---------------------------------------------------------------------------
@@ -996,6 +1051,70 @@ def test_validation_errors_do_not_echo_payload(service_client: Client):
         serialized = json.dumps(result)
         assert "attacker-hidden-user" not in serialized
         assert _count("profiles", "attacker-hidden-user") == 0
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_sql_validation_rejects_invalid_user_ids_without_ledger_rows(service_client: Client):
+    """Whitespace-only and oversized identities fail with a predictable
+    validation envelope through the SQL boundary and never create ledger rows
+    (issue #314 review)."""
+    user_id = _uid("uid_bounds")
+    _seed_user(user_id, revision=2)
+    try:
+        ws_result = _call_rpc(
+            service_client, "delete_history", _rpc_params("   ", new_operation_id())
+        )
+        assert ws_result["error"]["code"] == "validation_failed"
+
+        long_result = _call_rpc(
+            service_client, "delete_history", _rpc_params("x" * 129, new_operation_id())
+        )
+        assert long_result["error"]["code"] == "validation_failed"
+
+        # No ledger rows for the invalid identities.
+        assert _run_sql(
+            "SELECT count(*)::integer AS count FROM public.privacy_operations "
+            "WHERE user_id = '   ' OR user_id = '" + "x" * 129 + "'"
+        )[0]["count"] == 0
+
+        # Boundary: exactly 128 characters is accepted (no-op for missing user).
+        ok_user = "y" * 128
+        ok_result = _call_rpc(
+            service_client, "delete_history", _rpc_params(ok_user, new_operation_id())
+        )
+        assert "error" not in ok_result
+        assert ok_result["status"] == "applied"
+        assert ok_result["user_id"] == ok_user
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_backend_adapter_rejects_divergent_result_user(service_client: Client):
+    """The adapter fails closed when the RPC result belongs to another user
+    and never exposes the divergent identity (issue #314 review)."""
+    user_id = _uid("adapter_div")
+    _seed_user(user_id, revision=2)
+    divergent = "SECRET-DIVERGENT-USER-MARKER"
+
+    async def rpc_client(name: str, params: dict) -> dict:
+        result = _call_rpc(service_client, name, params)
+        result["user_id"] = divergent
+        return result
+
+    try:
+        with pytest.raises(ValidationError) as exc:
+            asyncio.run(
+                run_privacy_operation(
+                    rpc_client=rpc_client,
+                    operation=OPERATION_DELETE_HISTORY,
+                    authenticated_user_id=user_id,
+                    operation_id=new_operation_id(),
+                    payload={},
+                )
+            )
+        assert exc.value.code == "invalid_rpc_result"
+        assert divergent not in str(exc.value)
     finally:
         _cleanup_user(user_id)
 

--- a/backend/tests/test_privacy_operations_legacy.py
+++ b/backend/tests/test_privacy_operations_legacy.py
@@ -1,0 +1,367 @@
+"""Real Supabase integration test: privacy migration on a legacy upgrade (#314).
+
+This file is executed only by the database CI job. It must never be collected
+by the ordinary backend unit job (see the ignore list in
+``.github/workflows/ci.yml``).
+
+Scenario 15 of issue #314: the migration must work on a clean reset (proven
+by ``supabase/tests/database/06_privacy_data_operations.test.sql`` and every
+other database-integration suite) AND on a legacy upgrade: a database at the
+migrations previous to ``privacy_data_operations`` (00..06) with real legacy
+user data (profile, chat_logs, turn_requests, outbox_events, memories,
+archival_extractions, admission_reservations) receives the new migration via
+``supabase migration up --local``.
+
+Proves:
+1. The migration registers its version and applies additively.
+2. Legacy data is preserved untouched (no deletion, no revision change).
+3. The privacy_operations ledger exists with RLS/FORCE RLS and no grants.
+4. The four RPCs exist with SECURITY DEFINER, fixed search_path, and
+   service_role-only EXECUTE; PUBLIC/anon/authenticated have none.
+5. The primitives actually work on the upgraded database (delete_history
+   applied end to end, preserving memories and admission reservations).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from backend.supabase_cli import run_supabase_op
+
+LEGACY_HIDDEN_SUFFIX = ".legacy-test-hidden"
+_PRIVACY_FILENAME_RE = re.compile(
+    r"^\d+_privacy_data_operations\.sql(?:\.(?:tmp|legacy-test-hidden))?$"
+)
+
+
+def _find_privacy_migration() -> Path:
+    """Locate the privacy migration, tolerating CI/direct hidden states."""
+    matches = [
+        p
+        for p in Path("supabase/migrations").iterdir()
+        if _PRIVACY_FILENAME_RE.match(p.name)
+    ]
+    if not matches:
+        raise FileNotFoundError(
+            "supabase/migrations/*_privacy_data_operations.sql not found"
+        )
+    return next((p for p in matches if p.name.endswith(".sql")), matches[0])
+
+
+def _version_from_filename(name: str) -> str:
+    return Path(name).name.split("_", 1)[0]
+
+
+_PRIVACY_MIGRATION = _find_privacy_migration()
+MIGRATION = str(_PRIVACY_MIGRATION).removesuffix(LEGACY_HIDDEN_SUFFIX).removesuffix(".tmp")
+MIGRATION_VERSION = _version_from_filename(MIGRATION)
+MIGRATION_TMP = f"{MIGRATION}.tmp"
+
+RPC_SIGNATURES = {
+    "delete_history": "delete_history(text, uuid, jsonb)",
+    "delete_memories": "delete_memories(text, uuid, jsonb)",
+    "reset_emotional_state": "reset_emotional_state(text, uuid, jsonb)",
+    "reset_relationship_state": "reset_relationship_state(text, uuid, jsonb)",
+}
+
+
+# ---------------------------------------------------------------------------
+# Sanitized CLI / psql helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_supabase(op_id: str, args: list[str], check: bool = True):
+    result = run_supabase_op(op_id, args, check=False)
+    if check and result.returncode != 0:
+        raise AssertionError(f"Supabase operation failed: {op_id}")
+    return result
+
+
+def _run_psql(sql: str) -> None:
+    result = subprocess.run(
+        [
+            "docker", "exec", "-i", "supabase_db_app",
+            "psql", "-U", "postgres",
+            "-v", "ON_ERROR_STOP=1", "-q", "-f", "-",
+        ],
+        input=sql,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError("psql execution failed")
+
+
+def _query_json(query: str) -> list:
+    res = _run_supabase(
+        "privacy_legacy_query",
+        ["db", "query", "--agent=no", "--output", "json", query],
+        check=False,
+    )
+    if res.returncode != 0:
+        raise AssertionError("Query result: operation failed")
+    try:
+        data = json.loads(res.stdout)
+    except json.JSONDecodeError:
+        raise AssertionError("Query result: invalid JSON response")
+    if not isinstance(data, list):
+        raise AssertionError("Query result: expected a list")
+    return data
+
+
+def _query_scalar_bool(query: str) -> bool:
+    data = _query_json(query)
+    if len(data) != 1 or "result" not in data[0]:
+        raise AssertionError("Query result: expected exactly one scalar row")
+    value = data[0]["result"]
+    if not isinstance(value, bool):
+        raise AssertionError("Query result: expected a boolean")
+    return value
+
+
+def _query_scalar_int(query: str) -> int:
+    data = _query_json(query)
+    if len(data) != 1 or "result" not in data[0]:
+        raise AssertionError("Query result: expected exactly one scalar row")
+    value = data[0]["result"]
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise AssertionError("Query result: expected an integer")
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Migration file manipulation (restored in finally, CI-script aware)
+# ---------------------------------------------------------------------------
+
+
+def _hide_new_migration() -> None:
+    """Hide the new migration before a legacy baseline reset.
+
+    When the CI ``scripts/hide-migrations-after.sh`` already renamed the file
+    to ``<name>.legacy-test-hidden`` it stays as-is; otherwise (direct run)
+    the file is moved to ``<name>.tmp``. Both states are restored later.
+    """
+    if os.path.exists(MIGRATION) and not os.path.exists(MIGRATION_TMP):
+        os.rename(MIGRATION, MIGRATION_TMP)
+
+
+def _restore_new_migration() -> None:
+    if os.path.exists(MIGRATION_TMP):
+        os.rename(MIGRATION_TMP, MIGRATION)
+    elif os.path.exists(MIGRATION + LEGACY_HIDDEN_SUFFIX):
+        os.rename(MIGRATION + LEGACY_HIDDEN_SUFFIX, MIGRATION)
+
+
+# ---------------------------------------------------------------------------
+# Legacy fixture (data existing before the privacy migration)
+# ---------------------------------------------------------------------------
+
+LEGACY_USER = "privacy_legacy_user"
+
+
+def _seed_legacy_data() -> None:
+    _run_psql(
+        f"""
+        INSERT INTO public.profiles (user_id, persona_config, user_profile,
+            relationship_state, emotional_state, revision)
+        VALUES (
+            '{LEGACY_USER}', 'legacy-persona', '{{"k":"v"}}'::jsonb,
+            '{{"schema_version":1,"trust":0.9,"affection":0.8,"tension":0.1,"triggers":[],"timestamp":1700000000.0}}'::jsonb,
+            '{{"schema_version":1,"pleasure":0.9,"arousal":0.8,"dominance":0.7,"libido":0.1,"aggression":0.1,"connection":0.5,"energy":0.8,"tension":0.1,"coping_mode":"MANIC","timestamp":1700000000.0}}'::jsonb,
+            2
+        );
+
+        INSERT INTO public.chat_logs (user_id, role, content)
+        VALUES ('{LEGACY_USER}', 'user', 'legacy hello'),
+               ('{LEGACY_USER}', 'assistant', 'legacy hi');
+
+        INSERT INTO public.turn_requests (
+            id, user_id, request_id, payload_hash_sha256, status, expected_revision,
+            committed_revision, replay_payload, created_at, updated_at, completed_at
+        ) VALUES (
+            'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
+            '{LEGACY_USER}', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid,
+            'a'::text || repeat('0', 63), 'completed', 0, 2,
+            '{{"response":"legacy hi","message_id":"cccccccc-cccc-cccc-cccc-cccccccccccc"}}'::jsonb,
+            now(), now(), now()
+        );
+
+        INSERT INTO public.outbox_events (
+            event_type, contract_version, user_id, turn_request_id, payload, status,
+            attempts, next_attempt_at, idempotency_key, created_at, updated_at
+        ) VALUES (
+            'turn_completed', 1, '{LEGACY_USER}',
+            'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
+            '{{"ref":"t1"}}'::jsonb, 'pending', 0, now() + interval '1 second',
+            'legacy_k1', now(), now()
+        );
+
+        INSERT INTO public.memories (user_id, content, metadata)
+        VALUES ('{LEGACY_USER}', 'legacy memory', '{{}}'::jsonb);
+
+        INSERT INTO public.archival_extractions (
+            user_id, source_chat_log_id, extractor_version, schema_version,
+            idempotency_key, facts
+        )
+        SELECT '{LEGACY_USER}', id, 1, 1, 'legacy_arch_1', '{{"facts":[]}}'::jsonb
+        FROM public.chat_logs WHERE user_id = '{LEGACY_USER}' AND role = 'user';
+
+        INSERT INTO public.admission_reservations (
+            user_id, request_id, message_hmac_sha256, network_hmac_sha256,
+            estimated_units
+        ) VALUES (
+            '{LEGACY_USER}', 'dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid,
+            repeat('a', 64), repeat('b', 64), 10
+        );
+        """
+    )
+
+
+# ---------------------------------------------------------------------------
+# Catalog assertions after the upgrade
+# ---------------------------------------------------------------------------
+
+
+def _assert_ledger_state() -> None:
+    assert _query_scalar_bool(
+        "SELECT EXISTS("
+        "SELECT 1 FROM pg_class WHERE oid = 'public.privacy_operations'::regclass "
+        "AND relrowsecurity = true) AS result"
+    ), "RLS not enabled on privacy_operations"
+    assert _query_scalar_bool(
+        "SELECT EXISTS("
+        "SELECT 1 FROM pg_class WHERE oid = 'public.privacy_operations'::regclass "
+        "AND relforcerowsecurity = true) AS result"
+    ), "FORCE RLS not enabled on privacy_operations"
+    assert not _query_scalar_bool(
+        "SELECT has_table_privilege('service_role', "
+        "'public.privacy_operations', "
+        "'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER') AS result"
+    ), "service_role has table privileges on privacy_operations"
+    assert not _query_scalar_bool(
+        "SELECT has_table_privilege('public', "
+        "'public.privacy_operations', "
+        "'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER') AS result"
+    ), "PUBLIC has table privileges on privacy_operations"
+
+
+def _assert_rpc_state() -> None:
+    for name, signature in RPC_SIGNATURES.items():
+        assert _query_scalar_bool(
+            "SELECT EXISTS("
+            "SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace "
+            f"WHERE n.nspname = 'public' AND p.proname = '{name}' AND p.pronargs = 3"
+            ") AS result"
+        ), f"{name} missing after the upgrade"
+        assert _query_scalar_bool(
+            f"SELECT has_function_privilege('service_role', "
+            f"'public.{signature}', 'EXECUTE') AS result"
+        ), f"service_role missing EXECUTE on {name}"
+        for role in ("anon", "authenticated", "public"):
+            assert not _query_scalar_bool(
+                f"SELECT has_function_privilege('{role}', "
+                f"'public.{signature}', 'EXECUTE') AS result"
+            ), f"{role} gained EXECUTE on {name}"
+
+
+# ---------------------------------------------------------------------------
+# SCENARIO: legacy upgrade preserves data and installs the primitives
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.database_integration
+def test_legacy_upgrade_applies_privacy_primitives():
+    _hide_new_migration()
+    try:
+        _run_supabase("privacy_legacy_reset", ["db", "reset"])
+        _seed_legacy_data()
+
+        _restore_new_migration()
+        _run_supabase("privacy_legacy_upgrade", ["migration", "up", "--local"])
+
+        # ---- 1. Migration registered ----
+        assert _query_scalar_bool(
+            "SELECT EXISTS("
+            "SELECT 1 FROM supabase_migrations.schema_migrations "
+            f"WHERE version = '{MIGRATION_VERSION}'"
+            ") AS result"
+        ), "privacy migration timestamp not registered"
+
+        # ---- 2. Legacy data preserved untouched ----
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.profiles "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 1
+        assert _query_scalar_int(
+            "SELECT revision::int AS result FROM public.profiles "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 2, "legacy revision changed during the upgrade"
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.chat_logs "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 2
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.turn_requests "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 1
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.outbox_events "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 1
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.memories "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 1
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.archival_extractions "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 1
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.admission_reservations "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 1
+
+        # ---- 3. Ledger + RPC state ----
+        _assert_ledger_state()
+        _assert_rpc_state()
+
+        # ---- 4. Primitives work end to end on the upgraded database ----
+        result = _query_json(
+            "SELECT public.delete_history("
+            f"'{LEGACY_USER}', '99999999-9999-9999-9999-999999999999'::uuid, '{{}}'::jsonb"
+            ") AS result"
+        )
+        assert len(result) == 1 and result[0]["result"]["status"] == "applied"
+        assert result[0]["result"]["revision"] == 3
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.chat_logs "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 0
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.turn_requests "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 0
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.outbox_events "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 0
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.archival_extractions "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 0
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.memories "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 1, "delete_history must preserve memories after the upgrade"
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.admission_reservations "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 1, "delete_history must preserve admission reservations after the upgrade"
+    finally:
+        _restore_new_migration()

--- a/backend/tests/test_privacy_operations_preflight.py
+++ b/backend/tests/test_privacy_operations_preflight.py
@@ -1,0 +1,203 @@
+"""Real Supabase integration test: privacy migration preflight fail-closed (#314 review).
+
+This file is executed only by the database CI job. It must never be collected
+by the ordinary backend unit job (see the ignore list in
+``.github/workflows/ci.yml``).
+
+The preflight of ``privacy_data_operations`` must fail with SQLSTATE 23514
+when ANY mandatory dependency is missing. The original implementation checked
+``c.relname IN (...)`` which passes when at least ONE table of the set exists;
+this suite proves the fix by starting from a schema compatible with the
+migration (baseline + 00..06 + hardening), dropping EXACTLY ONE required table
+(every other dependency still present), applying the migration and requiring:
+
+1. the migration fails with 23514;
+2. ``privacy_operations`` was NOT created;
+3. NONE of the new functions (four RPCs, core, helpers) were installed;
+4. the environment is restored in ``finally`` (migration files and data).
+
+Each parametrized case exercises a table that the old ``IN (...)`` check would
+have masked: with the other five tables present, the buggy condition would
+have passed and let the migration install on a broken schema.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from backend.supabase_cli import run_supabase_op
+
+LEGACY_HIDDEN_SUFFIX = ".legacy-test-hidden"
+_PRIVACY_FILENAME_RE = re.compile(
+    r"^\d+_privacy_data_operations\.sql(?:\.(?:tmp|legacy-test-hidden))?$"
+)
+
+# The four public RPCs plus every internal core/helper created by the
+# migration. None of them may exist after a failed preflight.
+MIGRATION_FUNCTIONS = (
+    "delete_history",
+    "delete_memories",
+    "reset_emotional_state",
+    "reset_relationship_state",
+    "privacy_apply_operation",
+    "privacy_operation_payload_sha256",
+    "privacy_op_validation_error",
+    "privacy_is_neutral_snapshot",
+)
+
+# Tables that the old preflight masked with a single IN (...) check.
+MISSING_TABLE_CASES = (
+    "admission_reservations",
+    "turn_requests",
+    "archival_extractions",
+)
+
+
+def _find_privacy_migration() -> Path:
+    matches = [
+        p
+        for p in Path("supabase/migrations").iterdir()
+        if _PRIVACY_FILENAME_RE.match(p.name)
+    ]
+    if not matches:
+        raise FileNotFoundError(
+            "supabase/migrations/*_privacy_data_operations.sql not found"
+        )
+    return next((p for p in matches if p.name.endswith(".sql")), matches[0])
+
+
+_PRIVACY_MIGRATION = _find_privacy_migration()
+MIGRATION = str(_PRIVACY_MIGRATION).removesuffix(LEGACY_HIDDEN_SUFFIX).removesuffix(".tmp")
+MIGRATION_TMP = f"{MIGRATION}.tmp"
+
+
+# ---------------------------------------------------------------------------
+# Sanitized CLI / psql helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_supabase(op_id: str, args: list[str], check: bool = True):
+    result = run_supabase_op(op_id, args, check=False)
+    if check and result.returncode != 0:
+        raise AssertionError(f"Supabase operation failed: {op_id}")
+    return result
+
+
+def _run_psql(sql: str) -> None:
+    result = subprocess.run(
+        [
+            "docker", "exec", "-i", "supabase_db_app",
+            "psql", "-U", "postgres",
+            "-v", "ON_ERROR_STOP=1", "-q", "-f", "-",
+        ],
+        input=sql,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError("psql execution failed")
+
+
+def _query_scalar_bool(query: str) -> bool:
+    res = _run_supabase(
+        "privacy_legacy_query",
+        ["db", "query", "--agent=no", "--output", "json", query],
+        check=False,
+    )
+    if res.returncode != 0:
+        raise AssertionError("Query result: operation failed")
+    try:
+        data = json.loads(res.stdout)
+    except json.JSONDecodeError:
+        raise AssertionError("Query result: invalid JSON response")
+    if not isinstance(data, list) or len(data) != 1 or "result" not in data[0]:
+        raise AssertionError("Query result: expected exactly one scalar row")
+    value = data[0]["result"]
+    if not isinstance(value, bool):
+        raise AssertionError("Query result: expected a boolean")
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Migration file manipulation (restored in finally, CI-script aware)
+# ---------------------------------------------------------------------------
+
+
+def _hide_new_migration() -> None:
+    if os.path.exists(MIGRATION) and not os.path.exists(MIGRATION_TMP):
+        os.rename(MIGRATION, MIGRATION_TMP)
+
+
+def _restore_new_migration() -> None:
+    if os.path.exists(MIGRATION_TMP):
+        os.rename(MIGRATION_TMP, MIGRATION)
+    elif os.path.exists(MIGRATION + LEGACY_HIDDEN_SUFFIX):
+        os.rename(MIGRATION + LEGACY_HIDDEN_SUFFIX, MIGRATION)
+
+
+# ---------------------------------------------------------------------------
+# SCENARIO: each mandatory table absence makes the migration fail closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("missing_table", MISSING_TABLE_CASES)
+@pytest.mark.database_integration
+def test_preflight_fails_closed_on_missing_table(missing_table: str):
+    _hide_new_migration()
+    try:
+        # Baseline compatible with the migration (00..06 + hardening), with
+        # every required table present.
+        _run_supabase("privacy_legacy_reset", ["db", "reset"])
+
+        # Remove EXACTLY one mandatory dependency while every other table of
+        # the set remains present: this is the case the old IN (...) check
+        # masked.
+        _run_psql(f"DROP TABLE IF EXISTS public.{missing_table} CASCADE;")
+        assert _query_scalar_bool(
+            f"SELECT to_regclass('public.{missing_table}') IS NULL AS result"
+        ), f"{missing_table} was not actually dropped"
+
+        _restore_new_migration()
+
+        # Applying the migration must FAIL with 23514 BEFORE installing
+        # anything.
+        res = _run_supabase(
+            "privacy_legacy_upgrade", ["migration", "up", "--local"], check=False
+        )
+        assert res.returncode != 0, (
+            f"expected the privacy migration to fail when {missing_table} is missing"
+        )
+        assert "23514" in res.stderr, (
+            f"expected SQLSTATE 23514 from preflight, got: {res.stderr[-500:]}"
+        )
+
+        # The ledger must NOT have been created.
+        assert not _query_scalar_bool(
+            "SELECT to_regclass('public.privacy_operations') IS NOT NULL AS result"
+        ), "privacy_operations was created despite the failed preflight"
+
+        # NONE of the new functions may be installed.
+        for fn in MIGRATION_FUNCTIONS:
+            assert not _query_scalar_bool(
+                "SELECT EXISTS("
+                "SELECT 1 FROM pg_proc p "
+                "JOIN pg_namespace n ON n.oid = p.pronamespace "
+                f"WHERE n.nspname = 'public' AND p.proname = '{fn}'"
+                ") AS result"
+            ), f"{fn} was installed despite the failed preflight"
+
+        # The migration must NOT be registered.
+        assert not _query_scalar_bool(
+            "SELECT EXISTS("
+            "SELECT 1 FROM supabase_migrations.schema_migrations "
+            "WHERE name = 'privacy_data_operations'"
+            ") AS result"
+        ), "privacy migration was registered despite the failed preflight"
+    finally:
+        _restore_new_migration()

--- a/docs/architecture/user-data-lifecycle.md
+++ b/docs/architecture/user-data-lifecycle.md
@@ -81,7 +81,15 @@ never reach the increment path.
 `p_authenticated_user_id` is the ONLY identity input. `user_id` / `bond_label`
 inside payloads and snapshots are rejected at any depth by the existing
 `jsonb_snapshot_contract` validation. No body/snapshot-controlled identity is
-ever trusted.
+ever trusted. The identity is validated exactly as received (never normalized)
+against the persistent ledger contract — `1 <= char_length(user_id) <= 128`
+and `btrim(user_id) <> ''` — in BOTH the Python adapter (before the RPC) and
+the SQL helper (`privacy_op_validation_error`): empty, whitespace-only and
+oversized identities fail with a predictable `validation_failed` envelope
+instead of a generic persistence error. The adapter also binds the RPC result
+to the expected identity: a result whose `user_id` differs from the
+`authenticated_user_id` requested fails closed and never echoes the divergent
+value.
 
 ### 5. Server-owned RPCs, minimal grants
 
@@ -89,8 +97,9 @@ ever trusted.
 - `EXECUTE` granted to `service_role` ONLY; revoked from
   `PUBLIC`, `anon` and `authenticated`.
 - The internal core (`privacy_apply_operation`) and helpers
-  (`privacy_operation_payload_sha256`, `privacy_op_validation_error`) have NO
-  grants at all (owner `postgres` only).
+  (`privacy_operation_payload_sha256`, `privacy_op_validation_error`,
+  `privacy_is_neutral_snapshot`) have NO grants at all (owner `postgres`
+  only).
 - `privacy_operations` is `RLS + FORCE RLS` with no policies and NO table
   grants (not even `service_role`): the RPCs are the only access path.
 - Direct access to the internal structures follows the existing minimum
@@ -140,14 +149,41 @@ touches `memories` or the profile/persona/snapshots.
 
 No second emotional/relationship model is created in SQL. The resets reuse
 the EXISTING v1 contract validation (`jsonb_snapshot_contract`, migration
-#271) with the exact version and allowlist already used by `commit_turn`:
+#271) with the exact version and allowlist already used by `commit_turn`,
+AND additionally require the canonical NEUTRAL state (issue #314 review):
 
-- The server-side domain produces `EmotionalStateV1.neutral(...)` /
-  `RelationshipStateV1.neutral(...)` snapshots (the operation payload).
+- Neutrality is PRODUCED by the domain: `EmotionalStateV1.neutral(...)` /
+  `RelationshipStateV1.neutral(...)`. The Python adapter reconstructs the
+  canonical neutral snapshot through those constructors (using the payload's
+  own timestamp) and requires an exact match, so a structurally valid v1
+  snapshot with non-neutral values (for example `pleasure = 0.9`,
+  `coping_mode = 'MANIC'`) is rejected before the RPC.
+- Neutrality is VERIFIED at the privileged SQL boundary by
+  `privacy_is_neutral_snapshot(payload, kind)`: it first enforces the full v1
+  contract (`jsonb_snapshot_contract`) and then compares every state field
+  against the canonical neutral constants that mirror the domain
+  constructors. Cross-boundary tests (pgTAP and the real-database suites)
+  pin the SQL constants to the exact output of the Python constructors, so
+  the two boundaries cannot silently diverge.
 - The RPC requires `schema_version == 1`, the exact v1 field set/ranges,
-  positive timestamp, no identity/internal keys, size bound.
-- Malformed or non-v1 snapshots are rejected with `validation_failed`
-  before any mutation or ledger record.
+  positive timestamp, no identity/internal keys, size bound AND the canonical
+  neutral values.
+- Malformed, non-v1 or valid-but-non-neutral snapshots are rejected with
+  `validation_failed` before any mutation or ledger record.
+
+## Preflight (fail closed on any missing dependency)
+
+The migration preflight checks EVERY mandatory dependency individually with
+`pg_catalog.to_regclass(...) IS NULL` (NULL-safe) and raises SQLSTATE 23514
+before creating any object of the migration when any of the six required
+tables (`chat_logs`, `memories`, `archival_extractions`, `turn_requests`,
+`outbox_events`, `admission_reservations`), `profiles.revision`,
+`jsonb_snapshot_contract`, `pgcrypto` — or any drift of this migration's own
+objects — is missing. A partially incomplete schema can never pass because
+at least one table of the set exists. The CI preflight suite
+(`backend/tests/test_privacy_operations_preflight.py`) drops exactly one
+required table on a compatible baseline and proves the migration fails with
+23514 before installing the ledger or any function.
 
 ## Error envelopes
 

--- a/docs/architecture/user-data-lifecycle.md
+++ b/docs/architecture/user-data-lifecycle.md
@@ -1,0 +1,181 @@
+# User Data Lifecycle — Privacy Data Operations
+
+## Status
+
+Implemented by issue #314 (privacy chain #274, gate PROD-0 recovery #264).
+This document is the architectural record for the transactional, idempotent,
+server-owned privacy primitives that future leaves of the chain build on.
+
+## Scope
+
+This leaf creates ONLY the transactional/server-side foundation:
+
+- `delete_history` — atomic removal of turn history and its derivatives.
+- `delete_memories` — atomic removal of memories and ungoverned candidates.
+- `reset_emotional_state` — surgical replacement of the emotional snapshot.
+- `reset_relationship_state` — surgical replacement of the relationship
+  snapshot.
+
+Explicitly NOT done here: HTTP endpoints, UI, account/Auth deletion, durable
+workers/jobs, physical retention policy, export, model/formula changes,
+reactivation of archival extraction, #276, #315.
+
+## Problem
+
+Privacy operations must coexist with the existing transactional model
+(`profiles.revision`, `turn_requests`, `outbox_events`, versioned snapshots,
+per-user PostgreSQL locks) without:
+
+- touching another user's data;
+- interleaving with turn commits of the same user;
+- incrementing `revision` more than once on retries;
+- allowing divergent replays of the same `operation_id`;
+- leaving deletions partially applied;
+- deleting the anti-abuse ledger and enabling quota bypass.
+
+## Binding decisions
+
+### 1. PostgreSQL is the coordinator, reusing the commit_turn boundary
+
+Every operation acquires the exact same per-user advisory transaction lock as
+`commit_turn`:
+
+```sql
+pg_advisory_xact_lock(hashtextextended(authenticated_user_id, 0))
+```
+
+Deletions/resets of one user are therefore serialized against that user's
+turn commits and other privacy operations, while different users never
+contend on a global lock. The profile row is additionally locked `FOR UPDATE`.
+
+### 2. Persistent idempotency via a durable ledger
+
+`public.privacy_operations` records one row per APPLIED operation, keyed by
+`(user_id, operation_id)`, storing:
+
+- the operation name;
+- the SHA-256 fingerprint of the operation payload;
+- the sanitized public result.
+
+Replay semantics:
+
+- Same `operation_id` + same operation + same payload fingerprint → return
+  the stored result verbatim, with NO mutation and NO revision increment.
+- Same `operation_id` + divergent operation or payload → sanitized
+  `operation_conflict`.
+- The ledger survives restarts and different processes: no process-local
+  cache is involved.
+
+Keying by `(user_id, operation_id)` (not `operation_id` alone) means one user
+can never observe or collide with another user's ledger rows.
+
+### 3. Revision invalidation exactly once
+
+Every applied operation that has a profile increments `profiles.revision`
+exactly once, invalidating prior turn computations (a later `commit_turn`
+with the old `expected_revision` fails with `revision_mismatch`). Replays
+never reach the increment path.
+
+### 4. Identity comes only from the server-side boundary
+
+`p_authenticated_user_id` is the ONLY identity input. `user_id` / `bond_label`
+inside payloads and snapshots are rejected at any depth by the existing
+`jsonb_snapshot_contract` validation. No body/snapshot-controlled identity is
+ever trusted.
+
+### 5. Server-owned RPCs, minimal grants
+
+- The four RPCs are `SECURITY DEFINER` with fixed `search_path = public`.
+- `EXECUTE` granted to `service_role` ONLY; revoked from
+  `PUBLIC`, `anon` and `authenticated`.
+- The internal core (`privacy_apply_operation`) and helpers
+  (`privacy_operation_payload_sha256`, `privacy_op_validation_error`) have NO
+  grants at all (owner `postgres` only).
+- `privacy_operations` is `RLS + FORCE RLS` with no policies and NO table
+  grants (not even `service_role`): the RPCs are the only access path.
+- Direct access to the internal structures follows the existing minimum
+  grants/RLS model.
+
+### 6. Sanitized errors and results
+
+Results contain only `status`, `operation`, `operation_id`, `user_id`,
+`revision` and aggregate safe counts. Errors use constant sanitized
+envelopes (`validation_failed`, `operation_conflict`) or a constant
+`persistence error` (P0001) raised by `WHEN OTHERS`. Message/memory content,
+internal IDs, prompts, HMACs and raw SQL are never returned nor logged.
+
+## Data matrix
+
+| Data | `delete_history` | `delete_memories` | reset emotional | reset relational |
+|---|---|---|---|---|
+| `chat_logs` | deleted | preserved | preserved | preserved |
+| `turn_requests` | deleted | preserved | preserved | preserved |
+| `outbox_events` (derived) | deleted | preserved | preserved | preserved |
+| `archival_extractions` (history-derived) | deleted | deleted (ungoverned memory candidates) | preserved | preserved |
+| `memories` | preserved | deleted | preserved | preserved |
+| `persona_config` / `user_profile` | preserved | preserved | preserved | preserved |
+| `emotional_state` snapshot | preserved | preserved | replaced (validated v1 neutral) | preserved |
+| `relationship_state` snapshot | preserved | preserved | preserved | replaced (validated v1 neutral) |
+| `admission_reservations` (anti-abuse ledger) | preserved | preserved | preserved | preserved |
+| `profiles.revision` | +1 (applied, profile exists) | +1 (applied, profile exists) | +1 (applied, profile exists) | +1 (applied, profile exists) |
+| `privacy_operations` ledger | +1 row | +1 row | +1 row | +1 row |
+
+`delete_history` deliberately NEVER touches `admission_reservations`:
+history deletion cannot be used to bypass quota. `delete_history` also never
+touches `memories` or the profile/persona/snapshots.
+
+## Concurrency
+
+- All steps of one operation run in one transaction; any failure rolls back
+  everything.
+- Same-user operations (and turn commits) serialize on the per-user advisory
+  lock; different users proceed in parallel (no global lock).
+- Two identical concurrent operations with the same `operation_id`: the
+  first applies, the second observes the committed ledger row and replays.
+- Two different concurrent operations of the same user: both apply in some
+  serialized order; `revision` increments once per applied operation and the
+  final state is fully consistent (never partially interleaved).
+
+## Snapshots (resets)
+
+No second emotional/relationship model is created in SQL. The resets reuse
+the EXISTING v1 contract validation (`jsonb_snapshot_contract`, migration
+#271) with the exact version and allowlist already used by `commit_turn`:
+
+- The server-side domain produces `EmotionalStateV1.neutral(...)` /
+  `RelationshipStateV1.neutral(...)` snapshots (the operation payload).
+- The RPC requires `schema_version == 1`, the exact v1 field set/ranges,
+  positive timestamp, no identity/internal keys, size bound.
+- Malformed or non-v1 snapshots are rejected with `validation_failed`
+  before any mutation or ledger record.
+
+## Error envelopes
+
+| Case | Envelope |
+|---|---|
+| Invalid input (identity/operation/payload/snapshot) | `{"error":{"code":"validation_failed",...}}` |
+| Reused operation_id with divergent operation/payload | `{"error":{"code":"operation_conflict",...}}` |
+| Unexpected PostgreSQL failure | raised constant `persistence error` (P0001), rollback |
+
+## Files
+
+- `supabase/migrations/20260808220000_privacy_data_operations.sql`
+- `supabase/tests/database/06_privacy_data_operations.test.sql` (pgTAP)
+- `backend/privacy_operations.py` (pure Python adapter)
+- `backend/tests/test_privacy_operations.py` (unit, no DB)
+- `backend/tests/test_privacy_operations_integration.py` (real Supabase)
+- `backend/tests/test_privacy_operations_legacy.py` (legacy upgrade)
+
+## Rollback
+
+The migration is purely additive: dropping `privacy_operations` and the four
+RPCs restores the previous schema without touching any other object. Applied
+privacy operations themselves are destructive by design and are NOT
+reversible; idempotency guarantees they are never applied twice.
+
+## Out of scope (future leaves)
+
+- HTTP endpoints / UI exposing these primitives.
+- Account/Auth user deletion (#315), durable workers (#276), retention and
+  export policies.
+- Emotional/relationship formula, decay, appraisal or personality changes.

--- a/supabase/migrations/20260808220000_privacy_data_operations.sql
+++ b/supabase/migrations/20260808220000_privacy_data_operations.sql
@@ -1,0 +1,592 @@
+-- 20260808220000_privacy_data_operations.sql
+-- Transactional, idempotent privacy primitives (#314).
+--
+-- Purely additive migration. Creates the durable privacy operations ledger
+-- and four server-owned RPC primitives that run each privacy operation as a
+-- single PostgreSQL transaction:
+--
+--   1. delete_history            atomic removal of turn history + derivatives
+--   2. delete_memories           atomic removal of memories + candidates
+--   3. reset_emotional_state     replace ONLY the emotional snapshot (v1)
+--   4. reset_relationship_state  replace ONLY the relationship snapshot (v1)
+--
+-- Design and rationale: docs/architecture/user-data-lifecycle.md
+-- Issue: #314 (chain #274, gate PROD-0 recovery #264)
+-- Depends on: #271 (jsonb_snapshot_contract / commit_turn), #270, #265
+--
+-- Concurrency model (binding decision, mirrors commit_turn):
+--   * every operation acquires the SAME per-user advisory transaction lock as
+--     the turn commit: pg_advisory_xact_lock(hashtextextended(user_id, 0)).
+--     Deletions/resets can therefore never interleave with a turn commit of
+--     the same user, and distinct users are never globally serialized.
+--   * the profile row is additionally locked FOR UPDATE to serialize writers.
+--
+-- Idempotency model (binding decision):
+--   * every applied operation records a durable ledger row keyed by
+--     (user_id, operation_id) storing the sanitized public result and the
+--     SHA-256 fingerprint of the operation payload.
+--   * replay of the same (user_id, operation_id) with the SAME operation and
+--     payload returns the stored result WITHOUT re-running the mutation and
+--     WITHOUT incrementing revision (no process-local cache: the ledger
+--     survives restarts and is authoritative).
+--   * the same operation_id with a DIFFERENT operation or payload fails with
+--     a sanitized operation_conflict envelope.
+--
+-- Security posture (binding decisions):
+--   * identity comes ONLY from p_authenticated_user_id (server-side boundary).
+--     No user_id inside a payload/snapshot is ever trusted.
+--   * the four RPCs are SECURITY DEFINER with fixed search_path = public and
+--     EXECUTE granted to service_role only (revoked from PUBLIC, anon and
+--     authenticated).
+--   * the internal core/helpers have NO grants at all (owner postgres only).
+--   * privacy_operations is RLS + FORCE RLS with no policies and NO table
+--     grants (not even service_role): the RPCs are the only access path.
+--   * results and errors are sanitized: only status/operation/operation_id/
+--     user_id/revision and aggregate safe counts are returned. Message or
+--     memory content, internal message/memory IDs, prompts, HMACs and raw SQL
+--     are never returned nor logged.
+--   * admission_reservations (anti-abuse ledger / quota) is deliberately NOT
+--     touched by delete_history: quota cannot be bypassed by deleting history.
+
+-- =================================================================
+-- 0. PREFLIGHT: fail closed on missing dependencies and drift
+-- =================================================================
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'privacy_operations'
+    ) THEN
+        RAISE EXCEPTION 'Cannot apply privacy operations: privacy_operations already exists (unexpected drift)'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public'
+          AND p.proname IN (
+              'delete_history', 'delete_memories',
+              'reset_emotional_state', 'reset_relationship_state',
+              'privacy_apply_operation', 'privacy_operation_payload_sha256',
+              'privacy_op_validation_error'
+          )
+    ) THEN
+        RAISE EXCEPTION 'Cannot apply privacy operations: privacy functions already exist (unexpected drift)'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_attribute a
+        WHERE a.attrelid = 'public.profiles'::regclass
+          AND a.attname = 'revision'
+    ) THEN
+        RAISE EXCEPTION 'Missing dependency: profiles.revision column (issue #270)'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname IN (
+              'chat_logs', 'memories', 'archival_extractions',
+              'turn_requests', 'outbox_events', 'admission_reservations'
+          )
+    ) THEN
+        RAISE EXCEPTION 'Missing dependency: privacy target tables (issue #270/#271)'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public'
+          AND p.proname = 'jsonb_snapshot_contract'
+    ) THEN
+        RAISE EXCEPTION 'Missing dependency: public.jsonb_snapshot_contract (issue #271)'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_extension e
+        WHERE e.extname = 'pgcrypto'
+    ) THEN
+        RAISE EXCEPTION 'Missing dependency: pgcrypto extension (payload fingerprint)'
+            USING ERRCODE = '23514';
+    END IF;
+END $$;
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
+
+-- =================================================================
+-- 1. Durable privacy operations ledger
+-- =================================================================
+-- One row per APPLIED operation. Keyed by (user_id, operation_id) so a user
+-- can never observe or collide with another user's operation, and so a
+-- server-provided operation_id is globally reusable across users without
+-- cross-user interference. No FK to profiles: the ledger must durably record
+-- outcomes even for users without a profile row yet (idempotency must
+-- survive), and identity is server-provided at the same trust boundary as
+-- the user_id text keys used everywhere else.
+CREATE TABLE public.privacy_operations (
+    user_id text NOT NULL,
+    operation_id uuid NOT NULL,
+    operation text NOT NULL,
+    operation_payload_sha256 text NOT NULL,
+    status text NOT NULL,
+    applied_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+    result jsonb NOT NULL,
+
+    CONSTRAINT privacy_operations_pkey
+        PRIMARY KEY (user_id, operation_id),
+    CONSTRAINT privacy_operations_user_id_check
+        CHECK (
+            char_length(user_id) BETWEEN 1 AND 128
+            AND btrim(user_id) <> ''
+        ),
+    CONSTRAINT privacy_operations_operation_check
+        CHECK (operation IN (
+            'delete_history', 'delete_memories',
+            'reset_emotional_state', 'reset_relationship_state'
+        )),
+    CONSTRAINT privacy_operations_payload_hash_check
+        CHECK (operation_payload_sha256 ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT privacy_operations_status_check
+        CHECK (status = 'applied'),
+    CONSTRAINT privacy_operations_result_check
+        CHECK (jsonb_typeof(result) = 'object')
+);
+
+ALTER TABLE public.privacy_operations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.privacy_operations FORCE ROW LEVEL SECURITY;
+
+-- Server-owned ledger: no role (not even service_role) gets table access.
+-- The SECURITY DEFINER RPCs (owner postgres) are the only access path.
+REVOKE ALL PRIVILEGES ON TABLE public.privacy_operations
+    FROM PUBLIC, anon, authenticated, service_role;
+
+-- =================================================================
+-- 2. Payload fingerprint helper
+-- =================================================================
+-- Deterministic SHA-256 of the canonical jsonb serialization. jsonb::text is
+-- canonical for a stored jsonb value, so identical incoming JSON always hashes
+-- identically across processes and restarts. Used to bind an operation_id to
+-- its exact operation payload: a divergent payload on replay is a conflict.
+CREATE OR REPLACE FUNCTION public.privacy_operation_payload_sha256(
+    p_payload jsonb
+) RETURNS text
+LANGUAGE sql
+IMMUTABLE
+SET search_path = extensions
+AS $$
+    SELECT pg_catalog.encode(extensions.digest(p_payload::text, 'sha256'), 'hex');
+$$;
+
+REVOKE ALL ON FUNCTION public.privacy_operation_payload_sha256(jsonb)
+    FROM PUBLIC, anon, authenticated, service_role;
+
+-- =================================================================
+-- 3. Base validation helper (returns an error envelope or NULL)
+-- =================================================================
+CREATE OR REPLACE FUNCTION public.privacy_op_validation_error(
+    p_user_id text,
+    p_operation_id uuid,
+    p_payload jsonb
+) RETURNS jsonb
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+BEGIN
+    IF p_user_id IS NULL OR p_user_id = '' THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'authenticated_user_id is required'
+            )
+        );
+    END IF;
+    IF p_operation_id IS NULL THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'operation_id is required'
+            )
+        );
+    END IF;
+    IF p_payload IS NULL OR jsonb_typeof(p_payload) <> 'object' THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'operation_payload must be a JSON object'
+            )
+        );
+    END IF;
+    RETURN NULL;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.privacy_op_validation_error(text, uuid, jsonb)
+    FROM PUBLIC, anon, authenticated, service_role;
+
+-- =================================================================
+-- 4. Core: single transactional engine for all four operations
+-- =================================================================
+-- Executes every step of an operation in ONE transaction:
+--   Step 0  fail-fast validation (stable, sanitized envelopes)
+--   Step 1  per-user advisory lock (same boundary as commit_turn)
+--   Step 2  durable idempotency check against the ledger
+--   Step 3  profile row lock (serialize writers)
+--   Step 4  apply the mutation (deletes or snapshot replacement)
+--   Step 5  increment profiles.revision exactly once (invalidate prior turns)
+--   Step 6  build the sanitized public result
+--   Step 7  record the durable idempotency row
+-- Any unexpected failure rolls back the whole transaction (WHEN OTHERS raises
+-- a constant sanitized 'persistence error' P0001, never SQLERRM/SQLSTATE).
+--
+-- The resets reuse the EXISTING v1 snapshot contract (jsonb_snapshot_contract
+-- from #271). No second emotional/relationship model is created in SQL: the
+-- caller (server-side domain) produces EmotionalStateV1.neutral(...) /
+-- RelationshipStateV1.neutral(...) snapshots and this function requires the
+-- exact v1 allowlist/version already used by commit_turn.
+CREATE OR REPLACE FUNCTION public.privacy_apply_operation(
+    p_authenticated_user_id text,
+    p_operation text,
+    p_operation_id uuid,
+    p_operation_payload jsonb
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_validation_error jsonb;
+    v_payload_sha256 text;
+    v_ledger public.privacy_operations%ROWTYPE;
+    v_profile_exists boolean := FALSE;
+    v_current_revision bigint := 0;
+    v_new_revision bigint := 0;
+    v_profiles_updated bigint := 0;
+    v_count_chat_logs bigint := 0;
+    v_count_turn_requests bigint := 0;
+    v_count_outbox_events bigint := 0;
+    v_count_archival bigint := 0;
+    v_count_memories bigint := 0;
+    v_result jsonb;
+BEGIN
+    -- =============================================================
+    -- Step 0: input validation (fail fast, stable envelopes)
+    -- =============================================================
+    v_validation_error := public.privacy_op_validation_error(
+        p_authenticated_user_id, p_operation_id, p_operation_payload
+    );
+    IF v_validation_error IS NOT NULL THEN
+        RETURN v_validation_error;
+    END IF;
+
+    IF p_operation NOT IN (
+        'delete_history', 'delete_memories',
+        'reset_emotional_state', 'reset_relationship_state'
+    ) THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'operation is invalid'
+            )
+        );
+    END IF;
+
+    -- Resets require a VALID v1 snapshot produced by the domain. The
+    -- snapshot is the operation payload and is bound to the operation_id by
+    -- the fingerprint below.
+    IF p_operation = 'reset_emotional_state'
+       AND NOT public.jsonb_snapshot_contract(p_operation_payload, 'emotional') THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'emotional_state snapshot violates the v1 contract'
+            )
+        );
+    END IF;
+
+    IF p_operation = 'reset_relationship_state'
+       AND NOT public.jsonb_snapshot_contract(p_operation_payload, 'relationship') THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'relationship_state snapshot violates the v1 contract'
+            )
+        );
+    END IF;
+
+    v_payload_sha256 := public.privacy_operation_payload_sha256(p_operation_payload);
+
+    -- =============================================================
+    -- Step 1: per-user advisory transaction lock
+    -- The EXACT same boundary used by commit_turn (#271): deletions/resets
+    -- are serialized against turn commits of the same user, and different
+    -- users never contend on a global lock.
+    -- =============================================================
+    PERFORM pg_advisory_xact_lock(hashtextextended(p_authenticated_user_id, 0));
+
+    -- =============================================================
+    -- Step 2: durable idempotency check
+    -- A committed (user_id, operation_id) row with the same operation and
+    -- payload fingerprint is an exact replay: return the stored result
+    -- WITHOUT any mutation and WITHOUT any revision increment. Anything
+    -- divergent is a sanitized conflict.
+    -- =============================================================
+    SELECT * INTO v_ledger
+    FROM public.privacy_operations
+    WHERE user_id = p_authenticated_user_id
+      AND operation_id = p_operation_id;
+
+    IF FOUND THEN
+        IF v_ledger.operation = p_operation
+           AND v_ledger.operation_payload_sha256 = v_payload_sha256 THEN
+            RETURN v_ledger.result;
+        END IF;
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'operation_conflict',
+                'message', 'operation_id already used with a different operation or payload'
+            )
+        );
+    END IF;
+
+    -- =============================================================
+    -- Step 3: profile state (row lock serializes concurrent writers)
+    -- A missing profile is legal: there is no data to mutate, the operation
+    -- applies as a deterministic no-op and revision stays 0.
+    -- =============================================================
+    SELECT revision INTO v_current_revision
+    FROM public.profiles
+    WHERE user_id = p_authenticated_user_id
+    FOR UPDATE;
+
+    v_profile_exists := (v_current_revision IS NOT NULL);
+    IF NOT v_profile_exists THEN
+        v_current_revision := 0;
+    END IF;
+
+    -- =============================================================
+    -- Step 4: apply the operation (all steps in this one transaction)
+    -- delete_history removes chat_logs, turn_requests, their derived
+    -- outbox_events and archival_extractions derived from the history.
+    -- It deliberately NEVER touches memories, profiles/persona, snapshots
+    -- or admission_reservations.
+    -- delete_memories removes memories and archival/candidate material that
+    -- may still represent ungoverned memory. It never touches chat or
+    -- snapshots.
+    -- Resets replace ONLY the target snapshot column with the validated v1
+    -- snapshot produced by the domain.
+    -- =============================================================
+    IF p_operation = 'delete_history' THEN
+        DELETE FROM public.outbox_events
+        WHERE user_id = p_authenticated_user_id;
+        GET DIAGNOSTICS v_count_outbox_events = ROW_COUNT;
+
+        DELETE FROM public.turn_requests
+        WHERE user_id = p_authenticated_user_id;
+        GET DIAGNOSTICS v_count_turn_requests = ROW_COUNT;
+
+        DELETE FROM public.archival_extractions
+        WHERE user_id = p_authenticated_user_id;
+        GET DIAGNOSTICS v_count_archival = ROW_COUNT;
+
+        DELETE FROM public.chat_logs
+        WHERE user_id = p_authenticated_user_id;
+        GET DIAGNOSTICS v_count_chat_logs = ROW_COUNT;
+    ELSIF p_operation = 'delete_memories' THEN
+        DELETE FROM public.memories
+        WHERE user_id = p_authenticated_user_id;
+        GET DIAGNOSTICS v_count_memories = ROW_COUNT;
+
+        DELETE FROM public.archival_extractions
+        WHERE user_id = p_authenticated_user_id;
+        GET DIAGNOSTICS v_count_archival = ROW_COUNT;
+    ELSIF p_operation = 'reset_emotional_state' THEN
+        UPDATE public.profiles
+        SET emotional_state = p_operation_payload,
+            updated_at = timezone('utc'::text, now())
+        WHERE user_id = p_authenticated_user_id;
+        GET DIAGNOSTICS v_profiles_updated = ROW_COUNT;
+    ELSIF p_operation = 'reset_relationship_state' THEN
+        UPDATE public.profiles
+        SET relationship_state = p_operation_payload,
+            updated_at = timezone('utc'::text, now())
+        WHERE user_id = p_authenticated_user_id;
+        GET DIAGNOSTICS v_profiles_updated = ROW_COUNT;
+    END IF;
+
+    -- =============================================================
+    -- Step 5: revision invalidation (exactly once per applied operation)
+    -- Any applied operation that has a profile invalidates prior turn
+    -- computations exactly once. Replays never reach this step.
+    -- =============================================================
+    IF v_profile_exists THEN
+        v_new_revision := v_current_revision + 1;
+        UPDATE public.profiles
+        SET revision = v_new_revision,
+            updated_at = timezone('utc'::text, now())
+        WHERE user_id = p_authenticated_user_id;
+    END IF;
+
+    -- =============================================================
+    -- Step 6: build the sanitized public result
+    -- Only status, operation, operation_id, user_id, revision and aggregate
+    -- safe counts. Never message/memory content, internal IDs, prompts or
+    -- HMACs.
+    -- =============================================================
+    v_result := jsonb_build_object(
+        'status', 'applied',
+        'operation', p_operation,
+        'operation_id', p_operation_id::text,
+        'user_id', p_authenticated_user_id,
+        'revision', v_new_revision,
+        'counts', jsonb_build_object(
+            'chat_logs', v_count_chat_logs,
+            'turn_requests', v_count_turn_requests,
+            'outbox_events', v_count_outbox_events,
+            'archival_extractions', v_count_archival,
+            'memories', v_count_memories,
+            'profiles', v_profiles_updated
+        )
+    );
+
+    -- =============================================================
+    -- Step 7: durable idempotency record (same transaction)
+    -- =============================================================
+    INSERT INTO public.privacy_operations (
+        user_id, operation_id, operation, operation_payload_sha256,
+        status, applied_at, result
+    ) VALUES (
+        p_authenticated_user_id, p_operation_id, p_operation,
+        v_payload_sha256, 'applied', timezone('utc'::text, now()), v_result
+    );
+
+    RETURN v_result;
+EXCEPTION
+    WHEN OTHERS THEN
+        -- Unexpected PostgreSQL failure. Never expose SQLERRM, SQLSTATE,
+        -- constraint names or payload; propagate a constant sanitized message
+        -- so the RPC fails (rollback is automatic) and the Python layer maps
+        -- it to PersistenceError.
+        RAISE EXCEPTION 'persistence error' USING ERRCODE = 'P0001';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.privacy_apply_operation(text, text, uuid, jsonb)
+    FROM PUBLIC, anon, authenticated, service_role;
+
+-- =================================================================
+-- 5. Public RPC primitives (thin, server-owned wrappers)
+-- =================================================================
+-- Each wrapper fixes the operation name. The core performs validation
+-- (including the v1 snapshot contract for resets), locking, idempotency,
+-- mutation, revision bump and the durable ledger record.
+CREATE OR REPLACE FUNCTION public.delete_history(
+    p_authenticated_user_id text,
+    p_operation_id uuid,
+    p_operation_payload jsonb DEFAULT '{}'::jsonb
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    RETURN public.privacy_apply_operation(
+        p_authenticated_user_id, 'delete_history', p_operation_id, p_operation_payload
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.delete_memories(
+    p_authenticated_user_id text,
+    p_operation_id uuid,
+    p_operation_payload jsonb DEFAULT '{}'::jsonb
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    RETURN public.privacy_apply_operation(
+        p_authenticated_user_id, 'delete_memories', p_operation_id, p_operation_payload
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.reset_emotional_state(
+    p_authenticated_user_id text,
+    p_operation_id uuid,
+    p_operation_payload jsonb DEFAULT '{}'::jsonb
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    RETURN public.privacy_apply_operation(
+        p_authenticated_user_id, 'reset_emotional_state', p_operation_id, p_operation_payload
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.reset_relationship_state(
+    p_authenticated_user_id text,
+    p_operation_id uuid,
+    p_operation_payload jsonb DEFAULT '{}'::jsonb
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    RETURN public.privacy_apply_operation(
+        p_authenticated_user_id, 'reset_relationship_state', p_operation_id, p_operation_payload
+    );
+END;
+$$;
+
+-- =================================================================
+-- 6. Grants: EXECUTE for service_role ONLY on the four public primitives
+-- =================================================================
+REVOKE ALL ON FUNCTION public.delete_history(text, uuid, jsonb)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.delete_history(text, uuid, jsonb) TO service_role;
+
+REVOKE ALL ON FUNCTION public.delete_memories(text, uuid, jsonb)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.delete_memories(text, uuid, jsonb) TO service_role;
+
+REVOKE ALL ON FUNCTION public.reset_emotional_state(text, uuid, jsonb)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.reset_emotional_state(text, uuid, jsonb) TO service_role;
+
+REVOKE ALL ON FUNCTION public.reset_relationship_state(text, uuid, jsonb)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.reset_relationship_state(text, uuid, jsonb) TO service_role;
+
+-- =================================================================
+-- 7. Documentation comments
+-- =================================================================
+COMMENT ON FUNCTION public.delete_history(text, uuid, jsonb) IS
+'Atomic, idempotent privacy primitive (#314). Removes turn history (chat_logs, turn_requests, derived outbox_events and archival_extractions) in one transaction. Preserves memories, persona/profile, snapshots and admission_reservations. Same per-user advisory lock as commit_turn. Replay-safe via the durable privacy_operations ledger; divergent payloads conflict sanitized. SECURITY DEFINER, service_role only.';
+
+COMMENT ON FUNCTION public.delete_memories(text, uuid, jsonb) IS
+'Atomic, idempotent privacy primitive (#314). Removes memories and archival/candidate material that may still represent ungoverned memory in one transaction. Preserves chat history and snapshots. Same per-user advisory lock as commit_turn. Replay-safe via the durable privacy_operations ledger; divergent payloads conflict sanitized. SECURITY DEFINER, service_role only.';
+
+COMMENT ON FUNCTION public.reset_emotional_state(text, uuid, jsonb) IS
+'Atomic, idempotent privacy primitive (#314). Replaces ONLY profiles.emotional_state with a validated v1 snapshot (produced by the domain, EmotionalStateV1.neutral) and increments profiles.revision exactly once. Preserves history, memories and the relationship snapshot. Same per-user advisory lock as commit_turn. Replay-safe via the durable privacy_operations ledger; divergent payloads conflict sanitized. SECURITY DEFINER, service_role only.';
+
+COMMENT ON FUNCTION public.reset_relationship_state(text, uuid, jsonb) IS
+'Atomic, idempotent privacy primitive (#314). Replaces ONLY profiles.relationship_state with a validated v1 snapshot (produced by the domain, RelationshipStateV1.neutral) and increments profiles.revision exactly once. Preserves history, memories and the emotional snapshot. Same per-user advisory lock as commit_turn. Replay-safe via the durable privacy_operations ledger; divergent payloads conflict sanitized. SECURITY DEFINER, service_role only.';

--- a/supabase/migrations/20260808220000_privacy_data_operations.sql
+++ b/supabase/migrations/20260808220000_privacy_data_operations.sql
@@ -51,8 +51,14 @@
 -- =================================================================
 -- 0. PREFLIGHT: fail closed on missing dependencies and drift
 -- =================================================================
+-- Every mandatory dependency is checked INDIVIDUALLY: a partially
+-- incomplete schema can never pass because at least one table of the set
+-- exists. Missing drift detection here would let the primitives install on
+-- top of a broken schema, so each absence raises 23514 BEFORE any object of
+-- this migration is created.
 DO $$
 BEGIN
+    -- Drift: objects created by THIS migration must not exist yet.
     IF EXISTS (
         SELECT 1
         FROM pg_class c
@@ -73,10 +79,38 @@ BEGIN
               'delete_history', 'delete_memories',
               'reset_emotional_state', 'reset_relationship_state',
               'privacy_apply_operation', 'privacy_operation_payload_sha256',
-              'privacy_op_validation_error'
+              'privacy_op_validation_error', 'privacy_is_neutral_snapshot'
           )
     ) THEN
         RAISE EXCEPTION 'Cannot apply privacy operations: privacy functions already exist (unexpected drift)'
+            USING ERRCODE = '23514';
+    END IF;
+
+    -- Required tables: EVERY dependency must exist. to_regclass is NULL-safe
+    -- (no exception on missing relations) and each check is explicit, so a
+    -- single existing table can never mask another missing one.
+    IF pg_catalog.to_regclass('public.chat_logs') IS NULL THEN
+        RAISE EXCEPTION 'Missing dependency: public.chat_logs (issue #270)'
+            USING ERRCODE = '23514';
+    END IF;
+    IF pg_catalog.to_regclass('public.memories') IS NULL THEN
+        RAISE EXCEPTION 'Missing dependency: public.memories (issue #270)'
+            USING ERRCODE = '23514';
+    END IF;
+    IF pg_catalog.to_regclass('public.archival_extractions') IS NULL THEN
+        RAISE EXCEPTION 'Missing dependency: public.archival_extractions (issue #270)'
+            USING ERRCODE = '23514';
+    END IF;
+    IF pg_catalog.to_regclass('public.turn_requests') IS NULL THEN
+        RAISE EXCEPTION 'Missing dependency: public.turn_requests (issue #270)'
+            USING ERRCODE = '23514';
+    END IF;
+    IF pg_catalog.to_regclass('public.outbox_events') IS NULL THEN
+        RAISE EXCEPTION 'Missing dependency: public.outbox_events (issue #270)'
+            USING ERRCODE = '23514';
+    END IF;
+    IF pg_catalog.to_regclass('public.admission_reservations') IS NULL THEN
+        RAISE EXCEPTION 'Missing dependency: public.admission_reservations (issue #270)'
             USING ERRCODE = '23514';
     END IF;
 
@@ -87,20 +121,6 @@ BEGIN
           AND a.attname = 'revision'
     ) THEN
         RAISE EXCEPTION 'Missing dependency: profiles.revision column (issue #270)'
-            USING ERRCODE = '23514';
-    END IF;
-
-    IF NOT EXISTS (
-        SELECT 1
-        FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'public'
-          AND c.relname IN (
-              'chat_logs', 'memories', 'archival_extractions',
-              'turn_requests', 'outbox_events', 'admission_reservations'
-          )
-    ) THEN
-        RAISE EXCEPTION 'Missing dependency: privacy target tables (issue #270/#271)'
             USING ERRCODE = '23514';
     END IF;
 
@@ -197,6 +217,11 @@ REVOKE ALL ON FUNCTION public.privacy_operation_payload_sha256(jsonb)
 -- =================================================================
 -- 3. Base validation helper (returns an error envelope or NULL)
 -- =================================================================
+-- Mirrors the persistent ledger constraint exactly:
+--   char_length(user_id) BETWEEN 1 AND 128 AND btrim(user_id) <> ''
+-- Invalid identities (NULL, empty, whitespace-only, oversized) fail with a
+-- predictable validation envelope BEFORE any lock, mutation or ledger row,
+-- never with a generic persistence error from the ledger CHECK.
 CREATE OR REPLACE FUNCTION public.privacy_op_validation_error(
     p_user_id text,
     p_operation_id uuid,
@@ -206,11 +231,13 @@ LANGUAGE plpgsql
 IMMUTABLE
 AS $$
 BEGIN
-    IF p_user_id IS NULL OR p_user_id = '' THEN
+    IF p_user_id IS NULL
+       OR pg_catalog.char_length(p_user_id) NOT BETWEEN 1 AND 128
+       OR pg_catalog.btrim(p_user_id) = '' THEN
         RETURN jsonb_build_object(
             'error', jsonb_build_object(
                 'code', 'validation_failed',
-                'message', 'authenticated_user_id is required'
+                'message', 'authenticated_user_id is invalid'
             )
         );
     END IF;
@@ -238,6 +265,61 @@ REVOKE ALL ON FUNCTION public.privacy_op_validation_error(text, uuid, jsonb)
     FROM PUBLIC, anon, authenticated, service_role;
 
 -- =================================================================
+-- 3.1 Neutral snapshot verifier (reset semantics, issue #314 review)
+-- =================================================================
+-- The resets must ONLY ever persist the CANONICAL NEUTRAL state produced by
+-- the domain (EmotionalStateV1.neutral(...) / RelationshipStateV1.neutral(...)).
+-- A structurally valid v1 snapshot that is NOT neutral (for example
+-- pleasure = 0.9, coping_mode = 'MANIC') must be rejected.
+--
+-- Where neutrality is PRODUCED vs VERIFIED:
+--   * PRODUCED: backend/emotional_domain/models.py (EmotionalStateV1.neutral)
+--     and backend/relationship.py (RelationshipStateV1.neutral). The adapter
+--     backend/privacy_operations.py reconstructs the canonical neutral
+--     snapshot through those constructors and compares the payload.
+--   * VERIFIED here: this SQL helper is the privileged boundary check. The
+--     constant values below intentionally mirror the domain constructors and
+--     are pinned by cross-boundary tests: the pgTAP and integration suites
+--     prove this helper accepts the exact output of the Python constructors
+--     and rejects valid-but-non-neutral v1 snapshots, so the two boundaries
+--     cannot silently diverge.
+-- No second emotional/relationship model is created: this helper only
+-- compares scalar values against the canonical neutral constants and still
+-- requires the full v1 contract (jsonb_snapshot_contract) first.
+CREATE OR REPLACE FUNCTION public.privacy_is_neutral_snapshot(
+    p_payload jsonb,
+    p_snapshot_kind text
+) RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+SET search_path = pg_catalog
+AS $$
+    SELECT
+        public.jsonb_snapshot_contract(p_payload, p_snapshot_kind)
+        AND (
+            (p_snapshot_kind = 'emotional' AND
+             (p_payload->>'pleasure')::double precision = 0.0 AND
+             (p_payload->>'arousal')::double precision = 0.0 AND
+             (p_payload->>'dominance')::double precision = 0.0 AND
+             (p_payload->>'libido')::double precision = 0.0 AND
+             (p_payload->>'aggression')::double precision = 0.0 AND
+             (p_payload->>'connection')::double precision = 0.5 AND
+             (p_payload->>'energy')::double precision = 0.8 AND
+             (p_payload->>'tension')::double precision = 0.0 AND
+             p_payload->>'coping_mode' = 'HEALTHY')
+            OR
+            (p_snapshot_kind = 'relationship' AND
+             (p_payload->>'trust')::double precision = 0.5 AND
+             (p_payload->>'affection')::double precision = 0.3 AND
+             (p_payload->>'tension')::double precision = 0.0 AND
+             p_payload->'triggers' = '[]'::jsonb)
+        )
+$$;
+
+REVOKE ALL ON FUNCTION public.privacy_is_neutral_snapshot(jsonb, text)
+    FROM PUBLIC, anon, authenticated, service_role;
+
+-- =================================================================
 -- 4. Core: single transactional engine for all four operations
 -- =================================================================
 -- Executes every step of an operation in ONE transaction:
@@ -253,10 +335,12 @@ REVOKE ALL ON FUNCTION public.privacy_op_validation_error(text, uuid, jsonb)
 -- a constant sanitized 'persistence error' P0001, never SQLERRM/SQLSTATE).
 --
 -- The resets reuse the EXISTING v1 snapshot contract (jsonb_snapshot_contract
--- from #271). No second emotional/relationship model is created in SQL: the
--- caller (server-side domain) produces EmotionalStateV1.neutral(...) /
--- RelationshipStateV1.neutral(...) snapshots and this function requires the
--- exact v1 allowlist/version already used by commit_turn.
+-- from #271) AND additionally require the canonical NEUTRAL state produced by
+-- the domain (EmotionalStateV1.neutral(...) / RelationshipStateV1.neutral(...),
+-- verified by privacy_is_neutral_snapshot). No second emotional/relationship
+-- model is created in SQL: the caller (server-side domain) produces the neutral
+-- snapshots and this function requires the exact v1 allowlist/version already
+-- used by commit_turn plus the canonical neutral values.
 CREATE OR REPLACE FUNCTION public.privacy_apply_operation(
     p_authenticated_user_id text,
     p_operation text,
@@ -304,25 +388,29 @@ BEGIN
         );
     END IF;
 
-    -- Resets require a VALID v1 snapshot produced by the domain. The
-    -- snapshot is the operation payload and is bound to the operation_id by
-    -- the fingerprint below.
+    -- Resets require the CANONICAL NEUTRAL v1 snapshot produced by the
+    -- domain (EmotionalStateV1.neutral / RelationshipStateV1.neutral).
+    -- privacy_is_neutral_snapshot first enforces the full v1 contract and
+    -- then verifies the exact canonical neutral values, so a structurally
+    -- valid but non-neutral snapshot can never be persisted. The snapshot
+    -- is the operation payload and is bound to the operation_id by the
+    -- fingerprint below.
     IF p_operation = 'reset_emotional_state'
-       AND NOT public.jsonb_snapshot_contract(p_operation_payload, 'emotional') THEN
+       AND NOT public.privacy_is_neutral_snapshot(p_operation_payload, 'emotional') THEN
         RETURN jsonb_build_object(
             'error', jsonb_build_object(
                 'code', 'validation_failed',
-                'message', 'emotional_state snapshot violates the v1 contract'
+                'message', 'emotional_state snapshot must be the canonical neutral v1 state'
             )
         );
     END IF;
 
     IF p_operation = 'reset_relationship_state'
-       AND NOT public.jsonb_snapshot_contract(p_operation_payload, 'relationship') THEN
+       AND NOT public.privacy_is_neutral_snapshot(p_operation_payload, 'relationship') THEN
         RETURN jsonb_build_object(
             'error', jsonb_build_object(
                 'code', 'validation_failed',
-                'message', 'relationship_state snapshot violates the v1 contract'
+                'message', 'relationship_state snapshot must be the canonical neutral v1 state'
             )
         );
     END IF;
@@ -491,7 +579,7 @@ REVOKE ALL ON FUNCTION public.privacy_apply_operation(text, text, uuid, jsonb)
 -- 5. Public RPC primitives (thin, server-owned wrappers)
 -- =================================================================
 -- Each wrapper fixes the operation name. The core performs validation
--- (including the v1 snapshot contract for resets), locking, idempotency,
+-- (including the v1 neutral contract for resets), locking, idempotency,
 -- mutation, revision bump and the durable ledger record.
 CREATE OR REPLACE FUNCTION public.delete_history(
     p_authenticated_user_id text,
@@ -586,7 +674,7 @@ COMMENT ON FUNCTION public.delete_memories(text, uuid, jsonb) IS
 'Atomic, idempotent privacy primitive (#314). Removes memories and archival/candidate material that may still represent ungoverned memory in one transaction. Preserves chat history and snapshots. Same per-user advisory lock as commit_turn. Replay-safe via the durable privacy_operations ledger; divergent payloads conflict sanitized. SECURITY DEFINER, service_role only.';
 
 COMMENT ON FUNCTION public.reset_emotional_state(text, uuid, jsonb) IS
-'Atomic, idempotent privacy primitive (#314). Replaces ONLY profiles.emotional_state with a validated v1 snapshot (produced by the domain, EmotionalStateV1.neutral) and increments profiles.revision exactly once. Preserves history, memories and the relationship snapshot. Same per-user advisory lock as commit_turn. Replay-safe via the durable privacy_operations ledger; divergent payloads conflict sanitized. SECURITY DEFINER, service_role only.';
+'Atomic, idempotent privacy primitive (#314). Replaces ONLY profiles.emotional_state with the canonical NEUTRAL v1 snapshot (EmotionalStateV1.neutral, verified by privacy_is_neutral_snapshot) and increments profiles.revision exactly once. Preserves history, memories and the relationship snapshot. Same per-user advisory lock as commit_turn. Replay-safe via the durable privacy_operations ledger; divergent payloads conflict sanitized. SECURITY DEFINER, service_role only.';
 
 COMMENT ON FUNCTION public.reset_relationship_state(text, uuid, jsonb) IS
-'Atomic, idempotent privacy primitive (#314). Replaces ONLY profiles.relationship_state with a validated v1 snapshot (produced by the domain, RelationshipStateV1.neutral) and increments profiles.revision exactly once. Preserves history, memories and the emotional snapshot. Same per-user advisory lock as commit_turn. Replay-safe via the durable privacy_operations ledger; divergent payloads conflict sanitized. SECURITY DEFINER, service_role only.';
+'Atomic, idempotent privacy primitive (#314). Replaces ONLY profiles.relationship_state with the canonical NEUTRAL v1 snapshot (RelationshipStateV1.neutral, verified by privacy_is_neutral_snapshot) and increments profiles.revision exactly once. Preserves history, memories and the emotional snapshot. Same per-user advisory lock as commit_turn. Replay-safe via the durable privacy_operations ledger; divergent payloads conflict sanitized. SECURITY DEFINER, service_role only.';

--- a/supabase/tests/database/06_privacy_data_operations.test.sql
+++ b/supabase/tests/database/06_privacy_data_operations.test.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 CREATE EXTENSION IF NOT EXISTS pgtap;
-SELECT plan(99);
+SELECT plan(116);
 
 -- =================================================================
 -- 1. Migration and ledger (#314)
@@ -256,6 +256,56 @@ SELECT function_privs_are(
 SELECT ok(
     NOT has_function_privilege('public', 'public.privacy_op_validation_error(text, uuid, jsonb)', 'EXECUTE'),
     'PUBLIC has no EXECUTE on privacy_op_validation_error'
+);
+
+-- =================================================================
+-- 3.1 Neutral snapshot verifier (reset semantics, issue #314 review)
+-- =================================================================
+SELECT has_function(
+    'public', 'privacy_is_neutral_snapshot', ARRAY['jsonb', 'text'],
+    'privacy_is_neutral_snapshot(jsonb, text) exists'
+);
+SELECT function_privs_are(
+    'public', 'privacy_is_neutral_snapshot', ARRAY['jsonb', 'text'],
+    'service_role', ARRAY[]::text[],
+    'service_role has no EXECUTE on privacy_is_neutral_snapshot'
+);
+SELECT ok(
+    NOT has_function_privilege('public', 'public.privacy_is_neutral_snapshot(jsonb, text)', 'EXECUTE'),
+    'PUBLIC has no EXECUTE on privacy_is_neutral_snapshot'
+);
+
+-- Behavioral: the helper accepts the canonical neutral v1 output of the
+-- Python domain constructors and rejects structurally valid non-neutral v1
+-- snapshots. This pins the SQL constants to the domain so the two boundaries
+-- cannot silently diverge.
+SELECT ok(
+    public.privacy_is_neutral_snapshot(
+        '{"schema_version":1,"pleasure":0.0,"arousal":0.0,"dominance":0.0,"libido":0.0,"aggression":0.0,"connection":0.5,"energy":0.8,"tension":0.0,"coping_mode":"HEALTHY","timestamp":1700000000.0}'::jsonb,
+        'emotional'
+    ),
+    'privacy_is_neutral_snapshot accepts the canonical neutral emotional v1 snapshot'
+);
+SELECT ok(
+    NOT public.privacy_is_neutral_snapshot(
+        '{"schema_version":1,"pleasure":0.9,"arousal":0.8,"dominance":0.7,"libido":0.1,"aggression":0.1,"connection":0.5,"energy":0.8,"tension":0.1,"coping_mode":"MANIC","timestamp":1700000000.0}'::jsonb,
+        'emotional'
+    ),
+    'privacy_is_neutral_snapshot rejects a valid but non-neutral emotional v1 snapshot'
+);
+SELECT ok(
+    public.privacy_is_neutral_snapshot(
+        '{"schema_version":1,"trust":0.5,"affection":0.3,"tension":0.0,"triggers":[],"timestamp":1700000000.0}'::jsonb,
+        'relationship'
+    ),
+    'privacy_is_neutral_snapshot accepts the canonical neutral relationship v1 snapshot'
+);
+SELECT ok(
+    NOT public.privacy_is_neutral_snapshot(
+        '{"schema_version":1,"trust":0.9,"affection":0.8,"tension":0.1,"triggers":[],"timestamp":1700000000.0}'::jsonb,
+        'relationship'
+    ),
+    'privacy_is_neutral_snapshot rejects a valid but non-neutral relationship v1 snapshot'
 );
 
 -- =================================================================
@@ -675,6 +725,49 @@ SELECT is(
     'rejected reset leaves no durable ledger row'
 );
 
+-- Valid v1 but semantically NON-NEUTRAL snapshots are rejected without any
+-- mutation, revision bump or ledger record (issue #314 review).
+SELECT is(
+    (SELECT public.reset_emotional_state(
+        'privacy_tap_reset', '77777777-7777-7777-7777-777777777777'::uuid,
+        '{"schema_version":1,"pleasure":0.9,"arousal":0.8,"dominance":0.7,"libido":0.1,"aggression":0.1,"connection":0.5,"energy":0.8,"tension":0.1,"coping_mode":"MANIC","timestamp":1700000000.0}'::jsonb
+    )->'error'->>'code'),
+    'validation_failed',
+    'valid but non-neutral emotional v1 snapshot is rejected with validation_failed'
+);
+SELECT is(
+    (SELECT revision FROM public.profiles WHERE user_id = 'privacy_tap_reset')::bigint,
+    8::bigint,
+    'non-neutral emotional reset does not change revision'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.privacy_operations
+     WHERE user_id = 'privacy_tap_reset'
+       AND operation_id = '77777777-7777-7777-7777-777777777777'::uuid),
+    0,
+    'non-neutral emotional reset leaves no durable ledger row'
+);
+SELECT is(
+    (SELECT public.reset_relationship_state(
+        'privacy_tap_reset', '88888888-8888-8888-8888-888888888888'::uuid,
+        '{"schema_version":1,"trust":0.9,"affection":0.8,"tension":0.1,"triggers":[],"timestamp":1700000000.0}'::jsonb
+    )->'error'->>'code'),
+    'validation_failed',
+    'valid but non-neutral relationship v1 snapshot is rejected with validation_failed'
+);
+SELECT is(
+    (SELECT revision FROM public.profiles WHERE user_id = 'privacy_tap_reset')::bigint,
+    8::bigint,
+    'non-neutral relationship reset does not change revision'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.privacy_operations
+     WHERE user_id = 'privacy_tap_reset'
+       AND operation_id = '88888888-8888-8888-8888-888888888888'::uuid),
+    0,
+    'non-neutral relationship reset leaves no durable ledger row'
+);
+
 -- =================================================================
 -- 7. User isolation (A's operations never touch B, and vice versa)
 -- =================================================================
@@ -706,6 +799,43 @@ SELECT is(
     (SELECT count(*)::integer FROM public.memories WHERE user_id = 'privacy_tap_reset'),
     1,
     'user B operations never touch user A memories'
+);
+
+-- =================================================================
+-- 8. SQL-side authenticated_user_id bounds (issue #314 review)
+--    The SQL validation mirrors the persistent ledger contract
+--    (char_length BETWEEN 1 AND 128 AND btrim <> ''): invalid identities
+--    return a predictable validation envelope, never a generic P0001.
+-- =================================================================
+SELECT is(
+    (SELECT public.delete_history(
+        '   ', '99999999-9999-9999-9999-999999999998'::uuid, '{}'::jsonb
+    )->'error'->>'code'),
+    'validation_failed',
+    'whitespace-only user_id fails with validation_failed (predictable)'
+);
+SELECT is(
+    (SELECT public.delete_history(
+        repeat('x', 129), '99999999-9999-9999-9999-999999999997'::uuid, '{}'::jsonb
+    )->'error'->>'code'),
+    'validation_failed',
+    '129-character user_id fails with validation_failed (predictable)'
+);
+SELECT is(
+    (SELECT public.delete_history(
+        repeat('y', 128), '99999999-9999-9999-9999-999999999996'::uuid, '{}'::jsonb
+    )->>'status'),
+    'applied',
+    '128-character user_id is accepted (boundary)'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.privacy_operations
+     WHERE operation_id IN (
+         '99999999-9999-9999-9999-999999999998'::uuid,
+         '99999999-9999-9999-9999-999999999997'::uuid
+     )),
+    0,
+    'invalid identities leave no durable ledger rows'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/database/06_privacy_data_operations.test.sql
+++ b/supabase/tests/database/06_privacy_data_operations.test.sql
@@ -1,0 +1,712 @@
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgtap;
+SELECT plan(99);
+
+-- =================================================================
+-- 1. Migration and ledger (#314)
+-- =================================================================
+SELECT ok(
+    EXISTS(
+        SELECT 1
+        FROM supabase_migrations.schema_migrations
+        WHERE name = 'privacy_data_operations'
+    ),
+    'privacy_data_operations migration is registered'
+);
+
+SELECT ok(
+    EXISTS(
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public' AND c.relname = 'privacy_operations'
+    ),
+    'public.privacy_operations exists'
+);
+
+SELECT ok(
+    (SELECT relrowsecurity FROM pg_class WHERE oid = 'public.privacy_operations'::regclass),
+    'RLS is enabled on privacy_operations'
+);
+SELECT ok(
+    (SELECT relforcerowsecurity FROM pg_class WHERE oid = 'public.privacy_operations'::regclass),
+    'FORCE RLS is enabled on privacy_operations'
+);
+SELECT ok(
+    NOT has_table_privilege('anon', 'public.privacy_operations',
+        'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'),
+    'anon has no table privileges on privacy_operations'
+);
+SELECT ok(
+    NOT has_table_privilege('authenticated', 'public.privacy_operations',
+        'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'),
+    'authenticated has no table privileges on privacy_operations'
+);
+SELECT ok(
+    NOT has_table_privilege('public', 'public.privacy_operations',
+        'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'),
+    'PUBLIC has no table privileges on privacy_operations'
+);
+SELECT ok(
+    NOT has_table_privilege('service_role', 'public.privacy_operations',
+        'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'),
+    'service_role has no table privileges on privacy_operations (RPCs are the only path)'
+);
+
+-- =================================================================
+-- 2. Function shape: exists, SECURITY DEFINER, fixed search_path
+-- =================================================================
+SELECT has_function('public', 'delete_history', ARRAY['text', 'uuid', 'jsonb'],
+    'delete_history(text, uuid, jsonb) exists');
+SELECT has_function('public', 'delete_memories', ARRAY['text', 'uuid', 'jsonb'],
+    'delete_memories(text, uuid, jsonb) exists');
+SELECT has_function('public', 'reset_emotional_state', ARRAY['text', 'uuid', 'jsonb'],
+    'reset_emotional_state(text, uuid, jsonb) exists');
+SELECT has_function('public', 'reset_relationship_state', ARRAY['text', 'uuid', 'jsonb'],
+    'reset_relationship_state(text, uuid, jsonb) exists');
+SELECT has_function('public', 'privacy_apply_operation', ARRAY['text', 'text', 'uuid', 'jsonb'],
+    'privacy_apply_operation(text, text, uuid, jsonb) exists');
+SELECT has_function('public', 'privacy_operation_payload_sha256', ARRAY['jsonb'],
+    'privacy_operation_payload_sha256(jsonb) exists');
+SELECT has_function('public', 'privacy_op_validation_error', ARRAY['text', 'uuid', 'jsonb'],
+    'privacy_op_validation_error(text, uuid, jsonb) exists');
+
+SELECT is(
+    (SELECT prosecdef FROM pg_proc
+     WHERE proname = 'delete_history' AND pronamespace = 'public'::regnamespace
+       AND pronargs = 3),
+    true,
+    'delete_history is SECURITY DEFINER'
+);
+SELECT is(
+    (SELECT prosecdef FROM pg_proc
+     WHERE proname = 'delete_memories' AND pronamespace = 'public'::regnamespace
+       AND pronargs = 3),
+    true,
+    'delete_memories is SECURITY DEFINER'
+);
+SELECT is(
+    (SELECT prosecdef FROM pg_proc
+     WHERE proname = 'reset_emotional_state' AND pronamespace = 'public'::regnamespace
+       AND pronargs = 3),
+    true,
+    'reset_emotional_state is SECURITY DEFINER'
+);
+SELECT is(
+    (SELECT prosecdef FROM pg_proc
+     WHERE proname = 'reset_relationship_state' AND pronamespace = 'public'::regnamespace
+       AND pronargs = 3),
+    true,
+    'reset_relationship_state is SECURITY DEFINER'
+);
+
+SELECT is(
+    (SELECT COALESCE(
+        (SELECT setting FROM pg_proc p
+         CROSS JOIN LATERAL unnest(proconfig) AS cfg(setting)
+         WHERE p.proname = 'delete_history' AND p.pronamespace = 'public'::regnamespace
+           AND p.pronargs = 3 AND cfg.setting LIKE 'search_path=%'),
+        '')
+    ),
+    'search_path=public',
+    'delete_history has a fixed search_path = public'
+);
+SELECT is(
+    (SELECT COALESCE(
+        (SELECT setting FROM pg_proc p
+         CROSS JOIN LATERAL unnest(proconfig) AS cfg(setting)
+         WHERE p.proname = 'delete_memories' AND p.pronamespace = 'public'::regnamespace
+           AND p.pronargs = 3 AND cfg.setting LIKE 'search_path=%'),
+        '')
+    ),
+    'search_path=public',
+    'delete_memories has a fixed search_path = public'
+);
+SELECT is(
+    (SELECT COALESCE(
+        (SELECT setting FROM pg_proc p
+         CROSS JOIN LATERAL unnest(proconfig) AS cfg(setting)
+         WHERE p.proname = 'reset_emotional_state' AND p.pronamespace = 'public'::regnamespace
+           AND p.pronargs = 3 AND cfg.setting LIKE 'search_path=%'),
+        '')
+    ),
+    'search_path=public',
+    'reset_emotional_state has a fixed search_path = public'
+);
+SELECT is(
+    (SELECT COALESCE(
+        (SELECT setting FROM pg_proc p
+         CROSS JOIN LATERAL unnest(proconfig) AS cfg(setting)
+         WHERE p.proname = 'reset_relationship_state' AND p.pronamespace = 'public'::regnamespace
+           AND p.pronargs = 3 AND cfg.setting LIKE 'search_path=%'),
+        '')
+    ),
+    'search_path=public',
+    'reset_relationship_state has a fixed search_path = public'
+);
+
+-- =================================================================
+-- 3. ACLs: EXECUTE for service_role ONLY on the four public RPCs
+-- =================================================================
+SELECT function_privs_are(
+    'public', 'delete_history', ARRAY['text', 'uuid', 'jsonb'],
+    'anon', ARRAY[]::text[],
+    'anon has no EXECUTE on delete_history'
+);
+SELECT function_privs_are(
+    'public', 'delete_history', ARRAY['text', 'uuid', 'jsonb'],
+    'authenticated', ARRAY[]::text[],
+    'authenticated has no EXECUTE on delete_history'
+);
+SELECT function_privs_are(
+    'public', 'delete_history', ARRAY['text', 'uuid', 'jsonb'],
+    'service_role', ARRAY['EXECUTE'],
+    'service_role has EXECUTE on delete_history'
+);
+SELECT ok(
+    NOT has_function_privilege('public', 'public.delete_history(text, uuid, jsonb)', 'EXECUTE'),
+    'PUBLIC has no EXECUTE on delete_history'
+);
+
+SELECT function_privs_are(
+    'public', 'delete_memories', ARRAY['text', 'uuid', 'jsonb'],
+    'anon', ARRAY[]::text[],
+    'anon has no EXECUTE on delete_memories'
+);
+SELECT function_privs_are(
+    'public', 'delete_memories', ARRAY['text', 'uuid', 'jsonb'],
+    'authenticated', ARRAY[]::text[],
+    'authenticated has no EXECUTE on delete_memories'
+);
+SELECT function_privs_are(
+    'public', 'delete_memories', ARRAY['text', 'uuid', 'jsonb'],
+    'service_role', ARRAY['EXECUTE'],
+    'service_role has EXECUTE on delete_memories'
+);
+SELECT ok(
+    NOT has_function_privilege('public', 'public.delete_memories(text, uuid, jsonb)', 'EXECUTE'),
+    'PUBLIC has no EXECUTE on delete_memories'
+);
+
+SELECT function_privs_are(
+    'public', 'reset_emotional_state', ARRAY['text', 'uuid', 'jsonb'],
+    'anon', ARRAY[]::text[],
+    'anon has no EXECUTE on reset_emotional_state'
+);
+SELECT function_privs_are(
+    'public', 'reset_emotional_state', ARRAY['text', 'uuid', 'jsonb'],
+    'authenticated', ARRAY[]::text[],
+    'authenticated has no EXECUTE on reset_emotional_state'
+);
+SELECT function_privs_are(
+    'public', 'reset_emotional_state', ARRAY['text', 'uuid', 'jsonb'],
+    'service_role', ARRAY['EXECUTE'],
+    'service_role has EXECUTE on reset_emotional_state'
+);
+SELECT ok(
+    NOT has_function_privilege('public', 'public.reset_emotional_state(text, uuid, jsonb)', 'EXECUTE'),
+    'PUBLIC has no EXECUTE on reset_emotional_state'
+);
+
+SELECT function_privs_are(
+    'public', 'reset_relationship_state', ARRAY['text', 'uuid', 'jsonb'],
+    'anon', ARRAY[]::text[],
+    'anon has no EXECUTE on reset_relationship_state'
+);
+SELECT function_privs_are(
+    'public', 'reset_relationship_state', ARRAY['text', 'uuid', 'jsonb'],
+    'authenticated', ARRAY[]::text[],
+    'authenticated has no EXECUTE on reset_relationship_state'
+);
+SELECT function_privs_are(
+    'public', 'reset_relationship_state', ARRAY['text', 'uuid', 'jsonb'],
+    'service_role', ARRAY['EXECUTE'],
+    'service_role has EXECUTE on reset_relationship_state'
+);
+SELECT ok(
+    NOT has_function_privilege('public', 'public.reset_relationship_state(text, uuid, jsonb)', 'EXECUTE'),
+    'PUBLIC has no EXECUTE on reset_relationship_state'
+);
+
+-- Internal core/helpers: NO grants at all (owner postgres only).
+SELECT function_privs_are(
+    'public', 'privacy_apply_operation', ARRAY['text', 'text', 'uuid', 'jsonb'],
+    'service_role', ARRAY[]::text[],
+    'service_role has no EXECUTE on privacy_apply_operation'
+);
+SELECT ok(
+    NOT has_function_privilege('public', 'public.privacy_apply_operation(text, text, uuid, jsonb)', 'EXECUTE'),
+    'PUBLIC has no EXECUTE on privacy_apply_operation'
+);
+SELECT function_privs_are(
+    'public', 'privacy_operation_payload_sha256', ARRAY['jsonb'],
+    'service_role', ARRAY[]::text[],
+    'service_role has no EXECUTE on privacy_operation_payload_sha256'
+);
+SELECT ok(
+    NOT has_function_privilege('public', 'public.privacy_operation_payload_sha256(jsonb)', 'EXECUTE'),
+    'PUBLIC has no EXECUTE on privacy_operation_payload_sha256'
+);
+SELECT function_privs_are(
+    'public', 'privacy_op_validation_error', ARRAY['text', 'uuid', 'jsonb'],
+    'service_role', ARRAY[]::text[],
+    'service_role has no EXECUTE on privacy_op_validation_error'
+);
+SELECT ok(
+    NOT has_function_privilege('public', 'public.privacy_op_validation_error(text, uuid, jsonb)', 'EXECUTE'),
+    'PUBLIC has no EXECUTE on privacy_op_validation_error'
+);
+
+-- =================================================================
+-- 4. delete_history semantics (fixture user with full data)
+-- =================================================================
+INSERT INTO public.profiles (user_id, persona_config, user_profile,
+    relationship_state, emotional_state, revision)
+VALUES (
+    'privacy_tap_user', 'persona-config', '{}'::jsonb,
+    '{"schema_version":1,"trust":0.9,"affection":0.8,"tension":0.1,"triggers":[],"timestamp":1700000000.0}'::jsonb,
+    '{"schema_version":1,"pleasure":0.9,"arousal":0.8,"dominance":0.7,"libido":0.1,"aggression":0.1,"connection":0.5,"energy":0.8,"tension":0.1,"coping_mode":"MANIC","timestamp":1700000000.0}'::jsonb,
+    2
+);
+
+INSERT INTO public.chat_logs (user_id, role, content)
+VALUES ('privacy_tap_user', 'user', 'hello'),
+       ('privacy_tap_user', 'assistant', 'hi there');
+
+INSERT INTO public.turn_requests (
+    id, user_id, request_id, payload_hash_sha256, status, expected_revision,
+    committed_revision, replay_payload, created_at, updated_at, completed_at
+) VALUES (
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
+    'privacy_tap_user', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid,
+    'a'::text || repeat('0', 63), 'completed', 0, 2,
+    '{"response":"hi there","message_id":"cccccccc-cccc-cccc-cccc-cccccccccccc"}'::jsonb,
+    now(), now(), now()
+);
+
+INSERT INTO public.outbox_events (
+    event_type, contract_version, user_id, turn_request_id, payload, status,
+    attempts, next_attempt_at, idempotency_key, created_at, updated_at
+) VALUES (
+    'turn_completed', 1, 'privacy_tap_user',
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
+    '{"ref":"t1"}'::jsonb, 'pending', 0, now() + interval '1 second',
+    'privacy_tap_user_k1', now(), now()
+);
+
+INSERT INTO public.memories (user_id, content, metadata)
+VALUES ('privacy_tap_user', 'a durable memory', '{"tags":["x"]}'::jsonb);
+
+INSERT INTO public.archival_extractions (
+    user_id, source_chat_log_id, extractor_version, schema_version,
+    idempotency_key, facts
+)
+SELECT 'privacy_tap_user', id, 1, 1, 'privacy_tap_user_arch_1', '{"facts":[]}'::jsonb
+FROM public.chat_logs
+WHERE user_id = 'privacy_tap_user' AND role = 'user';
+
+INSERT INTO public.admission_reservations (
+    user_id, request_id, message_hmac_sha256, network_hmac_sha256, estimated_units
+) VALUES (
+    'privacy_tap_user', 'dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid,
+    repeat('a', 64), repeat('b', 64), 10
+);
+
+SELECT is(
+    (SELECT public.delete_history(
+        'privacy_tap_user', '11111111-1111-1111-1111-111111111111'::uuid, '{}'::jsonb
+    )->>'status'),
+    'applied',
+    'delete_history returns status applied'
+);
+SELECT is(
+    (SELECT public.delete_history(
+        'privacy_tap_user', '11111111-1111-1111-1111-111111111111'::uuid, '{}'::jsonb
+    )->>'operation'),
+    'delete_history',
+    'delete_history returns operation delete_history'
+);
+SELECT is(
+    (SELECT public.delete_history(
+        'privacy_tap_user', '11111111-1111-1111-1111-111111111111'::uuid, '{}'::jsonb
+    )->>'revision')::bigint,
+    3::bigint,
+    'delete_history increments revision exactly once (2 -> 3)'
+);
+SELECT is(
+    (SELECT (public.delete_history(
+        'privacy_tap_user', '11111111-1111-1111-1111-111111111111'::uuid, '{}'::jsonb
+    )->'counts'->>'chat_logs')::integer),
+    2,
+    'delete_history counts 2 chat_logs removed'
+);
+SELECT is(
+    (SELECT (public.delete_history(
+        'privacy_tap_user', '11111111-1111-1111-1111-111111111111'::uuid, '{}'::jsonb
+    )->'counts'->>'turn_requests')::integer),
+    1,
+    'delete_history counts 1 turn_request removed'
+);
+SELECT is(
+    (SELECT (public.delete_history(
+        'privacy_tap_user', '11111111-1111-1111-1111-111111111111'::uuid, '{}'::jsonb
+    )->'counts'->>'outbox_events')::integer),
+    1,
+    'delete_history counts 1 outbox_event removed'
+);
+SELECT is(
+    (SELECT (public.delete_history(
+        'privacy_tap_user', '11111111-1111-1111-1111-111111111111'::uuid, '{}'::jsonb
+    )->'counts'->>'archival_extractions')::integer),
+    1,
+    'delete_history counts 1 archival extraction removed'
+);
+SELECT is(
+    (SELECT (public.delete_history(
+        'privacy_tap_user', '11111111-1111-1111-1111-111111111111'::uuid, '{}'::jsonb
+    )->'counts'->>'memories')::integer),
+    0,
+    'delete_history never counts memories'
+);
+
+SELECT is(
+    (SELECT count(*)::integer FROM public.chat_logs WHERE user_id = 'privacy_tap_user'),
+    0,
+    'chat_logs are removed by delete_history'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.turn_requests WHERE user_id = 'privacy_tap_user'),
+    0,
+    'turn_requests are removed by delete_history'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.outbox_events WHERE user_id = 'privacy_tap_user'),
+    0,
+    'outbox_events are removed by delete_history'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.archival_extractions WHERE user_id = 'privacy_tap_user'),
+    0,
+    'archival_extractions are removed by delete_history'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.memories WHERE user_id = 'privacy_tap_user'),
+    1,
+    'memories are PRESERVED by delete_history'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.admission_reservations WHERE user_id = 'privacy_tap_user'),
+    1,
+    'admission_reservations are PRESERVED by delete_history (no quota bypass)'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.profiles WHERE user_id = 'privacy_tap_user'),
+    1,
+    'profile is PRESERVED by delete_history'
+);
+SELECT is(
+    (SELECT revision FROM public.profiles WHERE user_id = 'privacy_tap_user')::bigint,
+    3::bigint,
+    'profile revision is 3 after delete_history'
+);
+SELECT is(
+    (SELECT emotional_state->>'coping_mode' FROM public.profiles WHERE user_id = 'privacy_tap_user'),
+    'MANIC',
+    'emotional snapshot is PRESERVED by delete_history'
+);
+SELECT is(
+    (SELECT relationship_state->>'trust' FROM public.profiles WHERE user_id = 'privacy_tap_user'),
+    '0.9',
+    'relationship snapshot is PRESERVED by delete_history'
+);
+
+-- Replay: identical stored result, no mutation, no revision bump
+SELECT is(
+    (SELECT public.delete_history(
+        'privacy_tap_user', '11111111-1111-1111-1111-111111111111'::uuid, '{}'::jsonb
+    )),
+    (SELECT public.delete_history(
+        'privacy_tap_user', '11111111-1111-1111-1111-111111111111'::uuid, '{}'::jsonb
+    )),
+    'delete_history replay returns the identical stored result'
+);
+SELECT is(
+    (SELECT revision FROM public.profiles WHERE user_id = 'privacy_tap_user')::bigint,
+    3::bigint,
+    'delete_history replay does not increment revision again'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.privacy_operations
+     WHERE user_id = 'privacy_tap_user'
+       AND operation_id = '11111111-1111-1111-1111-111111111111'::uuid),
+    1,
+    'exactly one durable ledger row after delete_history + replay'
+);
+
+-- Divergent payload / divergent operation on the same operation_id
+SELECT is(
+    (SELECT public.delete_history(
+        'privacy_tap_user', '11111111-1111-1111-1111-111111111111'::uuid, '{"x":1}'::jsonb
+    )->'error'->>'code'),
+    'operation_conflict',
+    'delete_history same operation_id with divergent payload conflicts'
+);
+SELECT is(
+    (SELECT public.delete_memories(
+        'privacy_tap_user', '11111111-1111-1111-1111-111111111111'::uuid, '{}'::jsonb
+    )->'error'->>'code'),
+    'operation_conflict',
+    'same operation_id with a different operation conflicts'
+);
+
+-- =================================================================
+-- 5. delete_memories semantics
+-- =================================================================
+INSERT INTO public.profiles (user_id, persona_config, user_profile,
+    relationship_state, emotional_state, revision)
+VALUES (
+    'privacy_tap_mem', 'persona-config', '{}'::jsonb,
+    '{"schema_version":1,"trust":0.5,"affection":0.3,"tension":0.0,"triggers":[],"timestamp":1700000000.0}'::jsonb,
+    '{"schema_version":1,"pleasure":0.1,"arousal":0.2,"dominance":0.3,"libido":0.0,"aggression":0.0,"connection":0.5,"energy":0.8,"tension":0.0,"coping_mode":"HEALTHY","timestamp":1700000000.0}'::jsonb,
+    4
+);
+INSERT INTO public.chat_logs (user_id, role, content)
+VALUES ('privacy_tap_mem', 'user', 'hello'),
+       ('privacy_tap_mem', 'assistant', 'hi there');
+INSERT INTO public.memories (user_id, content, metadata)
+VALUES ('privacy_tap_mem', 'a durable memory', '{}'::jsonb);
+INSERT INTO public.archival_extractions (
+    user_id, source_chat_log_id, extractor_version, schema_version,
+    idempotency_key, facts
+)
+SELECT 'privacy_tap_mem', id, 1, 1, 'privacy_tap_mem_arch_1', '{"facts":[]}'::jsonb
+FROM public.chat_logs
+WHERE user_id = 'privacy_tap_mem' AND role = 'user';
+
+SELECT is(
+    (SELECT public.delete_memories(
+        'privacy_tap_mem', '22222222-2222-2222-2222-222222222222'::uuid, '{}'::jsonb
+    )->>'status'),
+    'applied',
+    'delete_memories returns status applied'
+);
+SELECT is(
+    (SELECT (public.delete_memories(
+        'privacy_tap_mem', '22222222-2222-2222-2222-222222222222'::uuid, '{}'::jsonb
+    )->'counts'->>'memories')::integer),
+    1,
+    'delete_memories counts 1 memory removed'
+);
+SELECT is(
+    (SELECT (public.delete_memories(
+        'privacy_tap_mem', '22222222-2222-2222-2222-222222222222'::uuid, '{}'::jsonb
+    )->'counts'->>'archival_extractions')::integer),
+    1,
+    'delete_memories counts 1 archival extraction removed'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.memories WHERE user_id = 'privacy_tap_mem'),
+    0,
+    'memories are removed by delete_memories'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.archival_extractions WHERE user_id = 'privacy_tap_mem'),
+    0,
+    'archival extractions are removed by delete_memories'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.chat_logs WHERE user_id = 'privacy_tap_mem'),
+    2,
+    'chat history is PRESERVED by delete_memories'
+);
+SELECT is(
+    (SELECT revision FROM public.profiles WHERE user_id = 'privacy_tap_mem')::bigint,
+    5::bigint,
+    'delete_memories increments revision exactly once (4 -> 5)'
+);
+SELECT is(
+    (SELECT public.delete_memories(
+        'privacy_tap_mem', '22222222-2222-2222-2222-222222222222'::uuid, '{}'::jsonb
+    )),
+    (SELECT public.delete_memories(
+        'privacy_tap_mem', '22222222-2222-2222-2222-222222222222'::uuid, '{}'::jsonb
+    )),
+    'delete_memories replay returns the identical stored result'
+);
+SELECT is(
+    (SELECT revision FROM public.profiles WHERE user_id = 'privacy_tap_mem')::bigint,
+    5::bigint,
+    'delete_memories replay does not increment revision again'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.privacy_operations
+     WHERE user_id = 'privacy_tap_mem'
+       AND operation_id = '22222222-2222-2222-2222-222222222222'::uuid),
+    1,
+    'exactly one durable ledger row after delete_memories + replay'
+);
+
+-- =================================================================
+-- 6. Reset semantics (v1 neutral snapshots, surgical replacement)
+-- =================================================================
+INSERT INTO public.profiles (user_id, persona_config, user_profile,
+    relationship_state, emotional_state, revision)
+VALUES (
+    'privacy_tap_reset', 'persona-config', '{}'::jsonb,
+    '{"schema_version":1,"trust":0.9,"affection":0.8,"tension":0.1,"triggers":[],"timestamp":1700000000.0}'::jsonb,
+    '{"schema_version":1,"pleasure":0.9,"arousal":0.8,"dominance":0.7,"libido":0.1,"aggression":0.1,"connection":0.5,"energy":0.8,"tension":0.1,"coping_mode":"MANIC","timestamp":1700000000.0}'::jsonb,
+    6
+);
+INSERT INTO public.chat_logs (user_id, role, content)
+VALUES ('privacy_tap_reset', 'user', 'hello');
+INSERT INTO public.memories (user_id, content, metadata)
+VALUES ('privacy_tap_reset', 'a durable memory', '{}'::jsonb);
+
+SELECT is(
+    (SELECT public.reset_emotional_state(
+        'privacy_tap_reset', '33333333-3333-3333-3333-333333333333'::uuid,
+        '{"schema_version":1,"pleasure":0.0,"arousal":0.0,"dominance":0.0,"libido":0.0,"aggression":0.0,"connection":0.5,"energy":0.8,"tension":0.0,"coping_mode":"HEALTHY","timestamp":1700000000.0}'::jsonb
+    )->>'status'),
+    'applied',
+    'reset_emotional_state returns status applied'
+);
+SELECT is(
+    (SELECT revision FROM public.profiles WHERE user_id = 'privacy_tap_reset')::bigint,
+    7::bigint,
+    'reset_emotional_state increments revision exactly once (6 -> 7)'
+);
+SELECT is(
+    (SELECT emotional_state FROM public.profiles WHERE user_id = 'privacy_tap_reset'),
+    '{"schema_version":1,"pleasure":0.0,"arousal":0.0,"dominance":0.0,"libido":0.0,"aggression":0.0,"connection":0.5,"energy":0.8,"tension":0.0,"coping_mode":"HEALTHY","timestamp":1700000000.0}'::jsonb,
+    'reset_emotional_state persists a valid v1 neutral snapshot'
+);
+SELECT is(
+    (SELECT relationship_state->>'trust' FROM public.profiles WHERE user_id = 'privacy_tap_reset'),
+    '0.9',
+    'reset_emotional_state PRESERVES the relationship snapshot'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.chat_logs WHERE user_id = 'privacy_tap_reset'),
+    1,
+    'reset_emotional_state PRESERVES chat history'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.memories WHERE user_id = 'privacy_tap_reset'),
+    1,
+    'reset_emotional_state PRESERVES memories'
+);
+SELECT is(
+    (SELECT public.reset_emotional_state(
+        'privacy_tap_reset', '33333333-3333-3333-3333-333333333333'::uuid,
+        '{"schema_version":1,"pleasure":0.0,"arousal":0.0,"dominance":0.0,"libido":0.0,"aggression":0.0,"connection":0.5,"energy":0.8,"tension":0.0,"coping_mode":"HEALTHY","timestamp":1700000000.0}'::jsonb
+    )),
+    (SELECT public.reset_emotional_state(
+        'privacy_tap_reset', '33333333-3333-3333-3333-333333333333'::uuid,
+        '{"schema_version":1,"pleasure":0.0,"arousal":0.0,"dominance":0.0,"libido":0.0,"aggression":0.0,"connection":0.5,"energy":0.8,"tension":0.0,"coping_mode":"HEALTHY","timestamp":1700000000.0}'::jsonb
+    )),
+    'reset_emotional_state replay returns the identical stored result'
+);
+SELECT is(
+    (SELECT revision FROM public.profiles WHERE user_id = 'privacy_tap_reset')::bigint,
+    7::bigint,
+    'reset_emotional_state replay does not increment revision again'
+);
+
+SELECT is(
+    (SELECT public.reset_relationship_state(
+        'privacy_tap_reset', '44444444-4444-4444-4444-444444444444'::uuid,
+        '{"schema_version":1,"trust":0.5,"affection":0.3,"tension":0.0,"triggers":[],"timestamp":1700000000.0}'::jsonb
+    )->>'status'),
+    'applied',
+    'reset_relationship_state returns status applied'
+);
+SELECT is(
+    (SELECT revision FROM public.profiles WHERE user_id = 'privacy_tap_reset')::bigint,
+    8::bigint,
+    'reset_relationship_state increments revision exactly once (7 -> 8)'
+);
+SELECT is(
+    (SELECT relationship_state FROM public.profiles WHERE user_id = 'privacy_tap_reset'),
+    '{"schema_version":1,"trust":0.5,"affection":0.3,"tension":0.0,"triggers":[],"timestamp":1700000000.0}'::jsonb,
+    'reset_relationship_state persists a valid v1 neutral snapshot'
+);
+SELECT is(
+    (SELECT emotional_state->>'coping_mode' FROM public.profiles WHERE user_id = 'privacy_tap_reset'),
+    'HEALTHY',
+    'reset_relationship_state PRESERVES the emotional snapshot'
+);
+SELECT is(
+    (SELECT public.reset_relationship_state(
+        'privacy_tap_reset', '44444444-4444-4444-4444-444444444444'::uuid,
+        '{"schema_version":1,"trust":0.5,"affection":0.3,"tension":0.0,"triggers":[],"timestamp":1700000000.0}'::jsonb
+    )),
+    (SELECT public.reset_relationship_state(
+        'privacy_tap_reset', '44444444-4444-4444-4444-444444444444'::uuid,
+        '{"schema_version":1,"trust":0.5,"affection":0.3,"tension":0.0,"triggers":[],"timestamp":1700000000.0}'::jsonb
+    )),
+    'reset_relationship_state replay returns the identical stored result'
+);
+SELECT is(
+    (SELECT revision FROM public.profiles WHERE user_id = 'privacy_tap_reset')::bigint,
+    8::bigint,
+    'reset_relationship_state replay does not increment revision again'
+);
+
+-- Invalid v1 snapshot is rejected without mutation or ledger record
+SELECT is(
+    (SELECT public.reset_emotional_state(
+        'privacy_tap_reset', '55555555-5555-5555-5555-555555555555'::uuid,
+        '{"schema_version":1,"pleasure":0.0,"arousal":0.0,"dominance":0.0,"libido":0.0,"aggression":0.0,"connection":0.5,"energy":0.8,"tension":0.0,"coping_mode":"BOGUS","timestamp":1700000000.0}'::jsonb
+    )->'error'->>'code'),
+    'validation_failed',
+    'invalid v1 emotional snapshot is rejected with validation_failed'
+);
+SELECT is(
+    (SELECT revision FROM public.profiles WHERE user_id = 'privacy_tap_reset')::bigint,
+    8::bigint,
+    'rejected reset does not change revision'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.privacy_operations
+     WHERE user_id = 'privacy_tap_reset'
+       AND operation_id = '55555555-5555-5555-5555-555555555555'::uuid),
+    0,
+    'rejected reset leaves no durable ledger row'
+);
+
+-- =================================================================
+-- 7. User isolation (A's operations never touch B, and vice versa)
+-- =================================================================
+INSERT INTO public.profiles (user_id, revision)
+VALUES ('privacy_tap_other', 0);
+INSERT INTO public.chat_logs (user_id, role, content)
+VALUES ('privacy_tap_other', 'user', 'other hello');
+INSERT INTO public.memories (user_id, content, metadata)
+VALUES ('privacy_tap_other', 'other memory', '{}'::jsonb);
+
+SELECT is(
+    (SELECT public.delete_history(
+        'privacy_tap_other', '66666666-6666-6666-6666-666666666666'::uuid, '{}'::jsonb
+    )->>'status'),
+    'applied',
+    'delete_history for user B returns status applied'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.chat_logs WHERE user_id = 'privacy_tap_other'),
+    0,
+    'user B chat history is removed'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.chat_logs WHERE user_id = 'privacy_tap_reset'),
+    1,
+    'user B operations never touch user A chat history'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.memories WHERE user_id = 'privacy_tap_reset'),
+    1,
+    'user B operations never touch user A memories'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Closes #314

## Origem

- Issue/tarefa: #314 (cadeia de privacidade #274, gate PROD-0 #264), status:ready
- Agente/autor: Jules
- Base: `main` em `ab12328800332d13631da2ab12da4f736cfa7f8c` (squash da PR #320)
- Revisão formal: review `4890123795` (4 violações de contrato corrigidas no HEAD `505d849`)

## Problema

O sistema já possui persistência transacional de turnos (`commit_turn`),
`profiles.revision`, `turn_requests`, `outbox_events`, snapshots versionados e
lock PostgreSQL por usuário, mas nenhuma primitiva server-owned para operações
de privacidade. A revisão formal apontou quatro desvios de contrato da #314:

1. O preflight usava `c.relname IN (...)` e só comprovava que PELO MENOS uma
   tabela obrigatória existia (schema parcial podia passar).
2. Os resets validavam apenas estrutura/versão v1 (`jsonb_snapshot_contract`),
   permitindo persistir um snapshot v1 válido porém NÃO neutro
   (ex.: `pleasure = 0.9`, `coping_mode = 'MANIC'`) numa operação chamada
   `reset_*`.
3. `parse_privacy_operation_result()` não comprovava que o `user_id` do
   resultado pertencia ao `authenticated_user_id` solicitado.
4. A validação de `authenticated_user_id` não espelhava a constraint
   persistente do ledger: whitespace-only e IDs acima de 128 caracteres
   atravessavam a validação e viravam erro genérico de persistência.

## Solução

Fundação transacional/somente banco (sem HTTP/UI) com quatro primitivas:
`delete_history`, `delete_memories`, `reset_emotional_state`,
`reset_relationship_state`, agora com as quatro correções:

### 1. Preflight realmente fail-closed (migration)

Cada tabela obrigatória (`chat_logs`, `memories`, `archival_extractions`,
`turn_requests`, `outbox_events`, `admission_reservations`) é verificada
individualmente com `pg_catalog.to_regclass(...) IS NULL` (NULL-safe) e
qualquer ausência levanta `23514` ANTES de criar qualquer objeto da
migration; `profiles.revision`, `jsonb_snapshot_contract`, `pgcrypto` e o
drift dos objetos próprios continuam verificados. Novo gate de CI:
`backend/tests/test_privacy_operations_preflight.py` (3 casos parametrizados:
`admission_reservations`, `turn_requests`, `archival_extractions`) parte de um
baseline compatível, remove EXATAMENTE uma dependência (as demais presentes —
o caso que o `IN (...)` mascarava), aplica a migration e exige `23514` com
`privacy_operations` não criada, nenhuma das 8 funções instalada e migration
não registrada.

### 2. Reset somente neutro canônico (Python + SQL)

- PRODUÇÃO da neutralidade: construtores do domínio
  `EmotionalStateV1.neutral(...)` / `RelationshipStateV1.neutral(...)`.
- VERIFICAÇÃO Python: o adapter reconstrói o snapshot neutro canônico pelos
  construtores (com o timestamp do payload) e exige igualdade exata; snapshot
  v1 válido mas não neutro é rejeitado antes da RPC.
- VERIFICAÇÃO SQL (fronteira privilegiada): nova helper
  `privacy_is_neutral_snapshot(payload, kind)` exige o contrato v1 completo e
  compara cada campo de estado com as constantes neutras canônicas que
  espelham o domínio; testes de fronteira cruzada (pgTAP + banco real) fixam
  as constantes SQL na saída exata dos construtores Python.
- Nenhum segundo modelo emocional/relacional foi criado no SQL; o contrato v1
  existente não foi enfraquecido.
- Testes: pgTAP (rejeição de snapshot válido não neutro emocional e
  relacional com revision/ledger intactos), unit Python (mesma cobertura) e
  integração real (mesma cobertura + replay idempotente do reset neutro).

### 3. Resultado vinculado ao usuário esperado (adapter)

`parse_privacy_operation_result(result, operation, operation_id,
expected_user_id)` agora exige `result.user_id == expected_user_id` e falha
fechado com mensagem constante e sanitizada (a identidade divergente — que
pode ser valor sensível controlado por atacante — nunca é ecoada).
`run_privacy_operation` encaminha a identidade esperada. Testes: user correto
aceito, user divergente rejeitado, marcador sensível ausente da exceção, e
encaminhamento correto pelo entry point (unit + integração real).

### 4. Validação de authenticated_user_id alinhada ao ledger

- Python (`_validate_user_id`): rejeita `None`, não-string, vazio,
  whitespace-only e > 128 caracteres ANTES da RPC (sem normalizar a
  identidade). Limites exatos testados: 1 aceito, 128 aceito, 129 rejeitado,
  `"   "` rejeitado, não-string rejeitado, RPC nunca chamada em falha Python.
- SQL (`privacy_op_validation_error`): espelha a constraint persistente
  (`char_length BETWEEN 1 AND 128 AND btrim <> ''`) e retorna
  `validation_failed` previsível (nunca P0001 genérico); nenhuma linha de
  ledger para identidade inválida (pgTAP + integração real).

## Decisões preservadas (não alteradas)

- PostgreSQL como coordenador com a MESMA fronteira por usuário de
  `commit_turn` (`pg_advisory_xact_lock(hashtextextended(user_id, 0))`) +
  `FOR UPDATE` no profile; sem lock global.
- Ledger durável `privacy_operations` chaveado por `(user_id, operation_id)`
  com fingerprint SHA-256: replay sem nova mutação/revision; `operation_id`
  divergente → `operation_conflict` sanitizado; sem cache process-local.
- `profiles.revision` incrementa exatamente uma vez por operação aplicada.
- RPCs `SECURITY DEFINER` (search_path fixo), `EXECUTE` somente para
  `service_role`; core/helpers sem grants; ledger `RLS + FORCE RLS` sem
  grants de tabela (nem service_role).
- Rollback transacional integral em falha intermediária; isolamento A/B;
  `admission_reservations` preservado por `delete_history` (sem bypass de
  quota); erros/resultados sanitizados.

## Escopo alterado

- [x] Backend
- [ ] Frontend (nenhuma alteração)
- [ ] Sistema emocional (fórmulas/decay/appraisal intactos; resets só
      substituem o snapshot pelo neutro canônico do domínio)
- [x] Memória/relacionamento (primitivas de exclusão/reset)
- [x] Autenticação/segurança (ACLs mínimas, identidade server-side,
      neutralidade, limites de user_id)
- [x] Infraestrutura/governança (migration versionada, preflight, CI database)

Arquivos/áreas afetadas:

- `supabase/migrations/20260808220000_privacy_data_operations.sql`
- `supabase/tests/database/06_privacy_data_operations.test.sql` (pgTAP 116)
- `backend/privacy_operations.py`
- `backend/tests/test_privacy_operations.py` (unit 60)
- `backend/tests/test_privacy_operations_integration.py` (real Supabase 38)
- `backend/tests/test_privacy_operations_legacy.py` (upgrade legado)
- `backend/tests/test_privacy_operations_preflight.py` (NOVO gate de CI)
- `.github/workflows/ci.yml` (passo preflight + ignore list backend)
- `docs/architecture/user-data-lifecycle.md` (decisões atualizadas)

## Validação

Resultados reais no HEAD final `505d849` (Supabase/PostgreSQL local, CLI
2.109.1 — mesmo pin da CI):

- `supabase db reset` + `supabase test db supabase/tests/database` →
  **Files=6, Tests=541, Result: PASS** (pgTAP 116 da suite de privacidade).
- Backend unit (job backend com a mesma ignore list): **2372 passed**
  (60 novos de `test_privacy_operations.py`).
- Privacy integration: **38 passed** (16 cenários da #314 + não-neutralidade,
  SQL user bounds, adapter divergente; concorrência com `threading.Barrier`,
  rollback com triggers descartáveis).
- Privacy legacy upgrade (CI-style `hide-migrations-after.sh 06`): **1 passed**.
- **NOVO** Privacy preflight (CI-style, 3 tabelas): **3 passed** — migration
  falha com `23514`, nada é instalado.
- Suites existentes reexecutadas: `test_atomic_turn_commit_integration` +
  `test_process_turn_integration` + `test_admission_ledger_integration` +
  `test_database_authorization_integration` +
  `test_transactional_schema_integration` → **131 passed**; `test_legacy_upgrade`
  2 passed; `test_transactional_schema_legacy` 2 passed;
  `test_rls_auto_enable_legacy` 5 passed.
- Frontend/docker: nenhuma alteração; jobs intactos.

- [x] Testes automatizados adicionados/atualizados
- [x] Testes relevantes passaram
- [x] Lint/build passaram (nenhuma dependência alterada; compilação Python OK)
- [x] Sem logs de depuração ou segredos
- [x] Estado e dados permanecem isolados por usuário

## Riscos e operação

- Migração: puramente aditiva; preflight agora falha fechado (23514) em
  qualquer dependência ausente antes de instalar objetos.
- Rollback: drop do ledger/funções restaura o schema anterior sem tocar
  outros objetos; as operações de privacidade são destrutivas por design e
  não reversíveis (idempotência garante aplicação única).
- Riscos residuais:
  - A neutralidade SQL usa constantes que espelham o domínio; a divergência
    silenciosa é prevenida pelos testes de fronteira cruzada (pgTAP +
    integração real fixam as constantes na saída dos construtores), mas
    mudanças futuras nos construtores neutros do domínio exigem atualizar os
    testes de pin.
  - Sem endpoint/UI ainda (fora de escopo; próximas folhas #315/#276).
  - `delete_history`/`delete_memories` com perfil inexistente aplicam no-op
    determinístico e registram o ledger (idempotência sobrevive sem FK para
    `profiles`).
  - Fingerprint usa serialização canônica de jsonb; payloads textualmente
    distintos mas semanticamente iguais (ex.: `1` vs `1.0`) podem ser
    tratados como divergentes — a camada Python serializa de forma
    determinística.
  - Auditoria obrigatória do SQL/concorrência pelo mantenedor (conforme #314).

## Fora de escopo

- Endpoints HTTP e UI; exclusão de conta/Auth; worker/job durável; retenção
  física; exportação (#315/#276).
- Alteração de modelos, fórmulas, decay, appraisal ou personalidade;
  reativação de archival extraction; edição de `.Jules/palette.md`;
  alteração de dependências; melhorias paralelas.
