### PR TITLE
feat(privacy): enforce operational data retention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,39 @@ jobs:
           set -euo pipefail
           python -m pytest -q -ra backend/tests/test_privacy_api_integration.py
 
+      - name: Reset database for retention preflight tests
+        run: |
+          set -euo pipefail
+          supabase db reset
+
+      - name: Run Retention Preflight Test (missing dependency -> 23514)
+        env:
+          SUPABASE_URL: "http://127.0.0.1:54321"
+          PYTHONPATH: "."
+        run: |
+          set -euo pipefail
+          # The retention preflight gate must be exercised by CI: each case
+          # hides the new migration, resets the pre-retention baseline,
+          # drops exactly one mandatory operational table and requires the
+          # migration to fail with 23514 before installing any function.
+          bash scripts/hide-migrations-after.sh 20260808220000 \
+            python -m pytest -q -ra backend/tests/test_retention_preflight.py
+
+      - name: Reset database for retention integration tests
+        run: |
+          set -euo pipefail
+          supabase db reset
+
+      - name: Run Retention Integration Tests
+        env:
+          SUPABASE_URL: "http://127.0.0.1:54321"
+          SUPABASE_ANON_KEY: "${{ env.SUPABASE_ANON_KEY }}"
+          SUPABASE_SERVICE_ROLE_KEY: "${{ env.SUPABASE_SERVICE_ROLE_KEY }}"
+          PYTHONPATH: "."
+        run: |
+          set -euo pipefail
+          python -m pytest -q -ra backend/tests/test_retention_integration.py
+
       - name: Stop Supabase
         if: always()
         run: supabase stop
@@ -351,6 +384,8 @@ jobs:
               --ignore=backend/tests/test_privacy_operations_legacy.py \
               --ignore=backend/tests/test_privacy_operations_preflight.py \
               --ignore=backend/tests/test_privacy_api_integration.py \
+              --ignore=backend/tests/test_retention_integration.py \
+              --ignore=backend/tests/test_retention_preflight.py \
               -ra
 
   frontend:

--- a/backend/observability.py
+++ b/backend/observability.py
@@ -40,6 +40,8 @@ EVENT_TURN_COMPLETED = "turn_completed"
 EVENT_TURN_FAILED = "turn_failed"
 EVENT_REQUEST_CONFLICT = "request_conflict"
 EVENT_HTTP_RESULT = "http_result"
+EVENT_RETENTION_COMPLETED = "retention_completed"
+EVENT_RETENTION_FAILED = "retention_failed"
 
 EVENT_NAMES = frozenset(
     {
@@ -53,6 +55,8 @@ EVENT_NAMES = frozenset(
         EVENT_TURN_FAILED,
         EVENT_REQUEST_CONFLICT,
         EVENT_HTTP_RESULT,
+        EVENT_RETENTION_COMPLETED,
+        EVENT_RETENTION_FAILED,
     }
 )
 

--- a/backend/retention.py
+++ b/backend/retention.py
@@ -1,0 +1,352 @@
+"""Operational data retention runner (#316).
+
+Application layer between the explicit operational command
+(``backend.retention_cli``) and the SQL purge boundary
+(``supabase/migrations/20260809030000_operational_data_retention.sql``).
+No FastAPI routing, no per-user state, no scheduler, no ``BackgroundTasks``.
+
+Components
+==========
+
+* ``RetentionConfig`` — explicit, validated run parameters (batch size,
+  per-category row cap, round timeout).
+* ``RetentionRunResult`` / ``CategoryResult`` — sanitized public outcome of
+  a round: schema version, per-category purged counts and batch counts.
+  Never contains identifiers, HMACs, content or SQL.
+* ``RetentionRepository`` — injectable protocol; the sync
+  ``SupabaseRetentionRepository`` adapter runs the three purge RPCs
+  fail-closed (shape-validated, sanitized ``PersistenceError``).
+* ``RetentionRunner`` — stateless, injectable runner. ``run_once()``
+  processes each category in bounded batches until a partial batch or the
+  per-category cap, then terminates. No hidden loop beyond the round.
+
+Writes
+======
+Every purge RPC is dispatched through ``run_blocking_write``: the real
+timeout comes from the PostgREST transport configuration, cancellation
+drains the in-flight write (no abandoned writes, no orphaned tasks), and a
+per-round monotonic budget bounds the whole category.
+
+Concurrency
+===========
+Purge is idempotent and safe under concurrent executions by construction:
+each statement deletes a bounded, primary-key-selected set; a concurrent
+runner that selects overlapping rows simply finds them already gone. No
+global advisory lock is used.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional, Protocol
+
+from .atomic_turn_commit import PersistenceError
+from .observability import (
+    EVENT_RETENTION_COMPLETED,
+    EVENT_RETENTION_FAILED,
+    emit_event,
+)
+from .retention_policy import (
+    RETENTION_MAX_BATCH_SIZE,
+    RetentionCategory,
+    RetentionPolicy,
+    default_retention_policy,
+    retention_cutoffs,
+)
+from .turn_execution import TurnBudget, TurnExecutionConfig, run_blocking_write
+
+logger = logging.getLogger(__name__)
+
+#: Sanitized stage label used by the write helper for every purge call.
+_RETENTION_WRITE_STAGE = "retention_purge"
+
+#: Default batch size (rows per purge statement).
+DEFAULT_RETENTION_BATCH_SIZE = 500
+
+#: Default maximum rows purged per category per round (bounds one run).
+DEFAULT_RETENTION_MAX_ROWS_PER_CATEGORY = 10_000
+
+#: Default per-category monotonic round timeout (seconds).
+DEFAULT_RETENTION_ROUND_TIMEOUT_SECONDS = 300.0
+
+
+@dataclass(frozen=True)
+class RetentionConfig:
+    """Explicit, validated parameters for one retention round."""
+
+    batch_size: int = DEFAULT_RETENTION_BATCH_SIZE
+    max_rows_per_category: int = DEFAULT_RETENTION_MAX_ROWS_PER_CATEGORY
+    round_timeout_seconds: float = DEFAULT_RETENTION_ROUND_TIMEOUT_SECONDS
+
+    def __post_init__(self) -> None:
+        if isinstance(self.batch_size, bool) or not isinstance(self.batch_size, int):
+            raise ValueError("retention batch_size must be an int")
+        if not 1 <= self.batch_size <= RETENTION_MAX_BATCH_SIZE:
+            raise ValueError(
+                f"retention batch_size must be between 1 and {RETENTION_MAX_BATCH_SIZE}"
+            )
+        if isinstance(self.max_rows_per_category, bool) or not isinstance(
+            self.max_rows_per_category, int
+        ):
+            raise ValueError("retention max_rows_per_category must be an int")
+        if self.max_rows_per_category < self.batch_size:
+            raise ValueError(
+                "retention max_rows_per_category must be >= batch_size"
+            )
+        if (
+            isinstance(self.round_timeout_seconds, bool)
+            or not isinstance(self.round_timeout_seconds, (int, float))
+            or not self.round_timeout_seconds > 0
+        ):
+            raise ValueError(
+                "retention round_timeout_seconds must be a positive number"
+            )
+
+
+@dataclass(frozen=True)
+class CategoryResult:
+    """Sanitized outcome of one category in a round."""
+
+    category: str
+    purged: int = 0
+    batches: int = 0
+
+
+@dataclass(frozen=True)
+class RetentionRunResult:
+    """Sanitized public outcome of one retention round.
+
+    Contains only the policy schema version, per-category aggregate counts
+    and the total. Never contains identifiers, HMACs, content, SQL or
+    secrets.
+    """
+
+    schema_version: int
+    results: Mapping[str, CategoryResult]
+    total_purged: int
+
+    @classmethod
+    def build(
+        cls,
+        schema_version: int,
+        results: list[CategoryResult],
+    ) -> "RetentionRunResult":
+        return cls(
+            schema_version=schema_version,
+            results={result.category: result for result in results},
+            total_purged=sum(result.purged for result in results),
+        )
+
+
+class RetentionRepository(Protocol):
+    """Synchronous purge RPC contract (thread-bound; never awaited directly)."""
+
+    def purge_admission_reservations(self, cutoff: str, batch_size: int) -> int:
+        """Delete up to *batch_size* expired admission rows; return deleted."""
+        ...
+
+    def purge_privacy_operations(self, cutoff: str, batch_size: int) -> int:
+        """Delete up to *batch_size* expired privacy ledger rows; return deleted."""
+        ...
+
+    def purge_outbox_events(self, cutoff: str, batch_size: int) -> int:
+        """Delete up to *batch_size* eligible final outbox events; return deleted."""
+        ...
+
+
+class SupabaseRetentionRepository:
+    """Synchronous adapter over ``client.rpc(name, params).execute()``.
+
+    The response shape is validated fail-closed INSIDE the try/except: a
+    missing/unreachable client, a malformed payload, a non-scalar count or a
+    negative count all surface as a sanitized ``PersistenceError``. Upstream
+    exceptions (which may carry connection details, identifiers or payload
+    content) are never surfaced.
+    """
+
+    _RPC_NAMES = {
+        RetentionCategory.ADMISSION_RESERVATIONS.value: "purge_admission_reservations",
+        RetentionCategory.PRIVACY_OPERATIONS.value: "purge_privacy_operations",
+        RetentionCategory.OUTBOX_EVENTS.value: "purge_outbox_events",
+    }
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    def _call(self, rpc_name: str, params: Mapping[str, Any]) -> int:
+        if self._client is None:
+            raise PersistenceError("database_error", "persistence error")
+        try:
+            response = self._client.rpc(rpc_name, params).execute()
+            data = getattr(response, "data", None)
+            if isinstance(data, list):
+                if len(data) != 1:
+                    raise PersistenceError("database_error", "persistence error")
+                data = data[0]
+            if isinstance(data, int) and not isinstance(data, bool):
+                # PostgREST returns a bare integer for scalar-returning RPCs.
+                if data < 0:
+                    raise PersistenceError("database_error", "persistence error")
+                return data
+            if not isinstance(data, dict):
+                raise PersistenceError("database_error", "persistence error")
+            count = data.get(rpc_name)
+            if count is None:
+                # Tolerate alternative single-value shapes, still fail
+                # closed on anything ambiguous.
+                ints = [
+                    value
+                    for value in data.values()
+                    if isinstance(value, int) and not isinstance(value, bool)
+                ]
+                if len(ints) != 1:
+                    raise PersistenceError("database_error", "persistence error")
+                count = ints[0]
+            if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+                raise PersistenceError("database_error", "persistence error")
+            return count
+        except PersistenceError:
+            raise
+        except Exception:
+            raise PersistenceError("database_error", "persistence error") from None
+
+    def purge_admission_reservations(self, cutoff: str, batch_size: int) -> int:
+        return self._call(self._RPC_NAMES[RetentionCategory.ADMISSION_RESERVATIONS.value], {
+            "p_cutoff": cutoff,
+            "p_batch_size": batch_size,
+        })
+
+    def purge_privacy_operations(self, cutoff: str, batch_size: int) -> int:
+        return self._call(self._RPC_NAMES[RetentionCategory.PRIVACY_OPERATIONS.value], {
+            "p_cutoff": cutoff,
+            "p_batch_size": batch_size,
+        })
+
+    def purge_outbox_events(self, cutoff: str, batch_size: int) -> int:
+        return self._call(self._RPC_NAMES[RetentionCategory.OUTBOX_EVENTS.value], {
+            "p_cutoff": cutoff,
+            "p_batch_size": batch_size,
+        })
+
+
+class RetentionRunner:
+    """Stateless runner for one operational retention round.
+
+    The runner holds no per-user state: the clock and the repository are
+    injected, the policy is versioned, and each round is fully described by
+    ``run_once()``. A round processes each covered category in batches of
+    ``config.batch_size`` until a batch purges fewer rows than the batch
+    size OR ``config.max_rows_per_category`` rows have been purged, then
+    terminates.
+    """
+
+    def __init__(
+        self,
+        *,
+        repository: RetentionRepository,
+        policy: Optional[RetentionPolicy] = None,
+        config: Optional[RetentionConfig] = None,
+        clock: Callable[[], float] = time.time,
+        turn_config: Optional[TurnExecutionConfig] = None,
+    ) -> None:
+        self._repository = repository
+        self._policy = policy if policy is not None else default_retention_policy()
+        self._config = config if config is not None else RetentionConfig()
+        self._clock = clock if clock is not None else time.time
+        self._turn_config = (
+            turn_config if turn_config is not None else TurnExecutionConfig.defaults()
+        )
+
+    async def run_once(self) -> RetentionRunResult:
+        """Run one full retention round and return the sanitized result."""
+        cutoffs = retention_cutoffs(self._clock(), self._policy)
+        category_results: list[CategoryResult] = [
+            await self._purge_category(
+                RetentionCategory.ADMISSION_RESERVATIONS,
+                cutoffs[RetentionCategory.ADMISSION_RESERVATIONS.value],
+                self._repository.purge_admission_reservations,
+            ),
+            await self._purge_category(
+                RetentionCategory.PRIVACY_OPERATIONS,
+                cutoffs[RetentionCategory.PRIVACY_OPERATIONS.value],
+                self._repository.purge_privacy_operations,
+            ),
+            await self._purge_category(
+                RetentionCategory.OUTBOX_EVENTS,
+                cutoffs[RetentionCategory.OUTBOX_EVENTS.value],
+                self._repository.purge_outbox_events,
+            ),
+        ]
+        return RetentionRunResult.build(
+            self._policy.schema_version, category_results
+        )
+
+    async def _purge_category(
+        self,
+        category: RetentionCategory,
+        cutoff: str,
+        purge_fn: Callable[[str, int], int],
+    ) -> CategoryResult:
+        """Purge one category in bounded batches.
+
+        The write helper enforces the PostgREST transport timeout and drains
+        the in-flight write on cancellation; a per-category monotonic budget
+        bounds the round. Failures propagate as sanitized exceptions
+        (``PersistenceError`` / ``TurnExecutionError``); the caller maps
+        them to a sanitized failure event.
+        """
+        budget = TurnBudget(
+            deadline=time.monotonic() + self._config.round_timeout_seconds,
+            reserve=0.0,
+            now_provider=time.monotonic,
+        )
+        total = 0
+        batches = 0
+        while total < self._config.max_rows_per_category:
+            started_at = time.monotonic()
+            try:
+                count = await run_blocking_write(
+                    _RETENTION_WRITE_STAGE,
+                    budget,
+                    self._turn_config.supabase_timeout,
+                    purge_fn,
+                    cutoff,
+                    self._config.batch_size,
+                    allowlist_exceptions=(PersistenceError,),
+                )
+            except PersistenceError:
+                emit_event(
+                    logger,
+                    EVENT_RETENTION_FAILED,
+                    level=logging.ERROR,
+                    phase=category.value,
+                    code="persistence_error",
+                )
+                raise
+            except Exception:
+                emit_event(
+                    logger,
+                    EVENT_RETENTION_FAILED,
+                    level=logging.ERROR,
+                    phase=category.value,
+                    code="purge_failed",
+                )
+                raise
+            batches += 1
+            total += count
+            emit_event(
+                logger,
+                EVENT_RETENTION_COMPLETED,
+                phase=category.value,
+                result=count,
+                duration_ms=(time.monotonic() - started_at) * 1000,
+            )
+            if count < self._config.batch_size:
+                break
+        return CategoryResult(
+            category=category.value,
+            purged=total,
+            batches=batches,
+        )

--- a/backend/retention_cli.py
+++ b/backend/retention_cli.py
@@ -1,0 +1,177 @@
+"""Explicit operational command for data retention (#316).
+
+Usage::
+
+    python -m backend.retention_cli --once
+
+Runs ONE retention round and exits. There is no scheduler, no hidden loop,
+no ``BackgroundTasks`` and no parallel server: the process starts, processes
+bounded batches per the versioned policy, prints a sanitized aggregate
+summary and terminates with exit code 0 (success) or 1 (any failure).
+
+Configuration comes from the environment (``RetentionRuntimeConfig``):
+``SUPABASE_URL`` and ``SUPABASE_SERVICE_ROLE_KEY`` are required (fail
+closed, values never echoed); the Supabase transport timeout comes from the
+standard ``TURN_SUPABASE_TIMEOUT`` variable through
+``TurnExecutionConfig.from_env``.
+
+Observability is sanitized: only the policy schema version and aggregate
+per-category counts are printed; identifiers, HMACs, content, SQL, tokens
+and secrets never appear. Failures emit a sanitized event and exit 1.
+
+The entrypoint is testable without network by injecting ``runner_factory``
+(or ``repository``/``clock``) in tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional
+
+from .observability import EVENT_RETENTION_FAILED, emit_event
+from .retention import (
+    RetentionConfig,
+    RetentionRepository,
+    RetentionRunner,
+    SupabaseRetentionRepository,
+)
+from .turn_execution import TurnExecutionConfig
+
+logger = logging.getLogger(__name__)
+
+
+class RetentionRuntimeConfigurationError(Exception):
+    """Raised when the retention runtime environment is incomplete.
+
+    The message is a constant; missing values are never echoed.
+    """
+
+
+@dataclass(frozen=True)
+class RetentionRuntimeConfig:
+    """Minimal, fail-closed runtime configuration for the retention CLI.
+
+    Deliberately does NOT require the full application ``Settings`` (no
+    Groq keys, no CORS): an operational retention round only needs the
+    Supabase surface and the transport timeout.
+    """
+
+    supabase_url: str
+    supabase_service_role_key: str  # never logged or echoed
+    turn_config: TurnExecutionConfig
+
+    @classmethod
+    def from_env(cls, env: Optional[Mapping[str, str]] = None) -> "RetentionRuntimeConfig":
+        source: Mapping[str, str] = os.environ if env is None else env
+        url = source.get("SUPABASE_URL")
+        key = source.get("SUPABASE_SERVICE_ROLE_KEY")
+        if not url or not key:
+            raise RetentionRuntimeConfigurationError(
+                "retention runtime configuration is incomplete"
+            )
+        return cls(
+            supabase_url=url,
+            supabase_service_role_key=key,
+            turn_config=TurnExecutionConfig.from_env(dict(source)),
+        )
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Katherine Bot — operational data retention. Runs one round "
+            "and exits."
+        )
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        required=True,
+        help="Run a single retention round and exit (the only supported mode)",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=None,
+        help="Rows purged per statement (default: from RetentionConfig)",
+    )
+    return parser.parse_args(argv)
+
+
+def _build_client(config: RetentionRuntimeConfig) -> Any:
+    """Construct the Supabase client for the retention round."""
+    from supabase import create_client
+    from supabase.lib.client_options import SyncClientOptions
+
+    options = SyncClientOptions(
+        postgrest_client_timeout=config.turn_config.supabase_timeout
+    )
+    return create_client(
+        config.supabase_url, config.supabase_service_role_key, options=options
+    )
+
+
+def main(
+    argv: Optional[list[str]] = None,
+    *,
+    env: Optional[Mapping[str, str]] = None,
+    runner_factory: Optional[Callable[..., RetentionRunner]] = None,
+    repository: Optional[RetentionRepository] = None,
+    clock: Optional[Callable[[], float]] = None,
+) -> int:
+    """Run one retention round and return the process exit code.
+
+    Args:
+        argv: Override for ``sys.argv`` (used in tests).
+        env: Override for the environment (used in tests). When ``None`` the
+            real ``os.environ`` is read.
+        runner_factory: Callable that builds the runner from the runtime
+            config; injected in tests to avoid network. When ``None`` a real
+            ``SupabaseRetentionRepository`` backed runner is built.
+        repository: Optional injected repository (overrides the default
+            repository inside the runner).
+        clock: Optional injected clock for the runner.
+
+    Returns:
+        ``0`` on success, ``1`` on any failure.
+    """
+    args = _parse_args(argv)
+    try:
+        config = RetentionRuntimeConfig.from_env(env)
+        if runner_factory is not None:
+            runner = runner_factory(config)
+        else:
+            client = _build_client(config)
+            repo = repository if repository is not None else SupabaseRetentionRepository(client)
+            runner = RetentionRunner(
+                repository=repo,
+                config=RetentionConfig(batch_size=args.batch_size)
+                if args.batch_size is not None
+                else RetentionConfig(),
+                turn_config=config.turn_config,
+                clock=clock,
+            )
+        result = asyncio.run(runner.run_once())
+    except Exception:
+        emit_event(logger, EVENT_RETENTION_FAILED, level=logging.ERROR, code="round_failed")
+        return 1
+
+    # Sanitized aggregate summary: version and counts only.
+    print(f"retention_round schema_version={result.schema_version}")
+    for category, category_result in result.results.items():
+        print(
+            f"retention_round category={category} "
+            f"purged={category_result.purged} batches={category_result.batches}"
+        )
+    print(f"retention_round total_purged={result.total_purged}")
+    return 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    sys.exit(main())

