### PR TITLE
feat(api): expose authenticated privacy actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,21 @@ jobs:
           bash scripts/hide-migrations-after.sh 20240101000006 \
             python -m pytest -q -ra backend/tests/test_privacy_operations_preflight.py
 
+      - name: Reset database for privacy API integration tests
+        run: |
+          set -euo pipefail
+          supabase db reset
+
+      - name: Run Privacy API Integration Tests
+        env:
+          SUPABASE_URL: "http://127.0.0.1:54321"
+          SUPABASE_ANON_KEY: "${{ env.SUPABASE_ANON_KEY }}"
+          SUPABASE_SERVICE_ROLE_KEY: "${{ env.SUPABASE_SERVICE_ROLE_KEY }}"
+          PYTHONPATH: "."
+        run: |
+          set -euo pipefail
+          python -m pytest -q -ra backend/tests/test_privacy_api_integration.py
+
       - name: Stop Supabase
         if: always()
         run: supabase stop
@@ -335,6 +350,7 @@ jobs:
               --ignore=backend/tests/test_privacy_operations_integration.py \
               --ignore=backend/tests/test_privacy_operations_legacy.py \
               --ignore=backend/tests/test_privacy_operations_preflight.py \
+              --ignore=backend/tests/test_privacy_api_integration.py \
               -ra
 
   frontend:

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -30,6 +30,7 @@ from .observability import (
     EVENT_SUPABASE_CLIENT_CREATION_FAILED,
     emit_event,
 )
+from .privacy_service import PrivacyService, SupabasePrivacyRepository
 from .settings import Settings
 from .turn_execution import TurnExecutionConfig
 
@@ -56,6 +57,7 @@ class ApplicationDependencies:
     health_checks: HealthRegistry
     clock: Callable[[], float] = field(default_factory=time.time)
     persistence_client: Any = None
+    privacy_service: Any = None
 
 
 def _supabase_factory_from_settings(settings: Settings) -> Callable[[], Optional[Any]]:
@@ -207,6 +209,16 @@ def build_default_dependencies(
         )
         created.append(health_checks)
 