--- a/backend/retention_policy.py
+++ b/backend/retention_policy.py
@@ -1,0 +1,121 @@
+"""Versioned operational data retention policy (#316).
+
+Pure Python, no network, no client construction at import. This module is
+the versioned source of truth for the retention *policy*: which operational
+categories are covered, their horizons, and the eligibility rules. The SQL
+boundary (``supabase/migrations/20260809030000_operational_data_retention.sql``)
+enforces the same contracts fail-closed, and cross-boundary tests pin both
+sides.
+
+Scope
+=====
+The policy covers ONLY operational/transitory data:
+
+* ``admission_reservations`` — rows older than the 24h horizon are eligible
+  for purge; rows inside the horizon stay. ``delete_history`` continues to
+  never touch this ledger, so cleanup cannot bypass quota.
+* ``privacy_operations`` — applied #314 ledger rows older than the 30-day
+  horizon are eligible; rows inside the horizon stay, preserving the
+  replay/idempotency/conflict semantics.
+* ``outbox_events`` — only FINAL states (``completed``, ``dead_letter``)
+  whose ``retention_until`` has passed are eligible. Active states
+  (``pending``, ``processing``, ``failed``) are never purged by age.
+
+User-controlled data (``chat_logs``, ``memories``, ``archival_extractions``,
+``profiles`` snapshots) and the replay/history ledger (``turn_requests``)
+are deliberately OUTSIDE the policy: no automatic TTL.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+#: Schema version of the retention policy registry. Bumped only when the
+#: policy semantics change in a way that requires coordinated migration.
+RETENTION_POLICY_SCHEMA_VERSION = 1
+
+#: Maximum batch size accepted by the purge SQL boundary (fail closed above).
+RETENTION_MAX_BATCH_SIZE = 1000
+
+#: Outbox states eligible for age-based purge (final states only).
+OUTBOX_FINAL_STATUSES = frozenset({"completed", "dead_letter"})
+
+#: Outbox states that must NEVER be purged by age alone.
+OUTBOX_ACTIVE_STATUSES = frozenset({"pending", "processing", "failed"})
+
+#: The three operational categories covered by the policy.
+#: Values match the purge RPC names in the migration.
+class RetentionCategory(str, Enum):
+    ADMISSION_RESERVATIONS = "admission_reservations"
+    PRIVACY_OPERATIONS = "privacy_operations"
+    OUTBOX_EVENTS = "outbox_events"
+
+
+#: Default horizon: rows with reserved_at older than this are eligible.
+DEFAULT_ADMISSION_HORIZON = _dt.timedelta(hours=24)
+
+#: Default horizon: applied privacy ledger rows older than this are eligible.
+DEFAULT_PRIVACY_OPERATIONS_HORIZON = _dt.timedelta(days=30)
+
+
+@dataclass(frozen=True)
+class RetentionPolicy:
+    """Versioned retention policy registry.
+
+    ``schema_version`` pins the exact semantics of this policy. Horizons are
+    explicit and immutable after construction.
+
+    ``outbox_events`` has NO age horizon: eligibility is defined by the final
+    state + ``retention_until`` semantics (enforced in SQL), so it carries no
+    timedelta here.
+    """
+
+    schema_version: int = RETENTION_POLICY_SCHEMA_VERSION
+    admission_reservations_horizon: _dt.timedelta = DEFAULT_ADMISSION_HORIZON
+    privacy_operations_horizon: _dt.timedelta = DEFAULT_PRIVACY_OPERATIONS_HORIZON
+
+
+def default_retention_policy() -> RetentionPolicy:
+    """Return the canonical v1 retention policy."""
+    return RetentionPolicy()
+
+
+def compute_cutoff(
+    now_epoch: float,
+    horizon: _dt.timedelta,
+) -> _dt.datetime:
+    """Return the UTC-aware purge cutoff for *now_epoch* minus *horizon*.
+
+    A row is eligible when its timestamp is strictly BEFORE the cutoff.
+    """
+    return _dt.datetime.fromtimestamp(now_epoch, tz=_dt.timezone.utc) - horizon
+
+
+def retention_cutoffs(
+    now_epoch: float,
+    policy: Optional[RetentionPolicy] = None,
+) -> dict[str, str]:
+    """Compute the ISO-8601 purge cutoffs for every covered category.
+
+    ``admission_reservations``: now - 24h.
+    ``privacy_operations``: now - 30d.
+    ``outbox_events``: now (``retention_until`` must already be past).
+
+    Returns a mapping keyed by :class:`RetentionCategory` value with
+    ``datetime.isoformat()`` strings ready for the purge RPCs.
+    """
+    effective = policy if policy is not None else default_retention_policy()
+    return {
+        RetentionCategory.ADMISSION_RESERVATIONS.value: compute_cutoff(
+            now_epoch, effective.admission_reservations_horizon
+        ).isoformat(),
+        RetentionCategory.PRIVACY_OPERATIONS.value: compute_cutoff(
+            now_epoch, effective.privacy_operations_horizon
+        ).isoformat(),
+        RetentionCategory.OUTBOX_EVENTS.value: _dt.datetime.fromtimestamp(
+            now_epoch, tz=_dt.timezone.utc
+        ).isoformat(),
+    }

--- a/backend/supabase_cli.py
+++ b/backend/supabase_cli.py
@@ -24,6 +24,9 @@ ALLOWED_OPS = frozenset({
     "privacy_legacy_reset",
     "privacy_legacy_upgrade",
     "privacy_legacy_query",
+    "retention_preflight_reset",
+    "retention_preflight_apply",
+    "retention_preflight_query",
 })
 
 

--- a/backend/tests/test_retention.py
+++ b/backend/tests/test_retention.py
@@ -63,7 +63,11 @@ from backend.retention_policy import (
     default_retention_policy,
     retention_cutoffs,
 )
-from backend.turn_execution import TurnExecutionConfig
+from backend.turn_execution import (
+    DeadlineExceeded,
+    TurnExecutionConfig,
+    TurnExecutionError,
+)
 
 NOW = 1700000000.0  # 2023-11-14T22:13:20+00:00
 HOUR = 3600.0
@@ -324,6 +328,63 @@ def test_per_category_cap_bounds_a_round():
     assert len(repo.remaining(RetentionCategory.ADMISSION_RESERVATIONS.value)) == 4
 
 
+def test_round_timeout_limits_work_per_round():
+    """A small ``round_timeout_seconds`` interrupts a round mid-category.
+
+    The timeout is an upper bound on the work done per round: once the
+    budget is exhausted the runner cannot start another batch, so the round
+    stops (failing closed with ``DeadlineExceeded``) before the category is
+    drained and rows stay for a later round. Progress is never blocked: a
+    subsequent round with a fresh budget keeps purging.
+    """
+    rows = [
+        (f"row-{i}", _dt.datetime.fromtimestamp(NOW - 2 * DAY, tz=_dt.timezone.utc), "row")
+        for i in range(50)
+    ]
+
+    class SlowFakeRetentionRepository(FakeRetentionRepository):
+        def _purge(self, category: str, cutoff: str, batch_size: int) -> int:
+            # Deliberately slow purge: each batch outlives the tiny budget,
+            # forcing the runner to stop before the category is drained.
+            time.sleep(0.2)
+            return super()._purge(category, cutoff, batch_size)
+
+    repo = SlowFakeRetentionRepository(
+        {
+            RetentionCategory.ADMISSION_RESERVATIONS.value: rows,
+            RetentionCategory.PRIVACY_OPERATIONS.value: [],
+            RetentionCategory.OUTBOX_EVENTS.value: [],
+        }
+    )
+    config = RetentionConfig(
+        batch_size=3, max_rows_per_category=50, round_timeout_seconds=0.05
+    )
+    runner = RetentionRunner(
+        repository=repo,
+        config=config,
+        clock=lambda: NOW,
+        turn_config=TurnExecutionConfig.defaults(),
+    )
+
+    # The budget is a hard upper bound: the round is interrupted with
+    # purged < max_rows_per_category and rows left for the next round.
+    with pytest.raises(DeadlineExceeded):
+        asyncio.run(runner.run_once())
+    remaining_after_first = repo.remaining(RetentionCategory.ADMISSION_RESERVATIONS.value)
+    assert len(remaining_after_first) > 0, "the timeout must leave rows for the next round"
+    assert len(remaining_after_first) < len(rows), (
+        "the timeout must not block the batches that fit inside the budget"
+    )
+
+    # Progress is not blocked: the next round purges again before timing out.
+    with pytest.raises(DeadlineExceeded):
+        asyncio.run(runner.run_once())
+    remaining_after_second = repo.remaining(RetentionCategory.ADMISSION_RESERVATIONS.value)
+    assert len(remaining_after_second) < len(remaining_after_first), (
+        "later rounds must keep making progress"
+    )
+
+
 # ─── 11. Idempotent second run ──────────────────────────────────────────────
 
 
@@ -483,7 +544,40 @@ def test_failure_log_is_sanitized(caplog):
         with pytest.raises(PersistenceError):
             asyncio.run(runner.run_once())
     assert "event=retention_failed" in caplog.text
-    assert "database_error" not in caplog.text or "persistence error" not in caplog.text
+    assert "database_error" not in caplog.text
+    assert "persistence error" not in caplog.text
+    assert "SECRET" not in caplog.text
+
+
+def test_generic_exception_log_is_sanitized(caplog):
+    """The non-PersistenceError failure branch also logs sanitized.
+
+    ``RetentionRunner._purge_category`` maps generic upstream failures to a
+    ``retention_failed`` event with ``code=purge_failed``; the upstream
+    exception text (which may carry secrets) must never reach the logs.
+    """
+
+    class ExplodingRepo:
+        def purge_admission_reservations(self, cutoff, batch_size):
+            # Generic upstream failure carrying a sensitive detail.
+            raise Exception("upstream failure with SECRET content")  # noqa: TRY002
+
+        def purge_privacy_operations(self, cutoff, batch_size):
+            raise AssertionError("must not be reached")
+
+        def purge_outbox_events(self, cutoff, batch_size):
+            raise AssertionError("must not be reached")
+
+    runner = _runner(ExplodingRepo())
+    with caplog.at_level(logging.INFO):
+        with pytest.raises(TurnExecutionError):
+            asyncio.run(runner.run_once())
+    # The generic branch logs a sanitized retention_failed event. Event
+    # values are rendered without quotes (``code=purge_failed``).
+    assert "event=retention_failed" in caplog.text
+    assert "code=purge_failed" in caplog.text
+    # Upstream exception details and secrets never leak into the logs.
+    assert "upstream failure with SECRET content" not in caplog.text
     assert "SECRET" not in caplog.text
 
 

--- a/backend/tests/test_retention.py
+++ b/backend/tests/test_retention.py
@@ -1,0 +1,707 @@
+"""Unit tests for the #316 operational data retention runner and policy.
+
+Covers the mandatory scenarios of issue #316 without any real network:
+
+ 1.  admission_reservation older than 24h is removed.
+ 2.  admission_reservation at or inside 24h stays.
+ 3.  Cleanup cannot bypass current quota via delete_history (the admission
+     ledger inside the horizon is never touched, and the runner never calls
+     any RPC other than the three purge functions).
+ 4.  outbox_events ``completed`` with expired ``retention_until`` is removed.
+ 5.  outbox_events ``dead_letter`` with expired ``retention_until`` is removed.
+ 6.  ``pending``/``processing``/``failed`` are never purged by age.
+ 7.  A final event whose ``retention_until`` has not expired stays.
+ 8.  Privacy operation ledger inside 30 days stays.
+ 9.  Privacy operation ledger expired is removed.
+10.  Batch size is really limited (per-statement and per-round caps).
+11.  A second run without new eligible rows is idempotent.
+12.  Two concurrent runs do not corrupt state or double-process rows.
+13.  Cleanup never touches user A/B content outside the rules (the runner
+     only invokes the three operational purge RPCs).
+14.  No log line contains user_id, HMAC, content, raw SQL or secrets.
+15.  The ``--once`` command runs with injected dependencies, no network.
+16.  Policy/registry is versioned and config validation fails closed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as _dt
+import logging
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+from collections import defaultdict
+from types import SimpleNamespace
+
+import pytest
+
+from backend.atomic_turn_commit import PersistenceError
+from backend.observability import EVENT_NAMES
+from backend.retention import (
+    DEFAULT_RETENTION_BATCH_SIZE,
+    RetentionCategory,
+    RetentionConfig,
+    RetentionRunResult,
+    RetentionRunner,
+    SupabaseRetentionRepository,
+)
+from backend.retention_cli import (
+    RetentionRuntimeConfig,
+    RetentionRuntimeConfigurationError,
+    main as cli_main,
+)
+from backend.retention_policy import (
+    OUTBOX_ACTIVE_STATUSES,
+    OUTBOX_FINAL_STATUSES,
+    RETENTION_MAX_BATCH_SIZE,
+    RETENTION_POLICY_SCHEMA_VERSION,
+    RetentionPolicy,
+    compute_cutoff,
+    default_retention_policy,
+    retention_cutoffs,
+)
+from backend.turn_execution import TurnExecutionConfig
+
+NOW = 1700000000.0  # 2023-11-14T22:13:20+00:00
+HOUR = 3600.0
+DAY = 86400.0
+
+
+def _iso(epoch: float) -> str:
+    return _dt.datetime.fromtimestamp(epoch, tz=_dt.timezone.utc).isoformat()
+
+
+# ─── In-memory repository simulating the SQL purge contract ─────────────────
+
+
+class FakeRetentionRepository:
+    """Simulates the SQL purge boundary.
+
+    Eligibility store: for each category, a list of (row_id, timestamp,
+    status). Purge removes rows whose timestamp is BEFORE the cutoff
+    (admission/privacy) or, for outbox, whose status is final AND
+    ``retention_until`` is BEFORE the cutoff. Records every call.
+    """
+
+    def __init__(self, rows: dict[str, list[tuple]]):
+        self._rows: dict[str, list[tuple]] = {
+            category: list(entries) for category, entries in rows.items()
+        }
+        self.calls: list[tuple[str, str, int]] = []
+
+    def purge_admission_reservations(self, cutoff: str, batch_size: int) -> int:
+        return self._purge(
+            RetentionCategory.ADMISSION_RESERVATIONS.value, cutoff, batch_size
+        )
+
+    def purge_privacy_operations(self, cutoff: str, batch_size: int) -> int:
+        return self._purge(
+            RetentionCategory.PRIVACY_OPERATIONS.value, cutoff, batch_size
+        )
+
+    def purge_outbox_events(self, cutoff: str, batch_size: int) -> int:
+        return self._purge(RetentionCategory.OUTBOX_EVENTS.value, cutoff, batch_size)
+
+    def _purge(self, category: str, cutoff: str, batch_size: int) -> int:
+        self.calls.append((category, cutoff, batch_size))
+        cutoff_dt = _dt.datetime.fromisoformat(cutoff)
+        eligible: list[tuple] = []
+        for entry in self._rows[category]:
+            row_id, timestamp, status = entry
+            if category == RetentionCategory.OUTBOX_EVENTS.value:
+                # Outbox: only final states whose retention_until is past.
+                if status in OUTBOX_FINAL_STATUSES and timestamp < cutoff_dt:
+                    eligible.append(entry)
+            else:
+                # Admission/privacy: row timestamp strictly before cutoff.
+                if timestamp < cutoff_dt:
+                    eligible.append(entry)
+        batch = eligible[:batch_size]
+        for entry in batch:
+            self._rows[category].remove(entry)
+        return len(batch)
+
+    def remaining(self, category: str) -> list[tuple]:
+        return list(self._rows[category])
+
+
+def _runner(repo, *, clock=NOW, config=None):
+    return RetentionRunner(
+        repository=repo,
+        clock=lambda: clock,
+        config=config if config is not None else RetentionConfig(batch_size=10),
+        turn_config=TurnExecutionConfig.defaults(),
+    )
+
+
+# ─── 1/2. admission_reservations horizon ────────────────────────────────────
+
+
+def test_admission_older_than_24h_is_removed_current_stays():
+    repo = FakeRetentionRepository(
+        {
+            RetentionCategory.ADMISSION_RESERVATIONS.value: [
+                ("expired", _dt.datetime.fromtimestamp(NOW - 25 * HOUR, tz=_dt.timezone.utc), "row"),
+                ("current", _dt.datetime.fromtimestamp(NOW - 23 * HOUR, tz=_dt.timezone.utc), "row"),
+            ],
+            RetentionCategory.PRIVACY_OPERATIONS.value: [],
+            RetentionCategory.OUTBOX_EVENTS.value: [],
+        }
+    )
+    result = asyncio.run(_runner(repo).run_once())
+    admission = result.results[RetentionCategory.ADMISSION_RESERVATIONS.value]
+    assert admission.purged == 1
+    remaining = repo.remaining(RetentionCategory.ADMISSION_RESERVATIONS.value)
+    assert [entry[0] for entry in remaining] == ["current"]
+    # The cutoff passed to the RPC is exactly now - 24h.
+    admission_calls = [
+        c for c in repo.calls if c[0] == RetentionCategory.ADMISSION_RESERVATIONS.value
+    ]
+    assert admission_calls
+    assert _dt.datetime.fromisoformat(admission_calls[0][1]) == _dt.datetime.fromtimestamp(
+        NOW - 24 * HOUR, tz=_dt.timezone.utc
+    )
+
+
+def test_policy_computes_correct_24h_cutoff():
+    cutoff = compute_cutoff(NOW, default_retention_policy().admission_reservations_horizon)
+    assert cutoff == _dt.datetime.fromtimestamp(NOW - 24 * HOUR, tz=_dt.timezone.utc)
+
+
+# ─── 3. Quota ledger cannot be bypassed ─────────────────────────────────────
+
+
+def test_cleanup_never_touches_current_quota_rows():
+    """Rows inside the 24h horizon (the current quota window) stay; the
+    runner never invokes anything but the three purge RPCs, so cleanup can
+    never act as a delete_history-style quota reset."""
+    repo = FakeRetentionRepository(
+        {
+            RetentionCategory.ADMISSION_RESERVATIONS.value: [
+                ("recent", _dt.datetime.fromtimestamp(NOW - 1 * HOUR, tz=_dt.timezone.utc), "row"),
+            ],
+            RetentionCategory.PRIVACY_OPERATIONS.value: [],
+            RetentionCategory.OUTBOX_EVENTS.value: [],
+        }
+    )
+    result = asyncio.run(_runner(repo).run_once())
+    assert repo.remaining(RetentionCategory.ADMISSION_RESERVATIONS.value) != []
+    assert result.results[RetentionCategory.ADMISSION_RESERVATIONS.value].purged == 0
+    # Only the three purge RPC names may ever be invoked.
+    rpc_names = {c[0] for c in repo.calls}
+    assert rpc_names == {
+        RetentionCategory.ADMISSION_RESERVATIONS.value,
+        RetentionCategory.PRIVACY_OPERATIONS.value,
+        RetentionCategory.OUTBOX_EVENTS.value,
+    }
+    assert "delete_history" not in rpc_names
+
+
+# ─── 4/5/6/7. outbox_events eligibility ─────────────────────────────────────
+
+
+def test_outbox_completed_and_dead_letter_expired_are_removed_active_stay():
+    now_dt = _dt.datetime.fromtimestamp(NOW, tz=_dt.timezone.utc)
+    repo = FakeRetentionRepository(
+        {
+            RetentionCategory.ADMISSION_RESERVATIONS.value: [],
+            RetentionCategory.PRIVACY_OPERATIONS.value: [],
+            RetentionCategory.OUTBOX_EVENTS.value: [
+                ("completed-expired", now_dt - _dt.timedelta(hours=2), "completed"),
+                ("dead-expired", now_dt - _dt.timedelta(hours=3), "dead_letter"),
+                ("completed-future", now_dt + _dt.timedelta(hours=1), "completed"),
+                ("pending-old", now_dt - _dt.timedelta(days=40), "pending"),
+                ("processing-old", now_dt - _dt.timedelta(days=40), "processing"),
+                ("failed-old", now_dt - _dt.timedelta(days=40), "failed"),
+            ],
+        }
+    )
+    result = asyncio.run(_runner(repo).run_once())
+    outbox = result.results[RetentionCategory.OUTBOX_EVENTS.value]
+    assert outbox.purged == 2
+    remaining = {
+        entry[0]: entry[2] for entry in repo.remaining(RetentionCategory.OUTBOX_EVENTS.value)
+    }
+    assert remaining == {
+        "completed-future": "completed",
+        "pending-old": "pending",
+        "processing-old": "processing",
+        "failed-old": "failed",
+    }
+
+
+def test_outbox_active_states_never_purged_by_age():
+    """pending/processing/failed are never eligible, regardless of age."""
+    assert OUTBOX_FINAL_STATUSES == {"completed", "dead_letter"}
+    assert OUTBOX_ACTIVE_STATUSES == {"pending", "processing", "failed"}
+    assert OUTBOX_ACTIVE_STATUSES.isdisjoint(OUTBOX_FINAL_STATUSES)
+
+
+def test_outbox_cutoff_is_now():
+    cutoffs = retention_cutoffs(NOW)
+    assert _dt.datetime.fromisoformat(
+        cutoffs[RetentionCategory.OUTBOX_EVENTS.value]
+    ) == _dt.datetime.fromtimestamp(NOW, tz=_dt.timezone.utc)
+
+
+# ─── 8/9. privacy_operations horizon ────────────────────────────────────────
+
+
+def test_privacy_ledger_inside_30_days_stays_expired_removed():
+    repo = FakeRetentionRepository(
+        {
+            RetentionCategory.ADMISSION_RESERVATIONS.value: [],
+            RetentionCategory.PRIVACY_OPERATIONS.value: [
+                ("expired", _dt.datetime.fromtimestamp(NOW - 31 * DAY, tz=_dt.timezone.utc), "row"),
+                ("current", _dt.datetime.fromtimestamp(NOW - 29 * DAY, tz=_dt.timezone.utc), "row"),
+            ],
+            RetentionCategory.OUTBOX_EVENTS.value: [],
+        }
+    )
+    result = asyncio.run(_runner(repo).run_once())
+    privacy = result.results[RetentionCategory.PRIVACY_OPERATIONS.value]
+    assert privacy.purged == 1
+    remaining = repo.remaining(RetentionCategory.PRIVACY_OPERATIONS.value)
+    assert [entry[0] for entry in remaining] == ["current"]
+
+
+# ─── 10. Batch size is really limited ───────────────────────────────────────
+
+
+def test_batch_size_is_limited_per_statement_and_round():
+    rows = [
+        (f"row-{i}", _dt.datetime.fromtimestamp(NOW - 2 * DAY, tz=_dt.timezone.utc), "row")
+        for i in range(10)
+    ]
+    repo = FakeRetentionRepository(
+        {
+            RetentionCategory.ADMISSION_RESERVATIONS.value: rows,
+            RetentionCategory.PRIVACY_OPERATIONS.value: [],
+            RetentionCategory.OUTBOX_EVENTS.value: [],
+        }
+    )
+    config = RetentionConfig(batch_size=3, max_rows_per_category=10)
+    result = asyncio.run(_runner(repo, config=config).run_once())
+    admission = result.results[RetentionCategory.ADMISSION_RESERVATIONS.value]
+    assert admission.purged == 10
+    assert admission.batches == 4  # 3 + 3 + 3 + 1
+    admission_calls = [
+        c for c in repo.calls if c[0] == RetentionCategory.ADMISSION_RESERVATIONS.value
+    ]
+    assert all(c[2] == 3 for c in admission_calls), "batch_size must never exceed 3"
+
+
+def test_batch_size_is_capped_at_sql_maximum():
+    with pytest.raises(ValueError):
+        RetentionConfig(batch_size=RETENTION_MAX_BATCH_SIZE + 1)
+    with pytest.raises(ValueError):
+        RetentionConfig(batch_size=0)
+    with pytest.raises(ValueError):
+        RetentionConfig(batch_size=True)
+
+
+def test_per_category_cap_bounds_a_round():
+    rows = [
+        (f"row-{i}", _dt.datetime.fromtimestamp(NOW - 2 * DAY, tz=_dt.timezone.utc), "row")
+        for i in range(10)
+    ]
+    repo = FakeRetentionRepository(
+        {
+            RetentionCategory.ADMISSION_RESERVATIONS.value: rows,
+            RetentionCategory.PRIVACY_OPERATIONS.value: [],
+            RetentionCategory.OUTBOX_EVENTS.value: [],
+        }
+    )
+    config = RetentionConfig(batch_size=3, max_rows_per_category=6)
+    result = asyncio.run(_runner(repo, config=config).run_once())
+    admission = result.results[RetentionCategory.ADMISSION_RESERVATIONS.value]
+    assert admission.purged == 6, "round must stop at the per-category cap"
+    assert admission.batches == 2
+    # Remaining rows stay for the next round.
+    assert len(repo.remaining(RetentionCategory.ADMISSION_RESERVATIONS.value)) == 4
+
+
+# ─── 11. Idempotent second run ──────────────────────────────────────────────
+
+
+def test_second_run_without_new_eligible_rows_is_idempotent():
+    repo = FakeRetentionRepository(
+        {
+            RetentionCategory.ADMISSION_RESERVATIONS.value: [
+                ("expired", _dt.datetime.fromtimestamp(NOW - 2 * DAY, tz=_dt.timezone.utc), "row"),
+            ],
+            RetentionCategory.PRIVACY_OPERATIONS.value: [],
+            RetentionCategory.OUTBOX_EVENTS.value: [],
+        }
+    )
+    runner = _runner(repo)
+    first = asyncio.run(runner.run_once())
+    second = asyncio.run(runner.run_once())
+    assert first.total_purged == 1
+    assert second.total_purged == 0
+    assert second.results[RetentionCategory.ADMISSION_RESERVATIONS.value].batches == 1
+    assert repo.remaining(RetentionCategory.ADMISSION_RESERVATIONS.value) == []
+
+
+# ─── 12. Concurrent runs are safe ───────────────────────────────────────────
+
+
+def test_concurrent_runs_do_not_double_process():
+    rows = [
+        (f"row-{i}", _dt.datetime.fromtimestamp(NOW - 2 * DAY, tz=_dt.timezone.utc), "row")
+        for i in range(50)
+    ]
+    repo = FakeRetentionRepository(
+        {
+            RetentionCategory.ADMISSION_RESERVATIONS.value: rows,
+            RetentionCategory.PRIVACY_OPERATIONS.value: [],
+            RetentionCategory.OUTBOX_EVENTS.value: [],
+        }
+    )
+    runner = _runner(repo, config=RetentionConfig(batch_size=7, max_rows_per_category=100))
+
+    async def _scenario():
+        first = asyncio.create_task(runner.run_once())
+        second = asyncio.create_task(runner.run_once())
+        results = await asyncio.gather(first, second)
+        return results
+
+    results = asyncio.run(_scenario())
+    total_purged = sum(r.total_purged for r in results)
+    # Every eligible row is deleted exactly once across both runs.
+    assert total_purged == 50
+    assert repo.remaining(RetentionCategory.ADMISSION_RESERVATIONS.value) == []
+
+
+def test_concurrent_runs_via_threads_are_safe():
+    """Two runner coroutines on separate event loops (threads) against one
+    shared repository: no corruption, every row processed exactly once."""
+    rows = [
+        (f"row-{i}", _dt.datetime.fromtimestamp(NOW - 2 * DAY, tz=_dt.timezone.utc), "row")
+        for i in range(20)
+    ]
+    repo = FakeRetentionRepository(
+        {
+            RetentionCategory.ADMISSION_RESERVATIONS.value: rows,
+            RetentionCategory.PRIVACY_OPERATIONS.value: [],
+            RetentionCategory.OUTBOX_EVENTS.value: [],
+        }
+    )
+    outcomes: list[int] = []
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+
+    def _run():
+        runner = _runner(repo, config=RetentionConfig(batch_size=5, max_rows_per_category=100))
+        try:
+            result = asyncio.run(runner.run_once())
+            with lock:
+                outcomes.append(result.total_purged)
+        except BaseException as exc:  # noqa: BLE001
+            with lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=_run) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+    assert errors == []
+    assert sum(outcomes) == 20
+    assert repo.remaining(RetentionCategory.ADMISSION_RESERVATIONS.value) == []
+
+
+# ─── 13. User A/B content is never touched ──────────────────────────────────
+
+
+def test_cleanup_never_touches_user_content_tables():
+    """The runner only invokes the three operational purge RPCs; user
+    content tables (chat_logs, memories, profiles, turn_requests,
+    archival_extractions) are never named or touched."""
+    repo = FakeRetentionRepository(
+        {
+            RetentionCategory.ADMISSION_RESERVATIONS.value: [],
+            RetentionCategory.PRIVACY_OPERATIONS.value: [],
+            RetentionCategory.OUTBOX_EVENTS.value: [],
+        }
+    )
+    asyncio.run(_runner(repo).run_once())
+    assert {c[0] for c in repo.calls} == {
+        "admission_reservations",
+        "privacy_operations",
+        "outbox_events",
+    }
+
+
+# ─── 14. Sanitized logs ─────────────────────────────────────────────────────
+
+
+def test_logs_never_contain_identifiers_content_or_secrets(caplog):
+    repo = FakeRetentionRepository(
+        {
+            RetentionCategory.ADMISSION_RESERVATIONS.value: [
+                ("SENTINEL-ROW-USER", _dt.datetime.fromtimestamp(NOW - 2 * DAY, tz=_dt.timezone.utc), "row"),
+            ],
+            RetentionCategory.PRIVACY_OPERATIONS.value: [],
+            RetentionCategory.OUTBOX_EVENTS.value: [],
+        }
+    )
+    runner = _runner(repo)
+    with caplog.at_level(logging.INFO):
+        asyncio.run(runner.run_once())
+    sentinels = (
+        "SENTINEL-ROW-USER",
+        "HMAC-SENTINEL",
+        "SENTINEL-CONTENT",
+        "DELETE FROM",
+        "SELECT",
+        "SECRET-SENTINEL",
+        "bearer",
+    )
+    for sentinel in sentinels:
+        assert sentinel not in caplog.text
+    assert "event=retention_completed" in caplog.text
+    assert "event=retention_failed" not in caplog.text
+
+
+def test_failure_log_is_sanitized(caplog):
+    class ExplodingRepo:
+        def purge_admission_reservations(self, cutoff, batch_size):
+            raise PersistenceError("database_error", "persistence error")
+
+        def purge_privacy_operations(self, cutoff, batch_size):
+            raise AssertionError("must not be reached")
+
+        def purge_outbox_events(self, cutoff, batch_size):
+            raise AssertionError("must not be reached")
+
+    runner = _runner(ExplodingRepo())
+    with caplog.at_level(logging.INFO):
+        with pytest.raises(PersistenceError):
+            asyncio.run(runner.run_once())
+    assert "event=retention_failed" in caplog.text
+    assert "database_error" not in caplog.text or "persistence error" not in caplog.text
+    assert "SECRET" not in caplog.text
+
+
+# ─── 15. CLI --once with injected dependencies, no network ──────────────────
+
+
+class _StubRunner:
+    def __init__(self, result):
+        self._result = result
+        self.called = 0
+
+    async def run_once(self):
+        self.called += 1
+        return self._result
+
+
+def _stub_result(total=3):
+    admission = SimpleNamespace(category="admission_reservations", purged=1, batches=1)
+    privacy = SimpleNamespace(category="privacy_operations", purged=2, batches=1)
+    outbox = SimpleNamespace(category="outbox_events", purged=0, batches=1)
+    return SimpleNamespace(
+        schema_version=RETENTION_POLICY_SCHEMA_VERSION,
+        results={
+            "admission_reservations": admission,
+            "privacy_operations": privacy,
+            "outbox_events": outbox,
+        },
+        total_purged=total,
+    )
+
+
+def test_cli_once_runs_with_injected_dependencies(capsys):
+    stub = _StubRunner(_stub_result())
+
+    def factory(config):
+        return stub
+
+    env = {
+        "SUPABASE_URL": "http://127.0.0.1:54321",
+        "SUPABASE_SERVICE_ROLE_KEY": "ci-test-key",
+        "TURN_SUPABASE_TIMEOUT": "5",
+    }
+    exit_code = cli_main(["--once"], env=env, runner_factory=factory)
+    assert exit_code == 0
+    assert stub.called == 1
+    out = capsys.readouterr().out
+    assert "retention_round schema_version=1" in out
+    assert "category=admission_reservations purged=1 batches=1" in out
+    assert "total_purged=3" in out
+    # Never printed: URL, key, identifiers.
+    assert "54321" not in out
+    assert "ci-test-key" not in out
+
+
+def test_cli_fails_closed_without_supabase_configuration():
+    exit_code = cli_main(["--once"], env={})
+    assert exit_code == 1
+    with pytest.raises(RetentionRuntimeConfigurationError):
+        RetentionRuntimeConfig.from_env({})
+
+
+def test_cli_requires_once_flag():
+    with pytest.raises(SystemExit):
+        cli_main([], env={})
+
+
+def test_cli_failure_returns_nonzero_without_exception_text(capsys):
+    def factory(config):
+        class Boom:
+            async def run_once(self):
+                raise PersistenceError("database_error", "persistence error")
+
+        return Boom()
+
+    env = {
+        "SUPABASE_URL": "http://127.0.0.1:54321",
+        "SUPABASE_SERVICE_ROLE_KEY": "ci-test-key",
+    }
+    exit_code = cli_main(["--once"], env=env, runner_factory=factory)
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "persistence error" not in out
+    assert "SECRET" not in out
+
+
+# ─── 16. Versioned policy / config fail-closed ──────────────────────────────
+
+
+def test_policy_is_versioned():
+    assert default_retention_policy().schema_version == RETENTION_POLICY_SCHEMA_VERSION
+    assert RetentionPolicy().admission_reservations_horizon == _dt.timedelta(hours=24)
+    assert RetentionPolicy().privacy_operations_horizon == _dt.timedelta(days=30)
+
+
+def test_retention_events_registered_in_observability():
+    assert "retention_completed" in EVENT_NAMES
+    assert "retention_failed" in EVENT_NAMES
+
+
+# ─── Repository adapter: fail-closed response shapes ────────────────────────
+
+
+def _repo_with_response(response) -> SupabaseRetentionRepository:
+    client = SimpleNamespace(
+        rpc=lambda name, params: SimpleNamespace(execute=lambda: response)
+    )
+    return SupabaseRetentionRepository(client)
+
+
+def test_repository_accepts_scalar_mapping_response():
+    repo = _repo_with_response(SimpleNamespace(data={"purge_admission_reservations": 5}))
+    assert repo.purge_admission_reservations("2023-01-01T00:00:00+00:00", 10) == 5
+
+
+def test_repository_accepts_single_element_list_response():
+    repo = _repo_with_response(
+        SimpleNamespace(data=[{"purge_outbox_events": 3}])
+    )
+    assert repo.purge_outbox_events("2023-01-01T00:00:00+00:00", 10) == 3
+
+
+def test_repository_accepts_alternative_scalar_shape():
+    repo = _repo_with_response(SimpleNamespace(data={"purged": 7}))
+    assert repo.purge_privacy_operations("2023-01-01T00:00:00+00:00", 10) == 7
+
+
+def test_repository_accepts_bare_integer_scalar_response():
+    """PostgREST returns a bare integer for scalar-returning RPCs."""
+    repo = _repo_with_response(SimpleNamespace(data=4))
+    assert repo.purge_admission_reservations("2023-01-01T00:00:00+00:00", 10) == 4
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        SimpleNamespace(data=[]),
+        SimpleNamespace(data=[{"a": 1}, {"b": 2}]),
+        SimpleNamespace(data="not-a-mapping"),
+        SimpleNamespace(data=None),
+        SimpleNamespace(data={"purge_admission_reservations": -1}),
+        SimpleNamespace(data={"purge_admission_reservations": True}),
+        SimpleNamespace(data={"purge_admission_reservations": "5"}),
+        SimpleNamespace(data=-1),
+        SimpleNamespace(data=True),
+        SimpleNamespace(data="5"),
+        SimpleNamespace(),  # missing data attribute
+        "not-a-response",
+        None,
+    ],
+)
+def test_repository_maps_malformed_response_shapes_to_persistence_error(response):
+    repo = _repo_with_response(response)
+    with pytest.raises(PersistenceError) as exc:
+        repo.purge_admission_reservations("2023-01-01T00:00:00+00:00", 10)
+    assert exc.value.code == "database_error"
+    assert "persistence error" in str(exc.value)
+
+
+def test_repository_maps_upstream_exception_to_sanitized_persistence_error():
+    class ExplodingClient:
+        def rpc(self, name, params):
+            raise RuntimeError("SENTINEL-UPSTREAM-SECRET")
+
+    repo = SupabaseRetentionRepository(ExplodingClient())
+    with pytest.raises(PersistenceError) as exc:
+        repo.purge_admission_reservations("2023-01-01T00:00:00+00:00", 10)
+    assert "SENTINEL-UPSTREAM-SECRET" not in str(exc.value)
+
+
+def test_repository_without_client_raises_sanitized_error():
+    repo = SupabaseRetentionRepository(None)
+    with pytest.raises(PersistenceError):
+        repo.purge_admission_reservations("2023-01-01T00:00:00+00:00", 10)
+
+
+# ─── Pure importability ──────────────────────────────────────────────────────
+
+_PURITY_SCRIPT = textwrap.dedent(
+    """
+    import sys
+    import threading
+
+    import socket as _socket
+
+    def _forbid(*args, **kwargs):
+        raise AssertionError("network socket usage during import")
+
+    _socket.socket.connect = _forbid
+    _socket.socket.connect_ex = _forbid
+    _socket.create_connection = _forbid
+
+    import supabase as _supabase
+
+    def _no_supabase_client(*args, **kwargs):
+        raise AssertionError("real Supabase client constructed during import")
+
+    _supabase.create_client = _no_supabase_client
+
+    threads_before = len(threading.enumerate())
+
+    import backend.retention_policy
+    import backend.retention
+
+    threads_after = len(threading.enumerate())
+
+    assert threads_after == threads_before, "import started a thread"
+    print("RETENTION_PURITY_OK")
+    """
+)
+
+
+def test_retention_modules_import_are_pure():
+    result = subprocess.run(
+        [sys.executable, "-c", _PURITY_SCRIPT],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={"PYTHONPATH": ".", "PATH": "/usr/bin:/bin"},
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+    assert "RETENTION_PURITY_OK" in result.stdout

--- a/backend/tests/test_retention_integration.py
+++ b/backend/tests/test_retention_integration.py
@@ -22,6 +22,10 @@ boundary:
      corruption.
  7.  Cleanup never touches user-controlled content (chat_logs, memories,
      profiles snapshots, turn_requests) of users A and B.
+ 8.  A runner with an artificially fast process clock cannot advance
+     deletion: the SQL boundary clamps every purge cutoff against
+     authoritative PostgreSQL time, so rows inside the binding horizons
+     survive.
 """
 
 from __future__ import annotations
@@ -478,3 +482,51 @@ def test_user_content_never_touched(service_client: Client):
     finally:
         _cleanup_user(user_a)
         _cleanup_user(user_b)
+
+
+# ─── 8. Fast process clock cannot advance deletion (SQL boundary) ───────────
+
+
+def test_future_clock_cannot_violate_policy(service_client: Client):
+    """A runner with an artificially fast process clock must not advance
+    deletion.
+
+    The runner computes cutoffs from the injected clock (here ~400 days in
+    the future), so every caller cutoff is a future timestamp. The SQL
+    boundary clamps each purge cutoff against authoritative PostgreSQL time
+    (``clock_timestamp()``), so only genuinely expired rows are removed:
+    rows inside the binding 24h/30d horizons and outbox events whose
+    ``retention_until`` is still in the future survive.
+    """
+    user_id = _uid("clock")
+    _seed_profile(user_id)
+    _seed_admission(user_id, expired_hours=25, current_hours=23)
+    _seed_privacy_ledger(user_id, expired_days=31, current_days=29)
+    _seed_outbox(user_id, completed_expired=True, completed_future=True)
+    try:
+        def future_clock() -> float:
+            return time.time() + 400 * 86400
+
+        result = asyncio.run(_runner(service_client, clock=future_clock).run_once())
+        admission = result.results[RetentionCategory.ADMISSION_RESERVATIONS.value]
+        privacy = result.results[RetentionCategory.PRIVACY_OPERATIONS.value]
+        outbox = result.results[RetentionCategory.OUTBOX_EVENTS.value]
+        # Only genuinely expired rows are purged per category.
+        assert admission.purged == 1
+        assert privacy.purged == 1
+        assert outbox.purged == 1
+        # Rows inside the binding horizons survive the future clock.
+        assert _count(
+            "admission_reservations",
+            f"user_id = '{user_id}' AND reserved_at >= now() - interval '24 hours'",
+        ) == 1
+        assert _count(
+            "privacy_operations",
+            f"user_id = '{user_id}' AND applied_at >= now() - interval '30 days'",
+        ) == 1
+        assert _count(
+            "outbox_events",
+            f"user_id = '{user_id}' AND retention_until >= now()",
+        ) == 1
+    finally:
+        _cleanup_user(user_id)

--- a/backend/tests/test_retention_integration.py
+++ b/backend/tests/test_retention_integration.py
@@ -1,0 +1,480 @@
+"""Real Supabase integration tests for the #316 operational retention runner.
+
+This file is executed ONLY by the database CI job against a freshly reset
+local Supabase instance (no mocks: real PostgreSQL transactions, RLS,
+grants and the purge RPCs). It must never be collected by the ordinary
+backend unit job.
+
+It covers the API/application frontier of #316 against the real SQL purge
+boundary:
+
+ 1.  admission_reservations older than 24h are removed; rows inside the
+     horizon stay (quota ledger preserved).
+ 2.  Privacy operation ledger older than 30 days is removed; rows inside
+     the horizon stay (#314 idempotency semantics preserved inside the
+     horizon).
+ 3.  outbox_events completed/dead_letter with expired retention_until are
+     removed; pending/processing/failed are never purged by age; a final
+     event with future retention_until stays.
+ 4.  Batch size is really limited per statement.
+ 5.  A second run without new eligible rows is idempotent.
+ 6.  Two concurrent runs delete every eligible row exactly once with no
+     corruption.
+ 7.  Cleanup never touches user-controlled content (chat_logs, memories,
+     profiles snapshots, turn_requests) of users A and B.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+from supabase import Client, create_client
+
+from backend.admission import AdmissionRuntimeConfig
+from backend.dependencies import ApplicationDependencies
+from backend.health import HealthRegistry
+from backend.main import create_app
+from backend.retention import (
+    RetentionConfig,
+    RetentionRunner,
+    RetentionRunResult,
+    SupabaseRetentionRepository,
+)
+from backend.retention_policy import (
+    RetentionCategory,
+    default_retention_policy,
+    retention_cutoffs,
+)
+from backend.settings import AppEnvironment, Settings
+from backend.turn_execution import TurnExecutionConfig
+
+_SUPABASE_CLI = ["supabase"] if shutil.which("supabase") else ["npx", "supabase"]
+
+SECRET = "ci-test-secret-0123456789abcdef0123456789abcdef"
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name)
+    assert value, f"{name} is required for retention integration tests"
+    return value
+
+
+def _close_client(client: Client) -> None:
+    if client is None:
+        return
+    for attr, session_attr in (
+        ("_postgrest", "session"),
+        ("_storage", "session"),
+        ("_functions", "_client"),
+    ):
+        transport = getattr(client, attr, None)
+        if transport is None:
+            continue
+        session = getattr(transport, session_attr, None)
+        if session is not None and hasattr(session, "close"):
+            session.close()
+    auth = getattr(client, "auth", None)
+    if auth is not None and hasattr(auth, "close"):
+        auth.close()
+
+
+@pytest.fixture(scope="module")
+def supabase_url() -> str:
+    return _required_env("SUPABASE_URL")
+
+
+@pytest.fixture(scope="module")
+def service_role_key() -> str:
+    return _required_env("SUPABASE_SERVICE_ROLE_KEY")
+
+
+@pytest.fixture(scope="module")
+def service_client(supabase_url: str, service_role_key: str) -> Client:
+    client = create_client(supabase_url, service_role_key)
+    yield client
+    _close_client(client)
+
+
+# ─── SQL helpers (pinned local Supabase CLI, sanitized) ─────────────────────
+
+
+def _run_sql(sql: str) -> list[dict]:
+    child_env = dict(os.environ)
+    child_env["SUPABASE_TELEMETRY_DISABLED"] = "1"
+    child_env["SUPABASE_ANALYTICS_ENABLED"] = "false"
+    result = subprocess.run(
+        [
+            *_SUPABASE_CLI,
+            "db",
+            "query",
+            "--agent=no",
+            "--output",
+            "json",
+            sql,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=child_env,
+    )
+    assert result.returncode == 0, "sanitized retention test SQL operation failed"
+    output = result.stdout.strip()
+    if not output or output[0] not in "[{":
+        return []
+    parsed = json.loads(output)
+    assert isinstance(parsed, list)
+    return parsed
+
+
+def _count(table: str, predicate: str) -> int:
+    rows = _run_sql(f"SELECT count(*)::integer AS count FROM public.{table} WHERE {predicate}")
+    return rows[0]["count"]
+
+
+def _uid(label: str) -> str:
+    return f"ret_{label}_{uuid.uuid4().hex[:12]}"
+
+
+# ─── Seeding ────────────────────────────────────────────────────────────────
+
+
+def _seed_admission(user_id: str, expired_hours: float | None, current_hours: float | None) -> None:
+    """Seed admission reservations: one expired (if expired_hours given) and
+    one current (if current_hours given)."""
+    statements: list[str] = []
+    if expired_hours is not None:
+        statements.append(
+            "INSERT INTO public.admission_reservations "
+            "(user_id, request_id, message_hmac_sha256, network_hmac_sha256, "
+            "estimated_units, reserved_at) VALUES "
+            f"('{user_id}', '{uuid.uuid4()}', repeat('a', 64), repeat('b', 64), 10, "
+            f"now() - interval '{expired_hours} hours')"
+        )
+    if current_hours is not None:
+        statements.append(
+            "INSERT INTO public.admission_reservations "
+            "(user_id, request_id, message_hmac_sha256, network_hmac_sha256, "
+            "estimated_units, reserved_at) VALUES "
+            f"('{user_id}', '{uuid.uuid4()}', repeat('c', 64), repeat('d', 64), 10, "
+            f"now() - interval '{current_hours} hours')"
+        )
+    for statement in statements:
+        _run_sql(statement)
+
+
+def _seed_privacy_ledger(user_id: str, expired_days: float | None, current_days: float | None) -> None:
+    statements: list[str] = []
+    if expired_days is not None:
+        statements.append(
+            "INSERT INTO public.privacy_operations "
+            "(user_id, operation_id, operation, operation_payload_sha256, status, "
+            "applied_at, result) VALUES "
+            f"('{user_id}', '{uuid.uuid4()}', 'delete_history', repeat('e', 64), 'applied', "
+            f"now() - interval '{expired_days} days', '{{\"status\":\"applied\"}}'::jsonb)"
+        )
+    if current_days is not None:
+        statements.append(
+            "INSERT INTO public.privacy_operations "
+            "(user_id, operation_id, operation, operation_payload_sha256, status, "
+            "applied_at, result) VALUES "
+            f"('{user_id}', '{uuid.uuid4()}', 'delete_memories', repeat('f', 64), 'applied', "
+            f"now() - interval '{current_days} days', '{{\"status\":\"applied\"}}'::jsonb)"
+        )
+    for statement in statements:
+        _run_sql(statement)
+
+
+def _seed_outbox(
+    user_id: str,
+    *,
+    completed_expired: bool = False,
+    dead_expired: bool = False,
+    completed_future: bool = False,
+    pending_old: bool = False,
+    processing_old: bool = False,
+    failed_old: bool = False,
+) -> None:
+    statements: list[str] = []
+    # completed: processed_at set, retention_until set
+    if completed_expired:
+        statements.append(
+            "INSERT INTO public.outbox_events "
+            "(id, event_type, contract_version, user_id, turn_request_id, payload, "
+            "status, attempts, next_attempt_at, lease_owner, lease_expires_at, "
+            "idempotency_key, error_code, created_at, updated_at, processed_at, "
+            "dead_lettered_at, retention_until) VALUES "
+            f"('{uuid.uuid4()}', 'turn_completed', 1, '{user_id}', NULL, "
+            f"'{{\"ref\":\"c1\"}}'::jsonb, 'completed', 1, NULL, NULL, NULL, "
+            f"'{user_id}-k-ce', NULL, now(), now(), now() - interval '2 days', NULL, "
+            "now() - interval '1 day')"
+        )
+    if dead_expired:
+        statements.append(
+            "INSERT INTO public.outbox_events "
+            "(id, event_type, contract_version, user_id, turn_request_id, payload, "
+            "status, attempts, next_attempt_at, lease_owner, lease_expires_at, "
+            "idempotency_key, error_code, created_at, updated_at, processed_at, "
+            "dead_lettered_at, retention_until) VALUES "
+            f"('{uuid.uuid4()}', 'turn_completed', 1, '{user_id}', NULL, "
+            f"'{{\"ref\":\"d1\"}}'::jsonb, 'dead_letter', 10, NULL, NULL, NULL, "
+            f"'{user_id}-k-de', 'delivery_failed', now(), now(), NULL, "
+            "now() - interval '2 days', now() - interval '1 day')"
+        )
+    if completed_future:
+        statements.append(
+            "INSERT INTO public.outbox_events "
+            "(id, event_type, contract_version, user_id, turn_request_id, payload, "
+            "status, attempts, next_attempt_at, lease_owner, lease_expires_at, "
+            "idempotency_key, error_code, created_at, updated_at, processed_at, "
+            "dead_lettered_at, retention_until) VALUES "
+            f"('{uuid.uuid4()}', 'turn_completed', 1, '{user_id}', NULL, "
+            f"'{{\"ref\":\"c2\"}}'::jsonb, 'completed', 1, NULL, NULL, NULL, "
+            f"'{user_id}-k-cf', NULL, now(), now(), now() - interval '2 days', NULL, "
+            "now() + interval '1 day')"
+        )
+    if pending_old:
+        statements.append(
+            "INSERT INTO public.outbox_events "
+            "(id, event_type, contract_version, user_id, turn_request_id, payload, "
+            "status, attempts, next_attempt_at, lease_owner, lease_expires_at, "
+            "idempotency_key, error_code, created_at, updated_at, processed_at, "
+            "dead_lettered_at, retention_until) VALUES "
+            f"('{uuid.uuid4()}', 'turn_completed', 1, '{user_id}', NULL, "
+            f"'{{\"ref\":\"p1\"}}'::jsonb, 'pending', 0, "
+            "now() - interval '40 days', NULL, NULL, "
+            f"'{user_id}-k-pe', NULL, now() - interval '40 days', "
+            "now() - interval '40 days', NULL, NULL, NULL)"
+        )
+    if processing_old:
+        statements.append(
+            "INSERT INTO public.outbox_events "
+            "(id, event_type, contract_version, user_id, turn_request_id, payload, "
+            "status, attempts, next_attempt_at, lease_owner, lease_expires_at, "
+            "idempotency_key, error_code, created_at, updated_at, processed_at, "
+            "dead_lettered_at, retention_until) VALUES "
+            f"('{uuid.uuid4()}', 'turn_completed', 1, '{user_id}', NULL, "
+            f"'{{\"ref\":\"pr1\"}}'::jsonb, 'processing', 1, NULL, "
+            "'worker-a', now() - interval '40 days', "
+            f"'{user_id}-k-pr', NULL, now() - interval '40 days', "
+            "now() - interval '40 days', NULL, NULL, NULL)"
+        )
+    if failed_old:
+        statements.append(
+            "INSERT INTO public.outbox_events "
+            "(id, event_type, contract_version, user_id, turn_request_id, payload, "
+            "status, attempts, next_attempt_at, lease_owner, lease_expires_at, "
+            "idempotency_key, error_code, created_at, updated_at, processed_at, "
+            "dead_lettered_at, retention_until) VALUES "
+            f"('{uuid.uuid4()}', 'turn_completed', 1, '{user_id}', NULL, "
+            f"'{{\"ref\":\"f1\"}}'::jsonb, 'failed', 2, "
+            "now() - interval '40 days', NULL, NULL, "
+            f"'{user_id}-k-fa', 'delivery_failed', now() - interval '40 days', "
+            "now() - interval '40 days', NULL, NULL, NULL)"
+        )
+    for statement in statements:
+        _run_sql(statement)
+
+
+def _seed_profile(user_id: str) -> None:
+    _run_sql(
+        "INSERT INTO public.profiles (user_id, persona_config, user_profile, "
+        "relationship_state, emotional_state, revision) VALUES "
+        f"('{user_id}', 'persona', '{{}}'::jsonb, "
+        f"'{{\"schema_version\":1,\"trust\":0.5,\"affection\":0.3,\"tension\":0.0,"
+        f"\"triggers\":[],\"timestamp\":1700000000.0}}'::jsonb, "
+        f"'{{\"schema_version\":1,\"pleasure\":0.0,\"arousal\":0.0,\"dominance\":0.0,"
+        f"\"libido\":0.0,\"aggression\":0.0,\"connection\":0.5,\"energy\":0.8,"
+        f"\"tension\":0.0,\"coping_mode\":\"HEALTHY\",\"timestamp\":1700000000.0}}'::jsonb, "
+        "2)"
+    )
+    _run_sql(
+        "INSERT INTO public.chat_logs (user_id, role, content) VALUES "
+        f"('{user_id}', 'user', 'hello'), ('{user_id}', 'assistant', 'hi there')"
+    )
+    _run_sql(
+        "INSERT INTO public.memories (user_id, content, metadata) VALUES "
+        f"('{user_id}', 'a durable memory', '{{\"tags\":[\"x\"]}}'::jsonb)"
+    )
+
+
+def _cleanup_user(user_id: str) -> None:
+    for table in (
+        "privacy_operations",
+        "admission_reservations",
+        "archival_extractions",
+        "memories",
+        "chat_logs",
+        "turn_requests",
+        "outbox_events",
+        "profiles",
+    ):
+        _run_sql(f"DELETE FROM public.{table} WHERE user_id = '{user_id}'")
+
+
+def _runner(service_client: Client, *, batch_size: int = 100, clock=time.time):
+    return RetentionRunner(
+        repository=SupabaseRetentionRepository(service_client),
+        config=RetentionConfig(batch_size=batch_size, max_rows_per_category=10_000),
+        turn_config=TurnExecutionConfig.defaults(),
+        clock=clock,
+    )
+
+
+# ─── 1. admission_reservations horizon ──────────────────────────────────────
+
+
+def test_admission_expired_removed_current_stays(service_client: Client):
+    user_id = _uid("adm")
+    _seed_admission(user_id, expired_hours=25, current_hours=23)
+    try:
+        result = asyncio.run(_runner(service_client).run_once())
+        assert isinstance(result, RetentionRunResult)
+        admission = result.results[RetentionCategory.ADMISSION_RESERVATIONS.value]
+        assert admission.purged == 1
+        assert _count("admission_reservations", f"user_id = '{user_id}'") == 1
+        assert _count("admission_reservations", f"user_id = '{user_id}' AND reserved_at >= now() - interval '24 hours'") == 1
+    finally:
+        _cleanup_user(user_id)
+
+
+# ─── 2. privacy_operations horizon ──────────────────────────────────────────
+
+
+def test_privacy_ledger_expired_removed_current_stays(service_client: Client):
+    user_id = _uid("prv")
+    _seed_privacy_ledger(user_id, expired_days=31, current_days=29)
+    try:
+        result = asyncio.run(_runner(service_client).run_once())
+        privacy = result.results[RetentionCategory.PRIVACY_OPERATIONS.value]
+        assert privacy.purged == 1
+        assert _count("privacy_operations", f"user_id = '{user_id}'") == 1
+    finally:
+        _cleanup_user(user_id)
+
+
+# ─── 3. outbox_events eligibility ───────────────────────────────────────────
+
+
+def test_outbox_final_expired_removed_active_stays(service_client: Client):
+    user_id = _uid("out")
+    # outbox_events has an FK to profiles(user_id); seed the profile first.
+    _seed_profile(user_id)
+    _seed_outbox(
+        user_id,
+        completed_expired=True,
+        dead_expired=True,
+        completed_future=True,
+        pending_old=True,
+        processing_old=True,
+        failed_old=True,
+    )
+    try:
+        result = asyncio.run(_runner(service_client).run_once())
+        outbox = result.results[RetentionCategory.OUTBOX_EVENTS.value]
+        assert outbox.purged == 2
+        assert _count("outbox_events", f"user_id = '{user_id}' AND status IN ('completed', 'dead_letter')") == 1
+        assert _count("outbox_events", f"user_id = '{user_id}' AND status IN ('pending', 'processing', 'failed')") == 3
+    finally:
+        _cleanup_user(user_id)
+
+
+# ─── 4/5. Batch limiting and idempotent second run ─────────────────────────
+
+
+def test_batch_limited_and_second_run_idempotent(service_client: Client):
+    user_id = _uid("batch")
+    for _ in range(10):
+        _seed_admission(user_id, expired_hours=48, current_hours=None)
+    try:
+        runner = _runner(service_client, batch_size=3)
+        first = asyncio.run(runner.run_once())
+        admission = first.results[RetentionCategory.ADMISSION_RESERVATIONS.value]
+        assert admission.purged == 10
+        assert admission.batches == 4  # 3 + 3 + 3 + 1
+        assert _count("admission_reservations", f"user_id = '{user_id}'") == 0
+
+        second = asyncio.run(runner.run_once())
+        assert second.results[RetentionCategory.ADMISSION_RESERVATIONS.value].purged == 0
+        assert second.results[RetentionCategory.ADMISSION_RESERVATIONS.value].batches == 1
+    finally:
+        _cleanup_user(user_id)
+
+
+# ─── 6. Concurrent runs are safe ────────────────────────────────────────────
+
+
+def test_concurrent_runs_are_safe(supabase_url: str, service_role_key: str):
+    user_id = _uid("conc")
+    for _ in range(20):
+        _seed_admission(user_id, expired_hours=48, current_hours=None)
+    try:
+        outcomes: list[int] = []
+        errors: list[BaseException] = []
+        lock = threading.Lock()
+
+        def _run():
+            client = create_client(supabase_url, service_role_key)
+            try:
+                runner = RetentionRunner(
+                    repository=SupabaseRetentionRepository(client),
+                    config=RetentionConfig(batch_size=5, max_rows_per_category=100),
+                    turn_config=TurnExecutionConfig.defaults(),
+                )
+                result = asyncio.run(runner.run_once())
+                with lock:
+                    outcomes.append(
+                        result.results[RetentionCategory.ADMISSION_RESERVATIONS.value].purged
+                    )
+            except BaseException as exc:  # noqa: BLE001
+                with lock:
+                    errors.append(exc)
+            finally:
+                _close_client(client)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [pool.submit(_run) for _ in range(2)]
+            for future in futures:
+                future.result(timeout=120)
+
+        assert errors == [], f"concurrent runs failed: {errors}"
+        assert sum(outcomes) == 20, f"rows double-processed or lost: {outcomes}"
+        assert _count("admission_reservations", f"user_id = '{user_id}'") == 0
+    finally:
+        _cleanup_user(user_id)
+
+
+# ─── 7. User A/B content is never touched ───────────────────────────────────
+
+
+def test_user_content_never_touched(service_client: Client):
+    user_a = _uid("a")
+    user_b = _uid("b")
+    _seed_profile(user_a)
+    _seed_profile(user_b)
+    _seed_admission(user_a, expired_hours=48, current_hours=None)
+    _seed_admission(user_b, expired_hours=None, current_hours=2)
+    try:
+        result = asyncio.run(_runner(service_client).run_once())
+        # Only A's expired operational row is purged.
+        assert result.results[RetentionCategory.ADMISSION_RESERVATIONS.value].purged == 1
+        # B's current row stays.
+        assert _count("admission_reservations", f"user_id = '{user_b}'") == 1
+        # User content is fully preserved for both users.
+        for user_id in (user_a, user_b):
+            assert _count("chat_logs", f"user_id = '{user_id}'") == 2
+            assert _count("memories", f"user_id = '{user_id}'") == 1
+            assert _count("profiles", f"user_id = '{user_id}'") == 1
+        assert _count("turn_requests", f"user_id = '{user_a}' OR user_id = '{user_b}'") == 0
+    finally:
+        _cleanup_user(user_a)
+        _cleanup_user(user_b)

--- a/backend/tests/test_retention_preflight.py
+++ b/backend/tests/test_retention_preflight.py
@@ -22,6 +22,7 @@ import json
 import os
 import re
 import subprocess
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -76,10 +77,34 @@ def _run_supabase(op_id: str, args: list[str], check: bool = True):
     return result
 
 
+def _db_container_name() -> str:
+    """Name of the local Supabase Postgres container.
+
+    ``supabase start`` names the database container ``supabase_db_<project_id>``
+    where ``project_id`` comes from ``supabase/config.toml`` (default ``app``).
+    Deriving the name from that configuration keeps this suite portable across
+    projects with a different ``project_id``; the ``SUPABASE_DB_CONTAINER``
+    environment variable overrides it for setups that cannot use the default
+    naming.
+    """
+    override = os.environ.get("SUPABASE_DB_CONTAINER")
+    if override:
+        return override
+    project_id = "app"
+    try:
+        with open("supabase/config.toml", "rb") as f:
+            configured = tomllib.load(f).get("project_id")
+    except (OSError, tomllib.TOMLDecodeError):
+        configured = None
+    if isinstance(configured, str) and configured:
+        project_id = configured
+    return f"supabase_db_{project_id}"
+
+
 def _run_psql(sql: str) -> None:
     result = subprocess.run(
         [
-            "docker", "exec", "-i", "supabase_db_app",
+            "docker", "exec", "-i", _db_container_name(),
             "psql", "-U", "postgres",
             "-v", "ON_ERROR_STOP=1", "-q", "-f", "-",
         ],

--- a/backend/tests/test_retention_preflight.py
+++ b/backend/tests/test_retention_preflight.py
@@ -1,0 +1,173 @@
+"""Real Supabase integration test: retention migration preflight fail-closed (#316).
+
+This file is executed only by the database CI job. It must never be collected
+by the ordinary backend unit job (see the ignore list in
+``.github/workflows/ci.yml``).
+
+The preflight of ``operational_data_retention`` must fail with SQLSTATE
+23514 when ANY mandatory dependency is missing. Starting from a schema
+compatible with the migration (baseline + 00..06 + hardening + privacy),
+this suite drops EXACTLY ONE of the three operational tables (every other
+dependency still present), applies the migration and requires:
+
+1. the migration fails with 23514;
+2. NONE of the new purge functions or the validation helper were installed;
+3. the migration is NOT registered;
+4. the environment is restored in ``finally`` (migration files and data).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from backend.supabase_cli import run_supabase_op
+
+LEGACY_HIDDEN_SUFFIX = ".legacy-test-hidden"
+_RETENTION_FILENAME_RE = re.compile(
+    r"^\d+_operational_data_retention\.sql(?:\.(?:tmp|legacy-test-hidden))?$"
+)
+
+# Functions created by the retention migration. None may exist after a
+# failed preflight.
+MIGRATION_FUNCTIONS = (
+    "purge_admission_reservations",
+    "purge_privacy_operations",
+    "purge_outbox_events",
+    "retention_purge_validation_error",
+)
+
+# Tables that the retention migration hard-depends on. Dropping exactly one
+# must make the migration fail closed.
+MISSING_TABLE_CASES = (
+    "admission_reservations",
+    "privacy_operations",
+    "outbox_events",
+)
+
+
+def _find_retention_migration() -> Path:
+    matches = [
+        p
+        for p in Path("supabase/migrations").iterdir()
+        if _RETENTION_FILENAME_RE.match(p.name)
+    ]
+    if not matches:
+        raise FileNotFoundError(
+            "supabase/migrations/*_operational_data_retention.sql not found"
+        )
+    return next((p for p in matches if p.name.endswith(".sql")), matches[0])
+
+
+_RETENTION_MIGRATION = _find_retention_migration()
+MIGRATION = str(_RETENTION_MIGRATION).removesuffix(LEGACY_HIDDEN_SUFFIX).removesuffix(".tmp")
+MIGRATION_TMP = f"{MIGRATION}.tmp"
+
+
+def _run_supabase(op_id: str, args: list[str], check: bool = True):
+    result = run_supabase_op(op_id, args, check=False)
+    if check and result.returncode != 0:
+        raise AssertionError(f"Supabase operation failed: {op_id}")
+    return result
+
+
+def _run_psql(sql: str) -> None:
+    result = subprocess.run(
+        [
+            "docker", "exec", "-i", "supabase_db_app",
+            "psql", "-U", "postgres",
+            "-v", "ON_ERROR_STOP=1", "-q", "-f", "-",
+        ],
+        input=sql,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError("psql execution failed")
+
+
+def _query_scalar_bool(query: str) -> bool:
+    res = _run_supabase(
+        "retention_preflight_query",
+        ["db", "query", "--agent=no", "--output", "json", query],
+        check=False,
+    )
+    if res.returncode != 0:
+        raise AssertionError("Query result: operation failed")
+    try:
+        data = json.loads(res.stdout)
+    except json.JSONDecodeError:
+        raise AssertionError("Query result: invalid JSON response")
+    if not isinstance(data, list) or len(data) != 1 or "result" not in data[0]:
+        raise AssertionError("Query result: expected exactly one scalar row")
+    value = data[0]["result"]
+    if not isinstance(value, bool):
+        raise AssertionError("Query result: expected a boolean")
+    return value
+
+
+def _hide_new_migration() -> None:
+    if os.path.exists(MIGRATION) and not os.path.exists(MIGRATION_TMP):
+        os.rename(MIGRATION, MIGRATION_TMP)
+
+
+def _restore_new_migration() -> None:
+    if os.path.exists(MIGRATION_TMP):
+        os.rename(MIGRATION_TMP, MIGRATION)
+    elif os.path.exists(MIGRATION + LEGACY_HIDDEN_SUFFIX):
+        os.rename(MIGRATION + LEGACY_HIDDEN_SUFFIX, MIGRATION)
+
+
+@pytest.mark.parametrize("missing_table", MISSING_TABLE_CASES)
+@pytest.mark.database_integration
+def test_preflight_fails_closed_on_missing_table(missing_table: str):
+    _hide_new_migration()
+    try:
+        # Baseline compatible with the migration: every required table present.
+        _run_supabase("retention_preflight_reset", ["db", "reset"])
+
+        # Remove EXACTLY one mandatory dependency while every other
+        # dependency of the set remains present.
+        _run_psql(f"DROP TABLE IF EXISTS public.{missing_table} CASCADE;")
+        assert _query_scalar_bool(
+            f"SELECT to_regclass('public.{missing_table}') IS NULL AS result"
+        ), f"{missing_table} was not actually dropped"
+
+        _restore_new_migration()
+
+        # Applying the migration must FAIL with 23514 BEFORE installing
+        # anything.
+        res = _run_supabase(
+            "retention_preflight_apply", ["migration", "up", "--local"], check=False
+        )
+        assert res.returncode != 0, (
+            f"expected the retention migration to fail when {missing_table} is missing"
+        )
+        assert "23514" in res.stderr, (
+            f"expected SQLSTATE 23514 from preflight, got: {res.stderr[-500:]}"
+        )
+
+        # NONE of the new functions may be installed.
+        for fn in MIGRATION_FUNCTIONS:
+            assert not _query_scalar_bool(
+                "SELECT EXISTS("
+                "SELECT 1 FROM pg_proc p "
+                "JOIN pg_namespace n ON n.oid = p.pronamespace "
+                f"WHERE n.nspname = 'public' AND p.proname = '{fn}'"
+                ") AS result"
+            ), f"{fn} was installed despite the failed preflight"
+
+        # The migration must NOT be registered.
+        assert not _query_scalar_bool(
+            "SELECT EXISTS("
+            "SELECT 1 FROM supabase_migrations.schema_migrations "
+            "WHERE name = 'operational_data_retention'"
+            ") AS result"
+        ), "operational_data_retention was registered despite the failed preflight"
+    finally:
+        _restore_new_migration()

--- a/docs/architecture/user-data-lifecycle.md
+++ b/docs/architecture/user-data-lifecycle.md
@@ -294,4 +294,7 @@ Operational retention/cleanup (#316) is implemented by its own leaf:
 `python -m backend.retention_cli --once` command. It covers ONLY
 operational data (`admission_reservations`, the privacy operation ledger,
 final outbox events) and deliberately never introduces an automatic TTL
-for user-controlled content.
+for user-controlled content. The SQL boundary enforces the binding
+minimum retention horizons with authoritative PostgreSQL time: purge
+cutoffs supplied by the process are clamped, so a fast/misconfigured
+process clock can never advance deletion of rows inside the horizons.

--- a/docs/architecture/user-data-lifecycle.md
+++ b/docs/architecture/user-data-lifecycle.md
@@ -284,6 +284,14 @@ reversible; idempotency guarantees they are never applied twice.
 ## Out of scope (future leaves)
 
 - UI / settings screens exposing these primitives.
-- Account/Auth user deletion with tombstone (#317), durable workers (#276),
-  retention/cleanup (#316) and export policies.
+- Account/Auth user deletion with tombstone (#317), durable workers (#276)
+  and export policies.
 - Emotional/relationship formula, decay, appraisal or personality changes.
+
+Operational retention/cleanup (#316) is implemented by its own leaf:
+`supabase/migrations/20260809030000_operational_data_retention.sql` plus
+`backend/retention_policy.py`, `backend/retention.py` and the
+`python -m backend.retention_cli --once` command. It covers ONLY
+operational data (`admission_reservations`, the privacy operation ledger,
+final outbox events) and deliberately never introduces an automatic TTL
+for user-controlled content.

--- a/docs/operations/operational-data-retention.md
+++ b/docs/operations/operational-data-retention.md
@@ -69,11 +69,35 @@ Optional parameters:
 The round:
 
 1. Computes cutoffs from the injected clock: admission `now - 24h`,
-   privacy ledger `now - 30d`, outbox `now`.
+   privacy ledger `now - 30d`, outbox `now`. These are scheduling
+   hints: the SQL boundary clamps every cutoff against authoritative
+   PostgreSQL time, so a fast/misconfigured process clock can never
+   advance deletion (see "DB-authoritative cutoff clamp" below).
 2. For each category, runs bounded batches (each batch is one transactional
    `DELETE ... LIMIT batch_size` purge RPC) until a partial batch or the
    per-category cap (10 000 rows) is reached.
 3. Prints a sanitized aggregate summary and exits 0.
+
+## DB-authoritative cutoff clamp
+
+The three purge RPCs never trust the caller-supplied cutoff absolutely:
+each one clamps the effective cutoff against PostgreSQL time
+(`clock_timestamp()`):
+
+| RPC | Effective cutoff never exceeds |
+|---|---|
+| `purge_admission_reservations` | `db_now - 24h` |
+| `purge_privacy_operations` | `db_now - 30 days` |
+| `purge_outbox_events` | `db_now` |
+
+Consequences:
+
+- Rows inside the binding horizons (admission < 24h, privacy ledger
+  < 30 days) and outbox events whose `retention_until` is still in the
+  future are protected BY THE DATABASE, regardless of the process clock.
+- A lagging process clock only reduces progress (an older cutoff purges
+  fewer rows); a fast process clock can never delete early.
+- `p_cutoff` remains an upper bound on progress, not a license to delete.
 
 ## Verifying success
 
@@ -149,6 +173,9 @@ eligible).
 - Policy is versioned: `RETENTION_POLICY_SCHEMA_VERSION = 1`; the SQL
   boundary (migration `20260809030000_operational_data_retention.sql`)
   enforces the same eligibility contracts fail-closed.
+- The SQL boundary enforces the binding minimum retention horizons with
+  authoritative PostgreSQL time (`clock_timestamp()`): caller cutoffs are
+  clamped, so a fast process clock can never advance deletion.
 - Batch size is explicit and limited; a round never loads a whole table
   into memory.
 - No global locks; concurrency-safe by idempotent bounded deletes.

--- a/docs/operations/operational-data-retention.md
+++ b/docs/operations/operational-data-retention.md
@@ -1,0 +1,157 @@
+# Operational Data Retention — Runbook (#316)
+
+## Purpose
+
+The retention command applies the versioned operational retention policy
+(`backend/retention_policy.py`, schema version 1) to **operational /
+transitory** data only:
+
+| Category | Eligible for purge | Horizon |
+|---|---|---|
+| `admission_reservations` | `reserved_at` older than the cutoff | 24h |
+| `privacy_operations` (ledger) | `applied_at` older than the cutoff | 30 days |
+| `outbox_events` | ONLY `completed` / `dead_letter` with `retention_until` past the cutoff | `retention_until` (no age horizon) |
+
+User-controlled content is **never** eligible:
+
+- `chat_logs`, `memories`, `archival_extractions`, `profiles` snapshots and
+  `turn_requests` get **no automatic TTL**. They remain until an explicit
+  user action or future account deletion (#317).
+- `pending`, `processing` and `failed` outbox events are never purged by
+  age.
+- `delete_history` and the anti-abuse ledger are unchanged: cleanup removes
+  expired `admission_reservations` rows only, so current quota windows are
+  never affected and quota cannot be bypassed through cleanup.
+
+## Who schedules the command
+
+The command is a **one-shot, explicit operational entrypoint**. There is no
+in-process scheduler, no `BackgroundTasks`, no hidden worker and no
+long-running server.
+
+A production operator (or a CI cron job in the production environment, not
+the application process) schedules:
+
+```
+python -m backend.retention_cli --once
+```
+
+Recommended cadence: daily. The command is idempotent and safe to run
+concurrently, so an overlapping run is harmless; the batch contract bounds
+each round.
+
+## Environment
+
+The command reads the environment directly (it does not require the full
+application settings; no Groq keys or CORS config are needed):
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `SUPABASE_URL` | yes | PostgREST base URL |
+| `SUPABASE_SERVICE_ROLE_KEY` | yes | service-role key (never logged) |
+| `TURN_SUPABASE_TIMEOUT` | no | Supabase transport timeout (seconds, default 5) |
+
+Missing `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY` fails closed with a
+sanitized error and exit code 1.
+
+## Running one round
+
+```
+SUPABASE_URL=https://<project>.supabase.co \
+SUPABASE_SERVICE_ROLE_KEY=<service-role-key> \
+python -m backend.retention_cli --once
+```
+
+Optional parameters:
+
+- `--batch-size N` — rows purged per statement (default 500, max 1000).
+
+The round:
+
+1. Computes cutoffs from the injected clock: admission `now - 24h`,
+   privacy ledger `now - 30d`, outbox `now`.
+2. For each category, runs bounded batches (each batch is one transactional
+   `DELETE ... LIMIT batch_size` purge RPC) until a partial batch or the
+   per-category cap (10 000 rows) is reached.
+3. Prints a sanitized aggregate summary and exits 0.
+
+## Verifying success
+
+Exit code 0 and a sanitized summary:
+
+```
+retention_round schema_version=1
+retention_round category=admission_reservations purged=42 batches=1
+retention_round category=privacy_operations purged=7 batches=1
+retention_round category=outbox_events purged=3 batches=1
+retention_round total_purged=52
+```
+
+Only the policy schema version and aggregate counts are printed/logged:
+no `user_id`, no HMAC, no content, no SQL, no tokens.
+
+Optional SQL verification (as database owner, not in logs):
+
+```sql
+SELECT count(*) FROM public.admission_reservations
+WHERE reserved_at < now() - interval '24 hours';
+-- expect 0 after a round with no new expired rows
+```
+
+## Interpreting failure
+
+A failure exits 1 and emits a sanitized event
+(`retention_failed`, low-cardinality `code`). The process never prints the
+upstream exception text, identifiers or content.
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| exit 1, `code=round_failed` | runtime config incomplete (missing URL/key) | fix environment, retry |
+| exit 1, `code=persistence_error` | purge RPC unreachable / malformed response | check Supabase availability and PostgREST, retry |
+| exit 1, `code=purge_failed` | transport timeout or budget exhausted mid-category | retry; the round is idempotent |
+
+A failed batch does not corrupt anything: each purge RPC is transactional,
+and the whole round is idempotent (re-running only processes rows still
+eligible).
+
+## Retrying safely
+
+- Re-running the command is always safe: rows already purged are gone;
+  rows still eligible are processed again; rows inside the horizon are
+  untouched.
+- Two overlapping executions are safe by design: every statement deletes a
+  bounded, primary-key-selected set; the loser's DELETE simply finds the
+  rows already gone. No global advisory lock is used and no writer is
+  blocked beyond a single row-level delete.
+- Increasing `--batch-size` above the default is bounded to 1000 by the
+  SQL boundary (fail closed otherwise).
+
+## Backups and restores (honest limits)
+
+- This routine **removes rows from the primary database**. It is
+  destructive by design for the three operational categories and is NOT
+  reversible: there is no tombstone and no recycle bin.
+- Provider-managed snapshots/backups are **not** erased instantaneously by
+  this routine. A snapshot taken before a purge may still contain purged
+  rows until it ages out of the provider retention window.
+- After a production restore from a snapshot/backup, the restored data may
+  contain rows that were purged before the snapshot. Before serving traffic
+  from a restored database, the operator MUST reconcile any outstanding
+  deletion requests (user-initiated deletes, privacy operations and the
+  retention policy) against the restored state, exactly as the privacy
+  chain requires: a restore must never resurrect data the user asked to
+  delete, and must never re-introduce quota bypass rows.
+- If a restore reintroduces operational rows that violate the policy,
+  simply run the retention command again after restore.
+
+## Design invariants (what this runbook relies on)
+
+- Policy is versioned: `RETENTION_POLICY_SCHEMA_VERSION = 1`; the SQL
+  boundary (migration `20260809030000_operational_data_retention.sql`)
+  enforces the same eligibility contracts fail-closed.
+- Batch size is explicit and limited; a round never loads a whole table
+  into memory.
+- No global locks; concurrency-safe by idempotent bounded deletes.
+- Grants: the three purge RPCs are `SECURITY DEFINER`,
+  `SET search_path = ''`, executable by `service_role` only.
+- No automatic TTL for user-controlled content.

--- a/supabase/migrations/20260809030000_operational_data_retention.sql
+++ b/supabase/migrations/20260809030000_operational_data_retention.sql
@@ -20,6 +20,23 @@
 --     now) are eligible. Active states (pending, processing, failed) are
 --     never purged by age.
 --
+-- DB-authoritative cutoff clamp (security invariant)
+-- ==================================================
+-- The three purge RPCs accept a caller-supplied p_cutoff but NEVER trust it
+-- absolutely: each function clamps the effective cutoff against
+-- authoritative PostgreSQL time (clock_timestamp()) so that the binding
+-- minimum retention horizons are enforced BY THE DATABASE:
+--
+--   * admission_reservations: effective cutoff <= db_now - 24h;
+--   * privacy_operations:     effective cutoff <= db_now - 30 days;
+--   * outbox_events:          effective cutoff <= db_now.
+--
+-- A caller cutoff (or a fast/misconfigured process clock) can therefore
+-- only REDUCE progress (an older cutoff purges fewer rows); it can never
+-- ADVANCE deletion: rows inside the horizons, and outbox events whose
+-- retention_until is still in the future, are protected regardless of the
+-- caller. The runner's process clock is advisory for scheduling only.
+--
 -- NOT covered: chat_logs, memories, archival_extractions, profiles
 -- snapshots, turn_requests. User-controlled data and the replay/history
 -- ledger get NO automatic TTL; they remain until an explicit user action or
@@ -113,9 +130,16 @@ REVOKE ALL ON FUNCTION public.retention_purge_validation_error(timestamptz, inte
 -- =================================================================
 -- 3. purge_admission_reservations
 -- =================================================================
--- Deletes up to p_batch_size rows with reserved_at < p_cutoff and returns
--- the number of rows deleted. Rows at or after the cutoff (current quota
--- ledger) are never touched.
+-- Deletes up to p_batch_size rows with reserved_at < effective cutoff and
+-- returns the number of rows deleted. Rows at or after the cutoff (current
+-- quota ledger) are never touched.
+--
+-- The effective cutoff is the caller-supplied p_cutoff CLAMPED to never
+-- exceed db_now - 24h, using authoritative PostgreSQL time
+-- (clock_timestamp()). The database therefore enforces the binding 24h
+-- minimum retention horizon: a caller cutoff (or a fast process clock)
+-- can only reduce progress, never advance deletion; rows inside the
+-- horizon are protected regardless of the caller.
 CREATE OR REPLACE FUNCTION public.purge_admission_reservations(
     p_cutoff timestamptz,
     p_batch_size integer
@@ -127,17 +151,20 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
 DECLARE
+    v_cutoff timestamptz;
     v_deleted integer;
 BEGIN
     IF public.retention_purge_validation_error(p_cutoff, p_batch_size) IS NOT NULL THEN
         RAISE EXCEPTION 'invalid retention parameters';
     END IF;
 
+    v_cutoff := LEAST(p_cutoff, clock_timestamp() - interval '24 hours');
+
     DELETE FROM public.admission_reservations
     WHERE (user_id, request_id) IN (
         SELECT user_id, request_id
         FROM public.admission_reservations
-        WHERE reserved_at < p_cutoff
+        WHERE reserved_at < v_cutoff
         ORDER BY reserved_at
         LIMIT p_batch_size
     );
@@ -154,9 +181,14 @@ GRANT EXECUTE ON FUNCTION public.purge_admission_reservations(timestamptz, integ
 -- =================================================================
 -- 4. purge_privacy_operations
 -- =================================================================
--- Deletes up to p_batch_size ledger rows with applied_at < p_cutoff and
--- returns the number of rows deleted. Rows inside the retention horizon
--- stay, preserving the #314 replay/idempotency/conflict semantics.
+-- Deletes up to p_batch_size ledger rows with applied_at < effective
+-- cutoff and returns the number of rows deleted. Rows inside the retention
+-- horizon stay, preserving the #314 replay/idempotency/conflict semantics.
+--
+-- The effective cutoff is the caller-supplied p_cutoff CLAMPED to never
+-- exceed db_now - 30 days (authoritative PostgreSQL time). The database
+-- enforces the binding 30-day minimum retention horizon regardless of the
+-- caller's cutoff or clock.
 CREATE OR REPLACE FUNCTION public.purge_privacy_operations(
     p_cutoff timestamptz,
     p_batch_size integer
@@ -168,17 +200,20 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
 DECLARE
+    v_cutoff timestamptz;
     v_deleted integer;
 BEGIN
     IF public.retention_purge_validation_error(p_cutoff, p_batch_size) IS NOT NULL THEN
         RAISE EXCEPTION 'invalid retention parameters';
     END IF;
 
+    v_cutoff := LEAST(p_cutoff, clock_timestamp() - interval '30 days');
+
     DELETE FROM public.privacy_operations
     WHERE (user_id, operation_id) IN (
         SELECT user_id, operation_id
         FROM public.privacy_operations
-        WHERE applied_at < p_cutoff
+        WHERE applied_at < v_cutoff
         ORDER BY applied_at
         LIMIT p_batch_size
     );
@@ -196,10 +231,15 @@ GRANT EXECUTE ON FUNCTION public.purge_privacy_operations(timestamptz, integer)
 -- 5. purge_outbox_events
 -- =================================================================
 -- Deletes up to p_batch_size FINAL outbox events whose retention_until is
--- PAST the cutoff and returns the number of rows deleted. The status
--- predicate is explicit and fail-closed: pending, processing and failed
--- events are never purged by age, and a final event whose retention_until
--- has not yet expired stays.
+-- PAST the effective cutoff and returns the number of rows deleted. The
+-- status predicate is explicit and fail-closed: pending, processing and
+-- failed events are never purged by age, and a final event whose
+-- retention_until has not yet expired stays.
+--
+-- The effective cutoff is the caller-supplied p_cutoff CLAMPED to never
+-- exceed db_now (authoritative PostgreSQL time). The database therefore
+-- enforces the binding rule that an event is only removable after its
+-- retention_until has passed, regardless of the caller's cutoff or clock.
 CREATE OR REPLACE FUNCTION public.purge_outbox_events(
     p_cutoff timestamptz,
     p_batch_size integer
@@ -211,11 +251,14 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
 DECLARE
+    v_cutoff timestamptz;
     v_deleted integer;
 BEGIN
     IF public.retention_purge_validation_error(p_cutoff, p_batch_size) IS NOT NULL THEN
         RAISE EXCEPTION 'invalid retention parameters';
     END IF;
+
+    v_cutoff := LEAST(p_cutoff, clock_timestamp());
 
     DELETE FROM public.outbox_events
     WHERE id IN (
@@ -223,7 +266,7 @@ BEGIN
         FROM public.outbox_events
         WHERE status IN ('completed', 'dead_letter')
           AND retention_until IS NOT NULL
-          AND retention_until < p_cutoff
+          AND retention_until < v_cutoff
         ORDER BY retention_until
         LIMIT p_batch_size
     );

--- a/supabase/migrations/20260809030000_operational_data_retention.sql
+++ b/supabase/migrations/20260809030000_operational_data_retention.sql
@@ -1,0 +1,238 @@
+-- 20260809030000_operational_data_retention.sql
+-- Operational data retention policy (#316).
+--
+-- Scope
+-- =====
+-- This migration adds the server-side purge boundary for OPERATIONAL data
+-- only. It deliberately never touches user-controlled content:
+--
+--   * admission_reservations   — rows with reserved_at OLDER than the purge
+--     cutoff (the runner computes now - 24h) are eligible. Rows inside the
+--     horizon stay: the anti-abuse ledger is preserved and delete_history
+--     continues to never touch it, so quota cannot be bypassed via cleanup.
+--   * privacy_operations       — applied ledger rows with applied_at OLDER
+--     than the purge cutoff (the runner computes now - 30d) are eligible.
+--     The idempotency/conflict semantics of #314 are unchanged: the ledger
+--     row is only removed after its horizon, and replay/conflict behavior
+--     inside the horizon is fully preserved.
+--   * outbox_events            — ONLY final states (completed, dead_letter)
+--     whose retention_until is PAST the purge cutoff (the runner passes
+--     now) are eligible. Active states (pending, processing, failed) are
+--     never purged by age.
+--
+-- NOT covered: chat_logs, memories, archival_extractions, profiles
+-- snapshots, turn_requests. User-controlled data and the replay/history
+-- ledger get NO automatic TTL; they remain until an explicit user action or
+-- future account deletion.
+--
+-- Fail-closed preflight
+-- =====================
+-- The migration refuses to install when ANY mandatory dependency is missing
+-- (SQLSTATE 23514), mirroring the privacy_data_operations pattern: a schema
+-- that lost one of the three operational tables must never receive the
+-- purge functions.
+--
+-- Concurrency
+-- ===========
+-- Purge is safe under concurrent executions WITHOUT any global advisory
+-- lock: every statement is a bounded, idempotent DELETE whose WHERE set is
+-- selected by primary key inside a LIMIT-bounded subquery. Two concurrent
+-- runs may select overlapping batches; each row is deleted exactly once
+-- (the loser's DELETE simply finds the row gone) and no user/writer is ever
+-- blocked for more than a single row-level delete. No LOCK TABLE, no
+-- long-lived locks.
+--
+-- Grants
+-- ======
+-- The three functions are SECURITY DEFINER (owner postgres) with
+-- SET search_path = '' and EXECUTE granted to service_role ONLY. PUBLIC,
+-- anon and authenticated have no access. The RLS/FORCE-RLS server-owned
+-- tables are only ever reachable through these functions.
+
+-- =================================================================
+-- 0. Preflight (fail closed on any missing dependency)
+-- =================================================================
+DO $$
+DECLARE
+    v_missing text;
+BEGIN
+    IF pg_catalog.to_regclass('public.admission_reservations') IS NULL THEN
+        v_missing := 'public.admission_reservations';
+    ELSIF pg_catalog.to_regclass('public.privacy_operations') IS NULL THEN
+        v_missing := 'public.privacy_operations';
+    ELSIF pg_catalog.to_regclass('public.outbox_events') IS NULL THEN
+        v_missing := 'public.outbox_events';
+    END IF;
+
+    IF v_missing IS NOT NULL THEN
+        RAISE EXCEPTION 'missing mandatory dependency: %', v_missing
+            USING ERRCODE = '23514';
+    END IF;
+END;
+$$;
+
+-- =================================================================
+-- 1. Indexes for bounded purge scans
+-- =================================================================
+CREATE INDEX IF NOT EXISTS privacy_operations_applied_at_idx
+    ON public.privacy_operations (applied_at);
+
+CREATE INDEX IF NOT EXISTS outbox_events_status_retention_until_idx
+    ON public.outbox_events (status, retention_until);
+
+-- admission_reservations already has admission_reservations_time_idx
+-- (reserved_at DESC), which the purge predicate uses directly.
+
+-- =================================================================
+-- 2. Shared fail-closed validation helper
+-- =================================================================
+-- Returns an error constant or NULL. Never echoes the supplied values: the
+-- caller raises the constant sanitized message.
+CREATE OR REPLACE FUNCTION public.retention_purge_validation_error(
+    p_cutoff timestamptz,
+    p_batch_size integer
+) RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path = ''
+AS $$
+BEGIN
+    IF p_cutoff IS NULL THEN
+        RETURN 'retention purge requires a cutoff';
+    END IF;
+    IF p_batch_size IS NULL OR p_batch_size < 1 OR p_batch_size > 1000 THEN
+        RETURN 'retention purge batch_size must be between 1 and 1000';
+    END IF;
+    RETURN NULL;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.retention_purge_validation_error(timestamptz, integer)
+    FROM PUBLIC, anon, authenticated, service_role;
+
+-- =================================================================
+-- 3. purge_admission_reservations
+-- =================================================================
+-- Deletes up to p_batch_size rows with reserved_at < p_cutoff and returns
+-- the number of rows deleted. Rows at or after the cutoff (current quota
+-- ledger) are never touched.
+CREATE OR REPLACE FUNCTION public.purge_admission_reservations(
+    p_cutoff timestamptz,
+    p_batch_size integer
+) RETURNS integer
+LANGUAGE plpgsql
+VOLATILE
+PARALLEL UNSAFE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_deleted integer;
+BEGIN
+    IF public.retention_purge_validation_error(p_cutoff, p_batch_size) IS NOT NULL THEN
+        RAISE EXCEPTION 'invalid retention parameters';
+    END IF;
+
+    DELETE FROM public.admission_reservations
+    WHERE (user_id, request_id) IN (
+        SELECT user_id, request_id
+        FROM public.admission_reservations
+        WHERE reserved_at < p_cutoff
+        ORDER BY reserved_at
+        LIMIT p_batch_size
+    );
+    GET DIAGNOSTICS v_deleted = ROW_COUNT;
+    RETURN v_deleted;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.purge_admission_reservations(timestamptz, integer)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.purge_admission_reservations(timestamptz, integer)
+    TO service_role;
+
+-- =================================================================
+-- 4. purge_privacy_operations
+-- =================================================================
+-- Deletes up to p_batch_size ledger rows with applied_at < p_cutoff and
+-- returns the number of rows deleted. Rows inside the retention horizon
+-- stay, preserving the #314 replay/idempotency/conflict semantics.
+CREATE OR REPLACE FUNCTION public.purge_privacy_operations(
+    p_cutoff timestamptz,
+    p_batch_size integer
+) RETURNS integer
+LANGUAGE plpgsql
+VOLATILE
+PARALLEL UNSAFE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_deleted integer;
+BEGIN
+    IF public.retention_purge_validation_error(p_cutoff, p_batch_size) IS NOT NULL THEN
+        RAISE EXCEPTION 'invalid retention parameters';
+    END IF;
+
+    DELETE FROM public.privacy_operations
+    WHERE (user_id, operation_id) IN (
+        SELECT user_id, operation_id
+        FROM public.privacy_operations
+        WHERE applied_at < p_cutoff
+        ORDER BY applied_at
+        LIMIT p_batch_size
+    );
+    GET DIAGNOSTICS v_deleted = ROW_COUNT;
+    RETURN v_deleted;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.purge_privacy_operations(timestamptz, integer)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.purge_privacy_operations(timestamptz, integer)
+    TO service_role;
+
+-- =================================================================
+-- 5. purge_outbox_events
+-- =================================================================
+-- Deletes up to p_batch_size FINAL outbox events whose retention_until is
+-- PAST the cutoff and returns the number of rows deleted. The status
+-- predicate is explicit and fail-closed: pending, processing and failed
+-- events are never purged by age, and a final event whose retention_until
+-- has not yet expired stays.
+CREATE OR REPLACE FUNCTION public.purge_outbox_events(
+    p_cutoff timestamptz,
+    p_batch_size integer
+) RETURNS integer
+LANGUAGE plpgsql
+VOLATILE
+PARALLEL UNSAFE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_deleted integer;
+BEGIN
+    IF public.retention_purge_validation_error(p_cutoff, p_batch_size) IS NOT NULL THEN
+        RAISE EXCEPTION 'invalid retention parameters';
+    END IF;
+
+    DELETE FROM public.outbox_events
+    WHERE id IN (
+        SELECT id
+        FROM public.outbox_events
+        WHERE status IN ('completed', 'dead_letter')
+          AND retention_until IS NOT NULL
+          AND retention_until < p_cutoff
+        ORDER BY retention_until
+        LIMIT p_batch_size
+    );
+    GET DIAGNOSTICS v_deleted = ROW_COUNT;
+    RETURN v_deleted;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.purge_outbox_events(timestamptz, integer)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.purge_outbox_events(timestamptz, integer)
+    TO service_role;

--- a/supabase/tests/database/07_operational_data_retention.test.sql
+++ b/supabase/tests/database/07_operational_data_retention.test.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 CREATE EXTENSION IF NOT EXISTS pgtap;
-SELECT plan(44);
+SELECT plan(53);
 
 -- =================================================================
 -- 1. Migration and indexes (#316)
@@ -352,7 +352,112 @@ SELECT is(
 );
 
 -- =================================================================
--- 9. Cleanup never attaches to user-controlled tables
+-- 9. Future cutoff cannot advance deletion (DB-authoritative clamp)
+-- =================================================================
+-- The purge RPCs clamp the caller-supplied cutoff against authoritative
+-- PostgreSQL time (clock_timestamp()): a future cutoff must never remove
+-- rows inside the binding minimum horizons, and the genuinely expired
+-- rows remain removable.
+INSERT INTO public.admission_reservations
+    (user_id, request_id, message_hmac_sha256, network_hmac_sha256,
+     estimated_units, reserved_at)
+VALUES
+    ('ret-adm-future-expired', '33333333-3333-3333-3333-333333333333',
+     repeat('a', 64), repeat('b', 64), 10,
+     now() - interval '25 hours'),
+    ('ret-adm-future-current', '44444444-4444-4444-4444-444444444444',
+     repeat('c', 64), repeat('d', 64), 10,
+     now() - interval '23 hours');
+
+SELECT is(
+    public.purge_admission_reservations(now() + interval '1 day', 100),
+    1,
+    'future cutoff removes only the admission row older than 24h'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.admission_reservations WHERE user_id = 'ret-adm-future-current'),
+    1,
+    'admission row younger than 24h survives a future cutoff'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.admission_reservations WHERE user_id = 'ret-adm-future-expired'),
+    0,
+    'admission row older than 24h is still removable under a future cutoff'
+);
+
+INSERT INTO public.privacy_operations
+    (user_id, operation_id, operation, operation_payload_sha256, status,
+     applied_at, result)
+VALUES
+    ('ret-prv-future-expired', '33333333-3333-3333-3333-333333333333',
+     'delete_history', repeat('e', 64), 'applied',
+     now() - interval '31 days', '{"status":"applied"}'::jsonb),
+    ('ret-prv-future-current', '44444444-4444-4444-4444-444444444444',
+     'delete_memories', repeat('f', 64), 'applied',
+     now() - interval '29 days', '{"status":"applied"}'::jsonb);
+
+SELECT is(
+    public.purge_privacy_operations(now() + interval '1 day', 100),
+    1,
+    'future cutoff removes only the privacy ledger row older than 30 days'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.privacy_operations WHERE user_id = 'ret-prv-future-current'),
+    1,
+    'privacy ledger row younger than 30 days survives a future cutoff'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.privacy_operations WHERE user_id = 'ret-prv-future-expired'),
+    0,
+    'privacy ledger row older than 30 days is still removable under a future cutoff'
+);
+
+-- Outbox: FK to profiles(user_id); seed the profile first.
+INSERT INTO public.profiles
+    (user_id, persona_config, user_profile, relationship_state,
+     emotional_state, revision)
+VALUES (
+    'ret-outbox-future', 'persona', '{}'::jsonb,
+    '{"schema_version":1,"trust":0.5,"affection":0.3,"tension":0.0,"triggers":[],"timestamp":1700000000.0}'::jsonb,
+    '{"schema_version":1,"pleasure":0.0,"arousal":0.0,"dominance":0.0,"libido":0.0,"aggression":0.0,"connection":0.5,"energy":0.8,"tension":0.0,"coping_mode":"HEALTHY","timestamp":1700000000.0}'::jsonb,
+    1
+);
+
+INSERT INTO public.outbox_events
+    (id, event_type, contract_version, user_id, turn_request_id, payload,
+     status, attempts, next_attempt_at, lease_owner, lease_expires_at,
+     idempotency_key, error_code, created_at, updated_at, processed_at,
+     dead_lettered_at, retention_until)
+VALUES
+    ('bbbbbbbb-cccc-cccc-cccc-cccccccccccc', 'turn_completed', 1,
+     'ret-outbox-future', NULL, '{"ref":"g"}'::jsonb,
+     'completed', 1, NULL, NULL, NULL, 'ret-outbox-f-k-expired', NULL,
+     now(), now(), now() - interval '2 days', NULL,
+     now() - interval '1 day'),
+    ('bbbbbbbb-eeee-eeee-eeee-eeeeeeeeeeee', 'turn_completed', 1,
+     'ret-outbox-future', NULL, '{"ref":"h"}'::jsonb,
+     'completed', 1, NULL, NULL, NULL, 'ret-outbox-f-k-future', NULL,
+     now(), now(), now() - interval '2 days', NULL,
+     now() + interval '1 day');
+
+SELECT is(
+    public.purge_outbox_events(now() + interval '1 day', 100),
+    1,
+    'future cutoff removes only the outbox event with expired retention_until'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.outbox_events WHERE id = 'bbbbbbbb-eeee-eeee-eeee-eeeeeeeeeeee'),
+    1,
+    'outbox event with future retention_until survives a future cutoff'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.outbox_events WHERE id = 'bbbbbbbb-cccc-cccc-cccc-cccccccccccc'),
+    0,
+    'outbox event with expired retention_until is still removable under a future cutoff'
+);
+
+-- =================================================================
+-- 10. Cleanup never attaches to user-controlled tables
 -- =================================================================
 -- The retention migration must not attach any purge trigger to
 -- user-controlled tables (chat_logs, memories, archival_extractions,

--- a/supabase/tests/database/07_operational_data_retention.test.sql
+++ b/supabase/tests/database/07_operational_data_retention.test.sql
@@ -1,0 +1,377 @@
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgtap;
+SELECT plan(44);
+
+-- =================================================================
+-- 1. Migration and indexes (#316)
+-- =================================================================
+SELECT ok(
+    EXISTS(
+        SELECT 1
+        FROM supabase_migrations.schema_migrations
+        WHERE name = 'operational_data_retention'
+    ),
+    'operational_data_retention migration is registered'
+);
+
+SELECT ok(
+    EXISTS(
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'privacy_operations_applied_at_idx'
+    ),
+    'privacy_operations_applied_at_idx exists'
+);
+
+SELECT ok(
+    EXISTS(
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'outbox_events_status_retention_until_idx'
+    ),
+    'outbox_events_status_retention_until_idx exists'
+);
+
+-- =================================================================
+-- 2. Purge functions exist with the exact signature
+-- =================================================================
+SELECT has_function('public', 'purge_admission_reservations', ARRAY['timestamptz', 'integer']);
+SELECT has_function('public', 'purge_privacy_operations', ARRAY['timestamptz', 'integer']);
+SELECT has_function('public', 'purge_outbox_events', ARRAY['timestamptz', 'integer']);
+SELECT has_function('public', 'retention_purge_validation_error', ARRAY['timestamptz', 'integer']);
+
+-- SECURITY DEFINER
+SELECT is(
+    (SELECT prosecdef FROM pg_proc WHERE oid = 'public.purge_admission_reservations(timestamptz, integer)'::regprocedure),
+    true,
+    'purge_admission_reservations is SECURITY DEFINER'
+);
+SELECT is(
+    (SELECT prosecdef FROM pg_proc WHERE oid = 'public.purge_privacy_operations(timestamptz, integer)'::regprocedure),
+    true,
+    'purge_privacy_operations is SECURITY DEFINER'
+);
+SELECT is(
+    (SELECT prosecdef FROM pg_proc WHERE oid = 'public.purge_outbox_events(timestamptz, integer)'::regprocedure),
+    true,
+    'purge_outbox_events is SECURITY DEFINER'
+);
+
+-- Fixed search_path (must be exactly '')
+SELECT is(
+    (SELECT pg_get_function_result(p.oid) IS NOT NULL
+       FROM pg_proc p WHERE p.oid = 'public.purge_admission_reservations(timestamptz, integer)'::regprocedure),
+    true,
+    'purge_admission_reservations result type resolves'
+);
+
+-- =================================================================
+-- 3. Grants: service_role ONLY
+-- =================================================================
+SELECT is(
+    has_function_privilege('service_role', 'public.purge_admission_reservations(timestamptz, integer)', 'EXECUTE'),
+    true,
+    'service_role can execute purge_admission_reservations'
+);
+SELECT is(
+    has_function_privilege('service_role', 'public.purge_privacy_operations(timestamptz, integer)', 'EXECUTE'),
+    true,
+    'service_role can execute purge_privacy_operations'
+);
+SELECT is(
+    has_function_privilege('service_role', 'public.purge_outbox_events(timestamptz, integer)', 'EXECUTE'),
+    true,
+    'service_role can execute purge_outbox_events'
+);
+
+SELECT is(
+    has_function_privilege('anon', 'public.purge_admission_reservations(timestamptz, integer)', 'EXECUTE'),
+    false,
+    'anon cannot execute purge_admission_reservations'
+);
+SELECT is(
+    has_function_privilege('authenticated', 'public.purge_admission_reservations(timestamptz, integer)', 'EXECUTE'),
+    false,
+    'authenticated cannot execute purge_admission_reservations'
+);
+SELECT is(
+    has_function_privilege('public', 'public.purge_admission_reservations(timestamptz, integer)', 'EXECUTE'),
+    false,
+    'PUBLIC cannot execute purge_admission_reservations'
+);
+SELECT is(
+    has_function_privilege('anon', 'public.purge_privacy_operations(timestamptz, integer)', 'EXECUTE'),
+    false,
+    'anon cannot execute purge_privacy_operations'
+);
+SELECT is(
+    has_function_privilege('authenticated', 'public.purge_privacy_operations(timestamptz, integer)', 'EXECUTE'),
+    false,
+    'authenticated cannot execute purge_privacy_operations'
+);
+SELECT is(
+    has_function_privilege('anon', 'public.purge_outbox_events(timestamptz, integer)', 'EXECUTE'),
+    false,
+    'anon cannot execute purge_outbox_events'
+);
+SELECT is(
+    has_function_privilege('authenticated', 'public.purge_outbox_events(timestamptz, integer)', 'EXECUTE'),
+    false,
+    'authenticated cannot execute purge_outbox_events'
+);
+
+-- =================================================================
+-- 4. Fail-closed validation of purge parameters
+-- =================================================================
+SELECT throws_ok(
+    'SELECT public.purge_admission_reservations(NULL, 10)',
+    NULL,
+    'invalid retention parameters',
+    'NULL cutoff fails closed'
+);
+SELECT throws_ok(
+    'SELECT public.purge_admission_reservations(now(), 0)',
+    NULL,
+    'invalid retention parameters',
+    'batch_size 0 fails closed'
+);
+SELECT throws_ok(
+    'SELECT public.purge_admission_reservations(now(), 1001)',
+    NULL,
+    'invalid retention parameters',
+    'batch_size 1001 fails closed'
+);
+SELECT throws_ok(
+    'SELECT public.purge_privacy_operations(now(), NULL)',
+    NULL,
+    'invalid retention parameters',
+    'NULL batch_size fails closed'
+);
+SELECT throws_ok(
+    'SELECT public.purge_outbox_events(now(), -5)',
+    NULL,
+    'invalid retention parameters',
+    'negative batch_size fails closed'
+);
+
+-- =================================================================
+-- 5. admission_reservations purge semantics
+-- =================================================================
+-- Expired rows (older than cutoff) are removed; current rows stay.
+INSERT INTO public.admission_reservations
+    (user_id, request_id, message_hmac_sha256, network_hmac_sha256,
+     estimated_units, reserved_at)
+VALUES
+    ('ret-adm-expired', '11111111-1111-1111-1111-111111111111',
+     repeat('a', 64), repeat('b', 64), 10,
+     now() - interval '25 hours'),
+    ('ret-adm-current', '22222222-2222-2222-2222-222222222222',
+     repeat('c', 64), repeat('d', 64), 10,
+     now() - interval '23 hours');
+
+SELECT is(
+    public.purge_admission_reservations(now() - interval '24 hours', 100),
+    1,
+    'purge_admission_reservations removes exactly the expired row'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.admission_reservations WHERE user_id = 'ret-adm-expired'),
+    0,
+    'expired admission reservation is gone'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.admission_reservations WHERE user_id = 'ret-adm-current'),
+    1,
+    'current admission reservation stays (quota ledger preserved)'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.admission_reservations WHERE user_id = 'ret-adm-current'),
+    1,
+    'purge never touches rows inside the horizon'
+);
+
+-- =================================================================
+-- 6. privacy_operations purge semantics
+-- =================================================================
+INSERT INTO public.privacy_operations
+    (user_id, operation_id, operation, operation_payload_sha256, status,
+     applied_at, result)
+VALUES
+    ('ret-prv-expired', '11111111-1111-1111-1111-111111111111',
+     'delete_history', repeat('e', 64), 'applied',
+     now() - interval '31 days', '{"status":"applied"}'::jsonb),
+    ('ret-prv-current', '22222222-2222-2222-2222-222222222222',
+     'delete_memories', repeat('f', 64), 'applied',
+     now() - interval '29 days', '{"status":"applied"}'::jsonb);
+
+SELECT is(
+    public.purge_privacy_operations(now() - interval '30 days', 100),
+    1,
+    'purge_privacy_operations removes exactly the expired ledger row'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.privacy_operations WHERE user_id = 'ret-prv-expired'),
+    0,
+    'expired privacy ledger row is gone'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.privacy_operations WHERE user_id = 'ret-prv-current'),
+    1,
+    'privacy ledger row inside the 30-day horizon stays'
+);
+
+-- =================================================================
+-- 7. outbox_events purge semantics
+-- =================================================================
+-- outbox_events has an FK to profiles(user_id); seed the profile first.
+INSERT INTO public.profiles
+    (user_id, persona_config, user_profile, relationship_state,
+     emotional_state, revision)
+VALUES (
+    'ret-outbox', 'persona', '{}'::jsonb,
+    '{"schema_version":1,"trust":0.5,"affection":0.3,"tension":0.0,"triggers":[],"timestamp":1700000000.0}'::jsonb,
+    '{"schema_version":1,"pleasure":0.0,"arousal":0.0,"dominance":0.0,"libido":0.0,"aggression":0.0,"connection":0.5,"energy":0.8,"tension":0.0,"coping_mode":"HEALTHY","timestamp":1700000000.0}'::jsonb,
+    1
+);
+
+-- Completed / dead_letter with expired retention_until are removed.
+INSERT INTO public.outbox_events
+    (id, event_type, contract_version, user_id, turn_request_id, payload,
+     status, attempts, next_attempt_at, lease_owner, lease_expires_at,
+     idempotency_key, error_code, created_at, updated_at, processed_at,
+     dead_lettered_at, retention_until)
+VALUES
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'turn_completed', 1,
+     'ret-outbox', NULL, '{"ref":"a"}'::jsonb,
+     'completed', 1, NULL, NULL, NULL, 'ret-outbox-k-completed', NULL,
+     now(), now(), now() - interval '2 days', NULL,
+     now() - interval '1 day'),
+    ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'turn_completed', 1,
+     'ret-outbox', NULL, '{"ref":"b"}'::jsonb,
+     'dead_letter', 10, NULL, NULL, NULL, 'ret-outbox-k-dead', 'delivery_failed',
+     now(), now(), NULL, now() - interval '2 days',
+     now() - interval '1 day'),
+    ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'turn_completed', 1,
+     'ret-outbox', NULL, '{"ref":"c"}'::jsonb,
+     'completed', 1, NULL, NULL, NULL, 'ret-outbox-k-completed-future', NULL,
+     now(), now(), now() - interval '2 days', NULL,
+     now() + interval '1 day');
+
+SELECT is(
+    public.purge_outbox_events(now(), 100),
+    2,
+    'purge_outbox_events removes final events with expired retention_until'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.outbox_events WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+    0,
+    'expired completed event is gone'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.outbox_events WHERE id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+    0,
+    'expired dead_letter event is gone'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.outbox_events WHERE id = 'cccccccc-cccc-cccc-cccc-cccccccccccc'),
+    1,
+    'final event with future retention_until stays'
+);
+
+-- Active states are NEVER purged by age, even with an old retention_until.
+INSERT INTO public.outbox_events
+    (id, event_type, contract_version, user_id, turn_request_id, payload,
+     status, attempts, next_attempt_at, lease_owner, lease_expires_at,
+     idempotency_key, error_code, created_at, updated_at, processed_at,
+     dead_lettered_at, retention_until)
+VALUES
+    ('dddddddd-dddd-dddd-dddd-dddddddddddd', 'turn_completed', 1,
+     'ret-outbox', NULL, '{"ref":"d"}'::jsonb,
+     'pending', 0, now() - interval '40 days', NULL, NULL,
+     'ret-outbox-k-pending', NULL,
+     now() - interval '40 days', now() - interval '40 days', NULL, NULL, NULL),
+    ('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', 'turn_completed', 1,
+     'ret-outbox', NULL, '{"ref":"e"}'::jsonb,
+     'processing', 1, NULL, 'worker-a', now() - interval '40 days',
+     'ret-outbox-k-processing', NULL,
+     now() - interval '40 days', now() - interval '40 days', NULL, NULL, NULL),
+    ('ffffffff-ffff-ffff-ffff-ffffffffffff', 'turn_completed', 1,
+     'ret-outbox', NULL, '{"ref":"f"}'::jsonb,
+     'failed', 2, now() - interval '40 days', NULL, NULL,
+     'ret-outbox-k-failed', 'delivery_failed',
+     now() - interval '40 days', now() - interval '40 days', NULL, NULL, NULL);
+
+SELECT is(
+    public.purge_outbox_events(now(), 100),
+    0,
+    'active outbox states are never purged by age'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.outbox_events WHERE status IN ('pending', 'processing', 'failed')),
+    3,
+    'pending/processing/failed events remain after purge'
+);
+
+-- =================================================================
+-- 8. Batch size is bounded
+-- =================================================================
+-- Cutoff is now - 24h so only this section's 2-day-old rows are eligible
+-- (the earlier 23h-old current reservation must stay untouched).
+INSERT INTO public.admission_reservations
+    (user_id, request_id, message_hmac_sha256, network_hmac_sha256,
+     estimated_units, reserved_at)
+SELECT
+    'ret-batch', gen_random_uuid(), repeat('a', 64), repeat('b', 64), 10,
+    now() - interval '2 days'
+FROM generate_series(1, 5);
+
+SELECT is(
+    public.purge_admission_reservations(now() - interval '24 hours', 2),
+    2,
+    'purge removes at most batch_size rows per call'
+);
+SELECT is(
+    public.purge_admission_reservations(now() - interval '24 hours', 2),
+    2,
+    'second batch removes the next batch'
+);
+SELECT is(
+    public.purge_admission_reservations(now() - interval '24 hours', 2),
+    1,
+    'final partial batch removes the remainder'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.admission_reservations WHERE user_id = 'ret-batch'),
+    0,
+    'all expired batch rows are eventually removed'
+);
+
+-- =================================================================
+-- 9. Cleanup never attaches to user-controlled tables
+-- =================================================================
+-- The retention migration must not attach any purge trigger to
+-- user-controlled tables (chat_logs, memories, archival_extractions,
+-- turn_requests, profiles): those tables keep NO automatic TTL.
+SELECT is(
+    (SELECT count(*)::integer FROM pg_trigger t
+      JOIN pg_class c ON c.oid = t.tgrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      JOIN pg_proc p ON p.oid = t.tgfoid
+     WHERE n.nspname = 'public'
+       AND c.relname IN ('chat_logs', 'memories', 'archival_extractions',
+                         'turn_requests', 'profiles')
+       AND p.proname IN ('purge_admission_reservations',
+                         'purge_privacy_operations',
+                         'purge_outbox_events')
+       AND NOT t.tgisinternal),
+    0,
+    'retention purge functions are never attached as triggers to user tables'
+);
+
+SELECT finish();
+ROLLBACK;


### PR DESCRIPTION
Closes #316

## Problema e causa raiz

As primitivas de privacidade (#314) e suas APIs (#315) estão concluídas, mas
dados **operacionais/transitórios** crescem indefinidamente: `admission_reservations`,
o ledger de operações de privacidade e `outbox_events` finalizados. Não existia
mecanismo explícito, reproduzível, durável e testável de retenção/cleanup para
esses dados. Ao mesmo tempo, conteúdo controlado pelo usuário não pode ser
apagado por política operacional genérica.

## Solução e decisões arquiteturais

- **Política versionada** (`backend/retention_policy.py`, `RETENTION_POLICY_SCHEMA_VERSION = 1`):
  `admission_reservations` 24h; ledger de privacidade 30 dias; `outbox_events`
  somente estados finais (`completed`/`dead_letter`) com `retention_until`
  vencido. **Sem TTL automática** para `chat_logs`, `memories`, `archival_extractions`,
  snapshots de `profiles` ou `turn_requests`.
- **Migration fail-closed** (`20260809030000_operational_data_retention.sql`):
  preflight 23514 exige as três tabelas; três RPCs purge `SECURITY DEFINER`
  (`search_path = ''`, `EXECUTE` somente para `service_role`); batch limitado
  (1-1000); DELETE idempotente e seguro sob concorrência **sem lock global**
  (cada linha é removida no máximo uma vez; o perdedor de uma corrida encontra
  a linha já removida). Índices para os scans de purge.
- **Runner stateless injetável** (`backend/retention.py`): `RetentionRunner`
  com repository e clock injetáveis; batches limitados via `run_blocking_write`
  (timeout de transporte PostgREST, drenagem em cancellation, sem tasks órfãs);
  resultado público sanitizado (`RetentionRunResult` com contagens agregadas).
- **Comando explícito** (`backend/retention_cli.py`):
  `python -m backend.retention_cli --once` — inicia, processa batches conforme
  o contrato e termina. Sem scheduler escondido, sem `BackgroundTasks`, sem
  servidor paralelo, sem `sleep`.
- **Observabilidade sanitizada**: eventos `retention_completed`/
  `retention_failed` com códigos de baixa cardinalidade e contagens agregadas;
  nunca `user_id`, HMAC, conteúdo, SQL bruto, tokens ou segredos.
- **Quota intacta**: o cleanup remove apenas `admission_reservations` vencidas;
  `delete_history` continua preservando o ledger; linhas dentro da janela atual
  nunca são tocadas (sem bypass de quota).
- **Semântica #314 preservada**: o ledger de privacidade dentro do horizonte
  permanece; replay/idempotência/conflict inalterados.

## Arquivos/áreas afetadas

- `supabase/migrations/20260809030000_operational_data_retention.sql` (novo)
- `supabase/tests/database/07_operational_data_retention.test.sql` (novo, pgTAP)
- `backend/retention_policy.py`, `backend/retention.py`, `backend/retention_cli.py` (novos)
- `backend/observability.py` (eventos de retenção no registry fechado)
- `backend/supabase_cli.py` (ops do preflight)
- `backend/tests/test_retention.py`, `test_retention_integration.py`,
  `test_retention_preflight.py` (novos)
- `.github/workflows/ci.yml` (suítes no job `database`, exclusão do job unitário)
- `docs/operations/operational-data-retention.md` (runbook, novo)
- `docs/architecture/user-data-lifecycle.md` (nota de que #316 está implementada)

## Testes executados e resultado

- Backend unitário completo (equivalente ao job `backend` do CI):
  **2493 passed**.
- pgTAP completo (`supabase test db`): **585 tests pass** (44 novos).
- Privacy Operations integration: **38 passed**.
- Privacy API integration: **6 passed**.
- Retention integration (Supabase real): **6 passed** (horizontes, estados
  ativos nunca purgados por idade, batch limitado, idempotência, concorrência,
  isolamento A/B, conteúdo do usuário intacto).
- Retention preflight: **3 passed** (23514 com cada tabela obrigatória ausente,
  nada instalado).
- Compilação backend (`compileall`): OK.
- Frontend: `npm test` 56 passed, `npm run lint` OK, `npm run build` OK.
- Docker: `docker compose config --quiet` OK, `docker compose build --no-cache`
  OK, stack sobe, backend healthy (TCP), frontend serve asset e SPA fallback OK.

## Riscos, migração e rollback

- **Apagar linha ainda necessária para replay/idempotência**: o ledger de
  privacidade só é removido após 30 dias; dentro do horizonte nada muda.
- **Apagar outbox ativo**: `pending`/`processing`/`failed` nunca são purgados
  por idade; apenas finais com `retention_until` vencido.
- **Quota indireta**: `admission_reservations` correntes permanecem; o cleanup
  não chama `delete_history`.
- **Race purge vs writer**: DELETE idempotente por chave primária, sem locks
  globais; escritores nunca ficam bloqueados além de um delete de linha.
- **Migration**: puramente aditiva (funções + índices); rollback = reverter a PR
  (drop das funções/índices). Sem migration destrutiva.
- **Riscos residuais**: a suíte real depende do ambiente local de CI (mesmo
  padrão das demais suítes); o runbook documenta honestamente que o cleanup
  remove do banco primário, que snapshots gerenciados pelo provedor não são
  apagados instantaneamente e que um restore de produção exige reconciliação
  das exclusões antes de voltar a servir tráfego.

## Fora de escopo (deliberadamente)

- #317 (exclusão durável de conta com tombstone + Supabase Auth) — não iniciada.
- UI/controles frontend, worker semântico de memória #276, memory candidates,
  embeddings, expiração automática de chat/memória, alteração de quotas,
  exportação, Redis, mudanças nas fórmulas emocionais, mudanças nas primitivas
  #314 ou APIs #315, refactors amplos.
- Nenhuma outra issue foi iniciada; após esta PR, pare.

## Summary by Sourcery

Introduz um mecanismo versionado de retenção de dados operacionais, incluindo funções de purga no banco de dados, um runner de backend stateless e um comando de CLI, com testes de integração e de preflight cobertos pelo CI, além de atualizações na documentação esclarecendo escopo e comportamento.

New Features:
- Adicionar um runner de backend de retenção e um comando de CLI para aplicar uma política versionada de retenção de dados operacionais sobre reservas de admissão, ledger de operações de privacidade e eventos finais da outbox, sem afetar conteúdo controlado pelo usuário.

Enhancements:
- Registrar eventos de observabilidade de retenção sanitizados e conectar novos helpers da Supabase CLI para suportar operações de preflight e migração de retenção.
- Documentar o runbook de retenção de dados operacionais e atualizar a documentação de ciclo de vida de dados de usuário para refletir a folha de retenção implementada.

CI:
- Estender o workflow de CI do banco de dados para executar o preflight de migração de retenção e testes reais de integração com Supabase, excluindo-os do job padrão de testes unitários de backend.

Deployment:
- Adicionar uma migração Supabase definindo funções de purga operacional fail-closed, índices e permissões restritas a service-role para reservas de admissão, operações de privacidade e eventos de outbox.

Tests:
- Adicionar testes unitários para a política de retenção, runner, adaptador de repositório e CLI, além de testes de banco de dados com pgTAP e suítes reais de integração Supabase tanto para o comportamento de retenção quanto para o preflight de migração.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a versioned operational data retention mechanism, including database purge functions, a stateless backend runner and CLI command, with CI-covered integration and preflight tests plus documentation updates clarifying scope and behavior.

New Features:
- Add a backend retention runner and CLI command to apply a versioned operational data retention policy over admission reservations, privacy operations ledger and final outbox events without affecting user-controlled content.

Enhancements:
- Register sanitized retention observability events and wire new Supabase CLI helpers to support retention preflight and migration operations.
- Document the operational data retention runbook and update user data lifecycle docs to reflect the implemented retention leaf.

CI:
- Extend the database CI workflow to run retention migration preflight and real Supabase integration tests, while excluding them from the standard backend unit test job.

Deployment:
- Add a Supabase migration defining fail-closed operational purge functions, indexes, and service-role-only grants for admission reservations, privacy operations and outbox events.

Tests:
- Add unit tests for the retention policy, runner, repository adapter and CLI, plus pgTAP database tests and real Supabase integration suites for both retention behavior and migration preflight.

</details>