+        # Stateless application service for the #315 privacy HTTP actions.
+        # It receives identity and operation_id per call and never stores
+        # per-user state; the injected clock and the operational turn
+        # configuration drive reset timestamps and the write budget.
+        privacy_service = PrivacyService(
+            repository=SupabasePrivacyRepository(supabase_client),
+            turn_config=settings.turn_config,
+            clock=time.time,
+        )
+
         dependencies = ApplicationDependencies(
             conversation_engine=engine,
             auth_client=supabase_client,
@@ -215,6 +227,7 @@ def build_default_dependencies(
             health_checks=health_checks,
             clock=time.time,
             persistence_client=supabase_client,
+            privacy_service=privacy_service,
         )
 
         # Owned resources created by this builder, closed at shutdown and on

--- a/backend/main.py
+++ b/backend/main.py
@@ -850,6 +850,16 @@ def get_history(request: Request, current_user=Depends(get_current_user)):
 # ``PrivacyService``. Error mapping is stable and sanitized: 401 auth,
 # 422 input, 409 operation conflict, 503 persistence, 500 fail-closed.
 
+#: Dispatch table: canonical #314 operation constant -> PrivacyService method.
+#: Each endpoint passes its own operation constant, so exactly one service
+#: method runs per request and adding a new operation is a single entry.
+_PRIVACY_ACTION_METHOD = {
+    OPERATION_DELETE_HISTORY: "delete_history",
+    OPERATION_DELETE_MEMORIES: "delete_memories",
+    OPERATION_RESET_EMOTIONAL_STATE: "reset_emotional_state",
+    OPERATION_RESET_RELATIONSHIP_STATE: "reset_relationship_state",
+}
+
 
 async def _run_privacy_action(
     operation: str,
@@ -859,8 +869,9 @@ async def _run_privacy_action(
 ) -> PrivacyOperationResponse:
     """Run one privacy action through the injected privacy service.
 
-    The service method is selected by the canonical operation constant, so
-    each endpoint invokes exactly its own operation and never another one.
+    The service method is resolved from the canonical operation constant via
+    ``_PRIVACY_ACTION_METHOD``, so each endpoint invokes exactly its own
+    operation and never another one.
     """
     deps = get_dependencies(request)
     service = deps.privacy_service
@@ -868,19 +879,13 @@ async def _run_privacy_action(
         raise HTTPException(
             status_code=503, detail=_PRIVACY_SERVICE_UNAVAILABLE_DETAIL
         )
+    method_name = _PRIVACY_ACTION_METHOD.get(operation)
+    if method_name is None:
+        raise HTTPException(status_code=500, detail=_PRIVACY_INTERNAL_DETAIL) from None
     user_id = getattr(current_user, "id", None)
     operation_id = str(input_data.operation_id)
     try:
-        if operation == OPERATION_DELETE_HISTORY:
-            result = await service.delete_history(user_id, operation_id)
-        elif operation == OPERATION_DELETE_MEMORIES:
-            result = await service.delete_memories(user_id, operation_id)
-        elif operation == OPERATION_RESET_EMOTIONAL_STATE:
-            result = await service.reset_emotional_state(user_id, operation_id)
-        elif operation == OPERATION_RESET_RELATIONSHIP_STATE:
-            result = await service.reset_relationship_state(user_id, operation_id)
-        else:
-            raise HTTPException(status_code=500, detail=_PRIVACY_INTERNAL_DETAIL)
+        result = await getattr(service, method_name)(user_id, operation_id)
     except HTTPException:
         raise
     except ConflictError as exc:

--- a/backend/main.py
+++ b/backend/main.py
@@ -850,17 +850,6 @@ def get_history(request: Request, current_user=Depends(get_current_user)):
 # ``PrivacyService``. Error mapping is stable and sanitized: 401 auth,
 # 422 input, 409 operation conflict, 503 persistence, 500 fail-closed.
 
-#: Dispatch table: canonical #314 operation constant -> PrivacyService method.
-#: Each endpoint passes its own operation constant, so exactly one service
-#: method runs per request and adding a new operation is a single entry.
-_PRIVACY_ACTION_METHOD = {
-    OPERATION_DELETE_HISTORY: "delete_history",
-    OPERATION_DELETE_MEMORIES: "delete_memories",
-    OPERATION_RESET_EMOTIONAL_STATE: "reset_emotional_state",
-    OPERATION_RESET_RELATIONSHIP_STATE: "reset_relationship_state",
-}
-
-
 async def _run_privacy_action(
     operation: str,
     input_data: PrivacyOperationInput,
@@ -869,9 +858,8 @@ async def _run_privacy_action(
 ) -> PrivacyOperationResponse:
     """Run one privacy action through the injected privacy service.
 
-    The service method is resolved from the canonical operation constant via
-    ``_PRIVACY_ACTION_METHOD``, so each endpoint invokes exactly its own
-    operation and never another one.
+    The service method is selected by the canonical operation constant, so
+    each endpoint invokes exactly its own operation and never another one.
     """
     deps = get_dependencies(request)
     service = deps.privacy_service
@@ -879,13 +867,21 @@ async def _run_privacy_action(
         raise HTTPException(
             status_code=503, detail=_PRIVACY_SERVICE_UNAVAILABLE_DETAIL
         )
-    method_name = _PRIVACY_ACTION_METHOD.get(operation)
-    if method_name is None:
-        raise HTTPException(status_code=500, detail=_PRIVACY_INTERNAL_DETAIL) from None
     user_id = getattr(current_user, "id", None)
     operation_id = str(input_data.operation_id)
     try:
-        result = await getattr(service, method_name)(user_id, operation_id)
+        if operation == OPERATION_DELETE_HISTORY:
+            result = await service.delete_history(user_id, operation_id)
+        elif operation == OPERATION_DELETE_MEMORIES:
+            result = await service.delete_memories(user_id, operation_id)
+        elif operation == OPERATION_RESET_EMOTIONAL_STATE:
+            result = await service.reset_emotional_state(user_id, operation_id)
+        elif operation == OPERATION_RESET_RELATIONSHIP_STATE:
+            result = await service.reset_relationship_state(user_id, operation_id)
+        else:
+            # Fail closed for any unknown operation: never dispatch to an
+            # unrelated method and never surface the operation value.
+            raise HTTPException(status_code=500, detail=_PRIVACY_INTERNAL_DETAIL) from None
     except HTTPException:
         raise
     except ConflictError as exc:

--- a/backend/main.py
+++ b/backend/main.py
@@ -31,6 +31,7 @@ import logging
 import time
 from contextlib import asynccontextmanager
 from typing import Optional
+from uuid import UUID
 
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
@@ -60,7 +61,7 @@ from .admission import (
     resolve_network_identity,
 )
 from .admission_contracts import AdmissionError, RequestIdentity, validate_new_message
-from .atomic_turn_commit import ConflictError, PersistenceError
+from .atomic_turn_commit import ConflictError, PersistenceError, ValidationError
 from .dependencies import (
     ApplicationDependencies,
     build_default_dependencies,
@@ -80,6 +81,13 @@ from .observability import (
     EVENT_TURN_FAILED,
     emit_event,
 )
+from .privacy_operations import (
+    OPERATION_DELETE_HISTORY,
+    OPERATION_DELETE_MEMORIES,
+    OPERATION_RESET_EMOTIONAL_STATE,
+    OPERATION_RESET_RELATIONSHIP_STATE,
+)
+from .privacy_service import PrivacyOperationResponse
 from .process_turn import TurnMode
 from .runtime_containment import validate_worker_configuration
 from .settings import Settings, SettingsConfigurationError
@@ -291,6 +299,19 @@ class ChatResponse(BaseModel):
     emotion_state: EmotionStateResponse
 
 
+class PrivacyOperationInput(BaseModel):
+    """Request body for the four #315 privacy actions.
+
+    Accepts ONLY ``operation_id`` (any canonical UUID version; normalized to
+    lowercase canonical form before reaching the privacy layer). Any extra
+    key, including ``user_id``, is rejected with 422: the authenticated
+    identity always comes from ``current_user.id``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    operation_id: UUID
+
+
 _VALIDATION_MESSAGES = {
     "invalid_request_id": "Invalid request identifier.",
     "message_too_long": "Message exceeds the character limit.",
@@ -467,6 +488,42 @@ def _admission_unavailable_error() -> HTTPException:
     )
 
 
+# ─── Privacy action error mapping (#315) ─────────────────────────────────────
+#
+# Stable, sanitized HTTP mapping for the four privacy actions. Every detail
+# is a public constant; exception text, identifiers and internal envelope
+# content never reach the response. After HTTP input validation, a
+# ValidationError raised by the #314 frontier is an internal contract
+# violation (malformed envelope, divergent identity, unexpected shape) and
+# fails closed as 500, never as 422.
+
+_PRIVACY_CONFLICT_DETAIL = {
+    "code": "operation_conflict",
+    "message": "Operation identifier was already used with a different operation.",
+}
+_PRIVACY_SERVICE_UNAVAILABLE_DETAIL = {
+    "code": "service_unavailable",
+    "message": "Service unavailable.",
+}
+_PRIVACY_PERSISTENCE_DETAIL = {
+    "code": TurnErrorCode.persistence_unavailable.value,
+    "message": "Persistence service unavailable.",
+}
+_PRIVACY_INTERNAL_DETAIL = {
+    "code": TurnErrorCode.internal_error.value,
+    "message": "Internal server error.",
+}
+
+
+def _map_privacy_conflict(exc: ConflictError) -> HTTPException:
+    """Map a #314 privacy conflict to a sanitized 409 or fail closed."""
+    if exc.code != "operation_conflict":
+        raise HTTPException(status_code=500, detail=_PRIVACY_INTERNAL_DETAIL) from None
+    emit_event(logger, EVENT_REQUEST_CONFLICT, code="operation_conflict")
+    emit_event(logger, EVENT_HTTP_RESULT, code=409)
+    return HTTPException(status_code=409, detail=_PRIVACY_CONFLICT_DETAIL)
+
+
 # ─── Lifespan ───────────────────────────────────────────────────────────────
 
 
@@ -592,6 +649,18 @@ def create_app(
     app.get("/live")(live_endpoint)
     app.get("/ready")(ready_endpoint)
     app.get("/health")(health_endpoint)
+    app.post(
+        "/privacy/delete-history", response_model=PrivacyOperationResponse
+    )(privacy_delete_history_endpoint)
+    app.post(
+        "/privacy/delete-memories", response_model=PrivacyOperationResponse
+    )(privacy_delete_memories_endpoint)
+    app.post(
+        "/privacy/reset-emotional-state", response_model=PrivacyOperationResponse
+    )(privacy_reset_emotional_state_endpoint)
+    app.post(
+        "/privacy/reset-relationship", response_model=PrivacyOperationResponse
+    )(privacy_reset_relationship_endpoint)
 
     return app
 
@@ -770,6 +839,117 @@ def get_history(request: Request, current_user=Depends(get_current_user)):
         return response.data[::-1] if response.data else []
     except Exception:
         raise HTTPException(status_code=500, detail="Internal Server Error")
+
+
+# ─── Privacy actions (#315) ──────────────────────────────────────────────────
+#
+# Four thin, authenticated HTTP actions over the #314 privacy frontier. The
+# identity always comes from ``current_user.id`` (never from the body, query
+# string, path or custom headers), the input DTO accepts ONLY a canonical
+# UUID ``operation_id``, and the application logic lives in the stateless
+# ``PrivacyService``. Error mapping is stable and sanitized: 401 auth,
+# 422 input, 409 operation conflict, 503 persistence, 500 fail-closed.
+
+
+async def _run_privacy_action(
+    operation: str,
+    input_data: PrivacyOperationInput,
+    request: Request,
+    current_user,
+) -> PrivacyOperationResponse:
+    """Run one privacy action through the injected privacy service.
+
+    The service method is selected by the canonical operation constant, so
+    each endpoint invokes exactly its own operation and never another one.
+    """
+    deps = get_dependencies(request)
+    service = deps.privacy_service
+    if service is None:
+        raise HTTPException(
+            status_code=503, detail=_PRIVACY_SERVICE_UNAVAILABLE_DETAIL
+        )
+    user_id = getattr(current_user, "id", None)
+    operation_id = str(input_data.operation_id)
+    try:
+        if operation == OPERATION_DELETE_HISTORY:
+            result = await service.delete_history(user_id, operation_id)
+        elif operation == OPERATION_DELETE_MEMORIES:
+            result = await service.delete_memories(user_id, operation_id)
+        elif operation == OPERATION_RESET_EMOTIONAL_STATE:
+            result = await service.reset_emotional_state(user_id, operation_id)
+        elif operation == OPERATION_RESET_RELATIONSHIP_STATE:
+            result = await service.reset_relationship_state(user_id, operation_id)
+        else:
+            raise HTTPException(status_code=500, detail=_PRIVACY_INTERNAL_DETAIL)
+    except HTTPException:
+        raise
+    except ConflictError as exc:
+        http_exc = _map_privacy_conflict(exc)
+        raise http_exc from None
+    except PersistenceError:
+        emit_event(logger, EVENT_HTTP_RESULT, code=503)
+        raise HTTPException(
+            status_code=503, detail=_PRIVACY_PERSISTENCE_DETAIL
+        ) from None
+    except ValidationError:
+        # After HTTP validation, a #314 ValidationError (invalid_rpc_result,
+        # divergent identity, malformed envelope) is a server-side contract
+        # violation: fail closed as 500, never present it as a client 422.
+        emit_event(logger, EVENT_HTTP_RESULT, code=500)
+        raise HTTPException(
+            status_code=500, detail=_PRIVACY_INTERNAL_DETAIL
+        ) from None
+    except Exception:
+        emit_event(logger, EVENT_HTTP_RESULT, code=500)
+        raise HTTPException(
+            status_code=500, detail=_PRIVACY_INTERNAL_DETAIL
+        ) from None
+    emit_event(logger, EVENT_HTTP_RESULT, code=200)
+    return result
+
+
+async def privacy_delete_history_endpoint(
+    input_data: PrivacyOperationInput,
+    request: Request,
+    current_user=Depends(get_current_user),
+):
+    """POST /privacy/delete-history — remove the caller's turn history."""
+    return await _run_privacy_action(
+        OPERATION_DELETE_HISTORY, input_data, request, current_user
+    )
+
+
+async def privacy_delete_memories_endpoint(
+    input_data: PrivacyOperationInput,
+    request: Request,
+    current_user=Depends(get_current_user),
+):
+    """POST /privacy/delete-memories — remove the caller's memories."""
+    return await _run_privacy_action(
+        OPERATION_DELETE_MEMORIES, input_data, request, current_user
+    )
+
+
+async def privacy_reset_emotional_state_endpoint(
+    input_data: PrivacyOperationInput,
+    request: Request,
+    current_user=Depends(get_current_user),
+):
+    """POST /privacy/reset-emotional-state — reset the emotional snapshot."""
+    return await _run_privacy_action(
+        OPERATION_RESET_EMOTIONAL_STATE, input_data, request, current_user
+    )
+
+
+async def privacy_reset_relationship_endpoint(
+    input_data: PrivacyOperationInput,
+    request: Request,
+    current_user=Depends(get_current_user),
+):
+    """POST /privacy/reset-relationship — reset the relationship snapshot."""
+    return await _run_privacy_action(
+        OPERATION_RESET_RELATIONSHIP_STATE, input_data, request, current_user
+    )
 
 
 async def live_endpoint():

--- a/backend/privacy_service.py
+++ b/backend/privacy_service.py
@@ -1,0 +1,253 @@
+"""Application layer exposing the #314 privacy primitives (#315).
+
+This module is the thin, stateless application boundary between the
+authenticated HTTP layer (``backend.main``) and the #314 Python frontier
+(``backend.privacy_operations``). It deliberately contains no FastAPI
+routing, no per-user state, and no re-implementation of the #314 semantics
+(ledger, locks, fingerprint, revision, neutrality, replay): every operation
+delegates to :func:`backend.privacy_operations.run_privacy_operation`, the
+single source of truth for the privacy frontier.
+
+Components
+==========
+
+* ``PrivacyOperationResponse`` — the explicit public projection of a
+  :class:`backend.privacy_operations.PrivacyOperationResult`. It exposes
+  ONLY ``operation``, ``status`` and the aggregate safe counts. It never
+  exposes ``user_id``, ``revision``, ``operation_id``, message/memory IDs,
+  content, snapshots, HMACs or any internal detail. Fresh executions and
+  idempotent replays produce the same projection: there is deliberately no
+  ``replayed`` field, because the persistent #314 contract does not provide
+  that semantic.
+* ``SupabasePrivacyRepository`` — synchronous adapter for
+  ``client.rpc(name, params).execute()`` with fail-closed response shape
+  validation. It must never be awaited directly on the event loop.
+* ``PrivacyService`` — a stateless, process-wide application service. The
+  authenticated identity and the operation_id are per-call arguments; no
+  snapshot or identifier is retained between requests. It uses an injected
+  clock for reset snapshot timestamps, creates a per-action budget from the
+  operational turn configuration, dispatches the synchronous repository
+  call through ``run_blocking_write`` (preserving the PostgREST transport
+  timeout, the operational budget, and correct drain-on-cancellation), and
+  delegates the operation to ``run_privacy_operation``.
+
+Ownership and testability
+=========================
+
+* The service is stateless and may live in the application container.
+  Identity, operation_id and snapshots are always per-call arguments.
+* The repository is injectable (a fake can record or stub RPC calls), the
+  clock is injectable (reset timestamps are deterministic in tests), and
+  the operational ``TurnExecutionConfig`` is injectable (budget/timeout
+  behavior is configurable).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, Mapping, Optional, Protocol
+
+from pydantic import BaseModel
+
+from backend.atomic_turn_commit import PersistenceError
+from backend.privacy_operations import (
+    OPERATION_DELETE_HISTORY,
+    OPERATION_DELETE_MEMORIES,
+    OPERATION_RESET_EMOTIONAL_STATE,
+    OPERATION_RESET_RELATIONSHIP_STATE,
+    PrivacyOperationResult,
+    neutral_emotional_snapshot,
+    neutral_relationship_snapshot,
+    run_privacy_operation,
+)
+from backend.turn_execution import TurnExecutionConfig, create_budget, run_blocking_write
+
+#: Sanitized stage label used by the write helper for every privacy RPC.
+_PRIVACY_WRITE_STAGE = "privacy_operation"
+
+
+class PrivacyOperationResponse(BaseModel):
+    """Public projection of an applied privacy operation.
+
+    Deliberately smaller than ``PrivacyOperationResult``: only the operation
+    name, the constant ``applied`` status and the aggregate safe counts are
+    exposed. Identity, revision, operation_id, internal IDs, content,
+    snapshots and secrets never appear here.
+    """
+
+    operation: str
+    status: str
+    counts: dict[str, int]
+
+    @classmethod
+    def from_result(cls, result: PrivacyOperationResult) -> "PrivacyOperationResponse":
+        """Build the public projection from the internal #314 result."""
+        return cls(
+            operation=result.operation,
+            status="applied",
+            counts=dict(result.counts),
+        )
+
+
+class PrivacyRepository(Protocol):
+    """Synchronous RPC repository contract.
+
+    ``call`` is thread-bound (``client.rpc(...).execute()`` blocks on
+    network I/O) and must be dispatched off the event loop by the service.
+    """
+
+    def call(self, rpc_name: str, params: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Invoke one privacy RPC and return the parsed result mapping."""
+        ...
+
+
+class SupabasePrivacyRepository:
+    """Synchronous adapter over ``client.rpc(name, params).execute()``.
+
+    The Supabase SDK used by this project exposes a synchronous RPC
+    (``client.rpc(name, params).execute()``). This adapter isolates that
+    blocking call so the service can run it through ``run_blocking_write``;
+    it must never be awaited directly on the event loop.
+
+    The response shape is validated fail-closed: PostgREST may return the
+    RPC result as a single mapping or as a single-element list. Anything
+    else (or a missing/unreachable client) surfaces as a sanitized
+    ``PersistenceError``, never as raw payload content.
+    """
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    def call(self, rpc_name: str, params: Mapping[str, Any]) -> Mapping[str, Any]:
+        if self._client is None:
+            raise PersistenceError("database_error", "persistence error")
+        try:
+            response = self._client.rpc(rpc_name, params).execute()
+        except Exception:
+            # Sanitized: the upstream exception may carry connection details,
+            # identifiers or payload content and is never surfaced.
+            raise PersistenceError("database_error", "persistence error") from None
+        data = response.data
+        if isinstance(data, list):
+            if len(data) != 1:
+                raise PersistenceError("database_error", "persistence error")
+            data = data[0]
+        if not isinstance(data, dict):
+            raise PersistenceError("database_error", "persistence error")
+        return data
+
+
+class PrivacyService:
+    """Stateless application service for the four #315 privacy actions.
+
+    The service holds no per-user state: the authenticated identity, the
+    operation_id and (for resets) the neutral snapshot are constructed per
+    call. The clock is injected so reset timestamps are deterministic in
+    tests, and the operational turn configuration drives the per-action
+    budget and the Supabase transport timeout.
+
+    Every method delegates to ``run_privacy_operation``; the blocking
+    Supabase RPC is dispatched through ``run_blocking_write``, so writes are
+    never abandoned on cancellation and no orphaned threads/tasks are
+    created.
+    """
+
+    def __init__(
+        self,
+        *,
+        repository: PrivacyRepository,
+        turn_config: TurnExecutionConfig,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._repository = repository
+        self._turn_config = turn_config
+        self._clock = clock
+
+    async def delete_history(
+        self, authenticated_user_id: str, operation_id: str
+    ) -> PrivacyOperationResponse:
+        """Apply ``delete_history`` for the authenticated identity."""
+        return await self._run(
+            OPERATION_DELETE_HISTORY,
+            authenticated_user_id,
+            operation_id,
+            payload=None,
+        )
+
+    async def delete_memories(
+        self, authenticated_user_id: str, operation_id: str
+    ) -> PrivacyOperationResponse:
+        """Apply ``delete_memories`` for the authenticated identity."""
+        return await self._run(
+            OPERATION_DELETE_MEMORIES,
+            authenticated_user_id,
+            operation_id,
+            payload=None,
+        )
+
+    async def reset_emotional_state(
+        self, authenticated_user_id: str, operation_id: str
+    ) -> PrivacyOperationResponse:
+        """Reset the emotional snapshot to the canonical neutral v1 state.
+
+        The neutral snapshot is built through the #314 helper using the
+        injected clock, so the reset timestamp is deterministic and never
+        hides a ``time.time()`` inside the service.
+        """
+        payload = neutral_emotional_snapshot(self._clock())
+        return await self._run(
+            OPERATION_RESET_EMOTIONAL_STATE,
+            authenticated_user_id,
+            operation_id,
+            payload=payload,
+        )
+
+    async def reset_relationship_state(
+        self, authenticated_user_id: str, operation_id: str
+    ) -> PrivacyOperationResponse:
+        """Reset the relationship snapshot to the canonical neutral v1 state."""
+        payload = neutral_relationship_snapshot(self._clock())
+        return await self._run(
+            OPERATION_RESET_RELATIONSHIP_STATE,
+            authenticated_user_id,
+            operation_id,
+            payload=payload,
+        )
+
+    async def _run(
+        self,
+        operation: str,
+        authenticated_user_id: str,
+        operation_id: str,
+        payload: Optional[Mapping[str, Any]],
+    ) -> PrivacyOperationResponse:
+        """Execute one operation with a per-action budget.
+
+        A fresh budget is created for each action from the operational turn
+        configuration. The synchronous repository call runs through
+        ``run_blocking_write`` (real timeout from the PostgREST transport,
+        drain-on-cancellation, no orphaned tasks); the resulting async
+        callable is handed to ``run_privacy_operation``, which remains the
+        single source of truth for validation, RPC invocation and result
+        parsing of the #314 frontier.
+        """
+        budget = create_budget(self._turn_config)
+
+        async def rpc_client(rpc_name: str, params: Mapping[str, Any]) -> Mapping[str, Any]:
+            return await run_blocking_write(
+                _PRIVACY_WRITE_STAGE,
+                budget,
+                self._turn_config.supabase_timeout,
+                self._repository.call,
+                rpc_name,
+                params,
+            )
+
+        result = await run_privacy_operation(
+            rpc_client=rpc_client,
+            operation=operation,
+            authenticated_user_id=authenticated_user_id,
+            operation_id=operation_id,
+            payload=payload,
+        )
+        return PrivacyOperationResponse.from_result(result)

--- a/backend/privacy_service.py
+++ b/backend/privacy_service.py
@@ -119,22 +119,33 @@ class SupabasePrivacyRepository:
         self._client = client
 
     def call(self, rpc_name: str, params: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Invoke one privacy RPC and return the parsed result mapping.
+
+        The response shape is validated fail-closed INSIDE the try/except:
+        a missing/unreachable client, a response without ``data``, a list
+        that is not exactly one element, or a non-dict payload all surface
+        as a sanitized ``PersistenceError``. Upstream exceptions (which may
+        carry connection details, identifiers or payload content) are never
+        surfaced.
+        """
         if self._client is None:
             raise PersistenceError("database_error", "persistence error")
         try:
             response = self._client.rpc(rpc_name, params).execute()
+            data = getattr(response, "data", None)
+            if isinstance(data, list):
+                if len(data) != 1:
+                    raise PersistenceError("database_error", "persistence error")
+                data = data[0]
+            if not isinstance(data, dict):
+                raise PersistenceError("database_error", "persistence error")
+            return data
+        except PersistenceError:
+            raise
         except Exception:
             # Sanitized: the upstream exception may carry connection details,
             # identifiers or payload content and is never surfaced.
             raise PersistenceError("database_error", "persistence error") from None
-        data = response.data
-        if isinstance(data, list):
-            if len(data) != 1:
-                raise PersistenceError("database_error", "persistence error")
-            data = data[0]
-        if not isinstance(data, dict):
-            raise PersistenceError("database_error", "persistence error")
-        return data
 
 
 class PrivacyService:

--- a/backend/tests/test_app_factory.py
+++ b/backend/tests/test_app_factory.py
@@ -606,6 +606,7 @@ def test_no_per_user_state_in_app_state_or_container():
         "health_checks",
         "clock",
         "persistence_client",
+        "privacy_service",
     }
     assert set(deps.__dataclass_fields__) == container_fields
     # No attribute of the container may hold a user identity.

--- a/backend/tests/test_privacy_api.py
+++ b/backend/tests/test_privacy_api.py
@@ -1,0 +1,1059 @@
+"""Tests for the #315 authenticated privacy HTTP API.
+
+Covers the mandatory scenarios of issue #315:
+
+ 1.  The four privacy routes without a bearer token return 401 and never
+     call the privacy service.
+ 2.  The identity passed to the service comes exclusively from
+     ``current_user.id`` (never from the body, query, path or headers).
+ 3.  A body containing ``user_id`` returns 422.
+ 4.  Any extra key returns 422.
+ 5.  An invalid ``operation_id`` returns a sanitized 422.
+ 6.  Each endpoint calls exactly the corresponding operation.
+ 7.  ``delete_history`` never calls delete memories nor resets.
+ 8.  ``delete_memories`` never calls history nor resets.
+ 9.  Emotional reset builds the canonical neutral v1 snapshot.
+10.  Relationship reset builds the canonical neutral v1 snapshot.
+11.  The reset clock is injectable and deterministically testable.
+12.  Replay of the same ``operation_id`` returns the same public result
+     without a second mutation.
+13.  Divergent reuse produces ``409 operation_conflict``.
+14.  Persistence failure produces a constant 503.
+15.  An unexpected error produces a sanitized 500.
+16-19. The public result never contains ``user_id``, ``revision``,
+     ``operation_id``, content or internal IDs.
+20.  User A cannot provoke an operation on user B's data.
+21.  Sentinels placed in ``user_id``, ``operation_id`` and the upstream
+     exception never reach logs or responses.
+22.  No route uses ``BackgroundTasks``.
+23.  A Supabase write is never abandoned on cancellation.
+24-29. ``/chat``, ``/history``, ``/live``, ``/ready``, ``ChatResponse`` and
+     ``create_app()`` import behavior remain compatible.
+30.  The whole backend suite stays green (CI).
+
+Replay/conflict unit behavior is exercised through a ledger-simulating
+repository that mirrors the #314 PostgreSQL contract; the real database
+behavior is verified by ``test_privacy_api_integration.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+from fastapi import BackgroundTasks
+from fastapi.testclient import TestClient
+
+import backend.main as main_module
+import backend.privacy_service as privacy_service_module
+from backend.admission import AdmissionRuntimeConfig
+from backend.atomic_turn_commit import ConflictError, PersistenceError, ValidationError
+from backend.emotion_presentation import EmotionStateResponse
+from backend.health import HealthRegistry
+from backend.privacy_operations import (
+    OPERATION_DELETE_HISTORY,
+    OPERATION_DELETE_MEMORIES,
+    OPERATION_RESET_EMOTIONAL_STATE,
+    OPERATION_RESET_RELATIONSHIP_STATE,
+    PrivacyOperationResult,
+    neutral_emotional_snapshot,
+    neutral_relationship_snapshot,
+)
+from backend.privacy_service import (
+    PrivacyOperationResponse,
+    PrivacyService,
+)
+from backend.process_turn import ProcessTurnResult
+from backend.settings import AppEnvironment, Settings
+from backend.turn_execution import TurnExecutionConfig
+
+SECRET = "s" * 40
+OP_ID = "11111111-1111-1111-1111-111111111111"
+OP_ID_2 = "22222222-2222-2222-2222-222222222222"
+SENTINEL_OP_ID = "99999999-9999-9999-9999-999999999999"
+SENTINEL_USER = "SENTINEL-USER-MARKER"
+SENTINEL_EXC = "SENTINEL-UPSTREAM-MARKER"
+VALID_CHAT_REQUEST_ID = "550e8400-e29b-41d4-a716-446655440000"
+
+PATHS = {
+    OPERATION_DELETE_HISTORY: "/privacy/delete-history",
+    OPERATION_DELETE_MEMORIES: "/privacy/delete-memories",
+    OPERATION_RESET_EMOTIONAL_STATE: "/privacy/reset-emotional-state",
+    OPERATION_RESET_RELATIONSHIP_STATE: "/privacy/reset-relationship",
+}
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _counts(**overrides) -> dict:
+    counts = {
+        "chat_logs": 0,
+        "turn_requests": 0,
+        "outbox_events": 0,
+        "archival_extractions": 0,
+        "memories": 0,
+        "profiles": 0,
+    }
+    counts.update(overrides)
+    return counts
+
+
+def _rpc_envelope(op: str, op_id: str = OP_ID, user_id: str = "user-a", revision: int = 1) -> dict:
+    """A #314 success envelope as returned by the PostgreSQL RPC."""
+    return {
+        "status": "applied",
+        "operation": op,
+        "operation_id": op_id,
+        "user_id": user_id,
+        "revision": revision,
+        "counts": _counts(),
+    }
+
+
+def _result(op: str, op_id: str = OP_ID, revision: int = 1, counts: dict | None = None):
+    return PrivacyOperationResult(
+        operation=op,
+        operation_id=op_id,
+        user_id="user-123",
+        revision=revision,
+        counts=counts if counts is not None else _counts(),
+    )
+
+
+def _settings(**overrides) -> Settings:
+    kwargs = {
+        "app_env": AppEnvironment.local,
+        "groq_api_key": "groq-key",
+        "admission_hmac_secret": SECRET,
+        "cors_allowed_origins": ("https://allowed.example",),
+    }
+    kwargs.update(overrides)
+    return Settings(**kwargs)
+
+
+class FakeAuth:
+    """Duck-typed auth surface exposing ``.auth.get_user(token)``."""
+
+    class _UserSurface:
+        def __init__(self, user_id: str):
+            self.user_id = user_id
+            self.calls: list[str] = []
+
+        def get_user(self, token: str):
+            self.calls.append(token)
+            return SimpleNamespace(user=SimpleNamespace(id=self.user_id))
+
+    def __init__(self, user_id: str = "user-123"):
+        self.auth = self._UserSurface(user_id)
+
+
+class FakeEngine:
+    def __init__(self, supabase=None):
+        self.memory_manager = SimpleNamespace(supabase=supabase)
+        self.groq_manager = object()
+
+
+class RecordingPrivacyService:
+    """Records every invocation; returns a canned result or raises."""
+
+    def __init__(self, result=None, error=None):
+        self.calls: list[tuple] = []
+        self.result = result
+        self.error = error
+
+    async def delete_history(self, user_id: str, operation_id: str):
+        self.calls.append(("delete_history", user_id, operation_id))
+        return await self._respond()
+
+    async def delete_memories(self, user_id: str, operation_id: str):
+        self.calls.append(("delete_memories", user_id, operation_id))
+        return await self._respond()
+
+    async def reset_emotional_state(self, user_id: str, operation_id: str):
+        self.calls.append(("reset_emotional_state", user_id, operation_id))
+        return await self._respond()
+
+    async def reset_relationship_state(self, user_id: str, operation_id: str):
+        self.calls.append(("reset_relationship_state", user_id, operation_id))
+        return await self._respond()
+
+    async def _respond(self):
+        if self.error is not None:
+            raise self.error
+        if isinstance(self.result, PrivacyOperationResult):
+            # Mirror the real service: the public projection is returned.
+            return PrivacyOperationResponse.from_result(self.result)
+        return self.result
+
+
+class _FakeSupabase:
+    """Duck-typed Supabase surface for the history route."""
+
+    def table(self, name):
+        return self
+
+    def select(self, cols):
+        return self
+
+    def eq(self, key, value):
+        return self
+
+    def order(self, col, **kwargs):
+        return self
+
+    def limit(self, n):
+        return self
+
+    def execute(self):
+        return SimpleNamespace(data=[{"content": "msg1", "role": "user"}], error=None)
+
+
+class _ChatSupabase:
+    """Duck-typed Supabase surface for the /chat admission RPC."""
+
+    def rpc(self, name, params):
+        return SimpleNamespace(
+            execute=lambda: SimpleNamespace(
+                data=[{"decision": "admitted", "retry_after_seconds": 0}], error=None
+            )
+        )
+
+
+class _FakeChatEngine:
+    """Engine double for the /chat compatibility test."""
+
+    def __init__(self):
+        self.memory_manager = SimpleNamespace(supabase=object())
+        self.groq_manager = object()
+        self.turn_calls = []
+
+    async def process_turn(
+        self, user_id, message, request_id, *, budget=None, mode=None, correlation=None
+    ):
+        self.turn_calls.append((user_id, message, request_id))
+        return ProcessTurnResult(
+            committed=object(),
+            response="compat response",
+            emotion_state=EmotionStateResponse(
+                schema_version=1,
+                mood_label="NEUTRA",
+                pad={"pleasure": 0.0, "arousal": 0.0, "dominance": 0.0},
+                dominant_emotions=[],
+                timestamp=1000.0,
+            ),
+        )
+
+
+def _make_app(
+    *,
+    service,
+    auth_user_id: str = "user-123",
+    persistence=None,
+    engine=None,
+):
+    settings = _settings()
+    deps = main_module.ApplicationDependencies(
+        conversation_engine=engine if engine is not None else FakeEngine(supabase=object()),
+        auth_client=FakeAuth(auth_user_id),
+        admission_config=AdmissionRuntimeConfig.from_values(SECRET),
+        turn_config=TurnExecutionConfig.defaults(),
+        health_checks=HealthRegistry(),
+        clock=time.time,
+        persistence_client=persistence,
+        privacy_service=service,
+    )
+    return main_module.create_app(settings=settings, dependencies=deps)
+
+
+def _auth_headers(token: str = "token-x") -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _assert_no_internal_fields(node) -> None:
+    """Fail if any key that could carry internal/sensitive data appears."""
+    forbidden = {
+        "user_id",
+        "revision",
+        "operation_id",
+        "id",
+        "content",
+        "snapshot",
+        "hmac",
+        "token",
+        "secret",
+        "sql",
+        "message_id",
+        "memory_id",
+        "ledger",
+    }
+
+    def walk(value) -> None:
+        if isinstance(value, dict):
+            for key, item in value.items():
+                assert key.lower() not in forbidden, f"internal field leaked: {key}"
+                walk(item)
+        elif isinstance(value, list):
+            for item in value:
+                walk(item)
+
+    walk(node)
+
+
+class LedgerSimulatingRepository:
+    """Mirrors the #314 durable ledger contract for unit tests.
+
+    Keyed by ``(authenticated_user_id, operation_id)``: the first call
+    applies (mutation counter +1) and stores the envelope; an identical
+    replay returns the stored envelope without a new mutation; a divergent
+    reuse of the same key returns the ``operation_conflict`` envelope. The
+    real database behavior is verified by the integration suite.
+    """
+
+    def __init__(self, envelope_factory):
+        self._ledger: dict[tuple, tuple] = {}
+        self.mutations = 0
+        self._envelope_factory = envelope_factory
+
+    def call(self, rpc_name: str, params: dict) -> dict:
+        key = (params["p_authenticated_user_id"], params["p_operation_id"])
+        payload = params["p_operation_payload"]
+        if key in self._ledger:
+            stored_rpc, stored_payload, stored_envelope = self._ledger[key]
+            if stored_rpc != rpc_name or stored_payload != payload:
+                return {
+                    "error": {
+                        "code": "operation_conflict",
+                        "message": "operation_id already used with a different operation or payload",
+                    }
+                }
+            return stored_envelope
+        envelope = self._envelope_factory(rpc_name, params)
+        self._ledger[key] = (rpc_name, payload, envelope)
+        self.mutations += 1
+        return envelope
+
+
+def _envelope_from_params(rpc_name: str, params: dict) -> dict:
+    """Build a success envelope from the RPC params (privacy RPC names equal
+    the canonical operation names)."""
+    return _rpc_envelope(
+        op=rpc_name,
+        op_id=params["p_operation_id"],
+        user_id=params["p_authenticated_user_id"],
+    )
+
+
+def _real_service(repo) -> PrivacyService:
+    return PrivacyService(
+        repository=repo,
+        turn_config=TurnExecutionConfig.defaults(),
+        clock=lambda: 1700000000.0,
+    )
+
+
+# ─── 1. 401 without bearer token, service untouched ─────────────────────────
+
+
+@pytest.mark.parametrize("path", sorted(PATHS.values()))
+def test_route_without_bearer_returns_401_and_does_not_call_service(path):
+    service = RecordingPrivacyService(result=_result(OPERATION_DELETE_HISTORY))
+    app = _make_app(service=service)
+    client = TestClient(app)
+    response = client.post(path, json={"operation_id": OP_ID})
+    assert response.status_code == 401
+    assert service.calls == [], "the privacy service must not be reached"
+
+
+# ─── 2. Identity comes exclusively from current_user.id ─────────────────────
+
+
+def test_identity_passed_to_service_comes_only_from_current_user():
+    service = RecordingPrivacyService(result=_result(OPERATION_DELETE_HISTORY))
+    app = _make_app(service=service, auth_user_id="authenticated-user-a")
+    client = TestClient(app)
+    response = client.post(
+        PATHS[OPERATION_DELETE_HISTORY],
+        json={"operation_id": OP_ID},
+        headers=_auth_headers(),
+    )
+    assert response.status_code == 200
+    assert service.calls == [("delete_history", "authenticated-user-a", OP_ID)]
+
+
+# ─── 3/4. Body with user_id or any extra key returns 422 ────────────────────
+
+
+@pytest.mark.parametrize("path", sorted(PATHS.values()))
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"user_id": "attacker-user"},
+        {"foo": "bar"},
+        {"operation_id": OP_ID, "operation": "delete_history"},
+        {"operation_id": OP_ID, "user_id": "a", "extra": True},
+    ],
+)
+def test_body_with_user_id_or_extra_key_returns_422(path, extra):
+    service = RecordingPrivacyService(result=_result(OPERATION_DELETE_HISTORY))
+    app = _make_app(service=service)
+    client = TestClient(app)
+    response = client.post(path, json=extra, headers=_auth_headers())
+    assert response.status_code == 422
+    assert service.calls == [], "invalid bodies must never reach the service"
+    body = response.json()
+    assert body == {"detail": {"code": "invalid_request", "message": "Invalid request body."}}
+
+
+# ─── 5. Invalid operation_id returns sanitized 422 ──────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "not-a-uuid",
+        "",
+        "123",
+        "550e8400-e29b-41d4-a716-44665544000Z",
+        ["11111111-1111-1111-1111-111111111111"],
+    ],
+)
+def test_invalid_operation_id_returns_422_sanitized(bad):
+    service = RecordingPrivacyService(result=_result(OPERATION_DELETE_HISTORY))
+    app = _make_app(service=service)
+    client = TestClient(app)
+    response = client.post(
+        PATHS[OPERATION_DELETE_HISTORY], json={"operation_id": bad}, headers=_auth_headers()
+    )
+    assert response.status_code == 422
+    assert service.calls == []
+    body = response.json()
+    assert body == {"detail": {"code": "invalid_request", "message": "Invalid request body."}}
+    # Sanitized: the offending input is never echoed.
+    assert repr(bad) not in response.text
+
+
+def test_compact_uuid_is_normalized_to_canonical_lowercase():
+    """A compact (no-dash) canonical UUID is accepted and normalized to the
+    dashed lowercase form required by the #314 contract."""
+    service = RecordingPrivacyService(result=_result(OPERATION_DELETE_HISTORY))
+    app = _make_app(service=service)
+    client = TestClient(app)
+    compact = "550e8400e29b41d4a716446655440000"
+    response = client.post(
+        PATHS[OPERATION_DELETE_HISTORY], json={"operation_id": compact}, headers=_auth_headers()
+    )
+    assert response.status_code == 200
+    assert service.calls == [
+        ("delete_history", "user-123", "550e8400-e29b-41d4-a716-446655440000")
+    ]
+
+
+def test_uppercase_uuid_is_normalized_to_lowercase_canonical():
+    """The contract accepts any canonical UUID version and normalizes it to
+    lowercase before reaching the privacy layer."""
+    service = RecordingPrivacyService(result=_result(OPERATION_DELETE_HISTORY))
+    app = _make_app(service=service)
+    client = TestClient(app)
+    uppercase = "550E8400-E29B-41D4-A716-446655440000"
+    response = client.post(
+        PATHS[OPERATION_DELETE_HISTORY], json={"operation_id": uppercase}, headers=_auth_headers()
+    )
+    assert response.status_code == 200
+    assert service.calls == [("delete_history", "user-123", "550e8400-e29b-41d4-a716-446655440000")]
+
+
+def test_non_v4_uuid_is_accepted():
+    """The #314 contract accepts canonical UUIDs of any version; the API must
+    not restrict to v4."""
+    service = RecordingPrivacyService(result=_result(OPERATION_DELETE_HISTORY))
+    app = _make_app(service=service)
+    client = TestClient(app)
+    v1_uuid = "11111111-1111-1111-8111-111111111111"
+    response = client.post(
+        PATHS[OPERATION_DELETE_HISTORY], json={"operation_id": v1_uuid}, headers=_auth_headers()
+    )
+    assert response.status_code == 200
+    assert service.calls == [("delete_history", "user-123", v1_uuid)]
+
+
+# ─── 6/7/8. Each endpoint calls exactly its own operation ───────────────────
+
+
+def test_each_endpoint_calls_exactly_its_operation():
+    expected = {
+        PATHS[OPERATION_DELETE_HISTORY]: "delete_history",
+        PATHS[OPERATION_DELETE_MEMORIES]: "delete_memories",
+        PATHS[OPERATION_RESET_EMOTIONAL_STATE]: "reset_emotional_state",
+        PATHS[OPERATION_RESET_RELATIONSHIP_STATE]: "reset_relationship_state",
+    }
+    for path, method_name in expected.items():
+        service = RecordingPrivacyService(result=_result(method_name))
+        app = _make_app(service=service)
+        client = TestClient(app)
+        response = client.post(path, json={"operation_id": OP_ID}, headers=_auth_headers())
+        assert response.status_code == 200
+        assert [call[0] for call in service.calls] == [method_name]
+        assert service.calls[0][1:] == ("user-123", OP_ID)
+
+
+def test_delete_history_never_calls_delete_memories_nor_resets():
+    service = RecordingPrivacyService(result=_result(OPERATION_DELETE_HISTORY))
+    app = _make_app(service=service)
+    client = TestClient(app)
+    response = client.post(
+        PATHS[OPERATION_DELETE_HISTORY], json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 200
+    assert service.calls == [("delete_history", "user-123", OP_ID)]
+
+
+def test_delete_memories_never_calls_history_nor_resets():
+    service = RecordingPrivacyService(result=_result(OPERATION_DELETE_MEMORIES))
+    app = _make_app(service=service)
+    client = TestClient(app)
+    response = client.post(
+        PATHS[OPERATION_DELETE_MEMORIES], json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 200
+    assert service.calls == [("delete_memories", "user-123", OP_ID)]
+
+
+# ─── 9/10/11. Resets build canonical neutral v1 snapshots with injected clock
+
+
+def test_emotional_reset_builds_canonical_neutral_v1_snapshot():
+    captured = {}
+
+    class CapturingRepo:
+        def call(self, rpc_name, params):
+            captured["rpc"] = rpc_name
+            captured["payload"] = params["p_operation_payload"]
+            return _rpc_envelope(OPERATION_RESET_EMOTIONAL_STATE)
+
+    service = PrivacyService(
+        repository=CapturingRepo(),
+        turn_config=TurnExecutionConfig.defaults(),
+        clock=lambda: 1700000000.0,
+    )
+    asyncio.run(service.reset_emotional_state("user-a", OP_ID))
+    expected = neutral_emotional_snapshot(1700000000.0)
+    assert captured["rpc"] == "reset_emotional_state"
+    assert captured["payload"] == expected
+    assert captured["payload"]["schema_version"] == 1
+    assert captured["payload"]["timestamp"] == 1700000000.0
+
+
+def test_relationship_reset_builds_canonical_neutral_v1_snapshot():
+    captured = {}
+
+    class CapturingRepo:
+        def call(self, rpc_name, params):
+            captured["rpc"] = rpc_name
+            captured["payload"] = params["p_operation_payload"]
+            return _rpc_envelope(OPERATION_RESET_RELATIONSHIP_STATE)
+
+    service = PrivacyService(
+        repository=CapturingRepo(),
+        turn_config=TurnExecutionConfig.defaults(),
+        clock=lambda: 1700000000.0,
+    )
+    asyncio.run(service.reset_relationship_state("user-a", OP_ID))
+    expected = neutral_relationship_snapshot(1700000000.0)
+    assert captured["rpc"] == "reset_relationship_state"
+    assert captured["payload"] == expected
+    assert captured["payload"]["schema_version"] == 1
+    assert captured["payload"]["timestamp"] == 1700000000.0
+
+
+def test_reset_clock_is_injectable_and_deterministic():
+    captured_timestamps = []
+
+    class Repo:
+        def call(self, rpc_name, params):
+            captured_timestamps.append(params["p_operation_payload"]["timestamp"])
+            return _rpc_envelope(
+                rpc_name,
+                op_id=params["p_operation_id"],
+                user_id=params["p_authenticated_user_id"],
+            )
+
+    service = PrivacyService(
+        repository=Repo(),
+        turn_config=TurnExecutionConfig.defaults(),
+        clock=lambda: 123456.789,
+    )
+    asyncio.run(service.reset_emotional_state("user-a", OP_ID))
+    asyncio.run(service.reset_relationship_state("user-a", OP_ID_2))
+    assert captured_timestamps == [123456.789, 123456.789]
+
+
+def test_delete_operations_send_empty_payload():
+    """Deletes never send a snapshot payload to the RPC."""
+    captured = []
+
+    class Repo:
+        def call(self, rpc_name, params):
+            captured.append((rpc_name, params["p_operation_payload"]))
+            return _rpc_envelope(rpc_name, op_id=params["p_operation_id"], user_id=params["p_authenticated_user_id"])
+
+    service = PrivacyService(
+        repository=Repo(),
+        turn_config=TurnExecutionConfig.defaults(),
+        clock=lambda: 1700000000.0,
+    )
+    asyncio.run(service.delete_history("user-a", OP_ID))
+    asyncio.run(service.delete_memories("user-a", OP_ID_2))
+    assert captured == [("delete_history", {}), ("delete_memories", {})]
+
+
+# ─── 12. Idempotent replay, same public result, no second mutation ──────────
+
+
+def test_replay_returns_same_public_result_without_second_mutation():
+    repo = LedgerSimulatingRepository(_envelope_from_params)
+    service = _real_service(repo)
+    first = asyncio.run(service.delete_history("user-a", OP_ID))
+    second = asyncio.run(service.delete_history("user-a", OP_ID))
+    assert first == second
+    assert first.operation == "delete_history"
+    assert first.status == "applied"
+    assert first.counts == _counts()
+    assert repo.mutations == 1, "replay must not re-apply the mutation"
+
+
+def test_replay_through_http_returns_identical_public_json():
+    repo = LedgerSimulatingRepository(_envelope_from_params)
+    service = _real_service(repo)
+    app = _make_app(service=service, auth_user_id="user-a")
+    client = TestClient(app)
+    headers = _auth_headers()
+    first = client.post(
+        PATHS[OPERATION_DELETE_HISTORY], json={"operation_id": OP_ID}, headers=headers
+    )
+    second = client.post(
+        PATHS[OPERATION_DELETE_HISTORY], json={"operation_id": OP_ID}, headers=headers
+    )
+    assert first.status_code == 200 and second.status_code == 200
+    assert first.json() == second.json()
+    assert repo.mutations == 1
+
+
+# ─── 13. Divergent reuse produces 409 operation_conflict ────────────────────
+
+
+def test_divergent_reuse_of_operation_id_conflicts_at_service_level():
+    repo = LedgerSimulatingRepository(_envelope_from_params)
+    service = _real_service(repo)
+    asyncio.run(service.delete_history("user-a", OP_ID))
+    with pytest.raises(ConflictError) as exc:
+        asyncio.run(service.delete_memories("user-a", OP_ID))
+    assert exc.value.code == "operation_conflict"
+
+
+def test_divergent_reuse_returns_409_http():
+    service = RecordingPrivacyService(
+        error=ConflictError(
+            code="operation_conflict",
+            message="operation_id already used with a different operation or payload",
+            expected_revision=0,
+        )
+    )
+    app = _make_app(service=service)
+    client = TestClient(app)
+    response = client.post(
+        PATHS[OPERATION_DELETE_HISTORY], json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 409
+    assert response.json() == {
+        "detail": {
+            "code": "operation_conflict",
+            "message": "Operation identifier was already used with a different operation.",
+        }
+    }
+
+
+# ─── 14. Persistence failure produces constant 503 ──────────────────────────
+
+
+def test_persistence_failure_returns_503_constant():
+    service = RecordingPrivacyService(
+        error=PersistenceError("database_error", "persistence error")
+    )
+    app = _make_app(service=service)
+    client = TestClient(app)
+    response = client.post(
+        PATHS[OPERATION_DELETE_HISTORY], json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 503
+    assert response.json() == {
+        "detail": {"code": "persistence_unavailable", "message": "Persistence service unavailable."}
+    }
+
+
+def test_persistence_failure_via_real_service_returns_503():
+    """A repository raising (upstream failure) surfaces as a constant 503."""
+
+    class FailingRepo:
+        def call(self, rpc_name, params):
+            raise RuntimeError(SENTINEL_EXC)
+
+    service = _real_service(FailingRepo())
+    app = _make_app(service=service, auth_user_id="user-a")
+    client = TestClient(app)
+    response = client.post(
+        PATHS[OPERATION_DELETE_HISTORY], json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 503
+    assert SENTINEL_EXC not in response.text
+    assert response.json() == {
+        "detail": {"code": "persistence_unavailable", "message": "Persistence service unavailable."}
+    }
+
+
+# ─── 15. Unexpected/internal errors fail closed as sanitized 500 ────────────
+
+
+def test_unexpected_error_returns_500_sanitized():
+    service = RecordingPrivacyService(error=RuntimeError(SENTINEL_EXC))
+    app = _make_app(service=service)
+    client = TestClient(app)
+    response = client.post(
+        PATHS[OPERATION_DELETE_HISTORY], json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 500
+    assert SENTINEL_EXC not in response.text
+    assert response.json() == {
+        "detail": {"code": "internal_error", "message": "Internal server error."}
+    }
+
+
+def test_internal_validation_error_is_500_not_422():
+    """A #314 ValidationError after HTTP validation (invalid_rpc_result,
+    divergent identity, malformed envelope) must fail closed as 500 and never
+    be presented as a client 422."""
+    divergent = "SECRET-OTHER-USER-MARKER"
+    service = RecordingPrivacyService(
+        error=ValidationError("invalid_rpc_result", "result user_id does not match the authenticated user")
+    )
+    app = _make_app(service=service)
+    client = TestClient(app)
+    response = client.post(
+        PATHS[OPERATION_DELETE_HISTORY], json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 500
+    assert divergent not in response.text
+    assert response.json() == {
+        "detail": {"code": "internal_error", "message": "Internal server error."}
+    }
+
+
+def test_unknown_conflict_code_fails_closed_500():
+    service = RecordingPrivacyService(
+        error=ConflictError(
+            code="unknown_conflict_code",
+            message="unexpected",
+            expected_revision=0,
+        )
+    )
+    app = _make_app(service=service)
+    client = TestClient(app)
+    response = client.post(
+        PATHS[OPERATION_DELETE_HISTORY], json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 500
+    assert response.json() == {
+        "detail": {"code": "internal_error", "message": "Internal server error."}
+    }
+
+
+# ─── 16-19. Public result never exposes internal fields ─────────────────────
+
+
+def test_public_projection_model_has_only_approved_fields():
+    assert set(PrivacyOperationResponse.model_fields) == {"operation", "status", "counts"}
+
+
+def test_public_response_json_contains_only_approved_data():
+    service = RecordingPrivacyService(
+        result=_result(
+            OPERATION_DELETE_HISTORY,
+            revision=7,
+            counts=_counts(chat_logs=3, memories=0),
+        )
+    )
+    app = _make_app(service=service)
+    client = TestClient(app)
+    response = client.post(
+        PATHS[OPERATION_DELETE_HISTORY], json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert set(body) == {"operation", "status", "counts"}
+    assert body["operation"] == "delete_history"
+    assert body["status"] == "applied"
+    assert body["counts"] == _counts(chat_logs=3, memories=0)
+    _assert_no_internal_fields(body)
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        _result(OPERATION_DELETE_HISTORY),
+        _result(OPERATION_DELETE_MEMORIES),
+        _result(OPERATION_RESET_EMOTIONAL_STATE),
+        _result(OPERATION_RESET_RELATIONSHIP_STATE),
+    ],
+)
+def test_all_operations_public_json_never_expose_internal_fields(result):
+    service = RecordingPrivacyService(result=result)
+    app = _make_app(service=service)
+    client = TestClient(app)
+    path = PATHS[result.operation]
+    response = client.post(path, json={"operation_id": OP_ID}, headers=_auth_headers())
+    assert response.status_code == 200
+    _assert_no_internal_fields(response.json())
+
+
+# ─── 20. User A cannot provoke operations on user B's data ──────────────────
+
+
+def test_user_a_cannot_target_user_b_via_body():
+    service = RecordingPrivacyService(result=_result(OPERATION_DELETE_HISTORY))
+    app = _make_app(service=service, auth_user_id="user-a")
+    client = TestClient(app)
+    response = client.post(
+        PATHS[OPERATION_DELETE_HISTORY],
+        json={"operation_id": OP_ID, "user_id": "user-b"},
+        headers=_auth_headers(),
+    )
+    assert response.status_code == 422
+    assert service.calls == []
+
+
+def test_same_operation_id_across_users_stays_isolated():
+    """The ledger is keyed per user: user B reusing user A's operation_id is
+    an independent operation, and divergent payloads never collide across
+    users."""
+    repo = LedgerSimulatingRepository(_envelope_from_params)
+    service = _real_service(repo)
+    asyncio.run(service.delete_history("user-a", OP_ID))
+    result_b = asyncio.run(service.delete_history("user-b", OP_ID))
+    assert result_b.operation == "delete_history"
+    assert repo.mutations == 2
+
+
+def test_divergent_result_identity_fails_closed_500():
+    """A privileged result bound to another identity must fail closed as 500
+    and never echo the divergent identity."""
+    divergent = "SECRET-OTHER-USER-MARKER"
+
+    class DivergentRepo:
+        def call(self, rpc_name, params):
+            envelope = _rpc_envelope(rpc_name, op_id=params["p_operation_id"])
+            envelope["user_id"] = divergent
+            return envelope
+
+    service = _real_service(DivergentRepo())
+    app = _make_app(service=service, auth_user_id="user-a")
+    client = TestClient(app)
+    response = client.post(
+        PATHS[OPERATION_DELETE_HISTORY], json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 500
+    assert divergent not in response.text
+
+
+# ─── 21. Sentinels never reach logs or responses ────────────────────────────
+
+
+def test_sentinels_never_reach_logs_or_responses(caplog):
+    service = RecordingPrivacyService(error=RuntimeError(SENTINEL_EXC))
+    app = _make_app(service=service, auth_user_id=SENTINEL_USER)
+    client = TestClient(app)
+    with caplog.at_level(logging.INFO):
+        response = client.post(
+            PATHS[OPERATION_DELETE_HISTORY],
+            json={"operation_id": SENTINEL_OP_ID},
+            headers=_auth_headers("SENTINEL-BEARER-TOKEN"),
+        )
+    assert response.status_code == 500
+    assert SENTINEL_USER not in response.text
+    assert SENTINEL_OP_ID not in response.text
+    assert SENTINEL_EXC not in response.text
+    assert "SENTINEL-BEARER-TOKEN" not in response.text
+    assert SENTINEL_USER not in caplog.text
+    assert SENTINEL_OP_ID not in caplog.text
+    assert SENTINEL_EXC not in caplog.text
+    assert "SENTINEL-BEARER-TOKEN" not in caplog.text
+
+
+# ─── 22. No route uses BackgroundTasks / fire-and-forget work ───────────────
+
+
+def test_no_route_uses_background_tasks():
+    app = _make_app(service=RecordingPrivacyService(result=_result(OPERATION_DELETE_HISTORY)))
+    for path in PATHS.values():
+        route = next(r for r in app.routes if getattr(r, "path", None) == path)
+        calls = [d.call for d in route.dependant.dependencies if d.call is not None]
+        assert BackgroundTasks not in calls, f"{path} must not use BackgroundTasks"
+    # The service module never schedules fire-and-forget work.
+    source = inspect.getsource(privacy_service_module)
+    for forbidden in ("BackgroundTasks", "asyncio.create_task", "ThreadPoolExecutor"):
+        assert forbidden not in source
+
+
+# ─── 23. A Supabase write is never abandoned on cancellation ────────────────
+
+
+def test_write_is_drained_on_cancellation():
+    entered = threading.Event()
+    release = threading.Event()
+    completed = []
+
+    def blocking_call(rpc_name, params):
+        entered.set()
+        release.wait(10)
+        completed.append(rpc_name)
+        return _rpc_envelope(rpc_name, op_id=params["p_operation_id"], user_id=params["p_authenticated_user_id"])
+
+    class BlockingRepo:
+        def call(self, rpc_name, params):
+            return blocking_call(rpc_name, params)
+
+    service = PrivacyService(
+        repository=BlockingRepo(),
+        turn_config=TurnExecutionConfig.defaults(),
+    )
+
+    async def scenario():
+        task = asyncio.create_task(service.delete_history("user-a", OP_ID))
+        await asyncio.to_thread(entered.wait, 5)
+        assert entered.is_set(), "worker never entered the blocking write"
+        task.cancel()
+        # The cancellation must not abandon the in-flight write: release the
+        # worker so the drain loop can complete it before propagating.
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert completed == ["delete_history"], "blocking write must be drained on cancellation"
+
+    asyncio.run(scenario())
+
+
+# ─── 24-28. Existing routes and contracts remain compatible ─────────────────
+
+
+def test_history_remains_compatible():
+    app = _make_app(
+        service=RecordingPrivacyService(result=_result(OPERATION_DELETE_HISTORY)),
+        persistence=_FakeSupabase(),
+    )
+    client = TestClient(app)
+    response = client.get("/history", headers=_auth_headers())
+    assert response.status_code == 200
+    assert response.json() == [{"content": "msg1", "role": "user"}]
+
+
+def test_live_remains_compatible():
+    app = _make_app(service=RecordingPrivacyService(result=_result(OPERATION_DELETE_HISTORY)))
+    client = TestClient(app)
+    response = client.get("/live")
+    assert response.status_code == 200
+    assert response.json() == {"status": "live"}
+
+
+def test_ready_remains_compatible():
+    app = _make_app(service=RecordingPrivacyService(result=_result(OPERATION_DELETE_HISTORY)))
+    client = TestClient(app)
+    response = client.get("/ready")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ready"
+
+
+def test_chat_remains_compatible():
+    engine = _FakeChatEngine()
+    app = _make_app(
+        service=RecordingPrivacyService(result=_result(OPERATION_DELETE_HISTORY)),
+        persistence=_ChatSupabase(),
+        engine=engine,
+    )
+    client = TestClient(app)
+    response = client.post(
+        "/chat",
+        json={"request_id": VALID_CHAT_REQUEST_ID, "message": "hello"},
+        headers=_auth_headers(),
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["response"] == "compat response"
+    assert body["emotion_state"]["schema_version"] == 1
+    assert len(engine.turn_calls) == 1
+    assert engine.turn_calls[0][0] == "user-123"
+
+
+def test_chat_response_contract_unchanged():
+    assert set(main_module.ChatResponse.model_fields) == {"response", "emotion_state"}
+
+
+def test_create_app_still_has_no_heavy_import_side_effects():
+    """Importing the app module builds no dependencies and starts no threads;
+    the factory defers heavy construction to the lifespan (also covered by
+    test_import_safety)."""
+    app = main_module.create_app(settings=_settings())
+    assert app.state.dependencies is None
+    assert app.state.lifespan_started is False
+    assert app.state.owned_resources == ()
+
+
+_PURITY_SCRIPT = textwrap.dedent(
+    """
+    import sys
+    import threading
+
+    import socket as _socket
+
+    def _forbid(*args, **kwargs):
+        raise AssertionError("network socket usage during import")
+
+    _socket.socket.connect = _forbid
+    _socket.socket.connect_ex = _forbid
+    _socket.create_connection = _forbid
+
+    import supabase as _supabase
+
+    def _no_supabase_client(*args, **kwargs):
+        raise AssertionError("real Supabase client constructed during import")
+
+    _supabase.create_client = _no_supabase_client
+
+    threads_before = len(threading.enumerate())
+
+    import backend.privacy_service
+
+    threads_after = len(threading.enumerate())
+
+    assert threads_after == threads_before, "import started a thread"
+    print("PRIVACY_SERVICE_PURITY_OK")
+    """
+)
+
+
+def test_privacy_service_import_is_pure():
+    result = subprocess.run(
+        [sys.executable, "-c", _PURITY_SCRIPT],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={"PYTHONPATH": ".", "PATH": "/usr/bin:/bin"},
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+    assert "PRIVACY_SERVICE_PURITY_OK" in result.stdout

--- a/backend/tests/test_privacy_api.py
+++ b/backend/tests/test_privacy_api.py
@@ -70,6 +70,7 @@ from backend.privacy_operations import (
 from backend.privacy_service import (
     PrivacyOperationResponse,
     PrivacyService,
+    SupabasePrivacyRepository,
 )
 from backend.process_turn import ProcessTurnResult
 from backend.settings import AppEnvironment, Settings
@@ -372,6 +373,22 @@ def test_route_without_bearer_returns_401_and_does_not_call_service(path):
     assert service.calls == [], "the privacy service must not be reached"
 
 
+@pytest.mark.parametrize("path", sorted(PATHS.values()))
+def test_route_without_wired_service_returns_503_constant(path):
+    """When ``privacy_service`` is not wired in the container, every privacy
+    endpoint fails closed with the sanitized 503 service-unavailable payload
+    (never a 500 and never an internal detail)."""
+    app = _make_app(service=None)
+    client = TestClient(app)
+    response = client.post(
+        path, json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 503
+    assert response.json() == {
+        "detail": {"code": "service_unavailable", "message": "Service unavailable."}
+    }
+
+
 # ─── 2. Identity comes exclusively from current_user.id ─────────────────────
 
 
@@ -612,6 +629,65 @@ def test_delete_operations_send_empty_payload():
     asyncio.run(service.delete_history("user-a", OP_ID))
     asyncio.run(service.delete_memories("user-a", OP_ID_2))
     assert captured == [("delete_history", {}), ("delete_memories", {})]
+
+
+# ─── Repository: malformed Supabase response shapes fail closed ─────────────
+
+
+def _repo_with_response(response) -> SupabasePrivacyRepository:
+    client = SimpleNamespace(
+        rpc=lambda name, params: SimpleNamespace(execute=lambda: response)
+    )
+    return SupabasePrivacyRepository(client)
+
+
+def test_repository_accepts_single_mapping_response():
+    repo = _repo_with_response(SimpleNamespace(data={"status": "applied"}))
+    assert repo.call("delete_history", {}) == {"status": "applied"}
+
+
+def test_repository_accepts_single_element_list_response():
+    repo = _repo_with_response(SimpleNamespace(data=[{"status": "applied"}]))
+    assert repo.call("delete_history", {}) == {"status": "applied"}
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        SimpleNamespace(data=[]),
+        SimpleNamespace(data=[{"a": 1}, {"b": 2}]),
+        SimpleNamespace(data="not-a-mapping"),
+        SimpleNamespace(data=None),
+        SimpleNamespace(),  # missing ``data`` attribute
+        "not-a-response",
+        None,
+    ],
+)
+def test_repository_maps_malformed_response_shapes_to_persistence_error(response):
+    repo = _repo_with_response(response)
+    with pytest.raises(PersistenceError) as exc:
+        repo.call("delete_history", {})
+    assert exc.value.code == "database_error"
+    assert "persistence error" in str(exc.value)
+
+
+def test_repository_maps_rpc_exception_to_persistence_error_sanitized():
+    class ExplodingClient:
+        def rpc(self, name, params):
+            raise RuntimeError(SENTINEL_EXC)
+
+    repo = SupabasePrivacyRepository(ExplodingClient())
+    with pytest.raises(PersistenceError) as exc:
+        repo.call("delete_history", {})
+    assert SENTINEL_EXC not in str(exc.value)
+    assert "persistence error" in str(exc.value)
+
+
+def test_repository_without_client_raises_sanitized_persistence_error():
+    repo = SupabasePrivacyRepository(None)
+    with pytest.raises(PersistenceError) as exc:
+        repo.call("delete_history", {})
+    assert exc.value.code == "database_error"
 
 
 # ─── 12. Idempotent replay, same public result, no second mutation ──────────

--- a/backend/tests/test_privacy_api_integration.py
+++ b/backend/tests/test_privacy_api_integration.py
@@ -1,0 +1,551 @@
+"""Real Supabase integration tests for the #315 privacy HTTP API frontier.
+
+This file is executed ONLY by the database CI job against a freshly reset
+local Supabase instance (no mocks: real GoTrue auth, real PostgreSQL
+transactions, locks, ledger and revision increments). It must never be
+collected by the ordinary backend unit job.
+
+It deliberately does NOT re-test the #314 SQL invariants (that is
+``test_privacy_operations_integration.py``); it covers the API frontier that
+#315 creates:
+
+ 1. Real authentication + operation through the endpoint: the public
+    response matches the #315 contract and ``profiles.revision`` increases
+    exactly once.
+ 2. Replay of the same ``operation_id`` returns the same public result
+    without a second mutation or revision increment.
+ 3. Users A and B are isolated: an operation of A never touches B's data,
+    and reusing the same ``operation_id`` across users is independent.
+ 4. Resets persist the canonical neutral v1 snapshot through the endpoint.
+ 5. A request without authentication does not mutate the database.
+ 6. The public response never exposes ``user_id``, ``revision``,
+    ``operation_id``, content or internal IDs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+from supabase import Client, create_client
+
+from backend.admission import AdmissionRuntimeConfig
+from backend.dependencies import ApplicationDependencies
+from backend.health import HealthRegistry
+from backend.main import create_app
+from backend.privacy_operations import (
+    OPERATION_DELETE_HISTORY,
+    OPERATION_RESET_EMOTIONAL_STATE,
+    OPERATION_RESET_RELATIONSHIP_STATE,
+    neutral_emotional_snapshot,
+    neutral_relationship_snapshot,
+    new_operation_id,
+)
+from backend.privacy_service import PrivacyService, SupabasePrivacyRepository
+from backend.settings import AppEnvironment, Settings
+from backend.turn_execution import TurnExecutionConfig
+
+_SUPABASE_CLI = ["supabase"] if shutil.which("supabase") else ["npx", "supabase"]
+
+SECRET = "ci-test-secret-0123456789abcdef0123456789abcdef"
+
+PATHS = {
+    "delete_history": "/privacy/delete-history",
+    "delete_memories": "/privacy/delete-memories",
+    "reset_emotional_state": "/privacy/reset-emotional-state",
+    "reset_relationship": "/privacy/reset-relationship",
+}
+
+
+# ─── Environment / clients ───────────────────────────────────────────────────
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name)
+    assert value, f"{name} is required for privacy API integration tests"
+    return value
+
+
+def _close_http_transports(client: Client) -> None:
+    if client is None:
+        return
+    for attr, session_attr in (
+        ("_postgrest", "session"),
+        ("_storage", "session"),
+        ("_functions", "_client"),
+    ):
+        transport = getattr(client, attr, None)
+        if transport is None:
+            continue
+        session = getattr(transport, session_attr, None)
+        if session is not None and hasattr(session, "close"):
+            session.close()
+
+
+def _close_client(client: Client) -> None:
+    if client is None:
+        return
+    _close_http_transports(client)
+    auth = getattr(client, "auth", None)
+    if auth is not None and hasattr(auth, "close"):
+        auth.close()
+
+
+@pytest.fixture(scope="module")
+def supabase_url() -> str:
+    return _required_env("SUPABASE_URL")
+
+
+@pytest.fixture(scope="module")
+def anon_key() -> str:
+    return _required_env("SUPABASE_ANON_KEY")
+
+
+@pytest.fixture(scope="module")
+def service_role_key() -> str:
+    return _required_env("SUPABASE_SERVICE_ROLE_KEY")
+
+
+@pytest.fixture(scope="module")
+def service_client(supabase_url: str, service_role_key: str) -> Client:
+    client = create_client(supabase_url, service_role_key)
+    yield client
+    _close_client(client)
+
+
+class _FakeEngine:
+    """Engine double: privacy routes never touch the conversation engine."""
+
+    def __init__(self):
+        self.memory_manager = SimpleNamespace(supabase=None)
+        self.groq_manager = object()
+
+
+@pytest.fixture(scope="module")
+def app_client(
+    supabase_url: str, service_role_key: str
+) -> tuple[TestClient, Client]:
+    """The real FastAPI application wired to the local Supabase instance."""
+    client = create_client(supabase_url, service_role_key)
+    privacy_service = PrivacyService(
+        repository=SupabasePrivacyRepository(client),
+        turn_config=TurnExecutionConfig.defaults(),
+        clock=time.time,
+    )
+    settings = Settings(
+        app_env=AppEnvironment.local,
+        groq_api_key="ci-groq-key",
+        admission_hmac_secret=SECRET,
+        cors_allowed_origins=("http://localhost:3000",),
+    )
+    deps = ApplicationDependencies(
+        conversation_engine=_FakeEngine(),
+        auth_client=client,
+        admission_config=AdmissionRuntimeConfig.from_values(SECRET),
+        turn_config=TurnExecutionConfig.defaults(),
+        health_checks=HealthRegistry(),
+        clock=time.time,
+        persistence_client=client,
+        privacy_service=privacy_service,
+    )
+    app = create_app(settings=settings, dependencies=deps)
+    yield TestClient(app), client
+    _close_client(client)
+
+
+@pytest.fixture(scope="module")
+def users(
+    supabase_url: str,
+    anon_key: str,
+    service_client: Client,
+) -> dict[str, dict]:
+    """Two real GoTrue users (``a`` and ``b``) with valid sessions."""
+    created: list[dict] = []
+    for label in ("a", "b"):
+        email = f"privacy-api-{label}-{uuid.uuid4().hex[:8]}@test.local"
+        password = "password123"
+        anon = create_client(supabase_url, anon_key)
+        try:
+            anon.auth.sign_up({"email": email, "password": password})
+            response = anon.auth.sign_in_with_password(
+                {"email": email, "password": password}
+            )
+            assert response is not None and response.user is not None
+            assert (
+                response.session is not None
+                and response.session.access_token is not None
+            )
+            created.append(
+                {
+                    "label": label,
+                    "id": response.user.id,
+                    "token": response.session.access_token,
+                    "email": email,
+                }
+            )
+        finally:
+            _close_client(anon)
+    yield {entry["label"]: entry for entry in created}
+    for entry in created:
+        for user in service_client.auth.admin.list_users():
+            if user.email == entry["email"]:
+                service_client.auth.admin.delete_user(user.id)
+
+
+# ─── SQL helpers (pinned local Supabase CLI, sanitized) ──────────────────────
+
+
+def _run_sql(sql: str) -> list[dict]:
+    child_env = dict(os.environ)
+    child_env["SUPABASE_TELEMETRY_DISABLED"] = "1"
+    child_env["SUPABASE_ANALYTICS_ENABLED"] = "false"
+    result = subprocess.run(
+        [
+            *_SUPABASE_CLI,
+            "db",
+            "query",
+            "--agent=no",
+            "--output",
+            "json",
+            sql,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=child_env,
+    )
+    assert result.returncode == 0, "sanitized privacy API test SQL operation failed"
+    output = result.stdout.strip()
+    if not output or output[0] not in "[{":
+        return []
+    parsed = json.loads(output)
+    assert isinstance(parsed, list)
+    return parsed
+
+
+def _count(table: str, user_id: str) -> int:
+    rows = _run_sql(
+        f"SELECT count(*)::integer AS count FROM public.{table} "
+        f"WHERE user_id = '{user_id}'"
+    )
+    return rows[0]["count"]
+
+
+def _revision(user_id: str) -> int:
+    rows = _run_sql(
+        f"SELECT revision FROM public.profiles WHERE user_id = '{user_id}'"
+    )
+    return rows[0]["revision"]
+
+
+def _emotional_state_of(user_id: str) -> dict:
+    rows = _run_sql(
+        f"SELECT emotional_state FROM public.profiles WHERE user_id = '{user_id}'"
+    )
+    return rows[0]["emotional_state"]
+
+
+def _relationship_state_of(user_id: str) -> dict:
+    rows = _run_sql(
+        f"SELECT relationship_state FROM public.profiles WHERE user_id = '{user_id}'"
+    )
+    return rows[0]["relationship_state"]
+
+
+# ─── Seeding / cleanup ───────────────────────────────────────────────────────
+
+
+def _emotional_state() -> dict:
+    return {
+        "schema_version": 1, "pleasure": 0.9, "arousal": 0.8, "dominance": 0.7,
+        "libido": 0.1, "aggression": 0.1, "connection": 0.5, "energy": 0.8,
+        "tension": 0.1, "coping_mode": "MANIC", "timestamp": 1700000000.0,
+    }
+
+
+def _relationship_state() -> dict:
+    return {
+        "schema_version": 1, "trust": 0.9, "affection": 0.8, "tension": 0.1,
+        "triggers": [], "timestamp": 1700000000.0,
+    }
+
+
+def _seed_user(
+    user_id: str,
+    *,
+    revision: int = 2,
+    with_turn: bool = True,
+    with_memory: bool = True,
+) -> None:
+    _run_sql(
+        "INSERT INTO public.profiles (user_id, persona_config, user_profile, "
+        "relationship_state, emotional_state, revision) VALUES "
+        f"('{user_id}', 'persona-config', '{{}}'::jsonb, "
+        f"'{json.dumps(_relationship_state())}'::jsonb, "
+        f"'{json.dumps(_emotional_state())}'::jsonb, {revision})"
+    )
+    _run_sql(
+        "INSERT INTO public.chat_logs (user_id, role, content) VALUES "
+        f"('{user_id}', 'user', 'hello'), ('{user_id}', 'assistant', 'hi there')"
+    )
+    if with_turn:
+        turn_id = str(uuid.uuid4())
+        _run_sql(
+            "INSERT INTO public.turn_requests ("
+            "id, user_id, request_id, payload_hash_sha256, status, expected_revision, "
+            "committed_revision, replay_payload, created_at, updated_at, completed_at) "
+            "VALUES "
+            f"('{turn_id}', '{user_id}', '{uuid.uuid4()}', "
+            f"'{'a' * 64}', 'completed', 0, {revision}, "
+            f"'{{\"response\":\"hi there\",\"message_id\":\"{uuid.uuid4()}\"}}'::jsonb, "
+            "now(), now(), now())"
+        )
+    if with_memory:
+        _run_sql(
+            "INSERT INTO public.memories (user_id, content, metadata) VALUES "
+            f"('{user_id}', 'a durable memory', '{{\"tags\":[\"x\"]}}'::jsonb)"
+        )
+    _run_sql(
+        "INSERT INTO public.archival_extractions ("
+        "user_id, source_chat_log_id, extractor_version, schema_version, "
+        "idempotency_key, facts) "
+        "SELECT '{user_id}', id, 1, 1, '{user_id}-arch-1', '{{\"facts\":[]}}'::jsonb "
+        "FROM public.chat_logs WHERE user_id = '{user_id}' AND role = 'user'".format(
+            user_id=user_id
+        )
+    )
+
+
+def _cleanup_user(user_id: str) -> None:
+    for table in (
+        "privacy_operations",
+        "admission_reservations",
+        "archival_extractions",
+        "memories",
+        "chat_logs",
+        "turn_requests",
+        "outbox_events",
+        "profiles",
+    ):
+        _run_sql(f"DELETE FROM public.{table} WHERE user_id = '{user_id}'")
+
+
+def _assert_public_contract(body: dict) -> None:
+    """The public projection contains ONLY operation/status/counts."""
+    assert set(body) == {"operation", "status", "counts"}
+    assert body["status"] == "applied"
+    forbidden = {"user_id", "revision", "operation_id", "id", "content", "snapshot"}
+    for key in forbidden:
+        assert key not in body
+
+
+# ─── 1/2. Operation via endpoint applies once and replays idempotently ──────
+
+
+def test_delete_history_via_endpoint_applies_once_and_replays(
+    app_client: tuple[TestClient, Client],
+    users: dict[str, dict],
+):
+    client, _ = app_client
+    user = users["a"]
+    _seed_user(user["id"], revision=2)
+    try:
+        headers = {"Authorization": f"Bearer {user['token']}"}
+        operation_id = new_operation_id()
+        before = _revision(user["id"])
+        assert _count("chat_logs", user["id"]) == 2
+
+        response = client.post(
+            PATHS["delete_history"],
+            json={"operation_id": operation_id},
+            headers=headers,
+        )
+        assert response.status_code == 200
+        body = response.json()
+        _assert_public_contract(body)
+        assert body["operation"] == "delete_history"
+        assert body["counts"]["chat_logs"] == 2
+
+        after = _revision(user["id"])
+        assert after == before + 1, "revision must increase exactly once"
+        assert _count("chat_logs", user["id"]) == 0
+        assert _count("turn_requests", user["id"]) == 0
+        assert _count("archival_extractions", user["id"]) == 0
+        # Non-history data is preserved.
+        assert _count("memories", user["id"]) == 1
+
+        # Replay: same operation_id -> same public result, no second mutation.
+        replay = client.post(
+            PATHS["delete_history"],
+            json={"operation_id": operation_id},
+            headers=headers,
+        )
+        assert replay.status_code == 200
+        assert replay.json() == body
+        assert _revision(user["id"]) == after, "replay must not increment revision"
+    finally:
+        _cleanup_user(user["id"])
+
+
+# ─── 4. Resets persist the canonical neutral v1 snapshot ────────────────────
+
+
+def test_reset_emotional_state_persists_neutral_snapshot(
+    app_client: tuple[TestClient, Client],
+    users: dict[str, dict],
+):
+    client, _ = app_client
+    user = users["a"]
+    _seed_user(user["id"], revision=2)
+    try:
+        headers = {"Authorization": f"Bearer {user['token']}"}
+        response = client.post(
+            PATHS["reset_emotional_state"],
+            json={"operation_id": new_operation_id()},
+            headers=headers,
+        )
+        assert response.status_code == 200
+        body = response.json()
+        _assert_public_contract(body)
+        assert body["operation"] == "reset_emotional_state"
+
+        stored = _emotional_state_of(user["id"])
+        # The stored snapshot is exactly the canonical neutral v1 snapshot
+        # built from its own timestamp (pins canonical neutrality).
+        assert stored == neutral_emotional_snapshot(stored["timestamp"])
+        assert stored["schema_version"] == 1
+        assert stored["coping_mode"] == "HEALTHY"
+        assert stored["pleasure"] == 0.0
+        # The relationship snapshot is preserved.
+        assert _relationship_state_of(user["id"])["trust"] == 0.9
+    finally:
+        _cleanup_user(user["id"])
+
+
+def test_reset_relationship_state_persists_neutral_snapshot(
+    app_client: tuple[TestClient, Client],
+    users: dict[str, dict],
+):
+    client, _ = app_client
+    user = users["a"]
+    _seed_user(user["id"], revision=2)
+    try:
+        headers = {"Authorization": f"Bearer {user['token']}"}
+        response = client.post(
+            PATHS["reset_relationship"],
+            json={"operation_id": new_operation_id()},
+            headers=headers,
+        )
+        assert response.status_code == 200
+        body = response.json()
+        _assert_public_contract(body)
+        assert body["operation"] == "reset_relationship_state"
+
+        stored = _relationship_state_of(user["id"])
+        assert stored == neutral_relationship_snapshot(stored["timestamp"])
+        assert stored["schema_version"] == 1
+        assert stored["trust"] == 0.5
+        assert stored["affection"] == 0.3
+        # The emotional snapshot is preserved.
+        assert _emotional_state_of(user["id"])["coping_mode"] == "MANIC"
+    finally:
+        _cleanup_user(user["id"])
+
+
+# ─── 3. Users A and B are isolated ──────────────────────────────────────────
+
+
+def test_users_a_and_b_are_isolated(
+    app_client: tuple[TestClient, Client],
+    users: dict[str, dict],
+):
+    client, _ = app_client
+    user_a, user_b = users["a"], users["b"]
+    _seed_user(user_a["id"], revision=2)
+    _seed_user(user_b["id"], revision=5)
+    try:
+        headers_a = {"Authorization": f"Bearer {user_a['token']}"}
+        headers_b = {"Authorization": f"Bearer {user_b['token']}"}
+        operation_id = new_operation_id()
+
+        # User A deletes their history.
+        response = client.post(
+            PATHS["delete_history"],
+            json={"operation_id": operation_id},
+            headers=headers_a,
+        )
+        assert response.status_code == 200
+        assert _count("chat_logs", user_a["id"]) == 0
+        # User B's data is untouched by A's operation.
+        assert _count("chat_logs", user_b["id"]) == 2
+
+        # User B reuses the SAME operation_id: keyed per user, so it is an
+        # independent operation, never a replay of A's ledger row.
+        response_b = client.post(
+            PATHS["delete_history"],
+            json={"operation_id": operation_id},
+            headers=headers_b,
+        )
+        assert response_b.status_code == 200
+        assert response_b.json()["operation"] == "delete_history"
+        assert _count("chat_logs", user_b["id"]) == 0
+
+        # Both revisions increased independently, exactly once each.
+        assert _revision(user_a["id"]) == 3
+        assert _revision(user_b["id"]) == 6
+    finally:
+        _cleanup_user(user_a["id"])
+        _cleanup_user(user_b["id"])
+
+
+# ─── 5. Request without authentication does not mutate ──────────────────────
+
+
+def test_request_without_auth_does_not_mutate(
+    app_client: tuple[TestClient, Client],
+    users: dict[str, dict],
+):
+    client, _ = app_client
+    user = users["a"]
+    _seed_user(user["id"], revision=2)
+    try:
+        before = _revision(user["id"])
+        response = client.post(
+            PATHS["delete_history"], json={"operation_id": new_operation_id()}
+        )
+        assert response.status_code == 401
+        assert _revision(user["id"]) == before
+        assert _count("chat_logs", user["id"]) == 2
+        assert _count("privacy_operations", user["id"]) == 0
+        assert _count("profiles", user["id"]) == 1
+    finally:
+        _cleanup_user(user["id"])
+
+
+# ─── 6. Public response never exposes internal fields ───────────────────────
+
+
+def test_public_responses_never_expose_internal_fields(
+    app_client: tuple[TestClient, Client],
+    users: dict[str, dict],
+):
+    client, _ = app_client
+    user = users["a"]
+    _seed_user(user["id"], revision=2)
+    try:
+        headers = {"Authorization": f"Bearer {user['token']}"}
+        for path in PATHS.values():
+            response = client.post(
+                path, json={"operation_id": new_operation_id()}, headers=headers
+            )
+            assert response.status_code == 200
+            _assert_public_contract(response.json())
+    finally:
+        _cleanup_user(user["id"])

--- a/docs/architecture/user-data-lifecycle.md
+++ b/docs/architecture/user-data-lifecycle.md
@@ -26,9 +26,9 @@ the authenticated HTTP application layer (#315):
 the #314 semantics: the service is a stateless application layer that
 delegates every operation to `run_privacy_operation`.
 
-Explicitly NOT done here: UI, account/Auth deletion, durable workers/jobs,
-physical retention policy, export, model/formula changes, reactivation of
-archival extraction, #276, #316.
+Explicitly NOT done here: UI, account/Auth deletion (#317), durable
+workers/jobs (#276), physical retention/cleanup policy (#316), export,
+model/formula changes, reactivation of archival extraction.
 
 ## Problem
 
@@ -284,6 +284,6 @@ reversible; idempotency guarantees they are never applied twice.
 ## Out of scope (future leaves)
 
 - UI / settings screens exposing these primitives.
-- Account/Auth user deletion (#316), durable workers (#276), retention and
-  export policies.
+- Account/Auth user deletion with tombstone (#317), durable workers (#276),
+  retention/cleanup (#316) and export policies.
 - Emotional/relationship formula, decay, appraisal or personality changes.

--- a/docs/architecture/user-data-lifecycle.md
+++ b/docs/architecture/user-data-lifecycle.md
@@ -2,13 +2,18 @@
 
 ## Status
 
-Implemented by issue #314 (privacy chain #274, gate PROD-0 recovery #264).
-This document is the architectural record for the transactional, idempotent,
-server-owned privacy primitives that future leaves of the chain build on.
+The transactional, idempotent, server-owned privacy primitives are implemented
+by issue #314 (privacy chain #274, gate PROD-0 recovery #264), and the
+authenticated HTTP frontier exposing them is implemented by issue #315
+(``POST /privacy/delete-history``, ``/privacy/delete-memories``,
+``/privacy/reset-emotional-state`` and ``/privacy/reset-relationship``).
+This document is the architectural record for the chain that future leaves
+build on.
 
 ## Scope
 
-This leaf creates ONLY the transactional/server-side foundation:
+This leaf creates ONLY the transactional/server-side foundation (#314) plus
+the authenticated HTTP application layer (#315):
 
 - `delete_history` — atomic removal of turn history and its derivatives.
 - `delete_memories` — atomic removal of memories and ungoverned candidates.
@@ -16,9 +21,14 @@ This leaf creates ONLY the transactional/server-side foundation:
 - `reset_relationship_state` — surgical replacement of the relationship
   snapshot.
 
-Explicitly NOT done here: HTTP endpoints, UI, account/Auth deletion, durable
-workers/jobs, physical retention policy, export, model/formula changes,
-reactivation of archival extraction, #276, #315.
+#315 exposes those four primitives through authenticated HTTP endpoints
+(`backend/privacy_service.py` + routes in `backend/main.py`) without touching
+the #314 semantics: the service is a stateless application layer that
+delegates every operation to `run_privacy_operation`.
+
+Explicitly NOT done here: UI, account/Auth deletion, durable workers/jobs,
+physical retention policy, export, model/formula changes, reactivation of
+archival extraction, #276, #316.
 
 ## Problem
 
@@ -193,14 +203,76 @@ required table on a compatible baseline and proves the migration fails with
 | Reused operation_id with divergent operation/payload | `{"error":{"code":"operation_conflict",...}}` |
 | Unexpected PostgreSQL failure | raised constant `persistence error` (P0001), rollback |
 
+## HTTP API frontier (#315)
+
+The four primitives are exposed over authenticated HTTP as four explicit
+actions, each receiving ONLY `{"operation_id": "<uuid>"}`:
+
+| Endpoint | Operation |
+|---|---|
+| `POST /privacy/delete-history` | `delete_history` |
+| `POST /privacy/delete-memories` | `delete_memories` |
+| `POST /privacy/reset-emotional-state` | `reset_emotional_state` |
+| `POST /privacy/reset-relationship` | `reset_relationship_state` |
+
+Binding decisions of the HTTP layer:
+
+1. **Identity is never client-supplied.** The body is `extra="forbid"` and
+   accepts only `operation_id`; any extra key (including `user_id`) returns
+   `422`. The only identity is `current_user.id` from the existing
+   `get_current_user` auth dependency. The UUID is normalized to lowercase
+   canonical form before reaching the privacy layer; any canonical UUID
+   version is accepted (no v4 restriction), matching the #314 contract.
+2. **`backend/privacy_service.py` is a stateless application service.** It
+   holds no per-user state: identity and `operation_id` are per-call
+   arguments. The repository (Supabase sync RPC adapter) and the clock are
+   injectable; reset snapshots are built with the injected clock through the
+   #314 neutral helpers, so the timestamp is never a hidden `time.time()`.
+3. **Writes use the existing bounded-write infrastructure.** The sync
+   `client.rpc(name, params).execute()` call runs through
+   `run_blocking_write` (per-action budget from the operational turn
+   configuration, real PostgREST transport timeout, drain-on-cancellation).
+   No `BackgroundTasks`, no fire-and-forget threads, no orphaned tasks.
+4. **Public response projection.** The response is deliberately smaller than
+   `PrivacyOperationResult`:
+
+   ```json
+   {
+     "operation": "delete_history",
+     "status": "applied",
+     "counts": { "chat_logs": 2, "turn_requests": 1, "outbox_events": 1,
+                 "archival_extractions": 1, "memories": 0, "profiles": 0 }
+   }
+   ```
+
+   `user_id`, `revision`, `operation_id`, internal IDs, content, snapshots
+   and secrets are never exposed. Fresh execution and idempotent replay
+   produce the same projection (there is no `replayed` field).
+5. **Stable sanitized HTTP errors.** Missing/invalid credentials → `401`;
+   invalid input / extra keys / invalid UUID → `422`; `operation_conflict`
+   → `409`; persistence failure → `503`; any unexpected failure or internal
+   contract violation (`invalid_rpc_result`, divergent identity, malformed
+   envelope) fails closed as a constant `500` and is never presented as a
+   client `422`.
+6. **Observability** uses only the existing sanitized events with
+   low-cardinality codes (`http_result`, `request_conflict`). Raw
+   `user_id`, `operation_id`, bearer tokens, content, snapshots, RPC payloads
+   and upstream exception text never reach logs or responses.
+
 ## Files
 
 - `supabase/migrations/20260808220000_privacy_data_operations.sql`
 - `supabase/tests/database/06_privacy_data_operations.test.sql` (pgTAP)
-- `backend/privacy_operations.py` (pure Python adapter)
+- `backend/privacy_operations.py` (pure Python adapter, #314)
+- `backend/privacy_service.py` (stateless application service + Supabase
+  repository adapter + public projection, #315)
+- `backend/main.py` (DTO, four authenticated routes, error mapping)
+- `backend/dependencies.py` (container wiring of the default service)
 - `backend/tests/test_privacy_operations.py` (unit, no DB)
 - `backend/tests/test_privacy_operations_integration.py` (real Supabase)
 - `backend/tests/test_privacy_operations_legacy.py` (legacy upgrade)
+- `backend/tests/test_privacy_api.py` (unit API/service, no DB)
+- `backend/tests/test_privacy_api_integration.py` (real Supabase, #315)
 
 ## Rollback
 
@@ -211,7 +283,7 @@ reversible; idempotency guarantees they are never applied twice.
 
 ## Out of scope (future leaves)
 
-- HTTP endpoints / UI exposing these primitives.
-- Account/Auth user deletion (#315), durable workers (#276), retention and
+- UI / settings screens exposing these primitives.
+- Account/Auth user deletion (#316), durable workers (#276), retention and
   export policies.
 - Emotional/relationship formula, decay, appraisal or personality changes.


### PR DESCRIPTION
Closes #315

## Problema e causa raiz

A #314 implementou as quatro primitivas transacionais de privacidade
(`delete_history`, `delete_memories`, `reset_emotional_state`,
`reset_relationship_state`) na fronteira Python
(`backend/privacy_operations.py`) e no PostgreSQL (RPCs, ledger, locks,
fingerprint, revision, neutralidade), mas não existia uma fronteira HTTP
autenticada para chamá-las. Esta PR adiciona **somente** a camada de
aplicação/API: nenhuma semântica transacional da #314 foi reimplementada ou
alterada.

## Solução e decisões arquiteturais

- **Quatro endpoints autenticados e separados**: `POST /privacy/delete-history`,
  `/privacy/delete-memories`, `/privacy/reset-emotional-state` e
  `/privacy/reset-relationship`. Cada um recebe apenas
  `{"operation_id": "<uuid>"}`.
- **Identidade nunca vem do cliente**: DTO Pydantic com `extra="forbid"`;
  `user_id` no body ou qualquer chave extra retorna `422`. A única identidade
  é `current_user.id` do `get_current_user` existente. O `operation_id` é
  normalizado para UUID canônico lowercase (qualquer versão aceita, sem
  restrição arbitrária a v4, compatível com o contrato da #314).
- **Camada de aplicação stateless** (`backend/privacy_service.py`):
  `PrivacyService` com repository/adapter injetável
  (`SupabasePrivacyRepository`) e clock injetado. Não guarda `user_id`,
  snapshots ou `operation_id` entre requests; cada operação delega a
  `run_privacy_operation`, a fonte de verdade da fronteira Python da #314.
- **Writes nunca bloqueiam o event loop e nunca são abandonadas**: o RPC
  síncrono `client.rpc(...).execute()` roda via `run_blocking_write`
  (budget por ação, timeout de transporte PostgREST, drenagem em
  cancellation). Sem `BackgroundTasks`, sem `create_task` solto, sem threads
  órfãs.
- **Resets usam exclusivamente snapshots neutros canônicos v1** construídos
  pelos helpers existentes da #314 com o timestamp do clock injetado.
- **Projeção pública explícita**: a resposta contém somente
  `{operation, status, counts}`; nunca expõe `user_id`, `revision`,
  `operation_id`, IDs internos, conteúdo, snapshots ou segredos. Fresh
  execution e replay idempotente produzem o mesmo contrato (sem campo
  `replayed`).
- **Erros HTTP estáveis e sanitizados**: `401` (auth), `422` (input/UUID
  inválido/chaves extras), `409` (`operation_conflict`), `503`
  (persistência), `500` constante (falha inesperada ou violação interna como
  `invalid_rpc_result`, identidade divergente, envelope malformado — nunca
  `422`).
- **Observabilidade**: somente eventos sanitizados existentes
  (`http_result`, `request_conflict`) com códigos de baixa cardinalidade;
  `user_id`, `operation_id`, bearer tokens, conteúdo e texto de exceção
  nunca chegam a logs ou respostas.
- **DI**: `privacy_service` adicionado ao container
  (`ApplicationDependencies`) com default compatível (`None`), construído em
  `build_default_dependencies` e injetável em testes.

## Arquivos/áreas afetadas

- `backend/privacy_service.py` (novo): service stateless, adapter Supabase,
  projeção pública.
- `backend/main.py`: DTO, quatro rotas, mapeamento de erros, handlers.
- `backend/dependencies.py`: wiring do service no composition root.
- `backend/tests/test_privacy_api.py` (novo): suíte unitária da API/service.
- `backend/tests/test_privacy_api_integration.py` (novo): suíte real contra
  Supabase local (job `database` do CI).
- `backend/tests/test_app_factory.py`: assert do campo do container.
- `.github/workflows/ci.yml`: registro da nova suíte de integração no job
  `database` e exclusão do job `backend` unitário.
- `docs/architecture/user-data-lifecycle.md`: registro da fronteira HTTP.

## Testes executados e resultado

- Suíte unitária completa do backend (equivalente ao job `backend` do CI,
  com as suítes de integração excluídas): **2451 passed** no HEAD final.
  Comando: `python -m pytest backend/tests --ignore=...` (mesmos `--ignore`
  do CI).
- Suíte de integração real da #315 contra Supabase local
  (`test_privacy_api_integration.py`): **6 passed** (auth real + operação,
  replay idempotente com revision +1 uma única vez, isolamento A/B, reset
  persiste snapshot neutro, sem autenticação não muta o banco, contrato
  público).
- Suíte de integração existente da #314
  (`test_privacy_operations_integration.py`): **38 passed** (inalterada).
- `python -m compileall -q backend`: OK.
- Cobertura dos 30 cenários obrigatórios da #315 nos testes unitários
  (401 sem token, identidade exclusiva de `current_user.id`, 422 para
  `user_id`/chaves extras, UUID inválido sanitizado, dispatch exato por
  endpoint, snapshots neutros v1, clock injetável, replay sem segunda
  mutação, conflito `409`, persistência `503`, erro interno `500`,
  projeção pública sem campos internos, isolamento A/B, sentinelas fora de
  logs/respostas, sem `BackgroundTasks`, drenagem de write em cancellation,
  compatibilidade de `/chat`, `/history`, `/live`, `/ready`, `ChatResponse`
  e `create_app()`).
- Revisão de mantenedor: cobertura adicional para `privacy_service` não
  injetado (503 `service_unavailable` em todos os quatro endpoints) e para
  formas malformadas de resposta do Supabase no repository (fail-closed como
  `PersistenceError` sanitizado, incluindo `data` ausente, listas
  vazias/múltiplas e payloads inválidos).

## Riscos, migração e rollback

- **Vazamento de identidade**: mitigado por `extra="forbid"` + identidade
  exclusivamente de `current_user.id` + projeção pública explícita.
- **Bloqueio do event loop / write órfã**: mitigado pelo uso de
  `run_blocking_write` com drenagem em cancellation (testado).
- **Estado por usuário no container**: `PrivacyService` é totalmente
  stateless; identidade e `operation_id` são argumentos por chamada.
- **Erro interno classificado como erro do usuário**: `ValidationError` da
  #314 após validação HTTP falha fechado como `500`, nunca `422` (testado).
- **Migração**: nenhuma migration nova. Rollback: reverter a PR restaura a
  `main` sem tocar nas tabelas/RPCs da #314.
- **Riscos residuais**: a suíte de integração depende do ambiente local de
  CI (mesmo padrão das demais suítes reais); sem serviço externo.

## Fora de escopo (deliberadamente)

- #316: retenção mínima / cleanup durável de dados operacionais (não
  iniciada).
- #317: exclusão durável de conta com tombstone + Supabase Auth (não
  iniciada).
- #276 (worker durável), exportação de dados, UI/settings de privacidade,
  alterações nas fórmulas emocionais/relacionamento, mudanças nas semânticas
  da #314, novas dependências, refactors amplos.
- Nenhuma dessas issues (#316, #317, #276) foi iniciada.

## Summary by Sourcery

Adicionar uma camada de API HTTP autenticada que expõe as operações de privacidade existentes e conectá-la por meio de um serviço de aplicação sem estado.

Novos recursos:
- Introduzir quatro endpoints HTTP de privacidade autenticados para excluir histórico, excluir memórias e redefinir o estado emocional e de relacionamento.
- Fornecer um `PrivacyService` sem estado e um repositório baseado em Supabase como camada de aplicação sobre as operações de privacidade existentes.

Melhorias:
- Definir um DTO restrito para operações de privacidade que imponha identidade derivada do servidor e normalização de UUID, retornando ao mesmo tempo uma projeção pública mínima.
- Adicionar mapeamento de erros estável e sanitizado e observabilidade para ações de privacidade sem expor identificadores internos ou segredos.
- Conectar o serviço de privacidade ao contêiner de dependências da aplicação preservando os contratos de rotas e respostas existentes.

CI:
- Estender o job de CI de banco de dados para executar novos testes de integração da API de privacidade contra uma instância local do Supabase resetada e excluí-los do job de testes unitários.

Documentação:
- Atualizar o registro de arquitetura do ciclo de vida de dados do usuário para documentar a nova fronteira HTTP autenticada e suas decisões de vinculação.

Testes:
- Adicionar testes unitários abrangentes para a API de privacidade e o comportamento do serviço, incluindo tratamento de identidade, repetição/idempotência, mapeamento de erros e compatibilidade com endpoints existentes.
- Adicionar testes reais de integração com Supabase validando operações de privacidade autenticadas, replays idempotentes, isolamento de usuários, neutralidade de snapshots e contratos de resposta pública.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an authenticated HTTP API layer exposing the existing privacy operations and wire it through a stateless application service.

New Features:
- Introduce four authenticated privacy HTTP endpoints for deleting history, deleting memories, and resetting emotional and relationship state.
- Provide a stateless PrivacyService and Supabase-backed repository as the application layer over the existing privacy operations.

Enhancements:
- Define a constrained DTO for privacy operations that enforces server-derived identity and UUID normalization while returning a minimal public projection.
- Add stable, sanitized error mapping and observability for privacy actions without exposing internal identifiers or secrets.
- Wire the privacy service into the application dependency container while preserving existing route and response contracts.

CI:
- Extend the database CI job to run new privacy API integration tests against a reset local Supabase instance and exclude them from the unit test job.

Documentation:
- Update the user data lifecycle architecture record to document the new authenticated HTTP frontier and its binding decisions.

Tests:
- Add comprehensive unit tests for the privacy API and service behavior, including identity handling, replay/idempotency, error mapping, and compatibility with existing endpoints.
- Add real Supabase integration tests validating authenticated privacy operations, idempotent replays, user isolation, snapshot neutrality, and public response contracts.

</details>