### PR TITLE
feat(privacy): add durable account deletion ledger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,51 @@ jobs:
           set -euo pipefail
           python -m pytest -q -ra backend/tests/test_retention_integration.py
 
+      - name: Run Account Deletion Integration Tests
+        env:
+          SUPABASE_URL: "http://127.0.0.1:54321"
+          SUPABASE_ANON_KEY: "${{ env.SUPABASE_ANON_KEY }}"
+          SUPABASE_SERVICE_ROLE_KEY: "${{ env.SUPABASE_SERVICE_ROLE_KEY }}"
+          PYTHONPATH: "."
+        run: |
+          set -euo pipefail
+          python -m pytest -q -ra backend/tests/test_account_deletion_integration.py
+
+      - name: Reset database for account deletion legacy upgrade test
+        run: |
+          set -euo pipefail
+          supabase db reset
+
+      - name: Run Account Deletion Legacy Upgrade Test
+        env:
+          SUPABASE_URL: "http://127.0.0.1:54321"
+          SUPABASE_SERVICE_ROLE_KEY: "${{ env.SUPABASE_SERVICE_ROLE_KEY }}"
+          PYTHONPATH: "."
+        run: |
+          set -euo pipefail
+          # Simulates a legacy database (migrations before the account
+          # deletion ledger) and applies the new migration via
+          # `supabase migration up --local`.
+          bash scripts/hide-migrations-after.sh 20260809030000 \
+            python -m pytest -q -ra backend/tests/test_account_deletion_legacy.py
+
+      - name: Reset database for account deletion preflight tests
+        run: |
+          set -euo pipefail
+          supabase db reset
+
+      - name: Run Account Deletion Preflight Test (missing dependency -> 23514)
+        env:
+          SUPABASE_URL: "http://127.0.0.1:54321"
+          PYTHONPATH: "."
+        run: |
+          set -euo pipefail
+          # Each case hides the new migration, resets the pre-ledger
+          # baseline, drops exactly one mandatory table and requires the
+          # migration to fail with 23514 before installing anything.
+          bash scripts/hide-migrations-after.sh 20260809030000 \
+            python -m pytest -q -ra backend/tests/test_account_deletion_preflight.py
+
       - name: Stop Supabase
         if: always()
         run: supabase stop
@@ -386,6 +431,9 @@ jobs:
               --ignore=backend/tests/test_privacy_api_integration.py \
               --ignore=backend/tests/test_retention_integration.py \
               --ignore=backend/tests/test_retention_preflight.py \
+              --ignore=backend/tests/test_account_deletion_integration.py \
+              --ignore=backend/tests/test_account_deletion_legacy.py \
+              --ignore=backend/tests/test_account_deletion_preflight.py \
               -ra
 
   frontend:

--- a/backend/account_deletion.py
+++ b/backend/account_deletion.py
@@ -1,0 +1,636 @@
+"""Durable account deletion ledger contract (#324).
+
+Server-side Python contract for the account deletion job ledger exposed by
+migration ``20260810120000_account_deletion_ledger``. This module is pure
+Python: no FastAPI, no Groq, no embeddings, no Supabase client construction
+at import time. It mirrors ``backend.privacy_operations`` and
+``backend.atomic_turn_commit``: validation runs BEFORE the RPC and unexpected
+persistence failures surface as sanitized ``PersistenceError``.
+
+Scope (deliberately narrow)
+==========================
+This PR stops at the database foundation:
+
+* domain models and strict parsers for the RPC envelopes;
+* a ``compute_account_deletion_user_ref`` HMAC helper with a DEDICATED
+  account-deletion domain (never correlated with the message/network/
+  correlation/user-reference domains);
+* a repository protocol + Supabase adapter for the eight runtime RPCs.
+
+There is deliberately NO HTTP endpoint, NO Supabase Auth Admin call and NO
+worker/CLI here: those belong to #325 (Auth deletion) and #326 (HTTP gate).
+
+Design guarantees (enforced by the database, mirrored here)
+===========================================================
+* Identity comes ONLY from ``authenticated_user_id`` (server-side
+  boundary). The persistent reference is an HMAC-SHA256 (lowercase hex,
+  64 chars) under the dedicated ``account-deletion`` domain.
+* Idempotency: the same (user_ref, operation_id) with the same intent
+  fingerprint is an exact replay; a divergent fingerprint is a sanitized
+  ``operation_conflict``. Different users never collide because the
+  reference is a domain-separated HMAC of the identity.
+* State machine: pending -> processing -> (failed | pending retry) ->
+  processing -> completed. ``db_purged_at`` is set only in the purge
+  transaction; ``user_id`` is minimized to NULL on finalize.
+* Every RPC result parser is strict: allowlisted fields, exact types
+  (bools rejected where ints are expected), UUID/hex/status validation,
+  unknown or missing fields fail closed, and a divergent identity in an
+  RPC result never leaks into an exception message.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import re
+import uuid as _uuid
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional
+
+from backend.atomic_turn_commit import (
+    ConflictError,
+    PersistenceError,
+    ValidationError,
+)
+from backend.admission import _validate_secret_bytes
+
+#: Dedicated HMAC domain for account deletion references. MUST stay distinct
+#: from the message/network/turn-correlation/user-reference domains so a
+#: persisted reference can never be correlated with USER_REFERENCE_DOMAIN
+#: values or any other purpose.
+ACCOUNT_DELETION_HMAC_DOMAIN = b"account-deletion"
+
+#: Ledger statuses (must match the database CHECK constraint).
+STATUS_PENDING = "pending"
+STATUS_PROCESSING = "processing"
+STATUS_COMPLETED = "completed"
+STATUS_FAILED = "failed"
+ACCOUNT_DELETION_STATUSES = frozenset(
+    {STATUS_PENDING, STATUS_PROCESSING, STATUS_COMPLETED, STATUS_FAILED}
+)
+
+#: Sanitized error codes used by the SQL boundary.
+ERROR_VALIDATION_FAILED = "validation_failed"
+ERROR_OPERATION_CONFLICT = "operation_conflict"
+ERROR_STATE_CONFLICT = "state_conflict"
+
+#: Lowercase hex patterns (same as the database).
+_HEX64_RE = re.compile(r"^[0-9a-f]{64}$")
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+_WORKER_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,64}$")
+_ERROR_CODE_RE = re.compile(r"^[a-z0-9_]{1,64}$")
+
+
+def compute_account_deletion_user_ref(secret_bytes: bytes, user_id: object) -> str:
+    """Compute the persistent, non-reversible HMAC reference for a user.
+
+    Domain-separated from every other HMAC purpose (dedicated
+    ``account-deletion`` domain), so the persisted reference can never be
+    correlated with ``USER_REFERENCE_DOMAIN`` values. Returns the exact
+    lowercase 64-character hex HMAC. The raw ``user_id`` is never logged.
+    """
+    validated_secret = _validate_secret_bytes(secret_bytes)
+    if not isinstance(user_id, str) or not user_id or not user_id.strip():
+        raise ValidationError("invalid_user_id", "user_id is invalid")
+    return hmac.new(
+        validated_secret,
+        ACCOUNT_DELETION_HMAC_DOMAIN + b"\x00" + user_id.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def compute_intent_fingerprint(payload: Mapping[str, Any]) -> str:
+    """Deterministic SHA-256 of the canonical JSON intent payload.
+
+    Mirrors the SQL helper ``account_deletion_intent_fingerprint_sha256``:
+    canonical ``json.dumps`` with sorted keys, compact separators, matching
+    the canonical ``jsonb::text`` serialization used by the database for
+    object payloads. Returns lowercase hex (64 chars).
+    """
+    if not isinstance(payload, Mapping):
+        raise ValidationError("invalid_intent_payload", "intent payload must be a JSON object")
+    canonical = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# ─── Strict envelope parsers ────────────────────────────────────────────────
+
+
+def _require_mapping(value: object, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise PersistenceError("database_error", "malformed retention response")
+    return value
+
+
+def _require_fields(
+    envelope: Mapping[str, Any],
+    required: frozenset[str],
+    optional: frozenset[str] = frozenset(),
+    label: str = "",
+) -> None:
+    """Require exactly *required* plus optionally *optional* fields.
+
+    PostgREST omits JSON null values from responses, so optional nullable
+    fields may be absent and are parsed as None.
+    """
+    keys = set(envelope)
+    if not required.issubset(keys) or not keys.issubset(required | optional):
+        raise PersistenceError("database_error", "malformed retention response")
+
+
+def _require_text(envelope: Mapping[str, Any], key: str) -> str:
+    value = envelope.get(key)
+    if not isinstance(value, str):
+        raise PersistenceError("database_error", "malformed retention response")
+    return value
+
+
+def _require_uuid_text(envelope: Mapping[str, Any], key: str) -> str:
+    value = _require_text(envelope, key)
+    if not _UUID_RE.match(value):
+        raise PersistenceError("database_error", "malformed retention response")
+    return value
+
+
+def _require_hex64(envelope: Mapping[str, Any], key: str) -> str:
+    value = _require_text(envelope, key)
+    if not _HEX64_RE.match(value):
+        raise PersistenceError("database_error", "malformed retention response")
+    return value
+
+
+def _optional_text(envelope: Mapping[str, Any], key: str) -> Optional[str]:
+    value = envelope.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise PersistenceError("database_error", "malformed retention response")
+    return value
+
+
+def _require_int(envelope: Mapping[str, Any], key: str) -> int:
+    value = envelope.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise PersistenceError("database_error", "malformed retention response")
+    return value
+
+
+def _parse_error_envelope(envelope: Mapping[str, Any]) -> "AccountDeletionError":
+    if set(envelope) != frozenset({"error"}):
+        raise PersistenceError("database_error", "malformed retention response")
+    error = _require_mapping(envelope["error"], "error")
+    if set(error) != frozenset({"code", "message"}):
+        raise PersistenceError("database_error", "malformed retention response")
+    code = _require_text(error, "code")
+    message = _require_text(error, "message")
+    return AccountDeletionError(code=code, message=message)
+
+
+# ─── Domain results ─────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class AccountDeletionError:
+    """Structured, sanitized error returned by the SQL boundary."""
+
+    code: str
+    message: str
+
+
+@dataclass(frozen=True)
+class RequestResult:
+    """Outcome of ``account_deletion_request``."""
+
+    status: str  # 'created' | 'replay'
+    job_id: str
+    job_status: str
+    db_purged_at: Optional[str] = None
+    completed_at: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class TombstoneStatus:
+    """Outcome of ``account_deletion_has_tombstone``."""
+
+    exists: bool
+    status: Optional[str]
+
+
+@dataclass(frozen=True)
+class AcquiredJob:
+    """One job claimed by a worker via ``account_deletion_acquire_lease``."""
+
+    job_id: str
+    user_id: str
+    user_ref_hmac_sha256: str
+    operation_id: str
+    status: str
+    lease_owner: str
+    lease_expires_at: str
+    attempts: int
+    db_purged_at: Optional[str]
+    intent_fingerprint_sha256: str
+
+
+@dataclass(frozen=True)
+class PurgeResult:
+    """Outcome of ``account_deletion_purge``."""
+
+    status: str  # 'purged' | 'already_purged'
+    job_id: str
+    db_purged_at: str
+    counts: Mapping[str, int]
+
+
+@dataclass(frozen=True)
+class FailureResult:
+    """Outcome of ``account_deletion_record_failure``."""
+
+    status: str
+    job_id: str
+    error_code: str
+    next_attempt_at: str
+
+
+@dataclass(frozen=True)
+class RetryResult:
+    """Outcome of ``account_deletion_record_retry``."""
+
+    status: str
+    job_id: str
+    next_attempt_at: str
+
+
+@dataclass(frozen=True)
+class FinalizeResult:
+    """Outcome of ``account_deletion_finalize``."""
+
+    status: str
+    job_id: str
+    completed_at: str
+    db_purged_at: str
+
+
+# ─── Parsers ────────────────────────────────────────────────────────────────
+
+
+def _parse_request_result(response: object) -> RequestResult:
+    envelope = _require_mapping(response, "request result")
+    if "error" in envelope:
+        error = _parse_error_envelope(envelope)
+        if error.code == ERROR_OPERATION_CONFLICT:
+            raise ConflictError(ERROR_OPERATION_CONFLICT, error.message, 0)
+        raise ValidationError(ERROR_VALIDATION_FAILED, error.message)
+    _require_fields(
+        envelope,
+        frozenset({"status", "job_id", "job_status"}),
+        frozenset({"db_purged_at", "completed_at"}),
+        "request result",
+    )
+    status = _require_text(envelope, "status")
+    if status not in ("created", "replay"):
+        raise PersistenceError("database_error", "malformed retention response")
+    job_status = _require_text(envelope, "job_status")
+    if job_status not in ACCOUNT_DELETION_STATUSES:
+        raise PersistenceError("database_error", "malformed retention response")
+    return RequestResult(
+        status=status,
+        job_id=_require_uuid_text(envelope, "job_id"),
+        job_status=job_status,
+        db_purged_at=_optional_text(envelope, "db_purged_at"),
+        completed_at=_optional_text(envelope, "completed_at"),
+    )
+
+
+def _parse_tombstone_result(response: object) -> TombstoneStatus:
+    envelope = _require_mapping(response, "tombstone result")
+    if "error" in envelope:
+        error = _parse_error_envelope(envelope)
+        raise ValidationError(ERROR_VALIDATION_FAILED, error.message)
+    _require_fields(envelope, frozenset({"exists"}), frozenset({"status"}), label="tombstone result")
+    exists = envelope.get("exists")
+    if not isinstance(exists, bool):
+        raise PersistenceError("database_error", "malformed retention response")
+    status = envelope.get("status")
+    if status is not None and (
+        not isinstance(status, str) or status not in ACCOUNT_DELETION_STATUSES
+    ):
+        raise PersistenceError("database_error", "malformed retention response")
+    return TombstoneStatus(exists=exists, status=status)
+
+
+def _parse_acquired_job(response: object, expected_user_id: Optional[str] = None) -> AcquiredJob:
+    envelope = _require_mapping(response, "acquire result")
+    if "error" in envelope:
+        error = _parse_error_envelope(envelope)
+        raise ValidationError(ERROR_VALIDATION_FAILED, error.message)
+    if envelope.get("found") is False:
+        raise PersistenceError("database_error", "malformed retention response")
+    _require_fields(
+        envelope,
+        frozenset(
+            {
+                "found",
+                "job_id",
+                "user_id",
+                "user_ref_hmac_sha256",
+                "operation_id",
+                "status",
+                "lease_owner",
+                "lease_expires_at",
+                "attempts",
+                "intent_fingerprint_sha256",
+            }
+        ),
+        frozenset({"db_purged_at"}),
+        "acquire result",
+    )
+    found = envelope.get("found")
+    if not isinstance(found, bool) or found is not True:
+        raise PersistenceError("database_error", "malformed retention response")
+    user_id = _require_text(envelope, "user_id")
+    if expected_user_id is not None and user_id != expected_user_id:
+        # Never echo the divergent identity: fail closed sanitized.
+        raise PersistenceError("database_error", "identity mismatch")
+    status = _require_text(envelope, "status")
+    if status != STATUS_PROCESSING:
+        raise PersistenceError("database_error", "malformed retention response")
+    return AcquiredJob(
+        job_id=_require_uuid_text(envelope, "job_id"),
+        user_id=user_id,
+        user_ref_hmac_sha256=_require_hex64(envelope, "user_ref_hmac_sha256"),
+        operation_id=_require_uuid_text(envelope, "operation_id"),
+        status=status,
+        lease_owner=_require_text(envelope, "lease_owner"),
+        lease_expires_at=_require_text(envelope, "lease_expires_at"),
+        attempts=_require_int(envelope, "attempts"),
+        db_purged_at=_optional_text(envelope, "db_purged_at"),
+        intent_fingerprint_sha256=_require_hex64(envelope, "intent_fingerprint_sha256"),
+    )
+
+
+def _parse_purge_result(response: object) -> PurgeResult:
+    envelope = _require_mapping(response, "purge result")
+    if "error" in envelope:
+        error = _parse_error_envelope(envelope)
+        if error.code == ERROR_OPERATION_CONFLICT:
+            raise ConflictError(ERROR_OPERATION_CONFLICT, error.message, 0)
+        raise ValidationError(ERROR_VALIDATION_FAILED, error.message)
+    _require_fields(envelope, frozenset({"status", "job_id", "db_purged_at", "counts"}), label="purge result")
+    status = _require_text(envelope, "status")
+    if status not in ("purged", "already_purged"):
+        raise PersistenceError("database_error", "malformed retention response")
+    counts = _require_mapping(envelope["counts"], "purge counts")
+    expected_counts = frozenset(
+        {
+            "outbox_events",
+            "turn_requests",
+            "archival_extractions",
+            "memories",
+            "chat_logs",
+            "admission_reservations",
+            "privacy_operations",
+            "profiles",
+        }
+    )
+    if set(counts) != expected_counts:
+        raise PersistenceError("database_error", "malformed retention response")
+    parsed_counts = {key: _require_int(counts, key) for key in expected_counts}
+    return PurgeResult(
+        status=status,
+        job_id=_require_uuid_text(envelope, "job_id"),
+        db_purged_at=_require_text(envelope, "db_purged_at"),
+        counts=parsed_counts,
+    )
+
+
+def _parse_failure_result(response: object) -> FailureResult:
+    envelope = _require_mapping(response, "failure result")
+    if "error" in envelope:
+        error = _parse_error_envelope(envelope)
+        raise ValidationError(ERROR_VALIDATION_FAILED, error.message)
+    _require_fields(envelope, frozenset({"status", "job_id", "error_code", "next_attempt_at"}), label="failure result")
+    if _require_text(envelope, "status") != "failed":
+        raise PersistenceError("database_error", "malformed retention response")
+    error_code = _require_text(envelope, "error_code")
+    if not _ERROR_CODE_RE.match(error_code):
+        raise PersistenceError("database_error", "malformed retention response")
+    return FailureResult(
+        status="failed",
+        job_id=_require_uuid_text(envelope, "job_id"),
+        error_code=error_code,
+        next_attempt_at=_require_text(envelope, "next_attempt_at"),
+    )
+
+
+def _parse_retry_result(response: object) -> RetryResult:
+    envelope = _require_mapping(response, "retry result")
+    if "error" in envelope:
+        error = _parse_error_envelope(envelope)
+        raise ValidationError(ERROR_VALIDATION_FAILED, error.message)
+    _require_fields(envelope, frozenset({"status", "job_id", "next_attempt_at"}), label="retry result")
+    if _require_text(envelope, "status") != "retry_scheduled":
+        raise PersistenceError("database_error", "malformed retention response")
+    return RetryResult(
+        status="retry_scheduled",
+        job_id=_require_uuid_text(envelope, "job_id"),
+        next_attempt_at=_require_text(envelope, "next_attempt_at"),
+    )
+
+
+def _parse_finalize_result(response: object) -> FinalizeResult:
+    envelope = _require_mapping(response, "finalize result")
+    if "error" in envelope:
+        error = _parse_error_envelope(envelope)
+        if error.code == ERROR_STATE_CONFLICT:
+            raise ConflictError(ERROR_OPERATION_CONFLICT, error.message, 0)
+        raise ValidationError(ERROR_VALIDATION_FAILED, error.message)
+    _require_fields(envelope, frozenset({"status", "job_id", "completed_at", "db_purged_at"}), label="finalize result")
+    if _require_text(envelope, "status") != "completed":
+        raise PersistenceError("database_error", "malformed retention response")
+    return FinalizeResult(
+        status="completed",
+        job_id=_require_uuid_text(envelope, "job_id"),
+        completed_at=_require_text(envelope, "completed_at"),
+        db_purged_at=_require_text(envelope, "db_purged_at"),
+    )
+
+
+def _parse_int_result(response: object) -> int:
+    if isinstance(response, bool) or not isinstance(response, int) or response < 0:
+        raise PersistenceError("database_error", "malformed retention response")
+    return response
+
+
+# ─── Repository boundary ────────────────────────────────────────────────────
+
+
+class AccountDeletionRepository:
+    """Synchronous RPC contract for the account deletion ledger.
+
+    All methods are thread-bound and never awaited directly. Responses are
+    strictly validated; malformed payloads and divergent identities fail
+    closed with sanitized ``PersistenceError``.
+    """
+
+    def request(
+        self,
+        authenticated_user_id: str,
+        user_ref_hmac_sha256: str,
+        operation_id: str,
+        intent_fingerprint_sha256: str,
+    ) -> RequestResult: ...
+
+    def has_tombstone(self, user_ref_hmac_sha256: str) -> TombstoneStatus: ...
+
+    def acquire_lease(
+        self, worker_id: str, lease_seconds: int, max_batch: int
+    ) -> AcquiredJob: ...
+
+    def purge(
+        self,
+        job_id: str,
+        worker_id: str,
+        intent_fingerprint_sha256: str,
+        expected_user_id: Optional[str] = None,
+    ) -> PurgeResult: ...
+
+    def record_failure(self, job_id: str, worker_id: str, error_code: str) -> FailureResult: ...
+
+    def record_retry(self, job_id: str, worker_id: str) -> RetryResult: ...
+
+    def finalize(self, job_id: str, worker_id: str) -> FinalizeResult: ...
+
+    def purge_completed(self, cutoff: str, batch_size: int) -> int: ...
+
+
+def _rpc_call(
+    client: Any,
+    rpc_name: str,
+    params: Mapping[str, Any],
+) -> Any:
+    if client is None:
+        raise PersistenceError("database_error", "persistence error")
+    try:
+        return client.rpc(rpc_name, params).execute().data
+    except PersistenceError:
+        raise
+    except Exception:
+        raise PersistenceError("database_error", "persistence error") from None
+
+
+class SupabaseAccountDeletionRepository:
+    """Synchronous adapter over ``client.rpc(name, params).execute()``.
+
+    Upstream exceptions (which may carry connection details, identifiers or
+    payload content) are never surfaced: everything maps to a sanitized
+    ``PersistenceError``. Results are parsed fail-closed by the strict
+    parsers above.
+    """
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    def request(
+        self,
+        authenticated_user_id: str,
+        user_ref_hmac_sha256: str,
+        operation_id: str,
+        intent_fingerprint_sha256: str,
+    ) -> RequestResult:
+        data = _rpc_call(
+            self._client,
+            "account_deletion_request",
+            {
+                "p_authenticated_user_id": authenticated_user_id,
+                "p_user_ref_hmac_sha256": user_ref_hmac_sha256,
+                "p_operation_id": operation_id,
+                "p_intent_fingerprint_sha256": intent_fingerprint_sha256,
+            },
+        )
+        return _parse_request_result(data)
+
+    def has_tombstone(self, user_ref_hmac_sha256: str) -> TombstoneStatus:
+        data = _rpc_call(
+            self._client,
+            "account_deletion_has_tombstone",
+            {"p_user_ref_hmac_sha256": user_ref_hmac_sha256},
+        )
+        return _parse_tombstone_result(data)
+
+    def acquire_lease(
+        self,
+        worker_id: str,
+        lease_seconds: int,
+        max_batch: int,
+        expected_user_id: Optional[str] = None,
+    ) -> AcquiredJob:
+        data = _rpc_call(
+            self._client,
+            "account_deletion_acquire_lease",
+            {
+                "p_worker_id": worker_id,
+                "p_lease_seconds": lease_seconds,
+                "p_max_batch": max_batch,
+            },
+        )
+        return _parse_acquired_job(data, expected_user_id=expected_user_id)
+
+    def purge(
+        self,
+        job_id: str,
+        worker_id: str,
+        intent_fingerprint_sha256: str,
+        expected_user_id: Optional[str] = None,
+    ) -> PurgeResult:
+        data = _rpc_call(
+            self._client,
+            "account_deletion_purge",
+            {
+                "p_job_id": job_id,
+                "p_worker_id": worker_id,
+                "p_intent_fingerprint_sha256": intent_fingerprint_sha256,
+            },
+        )
+        return _parse_purge_result(data)
+
+    def record_failure(self, job_id: str, worker_id: str, error_code: str) -> FailureResult:
+        data = _rpc_call(
+            self._client,
+            "account_deletion_record_failure",
+            {
+                "p_job_id": job_id,
+                "p_worker_id": worker_id,
+                "p_error_code": error_code,
+            },
+        )
+        return _parse_failure_result(data)
+
+    def record_retry(self, job_id: str, worker_id: str) -> RetryResult:
+        data = _rpc_call(
+            self._client,
+            "account_deletion_record_retry",
+            {"p_job_id": job_id, "p_worker_id": worker_id},
+        )
+        return _parse_retry_result(data)
+
+    def finalize(self, job_id: str, worker_id: str) -> FinalizeResult:
+        data = _rpc_call(
+            self._client,
+            "account_deletion_finalize",
+            {"p_job_id": job_id, "p_worker_id": worker_id},
+        )
+        return _parse_finalize_result(data)
+
+    def purge_completed(self, cutoff: str, batch_size: int) -> int:
+        data = _rpc_call(
+            self._client,
+            "account_deletion_purge_completed",
+            {"p_cutoff": cutoff, "p_batch_size": batch_size},
+        )
+        return _parse_int_result(data)

--- a/backend/account_deletion.py
+++ b/backend/account_deletion.py
@@ -74,6 +74,12 @@ ACCOUNT_DELETION_STATUSES = frozenset(
 ERROR_VALIDATION_FAILED = "validation_failed"
 ERROR_OPERATION_CONFLICT = "operation_conflict"
 ERROR_STATE_CONFLICT = "state_conflict"
+ERROR_ATTEMPTS_EXHAUSTED = "attempts_exhausted"
+
+#: Deterministic exhaustion ceiling (mirrors the SQL constant): a failed
+#: job whose attempts reach this ceiling is terminal (next_attempt_at NULL)
+#: and never claimed automatically again.
+ACCOUNT_DELETION_MAX_ATTEMPTS = 100
 
 #: Lowercase hex patterns (same as the database).
 _HEX64_RE = re.compile(r"^[0-9a-f]{64}$")
@@ -414,17 +420,24 @@ def _parse_failure_result(response: object) -> FailureResult:
     if "error" in envelope:
         error = _parse_error_envelope(envelope)
         raise ValidationError(ERROR_VALIDATION_FAILED, error.message)
-    _require_fields(envelope, frozenset({"status", "job_id", "error_code", "next_attempt_at"}), label="failure result")
+    _require_fields(
+        envelope,
+        frozenset({"status", "job_id", "error_code"}),
+        frozenset({"next_attempt_at"}),
+        label="failure result",
+    )
     if _require_text(envelope, "status") != "failed":
         raise PersistenceError("database_error", "malformed retention response")
     error_code = _require_text(envelope, "error_code")
     if not _ERROR_CODE_RE.match(error_code):
         raise PersistenceError("database_error", "malformed retention response")
+    # next_attempt_at is NULL for a TERMINAL exhausted job (PostgREST may
+    # send the field as null or omit it).
     return FailureResult(
         status="failed",
         job_id=_require_uuid_text(envelope, "job_id"),
         error_code=error_code,
-        next_attempt_at=_require_text(envelope, "next_attempt_at"),
+        next_attempt_at=_optional_text(envelope, "next_attempt_at"),
     )
 
 
@@ -433,14 +446,34 @@ def _parse_retry_result(response: object) -> RetryResult:
     if "error" in envelope:
         error = _parse_error_envelope(envelope)
         raise ValidationError(ERROR_VALIDATION_FAILED, error.message)
-    _require_fields(envelope, frozenset({"status", "job_id", "next_attempt_at"}), label="retry result")
-    if _require_text(envelope, "status") != "retry_scheduled":
-        raise PersistenceError("database_error", "malformed retention response")
-    return RetryResult(
-        status="retry_scheduled",
-        job_id=_require_uuid_text(envelope, "job_id"),
-        next_attempt_at=_require_text(envelope, "next_attempt_at"),
-    )
+    # Normal deferral: back to pending with a scheduled next_attempt_at.
+    if envelope.get("status") == "retry_scheduled":
+        _require_fields(
+            envelope,
+            frozenset({"status", "job_id", "next_attempt_at"}),
+            label="retry result",
+        )
+        return RetryResult(
+            status="retry_scheduled",
+            job_id=_require_uuid_text(envelope, "job_id"),
+            next_attempt_at=_require_text(envelope, "next_attempt_at"),
+        )
+    # Exhausted deferral: the attempts ceiling was reached, the job became
+    # a terminal failed job (next_attempt_at NULL, absent from the
+    # PostgREST response).
+    if envelope.get("status") == "failed" and envelope.get("error_code") == ERROR_ATTEMPTS_EXHAUSTED:
+        _require_fields(
+            envelope,
+            frozenset({"status", "job_id", "error_code"}),
+            frozenset({"next_attempt_at"}),
+            label="retry result",
+        )
+        return RetryResult(
+            status="failed",
+            job_id=_require_uuid_text(envelope, "job_id"),
+            next_attempt_at=None,
+        )
+    raise PersistenceError("database_error", "malformed retention response")
 
 
 def _parse_finalize_result(response: object) -> FinalizeResult:

--- a/backend/supabase_cli.py
+++ b/backend/supabase_cli.py
@@ -27,6 +27,12 @@ ALLOWED_OPS = frozenset({
     "retention_preflight_reset",
     "retention_preflight_apply",
     "retention_preflight_query",
+    "account_deletion_preflight_reset",
+    "account_deletion_preflight_apply",
+    "account_deletion_preflight_query",
+    "account_deletion_legacy_reset",
+    "account_deletion_legacy_upgrade",
+    "account_deletion_legacy_query",
 })
 
 

--- a/backend/tests/test_account_deletion.py
+++ b/backend/tests/test_account_deletion.py
@@ -240,6 +240,21 @@ def test_failure_and_retry_and_finalize_parse():
     assert finalize.status == "completed"
 
 
+def test_exhausted_retry_parses_as_terminal_failed():
+    """record_retry at the attempts ceiling returns a terminal failed job
+    (error_code attempts_exhausted, next_attempt_at absent/NULL)."""
+    repo = _client(
+        {
+            "status": "failed",
+            "job_id": JOB_ID,
+            "error_code": "attempts_exhausted",
+        }
+    )
+    result = repo.record_retry(JOB_ID, "worker-1")
+    assert result.status == "failed"
+    assert result.next_attempt_at is None
+
+
 def test_purge_completed_int_parses():
     repo = _client(3)
     assert repo.purge_completed("2026-01-01T00:00:00+00:00", 10) == 3

--- a/backend/tests/test_account_deletion.py
+++ b/backend/tests/test_account_deletion.py
@@ -1,0 +1,537 @@
+"""Unit tests for the #324 account deletion ledger Python contract.
+
+Covers the pure-Python domain/adapter layer of ``backend.account_deletion``
+without any network:
+
+ 1.  Valid domain results parse from well-formed RPC envelopes.
+ 2.  Invalid UUIDs, user_ids, HMACs and fingerprints are rejected.
+ 3.  Unknown statuses, extra fields, incomplete payloads and bools in
+     integer fields fail closed.
+ 4.  RPC results with a divergent identity fail closed sanitized (the
+     identity is never echoed in the exception).
+ 5.  Structured errors (validation/conflict) map to the right exceptions.
+ 6.  Malformed responses fail closed with PersistenceError.
+ 7.  Importing the module constructs no infrastructure and opens no
+     sockets (same purity gate as the retention modules).
+ 8.  No secret or identifier ever appears in an exception message or in
+     captured logs.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+import textwrap
+from types import SimpleNamespace
+
+import pytest
+
+from backend.account_deletion import (
+    ACCOUNT_DELETION_HMAC_DOMAIN,
+    ERROR_OPERATION_CONFLICT,
+    STATUS_COMPLETED,
+    STATUS_PENDING,
+    STATUS_PROCESSING,
+    SupabaseAccountDeletionRepository,
+    compute_account_deletion_user_ref,
+    compute_intent_fingerprint,
+)
+from backend.atomic_turn_commit import (
+    ConflictError,
+    PersistenceError,
+    ValidationError,
+)
+
+SECRET = b"ci-test-secret-0123456789abcdef0123456789abcdef"
+
+USER_ID = "user-A-1234"
+REF = "a" * 64
+FINGERPRINT = "b" * 64
+OPERATION_ID = "11111111-1111-1111-1111-111111111111"
+JOB_ID = "22222222-2222-2222-2222-222222222222"
+
+
+def _client(data) -> SupabaseAccountDeletionRepository:
+    client = SimpleNamespace(
+        rpc=lambda name, params: SimpleNamespace(execute=lambda: SimpleNamespace(data=data))
+    )
+    return SupabaseAccountDeletionRepository(client)
+
+
+# ─── 1. Valid results parse ─────────────────────────────────────────────────
+
+
+def test_request_created_parses():
+    repo = _client(
+        {
+            "status": "created",
+            "job_id": JOB_ID,
+            "job_status": "pending",
+            "db_purged_at": None,
+            "completed_at": None,
+        }
+    )
+    result = repo.request(USER_ID, REF, OPERATION_ID, FINGERPRINT)
+    assert result.status == "created"
+    assert result.job_id == JOB_ID
+    assert result.job_status == STATUS_PENDING
+
+
+def test_request_replay_parses():
+    repo = _client(
+        {
+            "status": "replay",
+            "job_id": JOB_ID,
+            "job_status": "completed",
+            "db_purged_at": "2026-08-09T00:00:00+00:00",
+            "completed_at": "2026-08-09T01:00:00+00:00",
+        }
+    )
+    result = repo.request(USER_ID, REF, OPERATION_ID, FINGERPRINT)
+    assert result.status == "replay"
+    assert result.job_status == STATUS_COMPLETED
+    assert result.db_purged_at is not None
+
+
+def test_absent_nullable_fields_parse_as_none():
+    """PostgREST omits JSON null values: absent optional fields are None."""
+    repo = _client(
+        {
+            "status": "created",
+            "job_id": JOB_ID,
+            "job_status": "pending",
+        }
+    )
+    result = repo.request(USER_ID, REF, OPERATION_ID, FINGERPRINT)
+    assert result.status == "created"
+    assert result.db_purged_at is None
+    assert result.completed_at is None
+
+    repo = _client({"exists": False})
+    result = repo.has_tombstone(REF)
+    assert result.exists is False
+    assert result.status is None
+
+    repo = _client(
+        {
+            "found": True,
+            "job_id": JOB_ID,
+            "user_id": USER_ID,
+            "user_ref_hmac_sha256": REF,
+            "operation_id": OPERATION_ID,
+            "status": "processing",
+            "lease_owner": "worker-1",
+            "lease_expires_at": "2026-08-09T01:00:00+00:00",
+            "attempts": 1,
+            "intent_fingerprint_sha256": FINGERPRINT,
+        }
+    )
+    job = repo.acquire_lease("worker-1", 60, 100)
+    assert job.db_purged_at is None
+
+
+def test_tombstone_parses():
+    repo = _client({"exists": True, "status": "processing"})
+    result = repo.has_tombstone(REF)
+    assert result.exists is True
+    assert result.status == STATUS_PROCESSING
+
+
+def test_acquire_lease_parses():
+    repo = _client(
+        {
+            "found": True,
+            "job_id": JOB_ID,
+            "user_id": USER_ID,
+            "user_ref_hmac_sha256": REF,
+            "operation_id": OPERATION_ID,
+            "status": "processing",
+            "lease_owner": "worker-1",
+            "lease_expires_at": "2026-08-09T01:00:00+00:00",
+            "attempts": 1,
+            "db_purged_at": None,
+            "intent_fingerprint_sha256": FINGERPRINT,
+        }
+    )
+    job = repo.acquire_lease("worker-1", 60, 100)
+    assert job.user_id == USER_ID
+    assert job.attempts == 1
+    assert job.status == STATUS_PROCESSING
+
+
+def test_purge_parses_counts():
+    repo = _client(
+        {
+            "status": "purged",
+            "job_id": JOB_ID,
+            "db_purged_at": "2026-08-09T00:00:00+00:00",
+            "counts": {
+                "outbox_events": 1,
+                "turn_requests": 2,
+                "archival_extractions": 3,
+                "memories": 4,
+                "chat_logs": 5,
+                "admission_reservations": 6,
+                "privacy_operations": 7,
+                "profiles": 8,
+            },
+        }
+    )
+    result = repo.purge(JOB_ID, "worker-1", FINGERPRINT, expected_user_id=USER_ID)
+    assert result.status == "purged"
+    assert result.counts["profiles"] == 8
+
+
+def test_already_purged_replay_parses():
+    repo = _client(
+        {
+            "status": "already_purged",
+            "job_id": JOB_ID,
+            "db_purged_at": "2026-08-09T00:00:00+00:00",
+            "counts": {
+                "outbox_events": 0,
+                "turn_requests": 0,
+                "archival_extractions": 0,
+                "memories": 0,
+                "chat_logs": 0,
+                "admission_reservations": 0,
+                "privacy_operations": 0,
+                "profiles": 0,
+            },
+        }
+    )
+    result = repo.purge(JOB_ID, "worker-1", FINGERPRINT)
+    assert result.status == "already_purged"
+
+
+def test_failure_and_retry_and_finalize_parse():
+    repo = _client(
+        {
+            "status": "failed",
+            "job_id": JOB_ID,
+            "error_code": "auth_unavailable",
+            "next_attempt_at": "2026-08-09T01:00:00+00:00",
+        }
+    )
+    failure = repo.record_failure(JOB_ID, "worker-1", "auth_unavailable")
+    assert failure.status == "failed"
+    assert failure.error_code == "auth_unavailable"
+
+    repo = _client(
+        {
+            "status": "retry_scheduled",
+            "job_id": JOB_ID,
+            "next_attempt_at": "2026-08-09T01:00:00+00:00",
+        }
+    )
+    retry = repo.record_retry(JOB_ID, "worker-1")
+    assert retry.status == "retry_scheduled"
+
+    repo = _client(
+        {
+            "status": "completed",
+            "job_id": JOB_ID,
+            "completed_at": "2026-08-09T01:00:00+00:00",
+            "db_purged_at": "2026-08-09T00:00:00+00:00",
+        }
+    )
+    finalize = repo.finalize(JOB_ID, "worker-1")
+    assert finalize.status == "completed"
+
+
+def test_purge_completed_int_parses():
+    repo = _client(3)
+    assert repo.purge_completed("2026-01-01T00:00:00+00:00", 10) == 3
+
+
+# ─── 2/3. HMAC and fingerprint domain helpers ───────────────────────────────
+
+
+def test_user_ref_hmac_is_lowercase_hex64_with_dedicated_domain():
+    ref = compute_account_deletion_user_ref(SECRET, USER_ID)
+    assert len(ref) == 64
+    assert all(c in "0123456789abcdef" for c in ref)
+    # Stable across calls, dedicated domain (never the user-reference domain).
+    assert ref == compute_account_deletion_user_ref(SECRET, USER_ID)
+    import hmac
+    import hashlib
+
+    expected = hmac.new(
+        SECRET,
+        ACCOUNT_DELETION_HMAC_DOMAIN + b"\x00" + USER_ID.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    assert ref == expected
+    assert ref != hmac.new(
+        SECRET, b"user-reference\x00" + USER_ID.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+
+
+def test_user_ref_rejects_invalid_user_id():
+    with pytest.raises(ValidationError):
+        compute_account_deletion_user_ref(SECRET, "")
+    with pytest.raises(ValidationError):
+        compute_account_deletion_user_ref(SECRET, "   ")
+    with pytest.raises(ValidationError):
+        compute_account_deletion_user_ref(SECRET, 123)
+
+
+def test_user_ref_rejects_invalid_secret():
+    with pytest.raises(Exception):
+        compute_account_deletion_user_ref(b"short", USER_ID)
+
+
+def test_intent_fingerprint_is_stable_and_object_only():
+    payload = {"op": "delete_account", "scope": ["db", "auth"]}
+    fp = compute_intent_fingerprint(payload)
+    assert len(fp) == 64
+    assert all(c in "0123456789abcdef" for c in fp)
+    assert fp == compute_intent_fingerprint({"op": "delete_account", "scope": ["db", "auth"]})
+    with pytest.raises(ValidationError):
+        compute_intent_fingerprint(["not", "an", "object"])
+    with pytest.raises(ValidationError):
+        compute_intent_fingerprint("text")
+
+
+# ─── 4/5/6/7. Strict parsers fail closed ────────────────────────────────────
+
+
+def test_invalid_uuid_in_job_id_fails_closed():
+    repo = _client(
+        {
+            "status": "created",
+            "job_id": "NOT-A-UUID",
+            "job_status": "pending",
+            "db_purged_at": None,
+            "completed_at": None,
+        }
+    )
+    with pytest.raises(PersistenceError):
+        repo.request(USER_ID, REF, OPERATION_ID, FINGERPRINT)
+
+
+def test_invalid_hmac_in_response_fails_closed():
+    repo = _client(
+        {
+            "found": True,
+            "job_id": JOB_ID,
+            "user_id": USER_ID,
+            "user_ref_hmac_sha256": "XYZ",
+            "operation_id": OPERATION_ID,
+            "status": "processing",
+            "lease_owner": "worker-1",
+            "lease_expires_at": "2026-08-09T01:00:00+00:00",
+            "attempts": 1,
+            "db_purged_at": None,
+            "intent_fingerprint_sha256": FINGERPRINT,
+        }
+    )
+    with pytest.raises(PersistenceError):
+        repo.acquire_lease("worker-1", 60, 100)
+
+
+def test_unknown_status_fails_closed():
+    repo = _client(
+        {
+            "status": "created",
+            "job_id": JOB_ID,
+            "job_status": "exploded",
+            "db_purged_at": None,
+            "completed_at": None,
+        }
+    )
+    with pytest.raises(PersistenceError):
+        repo.request(USER_ID, REF, OPERATION_ID, FINGERPRINT)
+
+
+def test_extra_fields_fail_closed():
+    repo = _client(
+        {
+            "status": "created",
+            "job_id": JOB_ID,
+            "job_status": "pending",
+            "db_purged_at": None,
+            "completed_at": None,
+            "sneaky": "field",
+        }
+    )
+    with pytest.raises(PersistenceError):
+        repo.request(USER_ID, REF, OPERATION_ID, FINGERPRINT)
+
+
+def test_incomplete_payload_fails_closed():
+    repo = _client({"status": "created", "job_id": JOB_ID})
+    with pytest.raises(PersistenceError):
+        repo.request(USER_ID, REF, OPERATION_ID, FINGERPRINT)
+
+
+def test_bool_in_int_field_fails_closed():
+    repo = _client(
+        {
+            "found": True,
+            "job_id": JOB_ID,
+            "user_id": USER_ID,
+            "user_ref_hmac_sha256": REF,
+            "operation_id": OPERATION_ID,
+            "status": "processing",
+            "lease_owner": "worker-1",
+            "lease_expires_at": "2026-08-09T01:00:00+00:00",
+            "attempts": True,
+            "db_purged_at": None,
+            "intent_fingerprint_sha256": FINGERPRINT,
+        }
+    )
+    with pytest.raises(PersistenceError):
+        repo.acquire_lease("worker-1", 60, 100)
+
+
+def test_bool_int_purge_completed_fails_closed():
+    repo = _client(True)
+    with pytest.raises(PersistenceError):
+        repo.purge_completed("2026-01-01T00:00:00+00:00", 10)
+    repo = _client(-1)
+    with pytest.raises(PersistenceError):
+        repo.purge_completed("2026-01-01T00:00:00+00:00", 10)
+
+
+def test_divergent_identity_fails_closed_without_echo():
+    repo = _client(
+        {
+            "found": True,
+            "job_id": JOB_ID,
+            "user_id": "some-other-user",
+            "user_ref_hmac_sha256": REF,
+            "operation_id": OPERATION_ID,
+            "status": "processing",
+            "lease_owner": "worker-1",
+            "lease_expires_at": "2026-08-09T01:00:00+00:00",
+            "attempts": 1,
+            "db_purged_at": None,
+            "intent_fingerprint_sha256": FINGERPRINT,
+        }
+    )
+    with pytest.raises(PersistenceError) as exc:
+        repo.acquire_lease("worker-1", 60, 100, expected_user_id=USER_ID)
+    assert "some-other-user" not in str(exc.value)
+    assert USER_ID not in str(exc.value)
+
+
+# ─── 10. Structured errors map correctly ────────────────────────────────────
+
+
+def test_operation_conflict_raises_conflict_error():
+    repo = _client(
+        {
+            "error": {
+                "code": ERROR_OPERATION_CONFLICT,
+                "message": "operation_id already used with a different intent",
+            }
+        }
+    )
+    with pytest.raises(ConflictError):
+        repo.request(USER_ID, REF, OPERATION_ID, FINGERPRINT)
+
+
+def test_validation_error_raises_validation_error():
+    repo = _client(
+        {
+            "error": {
+                "code": "validation_failed",
+                "message": "user_ref_hmac_sha256 must be 64 lowercase hex characters",
+            }
+        }
+    )
+    with pytest.raises(ValidationError):
+        repo.request(USER_ID, REF, OPERATION_ID, FINGERPRINT)
+
+
+def test_malformed_response_fails_closed():
+    for bad in ("not-a-mapping", 42, None, [], {"error": "not-an-object"}, {"error": {}}):
+        repo = _client(bad)
+        with pytest.raises(PersistenceError):
+            repo.request(USER_ID, REF, OPERATION_ID, FINGERPRINT)
+
+
+def test_upstream_exception_maps_to_sanitized_persistence_error():
+    class ExplodingClient:
+        def rpc(self, name, params):
+            raise RuntimeError("SENTINEL-UPSTREAM-SECRET")
+
+    repo = SupabaseAccountDeletionRepository(ExplodingClient())
+    with pytest.raises(PersistenceError) as exc:
+        repo.request(USER_ID, REF, OPERATION_ID, FINGERPRINT)
+    assert "SENTINEL-UPSTREAM-SECRET" not in str(exc.value)
+
+
+def test_repository_without_client_fails_closed():
+    repo = SupabaseAccountDeletionRepository(None)
+    with pytest.raises(PersistenceError):
+        repo.request(USER_ID, REF, OPERATION_ID, FINGERPRINT)
+
+
+# ─── 12. No secret or identifier in exceptions/logs ─────────────────────────
+
+
+def test_exceptions_never_echo_secrets_or_identities(caplog):
+    with caplog.at_level(logging.INFO):
+        repo = _client(
+            {
+                "status": "created",
+                "job_id": JOB_ID,
+                "job_status": "exploded",
+                "db_purged_at": None,
+                "completed_at": None,
+            }
+        )
+        with pytest.raises(PersistenceError):
+            repo.request(USER_ID, REF, OPERATION_ID, FINGERPRINT)
+    for sentinel in (SECRET.decode(), USER_ID, REF, FINGERPRINT, OPERATION_ID, JOB_ID):
+        assert sentinel not in caplog.text
+
+
+# ─── 13. Pure importability ─────────────────────────────────────────────────
+
+_PURITY_SCRIPT = textwrap.dedent(
+    """
+    import sys
+    import threading
+
+    import socket as _socket
+
+    def _forbid(*args, **kwargs):
+        raise AssertionError("network socket usage during import")
+
+    _socket.socket.connect = _forbid
+    _socket.socket.connect_ex = _forbid
+    _socket.create_connection = _forbid
+
+    import supabase as _supabase
+
+    def _no_supabase_client(*args, **kwargs):
+        raise AssertionError("real Supabase client constructed during import")
+
+    _supabase.create_client = _no_supabase_client
+
+    threads_before = len(threading.enumerate())
+
+    import backend.account_deletion
+
+    threads_after = len(threading.enumerate())
+
+    assert threads_after == threads_before, "import started a thread"
+    print("ACCOUNT_DELETION_PURITY_OK")
+    """
+)
+
+
+def test_account_deletion_import_is_pure():
+    result = subprocess.run(
+        [sys.executable, "-c", _PURITY_SCRIPT],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={"PYTHONPATH": ".", "PATH": "/usr/bin:/bin"},
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+    assert "ACCOUNT_DELETION_PURITY_OK" in result.stdout

--- a/backend/tests/test_account_deletion_integration.py
+++ b/backend/tests/test_account_deletion_integration.py
@@ -737,6 +737,75 @@ def test_attempts_exhaustion_is_terminal_and_tombstone_preserved(service_client:
         _cleanup_user(user_id)
 
 
+def test_expired_ceiling_lease_is_terminalized_not_reclaimed(service_client: Client):
+    """A processing job whose lease expired AT the attempts ceiling is
+    terminalized in place and NEVER delivered to another worker.
+
+    This closes the exhaustion loophole: without this, the last attempt
+    dying before record_failure/record_retry could be reclaimed an
+    unlimited number of times. The terminal state preserves the tombstone
+    and db_purged_at, and other eligible jobs still progress.
+    """
+    user_id = _uid("ceil")
+    ref = _ref(user_id)
+    op_id = _new_op_id()
+    fp = _fingerprint()
+    try:
+        request = _repo(service_client).request(user_id, ref, op_id, fp)
+        # Fast-forward to the boundary and simulate a worker that died
+        # with the lease held at the ceiling (attempt 100), without ever
+        # calling record_failure/record_retry.
+        _run_sql(
+            "UPDATE public.account_deletion_jobs "
+            "SET attempts = 100, status = 'processing', "
+            "lease_owner = 'worker-dead', "
+            "lease_expires_at = now() - interval '1 second' "
+            f"WHERE job_id = '{request.job_id}'"
+        )
+        # The next poll must NOT hand the job to another worker: it is
+        # terminalized and the poll reports no eligible job.
+        with pytest.raises(PersistenceError):
+            _repo(service_client).acquire_lease("worker-new", 60, 100)
+        row = _run_sql(
+            "SELECT status, error_code, lease_owner IS NULL AS lease_cleared, "
+            "next_attempt_at IS NULL AS terminal "
+            "FROM public.account_deletion_jobs WHERE job_id = "
+            f"'{request.job_id}'"
+        )[0]
+        assert row["status"] == "failed"
+        assert row["error_code"] == "attempts_exhausted"
+        assert row["lease_cleared"] is True
+        assert row["terminal"] is True
+        # The tombstone stays blocking and is never re-acquired.
+        assert _repo(service_client).has_tombstone(ref).exists is True
+        with pytest.raises(PersistenceError):
+            _repo(service_client).acquire_lease("worker-new2", 60, 100)
+
+        # db_purged_at is preserved when it was already set.
+        _run_sql(
+            "UPDATE public.account_deletion_jobs SET db_purged_at = "
+            "now() - interval '1 hour' "
+            f"WHERE job_id = '{request.job_id}'"
+        )
+        _run_sql(
+            "UPDATE public.account_deletion_jobs SET status = 'processing', "
+            "lease_owner = 'worker-dead2', "
+            "lease_expires_at = now() - interval '1 second' "
+            f"WHERE job_id = '{request.job_id}'"
+        )
+        with pytest.raises(PersistenceError):
+            _repo(service_client).acquire_lease("worker-new3", 60, 100)
+        row = _run_sql(
+            "SELECT status, db_purged_at IS NOT NULL AS purged "
+            "FROM public.account_deletion_jobs WHERE job_id = "
+            f"'{request.job_id}'"
+        )[0]
+        assert row["status"] == "failed"
+        assert row["purged"] is True, "terminalization must preserve db_purged_at"
+    finally:
+        _cleanup_user(user_id)
+
+
 # ─── 14/15/16. Finalize and minimization ────────────────────────────────────
 
 def test_finalize_clears_user_id_keeps_ref_and_tombstone(service_client: Client):

--- a/backend/tests/test_account_deletion_integration.py
+++ b/backend/tests/test_account_deletion_integration.py
@@ -1,0 +1,817 @@
+"""Real Supabase integration tests for the #324 account deletion ledger.
+
+This file is executed ONLY by the database CI job against a freshly reset
+local Supabase instance (no mocks: real PostgreSQL transactions, RLS,
+grants, advisory locks and the ledger RPCs). It must never be collected by
+the ordinary backend unit job (see the ignore list in
+``.github/workflows/ci.yml``).
+
+Covers the mandatory scenarios of #324:
+
+ 1.  The tombstone is created BEFORE any purge (request -> pending, data
+     untouched).
+ 2.  Replay of the same (ref, operation_id, fingerprint) is idempotent.
+ 3.  A divergent intent fingerprint produces a sanitized conflict.
+ 4.  The same operation_id for users A and B never interferes.
+ 5.  Two concurrent claims on independent connections: exactly one wins.
+ 6.  An expired lease makes the job eligible again.
+ 7.  An old worker cannot finalize after losing the lease.
+ 8.  Purge of A fully preserves B.
+ 9.  Every table of user A is removed.
+10.  The real FK graph does not break the purge.
+11.  An artificial failure mid-purge rolls back EVERY delete.
+12.  db_purged_at does not appear after the rollback.
+13.  A repeated purge on an empty database is a safe replay.
+14.  Finalize clears the raw user_id.
+15.  The user_ref HMAC persists after finalize.
+16.  The tombstone stays queryable by the defined contract.
+17.  Active/failed jobs are never purged by age.
+18.  Concurrent purge vs same-user writers is serialized by the per-user
+     advisory lock.
+19.  A different user is not globally blocked.
+
+Uses independent connections, barriers and direct SQL state manipulation
+(no long sleeps).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+from supabase import Client, create_client
+
+from backend.account_deletion import (
+    SupabaseAccountDeletionRepository,
+    compute_account_deletion_user_ref,
+    compute_intent_fingerprint,
+)
+from backend.atomic_turn_commit import PersistenceError
+from backend.privacy_operations import (
+    OPERATION_DELETE_HISTORY,
+    run_privacy_operation,
+)
+
+_SUPABASE_CLI = ["supabase"] if shutil.which("supabase") else ["npx", "supabase"]
+
+SECRET = b"ci-test-secret-0123456789abcdef0123456789abcdef"
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name)
+    assert value, f"{name} is required for account deletion integration tests"
+    return value
+
+
+def _close_client(client: Client) -> None:
+    if client is None:
+        return
+    for attr, session_attr in (
+        ("_postgrest", "session"),
+        ("_storage", "session"),
+        ("_functions", "_client"),
+    ):
+        transport = getattr(client, attr, None)
+        if transport is None:
+            continue
+        session = getattr(transport, session_attr, None)
+        if session is not None and hasattr(session, "close"):
+            session.close()
+    auth = getattr(client, "auth", None)
+    if auth is not None and hasattr(auth, "close"):
+        auth.close()
+
+
+@pytest.fixture(scope="module")
+def supabase_url() -> str:
+    return _required_env("SUPABASE_URL")
+
+
+@pytest.fixture(scope="module")
+def service_role_key() -> str:
+    return _required_env("SUPABASE_SERVICE_ROLE_KEY")
+
+
+@pytest.fixture(scope="module")
+def service_client(supabase_url: str, service_role_key: str) -> Client:
+    client = create_client(supabase_url, service_role_key)
+    yield client
+    _close_client(client)
+
+
+# ─── SQL helpers (pinned local Supabase CLI, sanitized) ─────────────────────
+
+
+def _run_sql(sql: str) -> list[dict]:
+    child_env = dict(os.environ)
+    child_env["SUPABASE_TELEMETRY_DISABLED"] = "1"
+    child_env["SUPABASE_ANALYTICS_ENABLED"] = "false"
+    result = subprocess.run(
+        [
+            *_SUPABASE_CLI,
+            "db",
+            "query",
+            "--agent=no",
+            "--output",
+            "json",
+            sql,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=child_env,
+    )
+    assert result.returncode == 0, "sanitized account deletion test SQL operation failed"
+    output = result.stdout.strip()
+    if not output or output[0] not in "[{":
+        return []
+    parsed = json.loads(output)
+    assert isinstance(parsed, list)
+    return parsed
+
+
+def _count(table: str, predicate: str) -> int:
+    rows = _run_sql(f"SELECT count(*)::integer AS count FROM public.{table} WHERE {predicate}")
+    return rows[0]["count"]
+
+
+def _uid(label: str) -> str:
+    return f"adl_{label}_{uuid.uuid4().hex[:12]}"
+
+
+def _ref(user_id: str) -> str:
+    return compute_account_deletion_user_ref(SECRET, user_id)
+
+
+def _fingerprint() -> str:
+    return compute_intent_fingerprint({"op": "delete_account", "scope": ["db", "auth"]})
+
+
+def _new_op_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _repo(client: Client) -> SupabaseAccountDeletionRepository:
+    return SupabaseAccountDeletionRepository(client)
+
+
+def _privacy_delete_history(client: Client, user_id: str) -> None:
+    """Run delete_history (same per-user advisory lock as the purge)."""
+
+    async def _rpc_client(name: str, params: dict) -> dict:
+        response = client.rpc(name, params).execute()
+        data = response.data
+        if isinstance(data, list):
+            data = data[0]
+        return data
+
+    async def _run():
+        return await run_privacy_operation(
+            rpc_client=_rpc_client,
+            operation=OPERATION_DELETE_HISTORY,
+            authenticated_user_id=user_id,
+            operation_id=str(uuid.uuid4()),
+            payload={},
+        )
+
+    asyncio.run(_run())
+
+
+# ─── Seeding ────────────────────────────────────────────────────────────────
+
+
+def _seed_profile(user_id: str) -> None:
+    _run_sql(
+        "INSERT INTO public.profiles (user_id, persona_config, user_profile, "
+        "relationship_state, emotional_state, revision) VALUES "
+        f"('{user_id}', 'persona', '{{}}'::jsonb, "
+        f"'{{\"schema_version\":1,\"trust\":0.5,\"affection\":0.3,\"tension\":0.0,"
+        f"\"triggers\":[],\"timestamp\":1700000000.0}}'::jsonb, "
+        f"'{{\"schema_version\":1,\"pleasure\":0.0,\"arousal\":0.0,\"dominance\":0.0,"
+        f"\"libido\":0.0,\"aggression\":0.0,\"connection\":0.5,\"energy\":0.8,"
+        f"\"tension\":0.0,\"coping_mode\":\"HEALTHY\",\"timestamp\":1700000000.0}}'::jsonb, "
+        "1)"
+    )
+
+
+def _seed_chat(user_id: str) -> None:
+    _run_sql(
+        "INSERT INTO public.chat_logs (user_id, role, content) VALUES "
+        f"('{user_id}', 'user', 'hello'), ('{user_id}', 'assistant', 'hi there')"
+    )
+
+
+def _seed_memories(user_id: str) -> None:
+    _run_sql(
+        "INSERT INTO public.memories (user_id, content, metadata) VALUES "
+        f"('{user_id}', 'a durable memory', '{{\"tags\":[\"x\"]}}'::jsonb)"
+    )
+
+
+def _seed_archival(user_id: str) -> None:
+    _run_sql(
+        "INSERT INTO public.archival_extractions "
+        "(user_id, source_chat_log_id, extractor_version, schema_version, "
+        "idempotency_key, facts) "
+        "SELECT user_id, id, 1, 1, "
+        f"'{user_id}-arch-1', '{{\"facts\":[]}}'::jsonb "
+        f"FROM public.chat_logs WHERE user_id = '{user_id}' AND role = 'user'"
+    )
+
+
+def _seed_turn_request(user_id: str) -> None:
+    _run_sql(
+        "INSERT INTO public.turn_requests ("
+        "id, user_id, request_id, payload_hash_sha256, status, expected_revision, "
+        "committed_revision, replay_payload, created_at, updated_at, completed_at) "
+        "VALUES ("
+        f"'{uuid.uuid4()}', '{user_id}', '{uuid.uuid4()}', "
+        f"'{'a' * 64}', 'completed', 0, 1, '{{\"response\":\"hi\"}}'::jsonb, "
+        "now(), now(), now())"
+    )
+
+
+def _seed_outbox(user_id: str) -> None:
+    _run_sql(
+        "INSERT INTO public.outbox_events ("
+        "event_type, contract_version, user_id, turn_request_id, payload, status, "
+        "attempts, next_attempt_at, idempotency_key, created_at, updated_at) "
+        "VALUES ("
+        f"'turn_completed', 1, '{user_id}', NULL, '{{\"ref\":\"t1\"}}'::jsonb, "
+        f"'pending', 0, now() + interval '1 second', '{user_id}-k1', now(), now())"
+    )
+
+
+def _seed_admission(user_id: str) -> None:
+    _run_sql(
+        "INSERT INTO public.admission_reservations ("
+        "user_id, request_id, message_hmac_sha256, network_hmac_sha256, estimated_units) "
+        "VALUES ("
+        f"'{user_id}', '{uuid.uuid4()}', repeat('a', 64), repeat('b', 64), 10)"
+    )
+
+
+def _seed_privacy_ledger(user_id: str) -> None:
+    _run_sql(
+        "INSERT INTO public.privacy_operations ("
+        "user_id, operation_id, operation, operation_payload_sha256, status, result) "
+        "VALUES ("
+        f"'{user_id}', '{uuid.uuid4()}', 'delete_history', repeat('c', 64), "
+        "'applied', '{}'::jsonb)"
+    )
+
+
+def _seed_full_user(user_id: str) -> None:
+    """Seed every table the purge removes (the real FK graph)."""
+    _seed_profile(user_id)
+    _seed_chat(user_id)
+    _seed_memories(user_id)
+    _seed_archival(user_id)
+    _seed_turn_request(user_id)
+    _seed_outbox(user_id)
+    _seed_admission(user_id)
+    _seed_privacy_ledger(user_id)
+
+
+def _cleanup_user(user_id: str) -> None:
+    for table in (
+        "privacy_operations",
+        "admission_reservations",
+        "archival_extractions",
+        "memories",
+        "chat_logs",
+        "turn_requests",
+        "outbox_events",
+        "profiles",
+    ):
+        _run_sql(f"DELETE FROM public.{table} WHERE user_id = '{user_id}'")
+    _run_sql(f"DELETE FROM public.account_deletion_jobs WHERE user_ref_hmac_sha256 = '{_ref(user_id)}'")
+
+
+# ─── 1/2/3/4. Request semantics ─────────────────────────────────────────────
+
+
+def test_tombstone_created_before_any_purge(service_client: Client):
+    user_id = _uid("tomb")
+    _seed_full_user(user_id)
+    ref = _ref(user_id)
+    op_id = _new_op_id()
+    fp = _fingerprint()
+    try:
+        result = _repo(service_client).request(user_id, ref, op_id, fp)
+        assert result.status == "created"
+        assert result.job_status == "pending"
+        # The tombstone exists BEFORE any purge; the data is untouched.
+        tombstone = _repo(service_client).has_tombstone(ref)
+        assert tombstone.exists is True
+        assert tombstone.status == "pending"
+        assert _count("profiles", f"user_id = '{user_id}'") == 1
+        assert _count("chat_logs", f"user_id = '{user_id}'") == 2
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_replay_is_idempotent(service_client: Client):
+    user_id = _uid("replay")
+    ref = _ref(user_id)
+    op_id = _new_op_id()
+    fp = _fingerprint()
+    try:
+        first = _repo(service_client).request(user_id, ref, op_id, fp)
+        second = _repo(service_client).request(user_id, ref, op_id, fp)
+        assert first.status == "created"
+        assert second.status == "replay"
+        assert second.job_id == first.job_id
+        assert _count("account_deletion_jobs", f"user_ref_hmac_sha256 = '{ref}'") == 1
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_divergent_fingerprint_conflicts(service_client: Client):
+    user_id = _uid("conflict")
+    ref = _ref(user_id)
+    op_id = _new_op_id()
+    fp = _fingerprint()
+    other_fp = compute_intent_fingerprint({"op": "delete_account", "scope": ["db"]})
+    try:
+        _repo(service_client).request(user_id, ref, op_id, fp)
+        with pytest.raises(Exception) as exc:
+            _repo(service_client).request(user_id, ref, op_id, other_fp)
+        assert "conflict" in str(exc.value).lower()
+        assert _count("account_deletion_jobs", f"user_ref_hmac_sha256 = '{ref}'") == 1
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_same_operation_id_across_users_no_interference(service_client: Client):
+    user_a = _uid("crossa")
+    user_b = _uid("crossb")
+    op_id = _new_op_id()  # Same operation_id for both users.
+    fp = _fingerprint()
+    try:
+        result_a = _repo(service_client).request(user_a, _ref(user_a), op_id, fp)
+        result_b = _repo(service_client).request(user_b, _ref(user_b), op_id, fp)
+        assert result_a.status == "created"
+        assert result_b.status == "created"
+        assert result_a.job_id != result_b.job_id
+        # Each user's tombstone is independent.
+        assert _repo(service_client).has_tombstone(_ref(user_a)).exists is True
+        assert _repo(service_client).has_tombstone(_ref(user_b)).exists is True
+    finally:
+        _cleanup_user(user_a)
+        _cleanup_user(user_b)
+
+
+# ─── 5/6/7. Leases ──────────────────────────────────────────────────────────
+
+
+def test_concurrent_claims_only_one_wins(
+    service_client: Client, supabase_url: str, service_role_key: str
+):
+    user_id = _uid("claim")
+    ref = _ref(user_id)
+    op_id = _new_op_id()
+    fp = _fingerprint()
+    winners: list[str] = []
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+    barrier = threading.Barrier(2)
+    try:
+        client = create_client(supabase_url, service_role_key)
+        _repo(client).request(user_id, ref, op_id, fp)
+        _close_client(client)
+
+        def _claim(worker: str):
+            own_client = create_client(supabase_url, service_role_key)
+            try:
+                barrier.wait(timeout=30)
+                job = _repo(own_client).acquire_lease(worker, 60, 100)
+                with lock:
+                    winners.append(job.job_id)
+            except PersistenceError:
+                # No eligible job: the expected outcome for the loser.
+                pass
+            except BaseException as exc:  # noqa: BLE001
+                with lock:
+                    errors.append(exc)
+            finally:
+                _close_client(own_client)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [pool.submit(_claim, f"worker-{i}") for i in range(2)]
+            for future in futures:
+                future.result(timeout=60)
+
+        assert errors == [], f"concurrent claims failed: {errors}"
+        assert len(winners) == 1, "exactly one worker must win the claim"
+        # A third claim while the lease is active finds no eligible job.
+        with pytest.raises(PersistenceError):
+            _repo(service_client).acquire_lease("worker-2", 60, 100)
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_expired_lease_requeues_job(service_client: Client):
+    user_id = _uid("lease")
+    ref = _ref(user_id)
+    op_id = _new_op_id()
+    fp = _fingerprint()
+    try:
+        request = _repo(service_client).request(user_id, ref, op_id, fp)
+        job = _repo(service_client).acquire_lease("worker-a", 60, 100)
+        assert job.job_id == request.job_id
+        # A second claim while the lease is active finds nothing.
+        with pytest.raises(PersistenceError):
+            _repo(service_client).acquire_lease("worker-b", 60, 100)
+        # Expire the lease directly (deterministic, no sleeps).
+        _run_sql(
+            "UPDATE public.account_deletion_jobs "
+            "SET lease_expires_at = now() - interval '1 second' "
+            f"WHERE job_id = '{job.job_id}'"
+        )
+        # Now the job is eligible again: a new worker can claim it.
+        reclaimed = _repo(service_client).acquire_lease("worker-b", 60, 100)
+        assert reclaimed.job_id == job.job_id
+        assert reclaimed.attempts == job.attempts + 1
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_old_worker_cannot_finalize_after_losing_lease(service_client: Client):
+    user_id = _uid("stale")
+    ref = _ref(user_id)
+    op_id = _new_op_id()
+    fp = _fingerprint()
+    try:
+        request = _repo(service_client).request(user_id, ref, op_id, fp)
+        job = _repo(service_client).acquire_lease("worker-old", 60, 100)
+        # Expire the lease; worker-new reclaims the job.
+        _run_sql(
+            "UPDATE public.account_deletion_jobs "
+            "SET lease_expires_at = now() - interval '1 second' "
+            f"WHERE job_id = '{job.job_id}'"
+        )
+        _repo(service_client).acquire_lease("worker-new", 60, 100)
+        # The old worker can no longer purge or finalize: fail closed.
+        with pytest.raises(PersistenceError):
+            _repo(service_client).purge(job.job_id, "worker-old", fp)
+        with pytest.raises(PersistenceError):
+            _repo(service_client).finalize(job.job_id, "worker-old")
+        assert request.job_id == job.job_id
+    finally:
+        _cleanup_user(user_id)
+
+
+# ─── 8/9/10. Purge semantics ────────────────────────────────────────────────
+
+
+def test_purge_removes_all_a_tables_and_preserves_b(service_client: Client):
+    user_a = _uid("pa")
+    user_b = _uid("pb")
+    _seed_full_user(user_a)
+    _seed_full_user(user_b)
+    ref_a = _ref(user_a)
+    op_a = _new_op_id()
+    fp_a = _fingerprint()
+    try:
+        request = _repo(service_client).request(user_a, ref_a, op_a, fp_a)
+        job = _repo(service_client).acquire_lease("worker-a", 60, 100)
+        assert job.user_id == user_a
+        result = _repo(service_client).purge(job.job_id, "worker-a", fp_a)
+        assert result.status == "purged"
+        # Every table of A is gone (the real FK graph did not break).
+        for table in (
+            "outbox_events",
+            "turn_requests",
+            "archival_extractions",
+            "memories",
+            "chat_logs",
+            "admission_reservations",
+            "privacy_operations",
+            "profiles",
+        ):
+            assert _count(table, f"user_id = '{user_a}'") == 0, f"{table} not purged"
+        # B is completely preserved.
+        expected_b = {
+            "outbox_events": 1,
+            "turn_requests": 1,
+            "archival_extractions": 1,
+            "memories": 1,
+            "chat_logs": 2,
+            "admission_reservations": 1,
+            "privacy_operations": 1,
+            "profiles": 1,
+        }
+        for table, expected in expected_b.items():
+            assert _count(table, f"user_id = '{user_b}'") == expected, (
+                f"{table} of B lost"
+            )
+        # The tombstone survived the purge.
+        assert _count("account_deletion_jobs", f"user_ref_hmac_sha256 = '{ref_a}'") == 1
+    finally:
+        _cleanup_user(user_a)
+        _cleanup_user(user_b)
+
+
+def test_artificial_failure_mid_purge_rolls_back(service_client: Client):
+    user_id = _uid("rollback")
+    _seed_full_user(user_id)
+    ref = _ref(user_id)
+    op_id = _new_op_id()
+    fp = _fingerprint()
+    try:
+        request = _repo(service_client).request(user_id, ref, op_id, fp)
+        job = _repo(service_client).acquire_lease("worker-rb", 60, 100)
+        # Install a BEFORE DELETE trigger on chat_logs for this user that
+        # fails: the purge deletes outbox/turn_requests/archival/memories
+        # first, then fails on chat_logs -> full rollback.
+        _run_sql(
+            "CREATE OR REPLACE FUNCTION public.adl_test_fail_trigger() RETURNS trigger "
+            "LANGUAGE plpgsql AS $$ BEGIN "
+            "RAISE EXCEPTION 'adl-test artificial failure'; END $$;"
+        )
+        _run_sql(
+            "CREATE TRIGGER adl_test_fail BEFORE DELETE ON public.chat_logs "
+            f"FOR EACH ROW WHEN (OLD.user_id = '{user_id}') "
+            "EXECUTE FUNCTION public.adl_test_fail_trigger()"
+        )
+        try:
+            with pytest.raises(PersistenceError):
+                _repo(service_client).purge(job.job_id, "worker-rb", fp)
+        finally:
+            _run_sql("DROP TRIGGER IF EXISTS adl_test_fail ON public.chat_logs")
+            _run_sql("DROP FUNCTION IF EXISTS public.adl_test_fail_trigger()")
+        # Rollback was integral: every table of A still has its rows.
+        for table, expected in (
+            ("outbox_events", 1),
+            ("turn_requests", 1),
+            ("archival_extractions", 1),
+            ("memories", 1),
+            ("chat_logs", 2),
+            ("admission_reservations", 1),
+            ("privacy_operations", 1),
+            ("profiles", 1),
+        ):
+            assert _count(table, f"user_id = '{user_id}'") == expected, (
+                f"{table} not rolled back"
+            )
+        # db_purged_at did NOT appear; the job is still processing and the
+        # tombstone remains.
+        row = _run_sql(
+            "SELECT db_purged_at IS NULL AS purged_null, status "
+            "FROM public.account_deletion_jobs WHERE job_id = "
+            f"'{job.job_id}'"
+        )[0]
+        assert row["purged_null"] is True
+        assert row["status"] == "processing"
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_repeated_purge_on_empty_db_is_safe(service_client: Client):
+    user_id = _uid("repeat")
+    _seed_full_user(user_id)
+    ref = _ref(user_id)
+    op_id = _new_op_id()
+    fp = _fingerprint()
+    try:
+        request = _repo(service_client).request(user_id, ref, op_id, fp)
+        job = _repo(service_client).acquire_lease("worker-r1", 60, 100)
+        first = _repo(service_client).purge(job.job_id, "worker-r1", fp)
+        assert first.status == "purged"
+        # Simulate the crash-after-DB-commit scenario: expire the lease,
+        # a new worker reclaims and purges again on the empty database.
+        _run_sql(
+            "UPDATE public.account_deletion_jobs "
+            "SET lease_expires_at = now() - interval '1 second' "
+            f"WHERE job_id = '{job.job_id}'"
+        )
+        reclaimed = _repo(service_client).acquire_lease("worker-r2", 60, 100)
+        assert reclaimed.job_id == job.job_id
+        second = _repo(service_client).purge(reclaimed.job_id, "worker-r2", fp)
+        assert second.status == "already_purged"
+        assert second.db_purged_at == first.db_purged_at
+        assert request.job_id == job.job_id
+    finally:
+        _cleanup_user(user_id)
+
+
+# ─── 14/15/16. Finalize and minimization ────────────────────────────────────
+
+
+def test_finalize_clears_user_id_keeps_ref_and_tombstone(service_client: Client):
+    user_id = _uid("final")
+    _seed_profile(user_id)
+    ref = _ref(user_id)
+    op_id = _new_op_id()
+    fp = _fingerprint()
+    try:
+        request = _repo(service_client).request(user_id, ref, op_id, fp)
+        job = _repo(service_client).acquire_lease("worker-f", 60, 100)
+        _repo(service_client).purge(job.job_id, "worker-f", fp)
+        result = _repo(service_client).finalize(job.job_id, "worker-f")
+        assert result.status == "completed"
+        # Raw user_id minimized to NULL; the HMAC reference persists.
+        row = _run_sql(
+            "SELECT user_id, user_ref_hmac_sha256, status "
+            "FROM public.account_deletion_jobs WHERE job_id = "
+            f"'{job.job_id}'"
+        )[0]
+        assert row["user_id"] is None
+        assert row["user_ref_hmac_sha256"] == ref
+        assert row["status"] == "completed"
+        # The tombstone stays queryable by the defined contract.
+        tombstone = _repo(service_client).has_tombstone(ref)
+        assert tombstone.exists is True
+        assert tombstone.status == "completed"
+        assert request.job_id == job.job_id
+    finally:
+        _cleanup_user(user_id)
+
+
+# ─── 17. Retention ──────────────────────────────────────────────────────────
+
+
+def test_active_and_failed_jobs_never_aged_out(service_client: Client):
+    user_a = _uid("ret-a")
+    user_b = _uid("ret-b")
+    user_c = _uid("ret-c")
+    ref_a = _ref(user_a)
+    ref_b = _ref(user_b)
+    ref_c = _ref(user_c)
+    fp = _fingerprint()
+    try:
+        # A: completed (purged + finalized).
+        req_a = _repo(service_client).request(user_a, ref_a, _new_op_id(), fp)
+        job_a = _repo(service_client).acquire_lease("worker-rt", 60, 100)
+        assert job_a.job_id == req_a.job_id
+        _repo(service_client).purge(job_a.job_id, "worker-rt", fp)
+        _repo(service_client).finalize(job_a.job_id, "worker-rt")
+        # Age A's completed tombstone beyond the 30-day horizon.
+        _run_sql(
+            "UPDATE public.account_deletion_jobs SET completed_at = "
+            "now() - interval '40 days', db_purged_at = now() - interval '40 days' "
+            f"WHERE job_id = '{job_a.job_id}'"
+        )
+        # B: failed with an old next_attempt_at (never aged out).
+        req_b = _repo(service_client).request(user_b, ref_b, _new_op_id(), fp)
+        job_b = _repo(service_client).acquire_lease("worker-rt", 60, 100)
+        assert job_b.job_id == req_b.job_id
+        _repo(service_client).record_failure(job_b.job_id, "worker-rt", "auth_unavailable")
+        _run_sql(
+            "UPDATE public.account_deletion_jobs SET next_attempt_at = "
+            "now() - interval '40 days', requested_at = now() - interval '40 days' "
+            f"WHERE job_id = '{job_b.job_id}'"
+        )
+        # C: pending, never aged out.
+        _repo(service_client).request(user_c, ref_c, _new_op_id(), fp)
+        _run_sql(
+            "UPDATE public.account_deletion_jobs SET next_attempt_at = "
+            "now() - interval '40 days', requested_at = now() - interval '40 days' "
+            f"WHERE user_ref_hmac_sha256 = '{ref_c}'"
+        )
+
+        # A future cutoff is clamped by the DB: only the aged completed
+        # tombstone of A is removed; active/failed jobs survive.
+        assert _repo(service_client).purge_completed(
+            "2099-01-01T00:00:00+00:00", 100
+        ) == 1
+        assert _count("account_deletion_jobs", f"user_ref_hmac_sha256 = '{ref_b}'") == 1
+        assert _count("account_deletion_jobs", f"user_ref_hmac_sha256 = '{ref_c}'") == 1
+        # A second pass removes nothing.
+        assert _repo(service_client).purge_completed(
+            "2020-01-01T00:00:00+00:00", 100
+        ) == 0
+    finally:
+        _cleanup_user(user_a)
+        _cleanup_user(user_b)
+        _cleanup_user(user_c)
+
+
+# ─── 18/19. Concurrency against the per-user lock ───────────────────────────
+
+
+def test_purge_serialized_with_same_user_writers(
+    supabase_url: str, service_role_key: str
+):
+    """The purge holds the same per-user advisory lock as commit_turn and
+    the privacy operations: a same-user writer (delete_history) that starts
+    concurrently is serialized and both complete without corruption."""
+    user_id = _uid("ser")
+    _seed_full_user(user_id)
+    ref = _ref(user_id)
+    op_id = _new_op_id()
+    fp = _fingerprint()
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+    barrier = threading.Barrier(2)
+    try:
+        client = create_client(supabase_url, service_role_key)
+        request = _repo(client).request(user_id, ref, op_id, fp)
+        _close_client(client)
+
+        def _purge_worker():
+            own_client = create_client(supabase_url, service_role_key)
+            try:
+                barrier.wait(timeout=30)
+                job = _repo(own_client).acquire_lease("worker-ser", 60, 100)
+                result = _repo(own_client).purge(job.job_id, "worker-ser", fp)
+                assert result.status == "purged"
+            except BaseException as exc:  # noqa: BLE001
+                with lock:
+                    errors.append(exc)
+            finally:
+                _close_client(own_client)
+
+        def _writer_worker():
+            own_client = create_client(supabase_url, service_role_key)
+            try:
+                barrier.wait(timeout=30)
+                # delete_history acquires the SAME per-user advisory lock.
+                _privacy_delete_history(own_client, user_id)
+            except BaseException as exc:  # noqa: BLE001
+                with lock:
+                    errors.append(exc)
+            finally:
+                _close_client(own_client)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [pool.submit(_purge_worker), pool.submit(_writer_worker)]
+            for future in futures:
+                future.result(timeout=120)
+
+        assert errors == [], f"serialized purge/writer failed: {errors}"
+        # Final state: user fully purged, tombstone intact.
+        assert _count("profiles", f"user_id = '{user_id}'") == 0
+        assert _count("account_deletion_jobs", f"user_ref_hmac_sha256 = '{ref}'") == 1
+        assert request.job_id is not None
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_different_users_not_globally_blocked(
+    supabase_url: str, service_role_key: str
+):
+    """A purge of A never blocks a same-operation writer of B: the per-user
+    advisory lock is scoped per user, never global."""
+    user_a = _uid("noblocka")
+    user_b = _uid("noblockb")
+    _seed_full_user(user_a)
+    _seed_full_user(user_b)
+    ref_a = _ref(user_a)
+    op_a = _new_op_id()
+    fp = _fingerprint()
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+    barrier = threading.Barrier(2)
+    try:
+        client = create_client(supabase_url, service_role_key)
+        _repo(client).request(user_a, ref_a, op_a, fp)
+        _close_client(client)
+
+        def _purge_a():
+            own_client = create_client(supabase_url, service_role_key)
+            try:
+                barrier.wait(timeout=30)
+                job = _repo(own_client).acquire_lease("worker-na", 60, 100)
+                result = _repo(own_client).purge(job.job_id, "worker-na", fp)
+                assert result.status == "purged"
+            except BaseException as exc:  # noqa: BLE001
+                with lock:
+                    errors.append(exc)
+            finally:
+                _close_client(own_client)
+
+        def _writer_b():
+            own_client = create_client(supabase_url, service_role_key)
+            try:
+                barrier.wait(timeout=30)
+                _privacy_delete_history(own_client, user_b)
+            except BaseException as exc:  # noqa: BLE001
+                with lock:
+                    errors.append(exc)
+            finally:
+                _close_client(own_client)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [pool.submit(_purge_a), pool.submit(_writer_b)]
+            for future in futures:
+                future.result(timeout=120)
+
+        assert errors == [], f"cross-user concurrency failed: {errors}"
+        # A fully purged; B's writer ran to completion and B's profile
+        # still exists (delete_history preserves profiles).
+        assert _count("profiles", f"user_id = '{user_a}'") == 0
+        assert _count("profiles", f"user_id = '{user_b}'") == 1
+    finally:
+        _cleanup_user(user_a)
+        _cleanup_user(user_b)

--- a/backend/tests/test_account_deletion_integration.py
+++ b/backend/tests/test_account_deletion_integration.py
@@ -605,8 +605,139 @@ def test_repeated_purge_on_empty_db_is_safe(service_client: Client):
         _cleanup_user(user_id)
 
 
-# ─── 14/15/16. Finalize and minimization ────────────────────────────────────
+# ─── 14. Failure/retry AFTER the DB purge preserve db_purged_at ─────────────
 
+
+def test_failure_after_purge_preserves_marker_and_retries_safely(service_client: Client):
+    """The future flow purge DB -> Auth fails -> retry must be representable.
+
+    After a successful purge, record_failure and record_retry transition the
+    job to failed/pending WITHOUT clearing db_purged_at; a reacquired job's
+    purge returns already_purged without repeating deletes; finalization
+    remains possible and minimizes user_id.
+    """
+    user_id = _uid("postpurge")
+    _seed_full_user(user_id)
+    ref = _ref(user_id)
+    op_id = _new_op_id()
+    fp = _fingerprint()
+    try:
+        # Purge succeeds first.
+        request = _repo(service_client).request(user_id, ref, op_id, fp)
+        job = _repo(service_client).acquire_lease("worker-pp", 60, 100)
+        purged = _repo(service_client).purge(job.job_id, "worker-pp", fp)
+        assert purged.status == "purged"
+        assert purged.db_purged_at is not None
+
+        # Auth deletion fails (simulated): record_failure keeps the marker
+        # and the tombstone stays blocking.
+        failure = _repo(service_client).record_failure(
+            job.job_id, "worker-pp", "auth_unavailable"
+        )
+        assert failure.status == "failed"
+        row = _run_sql(
+            "SELECT status, db_purged_at IS NOT NULL AS purged "
+            "FROM public.account_deletion_jobs WHERE job_id = "
+            f"'{job.job_id}'"
+        )[0]
+        assert row["status"] == "failed"
+        assert row["purged"] is True, "db_purged_at must survive record_failure"
+        assert _repo(service_client).has_tombstone(ref).exists is True
+
+        # Reacquire after the retry window: the purge replays safely.
+        _run_sql(
+            "UPDATE public.account_deletion_jobs SET next_attempt_at = "
+            "now() - interval '1 second' "
+            f"WHERE job_id = '{job.job_id}'"
+        )
+        reclaimed = _repo(service_client).acquire_lease("worker-pp2", 60, 100)
+        assert reclaimed.job_id == job.job_id
+        assert reclaimed.db_purged_at == purged.db_purged_at
+        replay = _repo(service_client).purge(reclaimed.job_id, "worker-pp2", fp)
+        assert replay.status == "already_purged"
+        # No delete was repeated: the user tables were already empty and
+        # stay empty; counts are zero.
+        assert replay.counts["profiles"] == 0
+        assert _count("profiles", f"user_id = '{user_id}'") == 0
+
+        # Purge -> record_retry -> reacquire is also safe.
+        _repo(service_client).record_retry(reclaimed.job_id, "worker-pp2")
+        row = _run_sql(
+            "SELECT status, db_purged_at IS NOT NULL AS purged "
+            "FROM public.account_deletion_jobs WHERE job_id = "
+            f"'{job.job_id}'"
+        )[0]
+        assert row["status"] == "pending"
+        assert row["purged"] is True, "db_purged_at must survive record_retry"
+        _run_sql(
+            "UPDATE public.account_deletion_jobs SET next_attempt_at = "
+            "now() - interval '1 second' "
+            f"WHERE job_id = '{job.job_id}'"
+        )
+        reclaimed2 = _repo(service_client).acquire_lease("worker-pp3", 60, 100)
+        assert reclaimed2.job_id == job.job_id
+        replay2 = _repo(service_client).purge(reclaimed2.job_id, "worker-pp3", fp)
+        assert replay2.status == "already_purged"
+
+        # Finalization after all retries is possible and minimizes user_id.
+        finalized = _repo(service_client).finalize(reclaimed2.job_id, "worker-pp3")
+        assert finalized.status == "completed"
+        row = _run_sql(
+            "SELECT user_id, user_ref_hmac_sha256, status "
+            "FROM public.account_deletion_jobs WHERE job_id = "
+            f"'{job.job_id}'"
+        )[0]
+        assert row["user_id"] is None
+        assert row["user_ref_hmac_sha256"] == ref
+        assert row["status"] == "completed"
+        assert request.job_id == job.job_id
+    finally:
+        _cleanup_user(user_id)
+
+
+def test_attempts_exhaustion_is_terminal_and_tombstone_preserved(service_client: Client):
+    """The attempts ceiling produces a deterministic terminal state.
+
+    The last allowed claim reaches the ceiling; record_failure at the
+    ceiling makes the job terminal (next_attempt_at NULL); no new automatic
+    claim happens; the tombstone stays blocking and preserved.
+    """
+    user_id = _uid("exhaust")
+    ref = _ref(user_id)
+    op_id = _new_op_id()
+    fp = _fingerprint()
+    try:
+        request = _repo(service_client).request(user_id, ref, op_id, fp)
+        # Fast-forward to the boundary: 99 attempts already consumed.
+        _run_sql(
+            "UPDATE public.account_deletion_jobs SET attempts = 99 "
+            f"WHERE job_id = '{request.job_id}'"
+        )
+        # Last allowed claim: 99 -> 100.
+        job = _repo(service_client).acquire_lease("worker-ex", 60, 100)
+        assert job.attempts == 100
+        # record_failure at the ceiling -> TERMINAL (next_attempt_at NULL).
+        failure = _repo(service_client).record_failure(
+            job.job_id, "worker-ex", "auth_unavailable"
+        )
+        assert failure.status == "failed"
+        row = _run_sql(
+            "SELECT next_attempt_at IS NULL AS terminal "
+            "FROM public.account_deletion_jobs WHERE job_id = "
+            f"'{job.job_id}'"
+        )[0]
+        assert row["terminal"] is True
+        # No new automatic claim: the exhausted job is never selected.
+        with pytest.raises(PersistenceError):
+            _repo(service_client).acquire_lease("worker-ex2", 60, 100)
+        # The tombstone stays blocking.
+        assert _repo(service_client).has_tombstone(ref).exists is True
+        assert _count("account_deletion_jobs", f"user_ref_hmac_sha256 = '{ref}'") == 1
+    finally:
+        _cleanup_user(user_id)
+
+
+# ─── 14/15/16. Finalize and minimization ────────────────────────────────────
 
 def test_finalize_clears_user_id_keeps_ref_and_tombstone(service_client: Client):
     user_id = _uid("final")

--- a/backend/tests/test_account_deletion_legacy.py
+++ b/backend/tests/test_account_deletion_legacy.py
@@ -365,3 +365,57 @@ def test_legacy_upgrade_applies_account_deletion_ledger():
         ), "completed job must minimize the raw user_id"
     finally:
         _restore_new_migration()
+
+
+@pytest.mark.database_integration
+def test_legacy_upgrade_fails_closed_on_drift():
+    """The legacy upgrade must also fail closed on drift.
+
+    A database that already contains an object owned by the new migration
+    (for example a preexisting ``account_deletion_assert_owner`` function
+    that the migration would otherwise silently replace via
+    CREATE OR REPLACE) must reject the upgrade with 23514, install nothing
+    and leave the migration unregistered.
+    """
+    _hide_new_migration()
+    try:
+        _run_supabase("account_deletion_legacy_reset", ["db", "reset"])
+        _seed_legacy_data()
+
+        # Install drift before restoring the new migration.
+        _run_psql(
+            "CREATE OR REPLACE FUNCTION public.account_deletion_assert_owner("
+            "p_job_id uuid, p_worker_id text) RETURNS text "
+            "LANGUAGE sql IMMUTABLE AS $$ SELECT 'drift'::text $$;"
+        )
+
+        _restore_new_migration()
+        res = _run_supabase(
+            "account_deletion_legacy_upgrade", ["migration", "up", "--local"], check=False
+        )
+        assert res.returncode != 0, "expected the legacy upgrade to fail on drift"
+        assert "23514" in res.stderr, (
+            f"expected SQLSTATE 23514 from the drift gate, got: {res.stderr[-500:]}"
+        )
+
+        # Nothing was installed and the migration is not registered.
+        assert not _query_scalar_bool(
+            "SELECT EXISTS("
+            "SELECT 1 FROM pg_class c "
+            "JOIN pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE n.nspname = 'public' AND c.relname = 'account_deletion_jobs'"
+            ") AS result"
+        ), "account_deletion_jobs was created despite the drift failure"
+        assert not _query_scalar_bool(
+            "SELECT EXISTS("
+            "SELECT 1 FROM supabase_migrations.schema_migrations "
+            f"WHERE version = '{MIGRATION_VERSION}'"
+            ") AS result"
+        ), "account deletion migration registered despite the drift failure"
+        # Legacy data remains untouched.
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.profiles "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 1, "legacy data was modified by the failed upgrade"
+    finally:
+        _restore_new_migration()

--- a/backend/tests/test_account_deletion_legacy.py
+++ b/backend/tests/test_account_deletion_legacy.py
@@ -1,0 +1,367 @@
+"""Real Supabase integration test: account deletion migration on a legacy
+upgrade (#324).
+
+This file is executed only by the database CI job. It must never be collected
+by the ordinary backend unit job (see the ignore list in
+``.github/workflows/ci.yml``).
+
+The new migration must work on a clean reset (proven by pgTAP 08) AND on a
+legacy upgrade: a database at the migrations previous to
+``account_deletion_ledger`` (baseline + turn schema + privacy + retention)
+with real legacy user data receives the new migration via
+``supabase migration up --local``.
+
+Proves:
+1. The migration registers its version and applies additively.
+2. Legacy data is preserved untouched.
+3. The ledger exists with RLS/FORCE RLS, zero policies and no grants.
+4. The RPCs exist with SECURITY DEFINER, empty search_path and
+   service_role-only EXECUTE; PUBLIC/anon/authenticated have none.
+5. The primitives actually work on the upgraded database (request -> claim
+   -> purge -> finalize end to end).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from backend.supabase_cli import run_supabase_op
+
+LEGACY_HIDDEN_SUFFIX = ".legacy-test-hidden"
+_ADL_FILENAME_RE = re.compile(
+    r"^\d+_account_deletion_ledger\.sql(?:\.(?:tmp|legacy-test-hidden))?$"
+)
+
+
+def _find_adl_migration() -> Path:
+    matches = [
+        p
+        for p in Path("supabase/migrations").iterdir()
+        if _ADL_FILENAME_RE.match(p.name)
+    ]
+    if not matches:
+        raise FileNotFoundError(
+            "supabase/migrations/*_account_deletion_ledger.sql not found"
+        )
+    return next((p for p in matches if p.name.endswith(".sql")), matches[0])
+
+
+def _version_from_filename(name: str) -> str:
+    return Path(name).name.split("_", 1)[0]
+
+
+_ADL_MIGRATION = _find_adl_migration()
+MIGRATION = str(_ADL_MIGRATION).removesuffix(LEGACY_HIDDEN_SUFFIX).removesuffix(".tmp")
+MIGRATION_VERSION = _version_from_filename(MIGRATION)
+MIGRATION_TMP = f"{MIGRATION}.tmp"
+
+RPC_SIGNATURES = {
+    "account_deletion_request": "account_deletion_request(text, text, uuid, text)",
+    "account_deletion_has_tombstone": "account_deletion_has_tombstone(text)",
+    "account_deletion_acquire_lease": "account_deletion_acquire_lease(text, integer, integer)",
+    "account_deletion_purge": "account_deletion_purge(uuid, text, text)",
+    "account_deletion_record_failure": "account_deletion_record_failure(uuid, text, text)",
+    "account_deletion_record_retry": "account_deletion_record_retry(uuid, text)",
+    "account_deletion_finalize": "account_deletion_finalize(uuid, text)",
+    "account_deletion_purge_completed": "account_deletion_purge_completed(timestamptz, integer)",
+}
+
+
+def _run_supabase(op_id: str, args: list[str], check: bool = True):
+    result = run_supabase_op(op_id, args, check=False)
+    if check and result.returncode != 0:
+        raise AssertionError(f"Supabase operation failed: {op_id}")
+    return result
+
+
+def _run_psql(sql: str) -> None:
+    result = subprocess.run(
+        [
+            "docker", "exec", "-i", "supabase_db_app",
+            "psql", "-U", "postgres",
+            "-v", "ON_ERROR_STOP=1", "-q", "-f", "-",
+        ],
+        input=sql,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError("psql execution failed")
+
+
+def _query_json(query: str) -> list:
+    res = _run_supabase(
+        "account_deletion_legacy_query",
+        ["db", "query", "--agent=no", "--output", "json", query],
+        check=False,
+    )
+    if res.returncode != 0:
+        raise AssertionError("Query result: operation failed")
+    try:
+        data = json.loads(res.stdout)
+    except json.JSONDecodeError:
+        raise AssertionError("Query result: invalid JSON response")
+    if not isinstance(data, list):
+        raise AssertionError("Query result: expected a list")
+    return data
+
+
+def _query_scalar_bool(query: str) -> bool:
+    data = _query_json(query)
+    if len(data) != 1 or "result" not in data[0]:
+        raise AssertionError("Query result: expected exactly one scalar row")
+    value = data[0]["result"]
+    if not isinstance(value, bool):
+        raise AssertionError("Query result: expected a boolean")
+    return value
+
+
+def _query_scalar_int(query: str) -> int:
+    data = _query_json(query)
+    if len(data) != 1 or "result" not in data[0]:
+        raise AssertionError("Query result: expected exactly one scalar row")
+    value = data[0]["result"]
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise AssertionError("Query result: expected an integer")
+    return value
+
+
+def _hide_new_migration() -> None:
+    if os.path.exists(MIGRATION) and not os.path.exists(MIGRATION_TMP):
+        os.rename(MIGRATION, MIGRATION_TMP)
+
+
+def _restore_new_migration() -> None:
+    if os.path.exists(MIGRATION_TMP):
+        os.rename(MIGRATION_TMP, MIGRATION)
+    elif os.path.exists(MIGRATION + LEGACY_HIDDEN_SUFFIX):
+        os.rename(MIGRATION + LEGACY_HIDDEN_SUFFIX, MIGRATION)
+
+
+LEGACY_USER = "adl_legacy_user"
+LEGACY_REF = "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+
+
+def _seed_legacy_data() -> None:
+    _run_psql(
+        f"""
+        INSERT INTO public.profiles (user_id, persona_config, user_profile,
+            relationship_state, emotional_state, revision)
+        VALUES (
+            '{LEGACY_USER}', 'legacy-persona', '{{"k":"v"}}'::jsonb,
+            '{{"schema_version":1,"trust":0.5,"affection":0.3,"tension":0.0,"triggers":[],"timestamp":1700000000.0}}'::jsonb,
+            '{{"schema_version":1,"pleasure":0.0,"arousal":0.0,"dominance":0.0,"libido":0.0,"aggression":0.0,"connection":0.5,"energy":0.8,"tension":0.0,"coping_mode":"HEALTHY","timestamp":1700000000.0}}'::jsonb,
+            2
+        );
+
+        INSERT INTO public.chat_logs (user_id, role, content)
+        VALUES ('{LEGACY_USER}', 'user', 'legacy hello'),
+               ('{LEGACY_USER}', 'assistant', 'legacy hi');
+
+        INSERT INTO public.memories (user_id, content, metadata)
+        VALUES ('{LEGACY_USER}', 'legacy memory', '{{}}'::jsonb);
+
+        INSERT INTO public.turn_requests (
+            id, user_id, request_id, payload_hash_sha256, status, expected_revision,
+            committed_revision, replay_payload, created_at, updated_at, completed_at
+        ) VALUES (
+            'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
+            '{LEGACY_USER}', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid,
+            'a'::text || repeat('0', 63), 'completed', 0, 2,
+            '{{"response":"legacy hi"}}'::jsonb,
+            now(), now(), now()
+        );
+
+        INSERT INTO public.outbox_events (
+            event_type, contract_version, user_id, turn_request_id, payload, status,
+            attempts, next_attempt_at, idempotency_key, created_at, updated_at
+        ) VALUES (
+            'turn_completed', 1, '{LEGACY_USER}',
+            'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
+            '{{"ref":"t1"}}'::jsonb, 'pending', 0, now() + interval '1 second',
+            'adl_legacy_k1', now(), now()
+        );
+
+        INSERT INTO public.archival_extractions (
+            user_id, source_chat_log_id, extractor_version, schema_version,
+            idempotency_key, facts
+        )
+        SELECT '{LEGACY_USER}', id, 1, 1, 'adl_legacy_arch_1', '{{"facts":[]}}'::jsonb
+        FROM public.chat_logs WHERE user_id = '{LEGACY_USER}' AND role = 'user';
+
+        INSERT INTO public.admission_reservations (
+            user_id, request_id, message_hmac_sha256, network_hmac_sha256,
+            estimated_units
+        ) VALUES (
+            '{LEGACY_USER}', 'dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid,
+            repeat('a', 64), repeat('b', 64), 10
+        );
+
+        INSERT INTO public.privacy_operations (
+            user_id, operation_id, operation, operation_payload_sha256, status, result
+        ) VALUES (
+            '{LEGACY_USER}', 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid,
+            'delete_history', repeat('c', 64), 'applied', '{{}}'::jsonb
+        );
+        """
+    )
+
+
+def _assert_ledger_state() -> None:
+    assert _query_scalar_bool(
+        "SELECT EXISTS("
+        "SELECT 1 FROM pg_class WHERE oid = 'public.account_deletion_jobs'::regclass "
+        "AND relrowsecurity = true) AS result"
+    ), "RLS not enabled on account_deletion_jobs"
+    assert _query_scalar_bool(
+        "SELECT EXISTS("
+        "SELECT 1 FROM pg_class WHERE oid = 'public.account_deletion_jobs'::regclass "
+        "AND relforcerowsecurity = true) AS result"
+    ), "FORCE RLS not enabled on account_deletion_jobs"
+    assert not _query_scalar_bool(
+        "SELECT has_table_privilege('service_role', "
+        "'public.account_deletion_jobs', "
+        "'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER') AS result"
+    ), "service_role has table privileges on account_deletion_jobs"
+    assert not _query_scalar_bool(
+        "SELECT has_table_privilege('public', "
+        "'public.account_deletion_jobs', "
+        "'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER') AS result"
+    ), "PUBLIC has table privileges on account_deletion_jobs"
+    assert _query_scalar_int(
+        "SELECT count(*)::int AS result FROM pg_policies "
+        "WHERE schemaname = 'public' AND tablename = 'account_deletion_jobs'"
+    ) == 0, "account_deletion_jobs has policies"
+
+
+def _assert_rpc_state() -> None:
+    for name, signature in RPC_SIGNATURES.items():
+        assert _query_scalar_bool(
+            "SELECT EXISTS("
+            "SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace "
+            f"WHERE n.nspname = 'public' AND p.proname = '{name}'"
+            ") AS result"
+        ), f"{name} missing after the upgrade"
+        assert _query_scalar_bool(
+            f"SELECT has_function_privilege('service_role', "
+            f"'public.{signature}', 'EXECUTE') AS result"
+        ), f"service_role missing EXECUTE on {name}"
+        for role in ("anon", "authenticated", "public"):
+            assert not _query_scalar_bool(
+                f"SELECT has_function_privilege('{role}', "
+                f"'public.{signature}', 'EXECUTE') AS result"
+            ), f"{role} gained EXECUTE on {name}"
+
+
+@pytest.mark.database_integration
+def test_legacy_upgrade_applies_account_deletion_ledger():
+    _hide_new_migration()
+    try:
+        _run_supabase("account_deletion_legacy_reset", ["db", "reset"])
+        _seed_legacy_data()
+
+        _restore_new_migration()
+        _run_supabase("account_deletion_legacy_upgrade", ["migration", "up", "--local"])
+
+        # ---- 1. Migration registered ----
+        assert _query_scalar_bool(
+            "SELECT EXISTS("
+            "SELECT 1 FROM supabase_migrations.schema_migrations "
+            f"WHERE version = '{MIGRATION_VERSION}'"
+            ") AS result"
+        ), "account deletion migration timestamp not registered"
+
+        # ---- 2. Legacy data preserved untouched ----
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.profiles "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 1
+        assert _query_scalar_int(
+            "SELECT revision::int AS result FROM public.profiles "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 2, "legacy revision changed during the upgrade"
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.chat_logs "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 2
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.turn_requests "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 1
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.outbox_events "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 1
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.memories "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 1
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.archival_extractions "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 1
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.admission_reservations "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 1
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.privacy_operations "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 1
+
+        # ---- 3. Ledger + RPC state ----
+        _assert_ledger_state()
+        _assert_rpc_state()
+
+        # ---- 4. The ledger works end to end on the upgraded database ----
+        result = _query_json(
+            "SELECT public.account_deletion_request("
+            f"'{LEGACY_USER}', '{LEGACY_REF}', "
+            "'99999999-9999-9999-9999-999999999999'::uuid, repeat('b', 64)"
+            ") AS result"
+        )
+        assert len(result) == 1 and result[0]["result"]["status"] == "created"
+        assert result[0]["result"]["job_status"] == "pending"
+
+        claim = _query_json(
+            "SELECT public.account_deletion_acquire_lease('legacy-worker', 60, 100) AS result"
+        )
+        assert len(claim) == 1 and claim[0]["result"]["found"] is True
+        job_id = claim[0]["result"]["job_id"]
+
+        purge = _query_json(
+            "SELECT public.account_deletion_purge("
+            f"'{job_id}'::uuid, 'legacy-worker', repeat('b', 64)) AS result"
+        )
+        assert len(purge) == 1 and purge[0]["result"]["status"] == "purged"
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.chat_logs "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 0
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.profiles "
+            f"WHERE user_id = '{LEGACY_USER}'"
+        ) == 0
+        # The tombstone survived the profiles DELETE.
+        assert _query_scalar_int(
+            "SELECT count(*)::int AS result FROM public.account_deletion_jobs "
+            f"WHERE user_ref_hmac_sha256 = '{LEGACY_REF}'"
+        ) == 1
+
+        finalize = _query_json(
+            "SELECT public.account_deletion_finalize("
+            f"'{job_id}'::uuid, 'legacy-worker') AS result"
+        )
+        assert len(finalize) == 1 and finalize[0]["result"]["status"] == "completed"
+        assert _query_scalar_bool(
+            "SELECT user_id IS NULL AS result FROM public.account_deletion_jobs "
+            f"WHERE user_ref_hmac_sha256 = '{LEGACY_REF}'"
+        ), "completed job must minimize the raw user_id"
+    finally:
+        _restore_new_migration()

--- a/backend/tests/test_account_deletion_preflight.py
+++ b/backend/tests/test_account_deletion_preflight.py
@@ -1,0 +1,195 @@
+"""Real Supabase integration test: account deletion preflight fail-closed (#324).
+
+This file is executed only by the database CI job. It must never be collected
+by the ordinary backend unit job (see the ignore list in
+``.github/workflows/ci.yml``).
+
+The preflight of ``account_deletion_ledger`` must fail with SQLSTATE 23514
+when ANY mandatory dependency is missing. Starting from a schema compatible
+with the migration (baseline + turn schema + privacy + retention), this
+suite drops EXACTLY ONE of the required tables (every other dependency still
+present), applies the migration and requires:
+
+1. the migration fails with 23514;
+2. ``account_deletion_jobs`` was NOT created;
+3. NONE of the new functions were installed;
+4. the environment is restored in ``finally`` (migration files and data).
+
+Each parametrized case exercises a table that a naive single ``IN (...)``
+preflight would have masked.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from backend.supabase_cli import run_supabase_op
+
+LEGACY_HIDDEN_SUFFIX = ".legacy-test-hidden"
+_ADL_FILENAME_RE = re.compile(
+    r"^\d+_account_deletion_ledger\.sql(?:\.(?:tmp|legacy-test-hidden))?$"
+)
+
+# Every function created by the migration. None may exist after a failed
+# preflight.
+MIGRATION_FUNCTIONS = (
+    "account_deletion_request",
+    "account_deletion_has_tombstone",
+    "account_deletion_acquire_lease",
+    "account_deletion_purge",
+    "account_deletion_record_failure",
+    "account_deletion_record_retry",
+    "account_deletion_finalize",
+    "account_deletion_purge_completed",
+    "account_deletion_validation_error",
+    "account_deletion_assert_owner",
+    "account_deletion_intent_fingerprint_sha256",
+)
+
+# Tables the migration hard-depends on. Dropping exactly one must make the
+# migration fail closed.
+MISSING_TABLE_CASES = (
+    "chat_logs",
+    "memories",
+    "archival_extractions",
+    "turn_requests",
+    "outbox_events",
+    "admission_reservations",
+    "privacy_operations",
+    "profiles",
+)
+
+
+def _find_adl_migration() -> Path:
+    matches = [
+        p
+        for p in Path("supabase/migrations").iterdir()
+        if _ADL_FILENAME_RE.match(p.name)
+    ]
+    if not matches:
+        raise FileNotFoundError(
+            "supabase/migrations/*_account_deletion_ledger.sql not found"
+        )
+    return next((p for p in matches if p.name.endswith(".sql")), matches[0])
+
+
+_ADL_MIGRATION = _find_adl_migration()
+MIGRATION = str(_ADL_MIGRATION).removesuffix(LEGACY_HIDDEN_SUFFIX).removesuffix(".tmp")
+MIGRATION_TMP = f"{MIGRATION}.tmp"
+
+
+def _run_supabase(op_id: str, args: list[str], check: bool = True):
+    result = run_supabase_op(op_id, args, check=False)
+    if check and result.returncode != 0:
+        raise AssertionError(f"Supabase operation failed: {op_id}")
+    return result
+
+
+def _run_psql(sql: str) -> None:
+    result = subprocess.run(
+        [
+            "docker", "exec", "-i", "supabase_db_app",
+            "psql", "-U", "postgres",
+            "-v", "ON_ERROR_STOP=1", "-q", "-f", "-",
+        ],
+        input=sql,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError("psql execution failed")
+
+
+def _query_scalar_bool(query: str) -> bool:
+    res = _run_supabase(
+        "account_deletion_preflight_query",
+        ["db", "query", "--agent=no", "--output", "json", query],
+        check=False,
+    )
+    if res.returncode != 0:
+        raise AssertionError("Query result: operation failed")
+    try:
+        data = json.loads(res.stdout)
+    except json.JSONDecodeError:
+        raise AssertionError("Query result: invalid JSON response")
+    if not isinstance(data, list) or len(data) != 1 or "result" not in data[0]:
+        raise AssertionError("Query result: expected exactly one scalar row")
+    value = data[0]["result"]
+    if not isinstance(value, bool):
+        raise AssertionError("Query result: expected a boolean")
+    return value
+
+
+def _hide_new_migration() -> None:
+    if os.path.exists(MIGRATION) and not os.path.exists(MIGRATION_TMP):
+        os.rename(MIGRATION, MIGRATION_TMP)
+
+
+def _restore_new_migration() -> None:
+    if os.path.exists(MIGRATION_TMP):
+        os.rename(MIGRATION_TMP, MIGRATION)
+    elif os.path.exists(MIGRATION + LEGACY_HIDDEN_SUFFIX):
+        os.rename(MIGRATION + LEGACY_HIDDEN_SUFFIX, MIGRATION)
+
+
+@pytest.mark.parametrize("missing_table", MISSING_TABLE_CASES)
+@pytest.mark.database_integration
+def test_preflight_fails_closed_on_missing_table(missing_table: str):
+    _hide_new_migration()
+    try:
+        # Baseline compatible with the migration: every required table present.
+        _run_supabase("account_deletion_preflight_reset", ["db", "reset"])
+
+        # Remove EXACTLY one mandatory dependency while every other
+        # dependency of the set remains present.
+        _run_psql(f"DROP TABLE IF EXISTS public.{missing_table} CASCADE;")
+        assert _query_scalar_bool(
+            f"SELECT to_regclass('public.{missing_table}') IS NULL AS result"
+        ), f"{missing_table} was not actually dropped"
+
+        _restore_new_migration()
+
+        # Applying the migration must FAIL with 23514 BEFORE installing
+        # anything.
+        res = _run_supabase(
+            "account_deletion_preflight_apply", ["migration", "up", "--local"], check=False
+        )
+        assert res.returncode != 0, (
+            f"expected the account deletion migration to fail when {missing_table} is missing"
+        )
+        assert "23514" in res.stderr, (
+            f"expected SQLSTATE 23514 from preflight, got: {res.stderr[-500:]}"
+        )
+
+        # NONE of the new objects may be installed.
+        assert not _query_scalar_bool(
+            "SELECT EXISTS("
+            "SELECT 1 FROM pg_class c "
+            "JOIN pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE n.nspname = 'public' AND c.relname = 'account_deletion_jobs'"
+            ") AS result"
+        ), "account_deletion_jobs was created despite the failed preflight"
+        for fn in MIGRATION_FUNCTIONS:
+            assert not _query_scalar_bool(
+                "SELECT EXISTS("
+                "SELECT 1 FROM pg_proc p "
+                "JOIN pg_namespace n ON n.oid = p.pronamespace "
+                f"WHERE n.nspname = 'public' AND p.proname = '{fn}'"
+                ") AS result"
+            ), f"{fn} was installed despite the failed preflight"
+
+        # The migration must NOT be registered.
+        assert not _query_scalar_bool(
+            "SELECT EXISTS("
+            "SELECT 1 FROM supabase_migrations.schema_migrations "
+            "WHERE name = 'account_deletion_ledger'"
+            ") AS result"
+        ), "account_deletion_ledger was registered despite the failed preflight"
+    finally:
+        _restore_new_migration()

--- a/backend/tests/test_account_deletion_preflight.py
+++ b/backend/tests/test_account_deletion_preflight.py
@@ -193,3 +193,75 @@ def test_preflight_fails_closed_on_missing_table(missing_table: str):
         ), "account_deletion_ledger was registered despite the failed preflight"
     finally:
         _restore_new_migration()
+
+
+@pytest.mark.database_integration
+def test_preflight_fails_closed_on_drift_of_own_object():
+    """A preexisting object with a name owned by the migration must block it.
+
+    Every object this migration creates (including internal helpers such as
+    ``account_deletion_assert_owner``) is part of the drift gate: a
+    preexisting function with one of those names must fail the migration
+    with 23514 BEFORE anything is installed or replaced.
+    """
+    _hide_new_migration()
+    try:
+        _run_supabase("account_deletion_preflight_reset", ["db", "reset"])
+
+        # Install drift: a preexisting function that the migration also
+        # creates via CREATE OR REPLACE (would otherwise be silently
+        # replaced instead of blocking the upgrade).
+        _run_psql(
+            "CREATE OR REPLACE FUNCTION public.account_deletion_assert_owner("
+            "p_job_id uuid, p_worker_id text) RETURNS text "
+            "LANGUAGE sql IMMUTABLE AS $$ SELECT 'drift'::text $$;"
+        )
+        assert _query_scalar_bool(
+            "SELECT EXISTS("
+            "SELECT 1 FROM pg_proc p "
+            "JOIN pg_namespace n ON n.oid = p.pronamespace "
+            "WHERE n.nspname = 'public' AND p.proname = 'account_deletion_assert_owner'"
+            ") AS result"
+        ), "drift function was not actually installed"
+
+        _restore_new_migration()
+
+        res = _run_supabase(
+            "account_deletion_preflight_apply", ["migration", "up", "--local"], check=False
+        )
+        assert res.returncode != 0, (
+            "expected the account deletion migration to fail on drift of its own object"
+        )
+        assert "23514" in res.stderr, (
+            f"expected SQLSTATE 23514 from the drift gate, got: {res.stderr[-500:]}"
+        )
+
+        # NONE of the new objects may be installed; the migration is not
+        # registered. The preexisting drift function itself remains (the
+        # migration failed before touching it), so it is excluded from the
+        # installed-check.
+        assert not _query_scalar_bool(
+            "SELECT EXISTS("
+            "SELECT 1 FROM pg_class c "
+            "JOIN pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE n.nspname = 'public' AND c.relname = 'account_deletion_jobs'"
+            ") AS result"
+        ), "account_deletion_jobs was created despite the drift failure"
+        for fn in MIGRATION_FUNCTIONS:
+            if fn == "account_deletion_assert_owner":
+                continue
+            assert not _query_scalar_bool(
+                "SELECT EXISTS("
+                "SELECT 1 FROM pg_proc p "
+                "JOIN pg_namespace n ON n.oid = p.pronamespace "
+                f"WHERE n.nspname = 'public' AND p.proname = '{fn}'"
+                ") AS result"
+            ), f"{fn} was installed despite the drift failure"
+        assert not _query_scalar_bool(
+            "SELECT EXISTS("
+            "SELECT 1 FROM supabase_migrations.schema_migrations "
+            "WHERE name = 'account_deletion_ledger'"
+            ") AS result"
+        ), "account_deletion_ledger was registered despite the drift failure"
+    finally:
+        _restore_new_migration()

--- a/docs/architecture/user-data-lifecycle.md
+++ b/docs/architecture/user-data-lifecycle.md
@@ -315,16 +315,23 @@ user after the commit is confirmed. The tombstone survives the
 
 `pending -> processing -> (failed | pending retry) -> processing -> completed`
 
-- `pending`: registered, not claimed.
+- `pending`: registered, not claimed. Always has a scheduled
+  `next_attempt_at`.
 - `processing`: claimed by exactly one worker (lease owner + expiry). The
   DB allows only `processing` to carry a lease.
 - `failed`: a worker reported a sanitized `error_code`; retry-eligible
   after `next_attempt_at` (backoff derived from `attempts`, 30s..1h).
+  A `failed` job whose `attempts` reached the deterministic ceiling (100)
+  is TERMINAL: `next_attempt_at` becomes NULL, it is never claimed
+  automatically again, and the tombstone stays blocking and operationally
+  recoverable by a privileged operator. `record_retry` at the ceiling also
+  becomes a terminal `failed` job with `error_code = attempts_exhausted`.
 - `completed`: DB purge committed (`db_purged_at`) AND the future Auth
   deletion confirmed (#325). Constraints reject every incoherent
   combination: `completed` requires `db_purged_at` + `completed_at` and
   NULL `user_id`; `failed` requires `error_code`; attempts are never
-  negative; lease owner and error codes use strict allowlists.
+  negative; lease owner and error codes use strict allowlists;
+  `pending` always has `next_attempt_at`.
 
 ### DB/Auth frontier and `db_purged_at`
 
@@ -332,9 +339,13 @@ user after the commit is confirmed. The tombstone survives the
 committed. It becomes non-NULL ONLY in the same transaction that completed
 every delete; any failure rolls the whole attempt back and the marker
 stays empty. It is set while the job is `processing` (purge done, Auth
-deletion pending) and is required for `completed`. A repeated purge after
-a crash (`DB commit` done, process died before Auth) is a safe replay:
-`db_purged_at` is authoritative and no delete depends on the row existing.
+deletion pending) and is required for `completed`. Once set it is NEVER
+cleared: retry/failure after the DB purge (e.g. the future Auth deletion
+failed) transition the job to `pending`/`failed` while PRESERVING the
+marker, and a reacquired job's purge returns `already_purged` without
+repeating deletes. A repeated purge after a crash (`DB commit` done,
+process died before Auth) is a safe replay for the same reason: no delete
+depends on the row existing.
 
 ### Purge order and locking
 

--- a/docs/architecture/user-data-lifecycle.md
+++ b/docs/architecture/user-data-lifecycle.md
@@ -298,3 +298,117 @@ for user-controlled content. The SQL boundary enforces the binding
 minimum retention horizons with authoritative PostgreSQL time: purge
 cutoffs supplied by the process are clamped, so a fast/misconfigured
 process clock can never advance deletion of rows inside the horizons.
+
+## Account deletion foundation (#324)
+
+The durable PostgreSQL/Supabase foundation for account deletion is its own
+leaf: `supabase/migrations/20260810120000_account_deletion_ledger.sql`
+plus `backend/account_deletion.py` (pure Python contract, no HTTP, no Auth
+Admin, no worker yet). Deleting an account crosses PostgreSQL and Supabase
+Auth; there is no distributed transaction that makes both atomically
+equivalent, so the architecture is: register a durable tombstone, purge the
+PostgreSQL data in one transaction, and only later (#325) delete the Auth
+user after the commit is confirmed. The tombstone survives the
+`profiles` DELETE (the job table has NO FK to `profiles`).
+
+### State machine
+
+`pending -> processing -> (failed | pending retry) -> processing -> completed`
+
+- `pending`: registered, not claimed.
+- `processing`: claimed by exactly one worker (lease owner + expiry). The
+  DB allows only `processing` to carry a lease.
+- `failed`: a worker reported a sanitized `error_code`; retry-eligible
+  after `next_attempt_at` (backoff derived from `attempts`, 30s..1h).
+- `completed`: DB purge committed (`db_purged_at`) AND the future Auth
+  deletion confirmed (#325). Constraints reject every incoherent
+  combination: `completed` requires `db_purged_at` + `completed_at` and
+  NULL `user_id`; `failed` requires `error_code`; attempts are never
+  negative; lease owner and error codes use strict allowlists.
+
+### DB/Auth frontier and `db_purged_at`
+
+`db_purged_at` is the authoritative marker that the PostgreSQL purge
+committed. It becomes non-NULL ONLY in the same transaction that completed
+every delete; any failure rolls the whole attempt back and the marker
+stays empty. It is set while the job is `processing` (purge done, Auth
+deletion pending) and is required for `completed`. A repeated purge after
+a crash (`DB commit` done, process died before Auth) is a safe replay:
+`db_purged_at` is authoritative and no delete depends on the row existing.
+
+### Purge order and locking
+
+The purge deletes the user's rows in one transaction, in FK-safe order
+analyzed from the migrations (no assumed cascade):
+
+1. `outbox_events` (FK profiles/turn_requests CASCADE)
+2. `turn_requests` (FK profiles CASCADE; chat_logs refs SET NULL)
+3. `archival_extractions` (FK profiles/chat_logs CASCADE)
+4. `memories` (FK profiles NO ACTION)
+5. `chat_logs` (FK profiles NO ACTION)
+6. `admission_reservations` (no FK)
+7. `privacy_operations` (no FK)
+8. `profiles` (last: snapshots, persona, `user_profile`)
+
+Before mutating data the purge acquires the SAME per-user advisory
+transaction lock as `commit_turn` and the privacy operations
+(`pg_advisory_xact_lock(hashtextextended(user_id, 0))`), so a concurrent
+turn commit of the same user can never recreate or modify data while the
+account is being deleted. Distinct users are never globally serialized.
+
+### Leases and retries
+
+Claims use `SELECT ... FOR UPDATE SKIP LOCKED`: two workers can never own
+the same job simultaneously. Leases expire, making a dead worker's job
+eligible again; every job-scoped RPC revalidates ownership (worker id +
+unexpired lease), so an old worker cannot purge, fail, retry or finalize
+after losing the lease. Retries are represented in the database:
+`attempts`, `next_attempt_at`, `record_failure` (status `failed`) and
+`record_retry` (status back to `pending`).
+
+### Identity minimization and HMAC policy
+
+While the job still needs to run the purge/Auth deletion, the raw
+`user_id` stays stored. On completion it is removed (NULL): only the
+sanitized reference remains for bounded audit and idempotency. The
+reference is an HMAC-SHA256 (lowercase hex, 64 chars) generated
+server-side with a DEDICATED `account-deletion` HMAC domain, distinct from
+the message/network/correlation/user-reference domains, so a persisted
+reference can never be correlated with `USER_REFERENCE_DOMAIN` values.
+The future HTTP client can never supply this reference; it is produced by
+the trusted backend.
+
+### Idempotency
+
+`(user_ref_hmac_sha256, operation_id)` is UNIQUE. The same pair with the
+same intent fingerprint is an exact replay (no second job); a divergent
+fingerprint is a sanitized `operation_conflict`. Different users never
+collide because the reference is a domain-separated HMAC of the identity.
+No process-local cache.
+
+### Retention of tombstones
+
+Completed tombstones are aged out by `account_deletion_purge_completed`
+(30-day horizon, batch-limited, idempotent, `completed` only, cutoff
+clamped by the DB against `clock_timestamp()` like #316).
+`pending`/`processing`/`failed` jobs are never removed by age. No new
+scheduler: the RPC reuses the operational cleanup model and the future
+worker may call it.
+
+### ACLs
+
+`account_deletion_jobs` is RLS + FORCE RLS with zero policies and no table
+grants (not even `service_role`). All runtime RPCs are `SECURITY DEFINER`
+with `SET search_path = ''`, EXECUTE granted to `service_role` only and
+revoked from `PUBLIC`/`anon`/`authenticated`; internal helpers
+(`account_deletion_validation_error`, `account_deletion_assert_owner`,
+`account_deletion_intent_fingerprint_sha256`) have no runtime grants. No
+dynamic SQL, no raw exception text, no parameters in logs.
+
+### Future leaves
+
+- #325: worker that claims jobs, runs the purge RPC, then deletes the Auth
+  user via Supabase Auth Admin and finalizes the job.
+- #326: HTTP tombstone gate that consults
+  `account_deletion_has_tombstone` before serving operations.
+- #318: tracking of the full deletion pipeline.

--- a/docs/operations/operational-data-retention.md
+++ b/docs/operations/operational-data-retention.md
@@ -11,6 +11,16 @@ transitory** data only:
 | `admission_reservations` | `reserved_at` older than the cutoff | 24h |
 | `privacy_operations` (ledger) | `applied_at` older than the cutoff | 30 days |
 | `outbox_events` | ONLY `completed` / `dead_letter` with `retention_until` past the cutoff | `retention_until` (no age horizon) |
+| `account_deletion_jobs` | ONLY `completed` tombstones with `completed_at` older than the cutoff | 30 days |
+
+The account deletion ledger (#324) is a fourth retention category: its
+completed tombstones are aged out by the privileged RPC
+`account_deletion_purge_completed(cutoff, batch_size)` (batch-limited,
+idempotent, cutoff clamped by the DB against `clock_timestamp()` — a fast
+process clock can never advance deletion). `pending`, `processing` and
+`failed` deletion jobs are NEVER removed by age: they are the durable
+record of an in-flight account deletion. The RPC is ready for the future
+worker (#325) to invoke; no scheduler is created by #324.
 
 User-controlled content is **never** eligible:
 

--- a/supabase/migrations/20260810120000_account_deletion_ledger.sql
+++ b/supabase/migrations/20260810120000_account_deletion_ledger.sql
@@ -1,0 +1,1080 @@
+-- 20260810120000_account_deletion_ledger.sql
+-- Durable account deletion ledger (#324).
+--
+-- Purely additive, fail-closed migration. Creates the server-owned
+-- account deletion job ledger and the privileged RPC boundary for the
+-- future account deletion pipeline. This PR deliberately stops at the
+-- database: no HTTP endpoint, no Supabase Auth Admin call, no worker/CLI.
+--
+-- Why a ledger (root cause)
+-- =========================
+-- Deleting an account crosses PostgreSQL and Supabase Auth. There is no
+-- distributed transaction that makes both steps atomically equivalent, so
+-- the mandatory architecture is:
+--
+--   1. register a durable tombstone (this ledger);
+--   2. purge the PostgreSQL data in ONE transaction (this migration);
+--   3. only in a later task (#325), and only after the commit above is
+--      confirmed, delete the Auth user;
+--   4. allow safe retry after a crash (leases + attempts + next_attempt_at).
+--
+-- The tombstone must survive the ``profiles`` DELETE, therefore the job
+-- table has NO foreign key to ``profiles`` (identity is a server-derived
+-- HMAC reference plus the raw user_id only while the job is active).
+--
+-- State machine
+-- =============
+--   pending     -> registered, not yet claimed
+--   processing  -> claimed by exactly one worker (lease owner + expiry)
+--   failed      -> a worker reported a sanitized failure; retry eligible
+--                  after next_attempt_at (backoff derived from attempts)
+--   completed   -> DB purge committed (db_purged_at) AND Auth deletion
+--                  confirmed later (#325); user_id minimized to NULL
+--
+-- Constraints reject incoherent states (details in the table DDL):
+--   * only processing carries a lease; pending/completed/failed never do;
+--   * completed <=> db_purged_at NOT NULL AND completed_at NOT NULL;
+--   * completed requires user_id IS NULL (identity minimization);
+--   * failed requires a sanitized error_code;
+--   * attempts is never negative; identifiers use strict allowlists.
+--
+-- Concurrency (binding decision, mirrors commit_turn / #314)
+-- ==========================================================
+--   * every purge acquires the SAME per-user advisory transaction lock as
+--     the turn commit: pg_advisory_xact_lock(hashtextextended(user_id, 0)).
+--     A concurrent turn commit of the same user can never interleave with
+--     the deletion; distinct users are never globally serialized.
+--   * lease claims use SELECT ... FOR UPDATE SKIP LOCKED: two workers can
+--     never own the same job simultaneously (no process-local lock).
+--   * ownership is validated on every job-scoped RPC (worker id + unexpired
+--     lease), so an old worker cannot finalize after losing the lease.
+--
+-- Purge atomicity / commit invariant
+-- ==================================
+--   * all user rows are deleted in ONE transaction;
+--   * db_purged_at is set in the SAME transaction that completed the purge
+--     (never before, never after a separate COMMIT);
+--   * any failure rolls back every delete of that attempt;
+--   * a repeated purge after the data is already gone is a safe no-op:
+--     db_purged_at is authoritative and no delete depends on the row
+--     still existing (replay returns already_purged without re-running).
+--
+-- Retention (completed tombstones)
+-- ================================
+--   * account_deletion_purge_completed deletes ONLY completed jobs older
+--     than the horizon; the cutoff is clamped by the database against
+--     clock_timestamp() - 30 days (authoritative PostgreSQL time), so a
+--     fast process clock can never advance deletion;
+--   * pending/processing/failed jobs are NEVER removed by age;
+--   * no scheduler is created here; the RPC reuses the operational
+--     cleanup model of #316 and the future worker may call it.
+--
+-- Security posture (binding decisions)
+-- ====================================
+--   * account_deletion_jobs is RLS + FORCE RLS with zero policies and NO
+--     table grants (not even service_role): the RPCs are the only path.
+--   * every runtime RPC is SECURITY DEFINER with SET search_path = '' and
+--     EXECUTE granted to service_role only (revoked from PUBLIC, anon and
+--     authenticated). No dynamic SQL, no raw exception text, no parameters
+--     in logs, sanitized jsonb envelopes only.
+--   * internal helpers have NO grants at all (owner postgres only).
+--   * identity comes ONLY from p_authenticated_user_id (server-side
+--     boundary). The persistent reference is an HMAC-SHA256 (lowercase
+--     hex, 64 chars) under a DEDICATED account-deletion domain, distinct
+--     from the message/network/correlation/user-reference domains, so it
+--     can never be correlated with USER_REFERENCE_DOMAIN values. The
+--     raw user_id is removed (NULL) once the job is completed.
+--   * idempotency: (user_ref_hmac_sha256, operation_id) is UNIQUE; the
+--     same pair with the same intent fingerprint is an exact replay (no
+--     second job); the same pair with a divergent fingerprint is a
+--     sanitized operation_conflict. Different users never collide because
+--     the reference is a domain-separated HMAC of the user identity.
+
+-- =================================================================
+-- 0. PREFLIGHT: fail closed on missing dependencies and drift
+-- =================================================================
+DO $$
+BEGIN
+    -- Drift: objects created by THIS migration must not exist yet.
+    IF EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'account_deletion_jobs'
+    ) THEN
+        RAISE EXCEPTION 'Cannot apply account deletion ledger: account_deletion_jobs already exists (unexpected drift)'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public'
+          AND p.proname IN (
+              'account_deletion_request', 'account_deletion_has_tombstone',
+              'account_deletion_acquire_lease', 'account_deletion_purge',
+              'account_deletion_record_failure', 'account_deletion_record_retry',
+              'account_deletion_finalize', 'account_deletion_purge_completed',
+              'account_deletion_validation_error', 'account_deletion_intent_fingerprint_sha256'
+          )
+    ) THEN
+        RAISE EXCEPTION 'Cannot apply account deletion ledger: account deletion functions already exist (unexpected drift)'
+            USING ERRCODE = '23514';
+    END IF;
+
+    -- Required tables: EVERY purge target must exist. Each check is
+    -- explicit so a single existing table can never mask another missing
+    -- one (same fail-closed pattern as #314/#316 preflights).
+    IF pg_catalog.to_regclass('public.chat_logs') IS NULL THEN
+        RAISE EXCEPTION 'Missing dependency: public.chat_logs' USING ERRCODE = '23514';
+    END IF;
+    IF pg_catalog.to_regclass('public.memories') IS NULL THEN
+        RAISE EXCEPTION 'Missing dependency: public.memories' USING ERRCODE = '23514';
+    END IF;
+    IF pg_catalog.to_regclass('public.archival_extractions') IS NULL THEN
+        RAISE EXCEPTION 'Missing dependency: public.archival_extractions' USING ERRCODE = '23514';
+    END IF;
+    IF pg_catalog.to_regclass('public.turn_requests') IS NULL THEN
+        RAISE EXCEPTION 'Missing dependency: public.turn_requests' USING ERRCODE = '23514';
+    END IF;
+    IF pg_catalog.to_regclass('public.outbox_events') IS NULL THEN
+        RAISE EXCEPTION 'Missing dependency: public.outbox_events' USING ERRCODE = '23514';
+    END IF;
+    IF pg_catalog.to_regclass('public.admission_reservations') IS NULL THEN
+        RAISE EXCEPTION 'Missing dependency: public.admission_reservations' USING ERRCODE = '23514';
+    END IF;
+    IF pg_catalog.to_regclass('public.privacy_operations') IS NULL THEN
+        RAISE EXCEPTION 'Missing dependency: public.privacy_operations' USING ERRCODE = '23514';
+    END IF;
+    IF pg_catalog.to_regclass('public.profiles') IS NULL THEN
+        RAISE EXCEPTION 'Missing dependency: public.profiles' USING ERRCODE = '23514';
+    END IF;
+
+    -- Drift of the per-user lock contract: the turn commit boundary must
+    -- exist (jsonb_snapshot_contract from #271 is the turn-commit contract
+    -- dependency; profiles.revision is required by the privacy chain).
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_attribute a
+        WHERE a.attrelid = 'public.profiles'::regclass
+          AND a.attname = 'revision'
+    ) THEN
+        RAISE EXCEPTION 'Missing dependency: profiles.revision column' USING ERRCODE = '23514';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public'
+          AND p.proname = 'jsonb_snapshot_contract'
+    ) THEN
+        RAISE EXCEPTION 'Missing dependency: public.jsonb_snapshot_contract (turn commit contract)' USING ERRCODE = '23514';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public'
+          AND p.proname = 'commit_turn'
+    ) THEN
+        RAISE EXCEPTION 'Missing dependency: public.commit_turn (per-user lock contract)' USING ERRCODE = '23514';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_extension e
+        WHERE e.extname = 'pgcrypto'
+    ) THEN
+        RAISE EXCEPTION 'Missing dependency: pgcrypto extension (intent fingerprint)' USING ERRCODE = '23514';
+    END IF;
+END $$;
+
+-- =================================================================
+-- 1. Durable account deletion job ledger
+-- =================================================================
+CREATE TABLE public.account_deletion_jobs (
+    job_id uuid NOT NULL DEFAULT gen_random_uuid(),
+    operation_id uuid NOT NULL,
+    -- Raw user identity: present ONLY while the job still needs to run the
+    -- DB purge / future Auth deletion; NULL once completed (minimization).
+    user_id text,
+    -- Server-derived, non-reversible reference (HMAC-SHA256, dedicated
+    -- account-deletion domain). Persists after completion for bounded
+    -- audit and idempotency. Never client-supplied.
+    user_ref_hmac_sha256 text NOT NULL,
+    -- SHA-256 fingerprint of the canonical intent payload; binds an
+    -- operation_id to its exact intent (replay vs conflict).
+    intent_fingerprint_sha256 text NOT NULL,
+    status text NOT NULL DEFAULT 'pending',
+    attempts integer NOT NULL DEFAULT 0,
+    lease_owner text,
+    lease_expires_at timestamptz,
+    next_attempt_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    db_purged_at timestamptz,
+    error_code text,
+    requested_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    completed_at timestamptz,
+
+    CONSTRAINT account_deletion_jobs_pkey
+        PRIMARY KEY (job_id),
+    -- Idempotency key: one job per (sanitized identity, operation_id).
+    -- Different users never collide because the reference is a
+    -- domain-separated HMAC of the identity. A divergent fingerprint is
+    -- detected by the request RPC (sanitized conflict) before any insert.
+    CONSTRAINT account_deletion_jobs_idempotency_key
+        UNIQUE (user_ref_hmac_sha256, operation_id),
+    CONSTRAINT account_deletion_jobs_user_id_check
+        CHECK (
+            user_id IS NULL
+            OR (char_length(user_id) BETWEEN 1 AND 128 AND btrim(user_id) <> '')
+        ),
+    CONSTRAINT account_deletion_jobs_user_ref_check
+        CHECK (user_ref_hmac_sha256 ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT account_deletion_jobs_fingerprint_check
+        CHECK (intent_fingerprint_sha256 ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT account_deletion_jobs_status_check
+        CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+    CONSTRAINT account_deletion_jobs_attempts_check
+        CHECK (attempts >= 0 AND attempts <= 1000),
+    CONSTRAINT account_deletion_jobs_lease_owner_check
+        CHECK (lease_owner IS NULL OR lease_owner ~ '^[A-Za-z0-9_.:-]{1,64}$'),
+    -- Lease fields travel together.
+    CONSTRAINT account_deletion_jobs_lease_pair_check
+        CHECK (
+            (lease_owner IS NULL AND lease_expires_at IS NULL)
+            OR (lease_owner IS NOT NULL AND lease_expires_at IS NOT NULL)
+        ),
+    -- Only processing carries a lease; pending/completed/failed never do.
+    CONSTRAINT account_deletion_jobs_lease_state_check
+        CHECK (
+            (status = 'processing' AND lease_owner IS NOT NULL AND lease_expires_at IS NOT NULL)
+            OR (status <> 'processing' AND lease_owner IS NULL AND lease_expires_at IS NULL)
+        ),
+    -- Raw identity is required while active, removed once completed.
+    CONSTRAINT account_deletion_jobs_user_id_state_check
+        CHECK (
+            (status = 'completed' AND user_id IS NULL)
+            OR (status <> 'completed' AND user_id IS NOT NULL)
+        ),
+    -- db_purged_at is set exactly when the purge transaction committed.
+    -- It may be non-NULL while the job is processing (purge committed,
+    -- awaiting the future Auth deletion confirmation in #325) and is
+    -- REQUIRED for completed. pending/failed never carry it.
+    CONSTRAINT account_deletion_jobs_db_purged_state_check
+        CHECK (
+            (status = 'completed' AND db_purged_at IS NOT NULL)
+            OR status = 'processing'
+            OR (status IN ('pending', 'failed') AND db_purged_at IS NULL)
+        ),
+    CONSTRAINT account_deletion_jobs_completed_at_state_check
+        CHECK ((status = 'completed') = (completed_at IS NOT NULL)),
+    CONSTRAINT account_deletion_jobs_error_code_check
+        CHECK (error_code IS NULL OR error_code ~ '^[a-z0-9_]{1,64}$'),
+    -- failed jobs must carry a sanitized error_code.
+    CONSTRAINT account_deletion_jobs_failed_error_check
+        CHECK (status <> 'failed' OR error_code IS NOT NULL)
+);
+
+-- Claim scan: eligible jobs ordered by next_attempt_at.
+CREATE INDEX account_deletion_jobs_status_next_attempt_idx
+    ON public.account_deletion_jobs (status, next_attempt_at);
+
+-- Tombstone lookup by server-derived reference.
+CREATE INDEX account_deletion_jobs_user_ref_idx
+    ON public.account_deletion_jobs (user_ref_hmac_sha256, requested_at DESC);
+
+-- Retention scan: only completed jobs are ever aged out.
+CREATE INDEX account_deletion_jobs_completed_at_idx
+    ON public.account_deletion_jobs (completed_at)
+    WHERE status = 'completed';
+
+ALTER TABLE public.account_deletion_jobs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.account_deletion_jobs FORCE ROW LEVEL SECURITY;
+
+-- Server-owned ledger: no role (not even service_role) gets table access.
+REVOKE ALL PRIVILEGES ON TABLE public.account_deletion_jobs
+    FROM PUBLIC, anon, authenticated, service_role;
+
+-- Intentionally no policies.
+
+-- =================================================================
+-- 2. Intent fingerprint helper (internal, no grants)
+-- =================================================================
+-- Deterministic SHA-256 of the canonical jsonb serialization, identical in
+-- spirit to privacy_operation_payload_sha256 (#314).
+CREATE OR REPLACE FUNCTION public.account_deletion_intent_fingerprint_sha256(
+    p_payload jsonb
+) RETURNS text
+LANGUAGE sql
+IMMUTABLE
+SET search_path = extensions
+AS $$
+    SELECT pg_catalog.encode(extensions.digest(p_payload::text, 'sha256'), 'hex');
+$$;
+
+REVOKE ALL ON FUNCTION public.account_deletion_intent_fingerprint_sha256(jsonb)
+    FROM PUBLIC, anon, authenticated, service_role;
+
+-- =================================================================
+-- 3. Base validation helper (internal, no grants)
+-- =================================================================
+-- Returns a sanitized error envelope or NULL. Mirrors the persistent
+-- ledger constraints exactly so invalid input fails BEFORE any lock,
+-- mutation or ledger row, never via a CHECK violation.
+CREATE OR REPLACE FUNCTION public.account_deletion_validation_error(
+    p_authenticated_user_id text,
+    p_user_ref_hmac_sha256 text,
+    p_operation_id uuid,
+    p_intent_fingerprint_sha256 text
+) RETURNS jsonb
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path = ''
+AS $$
+BEGIN
+    IF p_authenticated_user_id IS NULL
+       OR pg_catalog.char_length(p_authenticated_user_id) NOT BETWEEN 1 AND 128
+       OR pg_catalog.btrim(p_authenticated_user_id) = '' THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'authenticated_user_id is invalid'
+            )
+        );
+    END IF;
+    IF p_user_ref_hmac_sha256 IS NULL
+       OR p_user_ref_hmac_sha256 !~ '^[0-9a-f]{64}$' THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'user_ref_hmac_sha256 must be 64 lowercase hex characters'
+            )
+        );
+    END IF;
+    IF p_operation_id IS NULL THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'operation_id is required'
+            )
+        );
+    END IF;
+    IF p_intent_fingerprint_sha256 IS NULL
+       OR p_intent_fingerprint_sha256 !~ '^[0-9a-f]{64}$' THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'intent_fingerprint_sha256 must be 64 lowercase hex characters'
+            )
+        );
+    END IF;
+    RETURN NULL;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.account_deletion_validation_error(text, text, uuid, text)
+    FROM PUBLIC, anon, authenticated, service_role;
+
+-- =================================================================
+-- 4. account_deletion_request
+-- =================================================================
+-- Registers (or replays) an account deletion request. Server-side
+-- boundary only: identity, reference, operation_id and fingerprint are
+-- produced by the trusted backend, never by an HTTP client.
+--
+--   * same (ref, operation_id) + same fingerprint -> exact replay: the
+--     existing job state is returned, no second job is created;
+--   * same pair + divergent fingerprint -> sanitized operation_conflict;
+--   * different users never collide (ref is a domain-separated HMAC).
+CREATE OR REPLACE FUNCTION public.account_deletion_request(
+    p_authenticated_user_id text,
+    p_user_ref_hmac_sha256 text,
+    p_operation_id uuid,
+    p_intent_fingerprint_sha256 text
+) RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+PARALLEL UNSAFE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_validation_error jsonb;
+    v_job public.account_deletion_jobs%ROWTYPE;
+    v_job_id uuid;
+BEGIN
+    v_validation_error := public.account_deletion_validation_error(
+        p_authenticated_user_id,
+        p_user_ref_hmac_sha256,
+        p_operation_id,
+        p_intent_fingerprint_sha256
+    );
+    IF v_validation_error IS NOT NULL THEN
+        RETURN v_validation_error;
+    END IF;
+
+    -- Serialize request against concurrent purge/finalize of the same user.
+    PERFORM pg_catalog.pg_advisory_xact_lock(
+        pg_catalog.hashtextextended(p_authenticated_user_id, 0)
+    );
+
+    SELECT * INTO v_job
+    FROM public.account_deletion_jobs
+    WHERE user_ref_hmac_sha256 = p_user_ref_hmac_sha256
+      AND operation_id = p_operation_id;
+
+    IF FOUND THEN
+        IF v_job.intent_fingerprint_sha256 = p_intent_fingerprint_sha256 THEN
+            -- Exact replay: return the current sanitized state.
+            RETURN jsonb_build_object(
+                'status', 'replay',
+                'job_id', v_job.job_id::text,
+                'job_status', v_job.status,
+                'db_purged_at', v_job.db_purged_at,
+                'completed_at', v_job.completed_at
+            );
+        END IF;
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'operation_conflict',
+                'message', 'operation_id already used with a different intent'
+            )
+        );
+    END IF;
+
+    INSERT INTO public.account_deletion_jobs (
+        operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+        status, attempts, next_attempt_at
+    ) VALUES (
+        p_operation_id, p_authenticated_user_id, p_user_ref_hmac_sha256,
+        p_intent_fingerprint_sha256, 'pending', 0, clock_timestamp()
+    )
+    RETURNING job_id INTO v_job_id;
+
+    RETURN jsonb_build_object(
+        'status', 'created',
+        'job_id', v_job_id::text,
+        'job_status', 'pending'
+    );
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE EXCEPTION 'persistence error' USING ERRCODE = 'P0001';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.account_deletion_request(text, text, uuid, text)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.account_deletion_request(text, text, uuid, text)
+    TO service_role;
+
+-- =================================================================
+-- 5. account_deletion_has_tombstone
+-- =================================================================
+-- Sanitized lookup by server-derived reference: reports whether a
+-- blocking tombstone exists and its current status. Read-only, no lock.
+CREATE OR REPLACE FUNCTION public.account_deletion_has_tombstone(
+    p_user_ref_hmac_sha256 text
+) RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+PARALLEL UNSAFE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_status text;
+BEGIN
+    IF p_user_ref_hmac_sha256 IS NULL
+       OR p_user_ref_hmac_sha256 !~ '^[0-9a-f]{64}$' THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'user_ref_hmac_sha256 must be 64 lowercase hex characters'
+            )
+        );
+    END IF;
+
+    SELECT status INTO v_status
+    FROM public.account_deletion_jobs
+    WHERE user_ref_hmac_sha256 = p_user_ref_hmac_sha256
+    ORDER BY requested_at DESC
+    LIMIT 1;
+
+    IF v_status IS NULL THEN
+        RETURN jsonb_build_object('exists', false, 'status', NULL);
+    END IF;
+    RETURN jsonb_build_object('exists', true, 'status', v_status);
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE EXCEPTION 'persistence error' USING ERRCODE = 'P0001';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.account_deletion_has_tombstone(text)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.account_deletion_has_tombstone(text)
+    TO service_role;
+
+-- =================================================================
+-- 6. account_deletion_acquire_lease
+-- =================================================================
+-- Claims at most one eligible job for a worker. Real PostgreSQL row-level
+-- mechanism: FOR UPDATE SKIP LOCKED guarantees two workers can never own
+-- the same job simultaneously. Eligible:
+--   * pending with next_attempt_at <= now;
+--   * failed with next_attempt_at <= now (retry after backoff);
+--   * processing whose lease has EXPIRED (worker died -> recoverable).
+-- Each claim increments attempts (retries are represented in the DB).
+CREATE OR REPLACE FUNCTION public.account_deletion_acquire_lease(
+    p_worker_id text,
+    p_lease_seconds integer,
+    p_max_batch integer
+) RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+PARALLEL UNSAFE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_job public.account_deletion_jobs%ROWTYPE;
+    v_now timestamptz := clock_timestamp();
+BEGIN
+    IF p_worker_id IS NULL OR p_worker_id !~ '^[A-Za-z0-9_.:-]{1,64}$' THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'worker_id is invalid'
+            )
+        );
+    END IF;
+    IF p_lease_seconds IS NULL OR p_lease_seconds NOT BETWEEN 1 AND 3600 THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'lease_seconds must be between 1 and 3600'
+            )
+        );
+    END IF;
+    IF p_max_batch IS NULL OR p_max_batch NOT BETWEEN 1 AND 1000 THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'max_batch must be between 1 and 1000'
+            )
+        );
+    END IF;
+
+    SELECT * INTO v_job
+    FROM public.account_deletion_jobs
+    WHERE (
+            (status IN ('pending', 'failed') AND next_attempt_at <= v_now)
+            OR (status = 'processing' AND lease_expires_at < v_now)
+          )
+    ORDER BY next_attempt_at
+    LIMIT 1
+    FOR UPDATE SKIP LOCKED;
+
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object('found', false);
+    END IF;
+
+    UPDATE public.account_deletion_jobs
+    SET status = 'processing',
+        lease_owner = p_worker_id,
+        lease_expires_at = v_now + make_interval(secs => p_lease_seconds),
+        attempts = v_job.attempts + 1,
+        error_code = NULL,
+        updated_at = v_now
+    WHERE job_id = v_job.job_id
+    RETURNING
+        job_id, user_id, user_ref_hmac_sha256, operation_id, status,
+        lease_owner, lease_expires_at, attempts, db_purged_at,
+        intent_fingerprint_sha256
+    INTO
+        v_job.job_id, v_job.user_id, v_job.user_ref_hmac_sha256, v_job.operation_id,
+        v_job.status, v_job.lease_owner, v_job.lease_expires_at, v_job.attempts,
+        v_job.db_purged_at, v_job.intent_fingerprint_sha256;
+
+    RETURN jsonb_build_object(
+        'found', true,
+        'job_id', v_job.job_id::text,
+        'user_id', v_job.user_id,
+        'user_ref_hmac_sha256', v_job.user_ref_hmac_sha256,
+        'operation_id', v_job.operation_id::text,
+        'status', v_job.status,
+        'lease_owner', v_job.lease_owner,
+        'lease_expires_at', v_job.lease_expires_at,
+        'attempts', v_job.attempts,
+        'db_purged_at', v_job.db_purged_at,
+        'intent_fingerprint_sha256', v_job.intent_fingerprint_sha256
+    );
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE EXCEPTION 'persistence error' USING ERRCODE = 'P0001';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.account_deletion_acquire_lease(text, integer, integer)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.account_deletion_acquire_lease(text, integer, integer)
+    TO service_role;
+
+-- =================================================================
+-- 7. Ownership validation helper (internal, no grants)
+-- =================================================================
+-- Enforces that a job-scoped RPC is only accepted from the worker that
+-- currently owns an unexpired lease. A worker that lost its lease (or
+-- never had it) can never purge, fail, retry or finalize the job.
+CREATE OR REPLACE FUNCTION public.account_deletion_assert_owner(
+    p_job_id uuid,
+    p_worker_id text
+) RETURNS public.account_deletion_jobs
+LANGUAGE plpgsql
+VOLATILE
+SET search_path = ''
+AS $$
+DECLARE
+    v_job public.account_deletion_jobs%ROWTYPE;
+BEGIN
+    IF p_job_id IS NULL OR p_worker_id IS NULL
+       OR p_worker_id !~ '^[A-Za-z0-9_.:-]{1,64}$' THEN
+        RAISE EXCEPTION 'invalid account deletion job parameters'
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    SELECT * INTO v_job
+    FROM public.account_deletion_jobs
+    WHERE job_id = p_job_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'account deletion job not found'
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    IF v_job.status <> 'processing'
+       OR v_job.lease_owner IS DISTINCT FROM p_worker_id
+       OR v_job.lease_expires_at IS NULL
+       OR v_job.lease_expires_at <= clock_timestamp() THEN
+        RAISE EXCEPTION 'account deletion lease lost'
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    RETURN v_job;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.account_deletion_assert_owner(uuid, text)
+    FROM PUBLIC, anon, authenticated, service_role;
+
+-- =================================================================
+-- 8. account_deletion_purge
+-- =================================================================
+-- Executes the full PostgreSQL purge of one user in ONE transaction:
+--   1. ownership check (lease) + intent fingerprint check;
+--   2. per-user advisory lock (same boundary as commit_turn / #314);
+--   3. explicit deletes in FK-safe order (no assumed cascade);
+--   4. db_purged_at is set in the SAME transaction (commit invariant).
+-- Any failure rolls back every delete of this attempt. A repeated purge
+-- after the data is already gone (crash after DB commit, before Auth) is
+-- a safe replay: db_purged_at is authoritative and no delete depends on
+-- the row existing. The job/tombstone is NEVER deleted by the purge.
+--
+-- FK-safe order (analyzed from the migrations):
+--   outbox_events (FK profiles CASCADE, turn_requests CASCADE)
+--   turn_requests (FK profiles CASCADE; refs chat_logs SET NULL)
+--   archival_extractions (FK profiles CASCADE, chat_logs CASCADE)
+--   memories (FK profiles NO ACTION)          -- must precede profiles
+--   chat_logs (FK profiles NO ACTION)         -- must precede profiles
+--   admission_reservations (no FK)
+--   privacy_operations (no FK)
+--   profiles (last: snapshots, persona, user_profile)
+CREATE OR REPLACE FUNCTION public.account_deletion_purge(
+    p_job_id uuid,
+    p_worker_id text,
+    p_intent_fingerprint_sha256 text
+) RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+PARALLEL UNSAFE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_job public.account_deletion_jobs;
+    v_count_outbox bigint := 0;
+    v_count_turn_requests bigint := 0;
+    v_count_archival bigint := 0;
+    v_count_memories bigint := 0;
+    v_count_chat_logs bigint := 0;
+    v_count_admission bigint := 0;
+    v_count_privacy bigint := 0;
+    v_count_profiles bigint := 0;
+    v_now timestamptz := clock_timestamp();
+BEGIN
+    IF p_job_id IS NULL OR p_intent_fingerprint_sha256 IS NULL
+       OR p_intent_fingerprint_sha256 !~ '^[0-9a-f]{64}$' THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'purge parameters are invalid'
+            )
+        );
+    END IF;
+
+    v_job := public.account_deletion_assert_owner(p_job_id, p_worker_id);
+
+    -- The worker must present the same intent fingerprint bound to the
+    -- job; a divergent fingerprint means a misdirected worker.
+    IF v_job.intent_fingerprint_sha256 IS DISTINCT FROM p_intent_fingerprint_sha256 THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'operation_conflict',
+                'message', 'intent fingerprint does not match the job'
+            )
+        );
+    END IF;
+
+    -- Idempotent replay: the purge already committed. Never re-delete,
+    -- never touch the tombstone. Returns the same stable envelope shape
+    -- (zero counts) as a fresh purge.
+    IF v_job.db_purged_at IS NOT NULL THEN
+        RETURN jsonb_build_object(
+            'status', 'already_purged',
+            'job_id', v_job.job_id::text,
+            'db_purged_at', v_job.db_purged_at,
+            'counts', jsonb_build_object(
+                'outbox_events', 0,
+                'turn_requests', 0,
+                'archival_extractions', 0,
+                'memories', 0,
+                'chat_logs', 0,
+                'admission_reservations', 0,
+                'privacy_operations', 0,
+                'profiles', 0
+            )
+        );
+    END IF;
+
+    -- Same per-user transaction lock as commit_turn: a concurrent turn
+    -- commit of this user can never interleave with the deletion.
+    PERFORM pg_catalog.pg_advisory_xact_lock(
+        pg_catalog.hashtextextended(v_job.user_id, 0)
+    );
+
+    DELETE FROM public.outbox_events WHERE user_id = v_job.user_id;
+    GET DIAGNOSTICS v_count_outbox = ROW_COUNT;
+
+    DELETE FROM public.turn_requests WHERE user_id = v_job.user_id;
+    GET DIAGNOSTICS v_count_turn_requests = ROW_COUNT;
+
+    DELETE FROM public.archival_extractions WHERE user_id = v_job.user_id;
+    GET DIAGNOSTICS v_count_archival = ROW_COUNT;
+
+    DELETE FROM public.memories WHERE user_id = v_job.user_id;
+    GET DIAGNOSTICS v_count_memories = ROW_COUNT;
+
+    DELETE FROM public.chat_logs WHERE user_id = v_job.user_id;
+    GET DIAGNOSTICS v_count_chat_logs = ROW_COUNT;
+
+    DELETE FROM public.admission_reservations WHERE user_id = v_job.user_id;
+    GET DIAGNOSTICS v_count_admission = ROW_COUNT;
+
+    DELETE FROM public.privacy_operations WHERE user_id = v_job.user_id;
+    GET DIAGNOSTICS v_count_privacy = ROW_COUNT;
+
+    DELETE FROM public.profiles WHERE user_id = v_job.user_id;
+    GET DIAGNOSTICS v_count_profiles = ROW_COUNT;
+
+    -- Commit invariant: db_purged_at becomes non-NULL in the SAME
+    -- transaction that completed the purge. The job stays (tombstone).
+    UPDATE public.account_deletion_jobs
+    SET db_purged_at = v_now,
+        updated_at = v_now
+    WHERE job_id = v_job.job_id;
+
+    RETURN jsonb_build_object(
+        'status', 'purged',
+        'job_id', v_job.job_id::text,
+        'db_purged_at', v_now,
+        'counts', jsonb_build_object(
+            'outbox_events', v_count_outbox,
+            'turn_requests', v_count_turn_requests,
+            'archival_extractions', v_count_archival,
+            'memories', v_count_memories,
+            'chat_logs', v_count_chat_logs,
+            'admission_reservations', v_count_admission,
+            'privacy_operations', v_count_privacy,
+            'profiles', v_count_profiles
+        )
+    );
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE EXCEPTION 'persistence error' USING ERRCODE = 'P0001';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.account_deletion_purge(uuid, text, text)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.account_deletion_purge(uuid, text, text)
+    TO service_role;
+
+-- =================================================================
+-- 9. account_deletion_record_failure
+-- =================================================================
+-- A worker reports a sanitized failure: the job moves to failed with the
+-- error_code, its lease is released and next_attempt_at is set to a
+-- backoff derived from attempts (30s * attempts, capped at 1h) so the
+-- job becomes retry-eligible later. The raw user_id stays (retry still
+-- needs it).
+CREATE OR REPLACE FUNCTION public.account_deletion_record_failure(
+    p_job_id uuid,
+    p_worker_id text,
+    p_error_code text
+) RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+PARALLEL UNSAFE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_job public.account_deletion_jobs;
+    v_now timestamptz := clock_timestamp();
+    v_next_attempt_at timestamptz;
+BEGIN
+    IF p_error_code IS NULL OR p_error_code !~ '^[a-z0-9_]{1,64}$' THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'error_code is invalid'
+            )
+        );
+    END IF;
+
+    v_job := public.account_deletion_assert_owner(p_job_id, p_worker_id);
+
+    v_next_attempt_at := v_now
+        + make_interval(secs => LEAST(3600, 30 * v_job.attempts)::double precision);
+
+    UPDATE public.account_deletion_jobs
+    SET status = 'failed',
+        error_code = p_error_code,
+        lease_owner = NULL,
+        lease_expires_at = NULL,
+        next_attempt_at = v_next_attempt_at,
+        updated_at = v_now
+    WHERE job_id = v_job.job_id;
+
+    RETURN jsonb_build_object(
+        'status', 'failed',
+        'job_id', v_job.job_id::text,
+        'error_code', p_error_code,
+        'next_attempt_at', v_next_attempt_at
+    );
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE EXCEPTION 'persistence error' USING ERRCODE = 'P0001';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.account_deletion_record_failure(uuid, text, text)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.account_deletion_record_failure(uuid, text, text)
+    TO service_role;
+
+-- =================================================================
+-- 10. account_deletion_record_retry
+-- =================================================================
+-- A worker voluntarily defers the job (e.g. transient infrastructure
+-- unavailability): the job returns to pending with a backoff next_attempt
+-- and its lease released. Distinct from a failure (status stays failed
+-- there; here the job becomes pending again, error_code cleared).
+CREATE OR REPLACE FUNCTION public.account_deletion_record_retry(
+    p_job_id uuid,
+    p_worker_id text
+) RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+PARALLEL UNSAFE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_job public.account_deletion_jobs;
+    v_now timestamptz := clock_timestamp();
+    v_next_attempt_at timestamptz;
+BEGIN
+    v_job := public.account_deletion_assert_owner(p_job_id, p_worker_id);
+
+    v_next_attempt_at := v_now
+        + make_interval(secs => LEAST(3600, 30 * v_job.attempts)::double precision);
+
+    UPDATE public.account_deletion_jobs
+    SET status = 'pending',
+        error_code = NULL,
+        lease_owner = NULL,
+        lease_expires_at = NULL,
+        next_attempt_at = v_next_attempt_at,
+        updated_at = v_now
+    WHERE job_id = v_job.job_id;
+
+    RETURN jsonb_build_object(
+        'status', 'retry_scheduled',
+        'job_id', v_job.job_id::text,
+        'next_attempt_at', v_next_attempt_at
+    );
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE EXCEPTION 'persistence error' USING ERRCODE = 'P0001';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.account_deletion_record_retry(uuid, text)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.account_deletion_record_retry(uuid, text)
+    TO service_role;
+
+-- =================================================================
+-- 11. account_deletion_finalize
+-- =================================================================
+-- Called by the future worker AFTER it confirmed the Auth deletion
+-- (#325). Requires the DB purge to be committed (db_purged_at set) and
+-- current lease ownership. Marks the job completed and MINIMIZES
+-- identity: user_id -> NULL (only the server-derived HMAC reference
+-- remains for bounded audit/idempotency).
+CREATE OR REPLACE FUNCTION public.account_deletion_finalize(
+    p_job_id uuid,
+    p_worker_id text
+) RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+PARALLEL UNSAFE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_job public.account_deletion_jobs;
+    v_now timestamptz := clock_timestamp();
+BEGIN
+    v_job := public.account_deletion_assert_owner(p_job_id, p_worker_id);
+
+    IF v_job.db_purged_at IS NULL THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'state_conflict',
+                'message', 'cannot finalize before the database purge is committed'
+            )
+        );
+    END IF;
+
+    UPDATE public.account_deletion_jobs
+    SET status = 'completed',
+        user_id = NULL,
+        lease_owner = NULL,
+        lease_expires_at = NULL,
+        completed_at = v_now,
+        updated_at = v_now
+    WHERE job_id = v_job.job_id;
+
+    RETURN jsonb_build_object(
+        'status', 'completed',
+        'job_id', v_job.job_id::text,
+        'completed_at', v_now,
+        'db_purged_at', v_job.db_purged_at
+    );
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE EXCEPTION 'persistence error' USING ERRCODE = 'P0001';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.account_deletion_finalize(uuid, text)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.account_deletion_finalize(uuid, text)
+    TO service_role;
+
+-- =================================================================
+-- 12. account_deletion_purge_completed (retention of tombstones)
+-- =================================================================
+-- Deletes up to p_batch_size COMPLETED jobs whose completed_at is older
+-- than the effective cutoff. The cutoff is clamped to never exceed
+-- clock_timestamp() - 30 days (authoritative PostgreSQL time), reusing
+-- the #316 model: a fast process clock can only reduce progress, never
+-- advance deletion. pending/processing/failed jobs are never removed by
+-- age. Idempotent and bounded.
+CREATE OR REPLACE FUNCTION public.account_deletion_purge_completed(
+    p_cutoff timestamptz,
+    p_batch_size integer
+) RETURNS integer
+LANGUAGE plpgsql
+VOLATILE
+PARALLEL UNSAFE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_cutoff timestamptz;
+    v_deleted integer;
+BEGIN
+    IF p_cutoff IS NULL OR p_batch_size IS NULL
+       OR p_batch_size NOT BETWEEN 1 AND 1000 THEN
+        RAISE EXCEPTION 'invalid retention parameters';
+    END IF;
+
+    v_cutoff := LEAST(p_cutoff, clock_timestamp() - interval '30 days');
+
+    DELETE FROM public.account_deletion_jobs
+    WHERE job_id IN (
+        SELECT job_id
+        FROM public.account_deletion_jobs
+        WHERE status = 'completed'
+          AND completed_at < v_cutoff
+        ORDER BY completed_at
+        LIMIT p_batch_size
+    );
+    GET DIAGNOSTICS v_deleted = ROW_COUNT;
+    RETURN v_deleted;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.account_deletion_purge_completed(timestamptz, integer)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.account_deletion_purge_completed(timestamptz, integer)
+    TO service_role;
+
+-- =================================================================
+-- 13. Documentation comments
+-- =================================================================
+COMMENT ON TABLE public.account_deletion_jobs IS
+'Durable, server-owned account deletion ledger (#324). Tombstone survives the profiles DELETE; no FK to profiles. States: pending/processing/completed/failed. Raw user_id is minimized to NULL on completion; the domain-separated HMAC reference persists for bounded audit/idempotency. RLS + FORCE RLS, zero policies, no table grants (not even service_role).';
+
+COMMENT ON FUNCTION public.account_deletion_request(text, text, uuid, text) IS
+'Register or replay an account deletion request (#324). Same (ref, operation_id) with same fingerprint replays; divergent fingerprint conflicts sanitized. SECURITY DEFINER, service_role only.';
+
+COMMENT ON FUNCTION public.account_deletion_has_tombstone(text) IS
+'Sanitized tombstone lookup by server-derived reference (#324/#326). SECURITY DEFINER, service_role only.';
+
+COMMENT ON FUNCTION public.account_deletion_acquire_lease(text, integer, integer) IS
+'Claim one eligible account deletion job with FOR UPDATE SKIP LOCKED; increments attempts (#324). SECURITY DEFINER, service_role only.';
+
+COMMENT ON FUNCTION public.account_deletion_purge(uuid, text, text) IS
+'Atomic per-user PostgreSQL purge in one transaction with the commit_turn advisory lock; db_purged_at set in the same transaction; replay-safe; tombstone never deleted (#324). SECURITY DEFINER, service_role only.';
+
+COMMENT ON FUNCTION public.account_deletion_record_failure(uuid, text, text) IS
+'Record a sanitized failure, release the lease, schedule a backoff retry (#324). SECURITY DEFINER, service_role only.';
+
+COMMENT ON FUNCTION public.account_deletion_record_retry(uuid, text) IS
+'Voluntarily defer a job: back to pending with backoff, lease released (#324). SECURITY DEFINER, service_role only.';
+
+COMMENT ON FUNCTION public.account_deletion_finalize(uuid, text) IS
+'Complete a job after the future worker confirms the Auth deletion (#325); requires db_purged_at; minimizes user_id to NULL (#324). SECURITY DEFINER, service_role only.';
+
+COMMENT ON FUNCTION public.account_deletion_purge_completed(timestamptz, integer) IS
+'Retention of completed tombstones older than 30 days; cutoff clamped by the DB; active/failed jobs never aged out (#324, model of #316). SECURITY DEFINER, service_role only.';

--- a/supabase/migrations/20260810120000_account_deletion_ledger.sql
+++ b/supabase/migrations/20260810120000_account_deletion_ledger.sql
@@ -28,15 +28,25 @@
 --   processing  -> claimed by exactly one worker (lease owner + expiry)
 --   failed      -> a worker reported a sanitized failure; retry eligible
 --                  after next_attempt_at (backoff derived from attempts)
+--                  UNLESS next_attempt_at IS NULL, which is the TERMINAL
+--                  exhausted state (attempts ceiling reached): never
+--                  claimed automatically again, tombstone stays blocking
 --   completed   -> DB purge committed (db_purged_at) AND Auth deletion
 --                  confirmed later (#325); user_id minimized to NULL
+--
+-- ``db_purged_at`` is authoritative and NEVER cleared: once the DB purge
+-- committed, retry/failure transitions (e.g. the future Auth deletion
+-- failed) move the job to pending/failed while PRESERVING the marker, so
+-- a later purge call returns already_purged without repeating deletes.
 --
 -- Constraints reject incoherent states (details in the table DDL):
 --   * only processing carries a lease; pending/completed/failed never do;
 --   * completed <=> db_purged_at NOT NULL AND completed_at NOT NULL;
 --   * completed requires user_id IS NULL (identity minimization);
 --   * failed requires a sanitized error_code;
---   * attempts is never negative; identifiers use strict allowlists.
+--   * attempts is never negative; identifiers use strict allowlists;
+--   * pending always has next_attempt_at; only a terminal failed job may
+--     have next_attempt_at NULL.
 --
 -- Concurrency (binding decision, mirrors commit_turn / #314)
 -- ==========================================================
@@ -117,7 +127,8 @@ BEGIN
               'account_deletion_acquire_lease', 'account_deletion_purge',
               'account_deletion_record_failure', 'account_deletion_record_retry',
               'account_deletion_finalize', 'account_deletion_purge_completed',
-              'account_deletion_validation_error', 'account_deletion_intent_fingerprint_sha256'
+              'account_deletion_validation_error', 'account_deletion_intent_fingerprint_sha256',
+              'account_deletion_assert_owner'
           )
     ) THEN
         RAISE EXCEPTION 'Cannot apply account deletion ledger: account deletion functions already exist (unexpected drift)'
@@ -213,7 +224,10 @@ CREATE TABLE public.account_deletion_jobs (
     attempts integer NOT NULL DEFAULT 0,
     lease_owner text,
     lease_expires_at timestamptz,
-    next_attempt_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    -- NULL only for a TERMINAL failed job (attempts exhausted): never
+    -- claimed automatically again. pending always has a scheduled value
+    -- (enforced by account_deletion_jobs_pending_next_attempt_check).
+    next_attempt_at timestamptz DEFAULT clock_timestamp(),
     db_purged_at timestamptz,
     error_code text,
     requested_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -261,18 +275,22 @@ CREATE TABLE public.account_deletion_jobs (
             (status = 'completed' AND user_id IS NULL)
             OR (status <> 'completed' AND user_id IS NOT NULL)
         ),
-    -- db_purged_at is set exactly when the purge transaction committed.
-    -- It may be non-NULL while the job is processing (purge committed,
-    -- awaiting the future Auth deletion confirmation in #325) and is
-    -- REQUIRED for completed. pending/failed never carry it.
+    -- db_purged_at is the authoritative marker that the purge transaction
+    -- committed. It is REQUIRED for completed and may be present in ANY
+    -- active state: once set it is NEVER cleared, so retry/failure after
+    -- the DB purge (e.g. the future Auth deletion failed) transition the
+    -- job to pending/failed while preserving the marker.
     CONSTRAINT account_deletion_jobs_db_purged_state_check
         CHECK (
             (status = 'completed' AND db_purged_at IS NOT NULL)
-            OR status = 'processing'
-            OR (status IN ('pending', 'failed') AND db_purged_at IS NULL)
+            OR status IN ('pending', 'processing', 'failed')
         ),
     CONSTRAINT account_deletion_jobs_completed_at_state_check
         CHECK ((status = 'completed') = (completed_at IS NOT NULL)),
+    -- pending always has a scheduled next_attempt_at (even if already
+    -- past); only a terminal failed job may have next_attempt_at NULL.
+    CONSTRAINT account_deletion_jobs_pending_next_attempt_check
+        CHECK (status <> 'pending' OR next_attempt_at IS NOT NULL),
     CONSTRAINT account_deletion_jobs_error_code_check
         CHECK (error_code IS NULL OR error_code ~ '^[a-z0-9_]{1,64}$'),
     -- failed jobs must carry a sanitized error_code.
@@ -544,6 +562,11 @@ AS $$
 DECLARE
     v_job public.account_deletion_jobs%ROWTYPE;
     v_now timestamptz := clock_timestamp();
+    -- Deterministic exhaustion ceiling: a failed job whose attempts reach
+    -- this ceiling becomes TERMINAL (next_attempt_at = NULL) and is never
+    -- claimed again automatically. The tombstone stays blocking and
+    -- remains operationally recoverable by a privileged operator.
+    v_max_attempts constant integer := 100;
 BEGIN
     IF p_worker_id IS NULL OR p_worker_id !~ '^[A-Za-z0-9_.:-]{1,64}$' THEN
         RETURN jsonb_build_object(
@@ -570,10 +593,17 @@ BEGIN
         );
     END IF;
 
+    -- Exhausted jobs (failed with next_attempt_at IS NULL) are excluded:
+    -- they are terminal and must never be claimed automatically. New
+    -- attempts are only allowed BELOW the ceiling; a job at the ceiling
+    -- can only be recovered by resuming an expired processing lease.
     SELECT * INTO v_job
     FROM public.account_deletion_jobs
     WHERE (
-            (status IN ('pending', 'failed') AND next_attempt_at <= v_now)
+            (status IN ('pending', 'failed')
+             AND next_attempt_at IS NOT NULL
+             AND next_attempt_at <= v_now
+             AND attempts < v_max_attempts)
             OR (status = 'processing' AND lease_expires_at < v_now)
           )
     ORDER BY next_attempt_at
@@ -584,11 +614,16 @@ BEGIN
         RETURN jsonb_build_object('found', false);
     END IF;
 
+    -- Resuming an expired lease of the LAST attempt does not consume a new
+    -- attempt: attempts never exceeds the ceiling.
     UPDATE public.account_deletion_jobs
     SET status = 'processing',
         lease_owner = p_worker_id,
         lease_expires_at = v_now + make_interval(secs => p_lease_seconds),
-        attempts = v_job.attempts + 1,
+        attempts = CASE
+            WHEN v_job.attempts < v_max_attempts THEN v_job.attempts + 1
+            ELSE v_job.attempts
+        END,
         error_code = NULL,
         updated_at = v_now
     WHERE job_id = v_job.job_id
@@ -848,6 +883,8 @@ DECLARE
     v_job public.account_deletion_jobs;
     v_now timestamptz := clock_timestamp();
     v_next_attempt_at timestamptz;
+    -- Same deterministic ceiling as account_deletion_acquire_lease.
+    v_max_attempts constant integer := 100;
 BEGIN
     IF p_error_code IS NULL OR p_error_code !~ '^[a-z0-9_]{1,64}$' THEN
         RETURN jsonb_build_object(
@@ -860,8 +897,15 @@ BEGIN
 
     v_job := public.account_deletion_assert_owner(p_job_id, p_worker_id);
 
-    v_next_attempt_at := v_now
-        + make_interval(secs => LEAST(3600, 30 * v_job.attempts)::double precision);
+    -- Attempts exhausted: the job becomes TERMINAL (next_attempt_at NULL),
+    -- never claimed automatically again. The tombstone stays blocking and
+    -- db_purged_at (if the DB purge already committed) is preserved.
+    IF v_job.attempts >= v_max_attempts THEN
+        v_next_attempt_at := NULL;
+    ELSE
+        v_next_attempt_at := v_now
+            + make_interval(secs => LEAST(3600, 30 * v_job.attempts)::double precision);
+    END IF;
 
     UPDATE public.account_deletion_jobs
     SET status = 'failed',
@@ -910,8 +954,32 @@ DECLARE
     v_job public.account_deletion_jobs;
     v_now timestamptz := clock_timestamp();
     v_next_attempt_at timestamptz;
+    -- Same deterministic ceiling as account_deletion_acquire_lease.
+    v_max_attempts constant integer := 100;
 BEGIN
     v_job := public.account_deletion_assert_owner(p_job_id, p_worker_id);
+
+    -- Attempts exhausted: a voluntary deferral becomes a TERMINAL failure
+    -- (next_attempt_at NULL, error_code attempts_exhausted), never claimed
+    -- automatically again. The tombstone stays blocking and db_purged_at
+    -- (if the DB purge already committed) is preserved.
+    IF v_job.attempts >= v_max_attempts THEN
+        UPDATE public.account_deletion_jobs
+        SET status = 'failed',
+            error_code = 'attempts_exhausted',
+            lease_owner = NULL,
+            lease_expires_at = NULL,
+            next_attempt_at = NULL,
+            updated_at = v_now
+        WHERE job_id = v_job.job_id;
+
+        RETURN jsonb_build_object(
+            'status', 'failed',
+            'job_id', v_job.job_id::text,
+            'error_code', 'attempts_exhausted',
+            'next_attempt_at', NULL
+        );
+    END IF;
 
     v_next_attempt_at := v_now
         + make_interval(secs => LEAST(3600, 30 * v_job.attempts)::double precision);

--- a/supabase/migrations/20260810120000_account_deletion_ledger.sql
+++ b/supabase/migrations/20260810120000_account_deletion_ledger.sql
@@ -253,8 +253,12 @@ CREATE TABLE public.account_deletion_jobs (
         CHECK (intent_fingerprint_sha256 ~ '^[0-9a-f]{64}$'),
     CONSTRAINT account_deletion_jobs_status_check
         CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+    -- attempts is never negative and never exceeds the operational
+    -- exhaustion ceiling (single authoritative rule, mirrored by
+    -- v_max_attempts = 100 in the RPCs): a schema-level state with more
+    -- attempts than the state machine allows is rejected.
     CONSTRAINT account_deletion_jobs_attempts_check
-        CHECK (attempts >= 0 AND attempts <= 1000),
+        CHECK (attempts >= 0 AND attempts <= 100),
     CONSTRAINT account_deletion_jobs_lease_owner_check
         CHECK (lease_owner IS NULL OR lease_owner ~ '^[A-Za-z0-9_.:-]{1,64}$'),
     -- Lease fields travel together.
@@ -544,10 +548,17 @@ GRANT EXECUTE ON FUNCTION public.account_deletion_has_tombstone(text)
 -- Claims at most one eligible job for a worker. Real PostgreSQL row-level
 -- mechanism: FOR UPDATE SKIP LOCKED guarantees two workers can never own
 -- the same job simultaneously. Eligible:
---   * pending with next_attempt_at <= now;
---   * failed with next_attempt_at <= now (retry after backoff);
---   * processing whose lease has EXPIRED (worker died -> recoverable).
--- Each claim increments attempts (retries are represented in the DB).
+--   * pending with next_attempt_at <= now AND attempts < ceiling;
+--   * failed with next_attempt_at <= now (retry after backoff) AND
+--     attempts < ceiling;
+--   * processing whose lease has EXPIRED with attempts < ceiling
+--     (worker died -> recoverable; the recovery consumes the next
+--     attempt, up to the ceiling).
+-- A processing job whose lease expired AT the attempts ceiling is NEVER
+-- handed to another worker automatically: it is terminalized in place
+-- (failed, error_code attempts_exhausted, lease cleared, next_attempt_at
+-- NULL) and the scan continues, so other eligible jobs still progress
+-- (no starvation) and attempts never exceeds the ceiling.
 CREATE OR REPLACE FUNCTION public.account_deletion_acquire_lease(
     p_worker_id text,
     p_lease_seconds integer,
@@ -562,10 +573,13 @@ AS $$
 DECLARE
     v_job public.account_deletion_jobs%ROWTYPE;
     v_now timestamptz := clock_timestamp();
-    -- Deterministic exhaustion ceiling: a failed job whose attempts reach
-    -- this ceiling becomes TERMINAL (next_attempt_at = NULL) and is never
-    -- claimed again automatically. The tombstone stays blocking and
-    -- remains operationally recoverable by a privileged operator.
+    -- Deterministic exhaustion ceiling (single authoritative rule,
+    -- mirrored by account_deletion_jobs_attempts_check <= 100): a job
+    -- whose attempts reach this ceiling is TERMINAL (next_attempt_at
+    -- NULL) and is never claimed again automatically, neither from
+    -- pending/failed nor from an expired processing lease. The tombstone
+    -- stays blocking and remains operationally recoverable by a
+    -- privileged operator.
     v_max_attempts constant integer := 100;
 BEGIN
     IF p_worker_id IS NULL OR p_worker_id !~ '^[A-Za-z0-9_.:-]{1,64}$' THEN
@@ -593,62 +607,79 @@ BEGIN
         );
     END IF;
 
-    -- Exhausted jobs (failed with next_attempt_at IS NULL) are excluded:
-    -- they are terminal and must never be claimed automatically. New
-    -- attempts are only allowed BELOW the ceiling; a job at the ceiling
-    -- can only be recovered by resuming an expired processing lease.
-    SELECT * INTO v_job
-    FROM public.account_deletion_jobs
-    WHERE (
-            (status IN ('pending', 'failed')
-             AND next_attempt_at IS NOT NULL
-             AND next_attempt_at <= v_now
-             AND attempts < v_max_attempts)
-            OR (status = 'processing' AND lease_expires_at < v_now)
-          )
-    ORDER BY next_attempt_at
-    LIMIT 1
-    FOR UPDATE SKIP LOCKED;
+    LOOP
+        -- Exhausted jobs (failed with next_attempt_at IS NULL) and new
+        -- attempts at/above the ceiling are excluded. Expired processing
+        -- leases are scanned WITHOUT an attempts filter so an
+        -- at-the-ceiling lease can be terminalized below.
+        SELECT * INTO v_job
+        FROM public.account_deletion_jobs
+        WHERE (
+                (status IN ('pending', 'failed')
+                 AND next_attempt_at IS NOT NULL
+                 AND next_attempt_at <= v_now
+                 AND attempts < v_max_attempts)
+                OR (status = 'processing' AND lease_expires_at < v_now)
+              )
+        ORDER BY next_attempt_at
+        LIMIT 1
+        FOR UPDATE SKIP LOCKED;
 
-    IF NOT FOUND THEN
-        RETURN jsonb_build_object('found', false);
-    END IF;
+        IF NOT FOUND THEN
+            RETURN jsonb_build_object('found', false);
+        END IF;
 
-    -- Resuming an expired lease of the LAST attempt does not consume a new
-    -- attempt: attempts never exceeds the ceiling.
-    UPDATE public.account_deletion_jobs
-    SET status = 'processing',
-        lease_owner = p_worker_id,
-        lease_expires_at = v_now + make_interval(secs => p_lease_seconds),
-        attempts = CASE
-            WHEN v_job.attempts < v_max_attempts THEN v_job.attempts + 1
-            ELSE v_job.attempts
-        END,
-        error_code = NULL,
-        updated_at = v_now
-    WHERE job_id = v_job.job_id
-    RETURNING
-        job_id, user_id, user_ref_hmac_sha256, operation_id, status,
-        lease_owner, lease_expires_at, attempts, db_purged_at,
-        intent_fingerprint_sha256
-    INTO
-        v_job.job_id, v_job.user_id, v_job.user_ref_hmac_sha256, v_job.operation_id,
-        v_job.status, v_job.lease_owner, v_job.lease_expires_at, v_job.attempts,
-        v_job.db_purged_at, v_job.intent_fingerprint_sha256;
+        -- Expired lease AT the ceiling: terminalize in place (never
+        -- delivered to another worker automatically), preserving
+        -- db_purged_at and the tombstone, then keep scanning so other
+        -- eligible jobs still progress.
+        IF v_job.status = 'processing' AND v_job.attempts >= v_max_attempts THEN
+            UPDATE public.account_deletion_jobs
+            SET status = 'failed',
+                error_code = 'attempts_exhausted',
+                lease_owner = NULL,
+                lease_expires_at = NULL,
+                next_attempt_at = NULL,
+                updated_at = v_now
+            WHERE job_id = v_job.job_id;
+            CONTINUE;
+        END IF;
 
-    RETURN jsonb_build_object(
-        'found', true,
-        'job_id', v_job.job_id::text,
-        'user_id', v_job.user_id,
-        'user_ref_hmac_sha256', v_job.user_ref_hmac_sha256,
-        'operation_id', v_job.operation_id::text,
-        'status', v_job.status,
-        'lease_owner', v_job.lease_owner,
-        'lease_expires_at', v_job.lease_expires_at,
-        'attempts', v_job.attempts,
-        'db_purged_at', v_job.db_purged_at,
-        'intent_fingerprint_sha256', v_job.intent_fingerprint_sha256
-    );
+        -- Recovery/claim below the ceiling: consumes the next attempt.
+        -- v_job.attempts < v_max_attempts is guaranteed here (the
+        -- at-the-ceiling branch above already terminalized), so attempts
+        -- never exceeds the ceiling.
+        UPDATE public.account_deletion_jobs
+        SET status = 'processing',
+            lease_owner = p_worker_id,
+            lease_expires_at = v_now + make_interval(secs => p_lease_seconds),
+            attempts = v_job.attempts + 1,
+            error_code = NULL,
+            updated_at = v_now
+        WHERE job_id = v_job.job_id
+        RETURNING
+            job_id, user_id, user_ref_hmac_sha256, operation_id, status,
+            lease_owner, lease_expires_at, attempts, db_purged_at,
+            intent_fingerprint_sha256
+        INTO
+            v_job.job_id, v_job.user_id, v_job.user_ref_hmac_sha256, v_job.operation_id,
+            v_job.status, v_job.lease_owner, v_job.lease_expires_at, v_job.attempts,
+            v_job.db_purged_at, v_job.intent_fingerprint_sha256;
+
+        RETURN jsonb_build_object(
+            'found', true,
+            'job_id', v_job.job_id::text,
+            'user_id', v_job.user_id,
+            'user_ref_hmac_sha256', v_job.user_ref_hmac_sha256,
+            'operation_id', v_job.operation_id::text,
+            'status', v_job.status,
+            'lease_owner', v_job.lease_owner,
+            'lease_expires_at', v_job.lease_expires_at,
+            'attempts', v_job.attempts,
+            'db_purged_at', v_job.db_purged_at,
+            'intent_fingerprint_sha256', v_job.intent_fingerprint_sha256
+        );
+    END LOOP;
 EXCEPTION
     WHEN OTHERS THEN
         RAISE EXCEPTION 'persistence error' USING ERRCODE = 'P0001';

--- a/supabase/tests/database/08_account_deletion_ledger.test.sql
+++ b/supabase/tests/database/08_account_deletion_ledger.test.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 CREATE EXTENSION IF NOT EXISTS pgtap;
-SELECT plan(114);
+SELECT plan(125);
 
 -- =================================================================
 -- 1. Table exists with the exact columns
@@ -41,6 +41,7 @@ SELECT is(
         'account_deletion_jobs_lease_owner_check',
         'account_deletion_jobs_lease_pair_check',
         'account_deletion_jobs_lease_state_check',
+        'account_deletion_jobs_pending_next_attempt_check',
         'account_deletion_jobs_pkey',
         'account_deletion_jobs_status_check',
         'account_deletion_jobs_user_id_check',
@@ -320,6 +321,36 @@ SELECT throws_ok(
     NULL, NULL,
     'completed with a raw user_id is rejected (identity minimization)'
 );
+-- failed after the DB purge PRESERVES db_purged_at (retry/failure after
+-- the purge is representable; the marker is never cleared)
+SELECT lives_ok(
+    'INSERT INTO public.account_deletion_jobs
+        (operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+         status, attempts, error_code, db_purged_at, next_attempt_at)
+     VALUES (gen_random_uuid(), ''u-1'', repeat(''a'', 64), repeat(''b'', 64),
+         ''failed'', 2, ''auth_unavailable'', now() - interval ''1 hour'',
+         now() + interval ''1 minute'')',
+    'failed job preserves db_purged_at (post-purge failure is representable)'
+);
+-- pending after the DB purge PRESERVES db_purged_at (retry after purge)
+SELECT lives_ok(
+    'INSERT INTO public.account_deletion_jobs
+        (operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+         status, attempts, db_purged_at, next_attempt_at)
+     VALUES (gen_random_uuid(), ''u-1'', repeat(''a'', 64), repeat(''b'', 64),
+         ''pending'', 2, now() - interval ''1 hour'', now() + interval ''1 minute'')',
+    'pending job preserves db_purged_at (post-purge retry is representable)'
+);
+-- pending must always have a scheduled next_attempt_at
+SELECT throws_ok(
+    'INSERT INTO public.account_deletion_jobs
+        (operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+         status, next_attempt_at)
+     VALUES (gen_random_uuid(), ''u-1'', repeat(''a'', 64), repeat(''b'', 64),
+         ''pending'', NULL)',
+    NULL, NULL,
+    'pending without next_attempt_at is rejected'
+);
 -- failed requires a sanitized error_code
 SELECT throws_ok(
     'INSERT INTO public.account_deletion_jobs
@@ -555,6 +586,88 @@ SELECT is(
     'tombstone lookup still works after completion'
 );
 
+-- =================================================================
+-- 10. Attempts exhaustion (deterministic terminal state)
+-- =================================================================
+-- The ceiling is 100. A job at 99 may be claimed once more (the last
+-- allowed claim); record_failure at the ceiling makes it TERMINAL
+-- (next_attempt_at NULL); the claim never selects exhausted jobs and the
+-- tombstone stays blocking.
+INSERT INTO public.account_deletion_jobs (
+    operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+    status, attempts, next_attempt_at
+) VALUES (
+    '55555555-5555-5555-5555-555555555555'::uuid, 'adl-exhaust',
+    repeat('5', 64), repeat('6', 64), 'pending', 99, clock_timestamp()
+);
+
+SELECT is(
+    (public.account_deletion_acquire_lease('worker-ex', 60, 100)->>'attempts')::integer,
+    100,
+    'the last allowed claim reaches the attempts ceiling'
+);
+SELECT is(
+    (public.account_deletion_record_failure(
+        (SELECT job_id FROM public.account_deletion_jobs
+          WHERE user_ref_hmac_sha256 = repeat('5', 64)),
+        'worker-ex', 'auth_unavailable')->>'next_attempt_at') IS NULL,
+    true,
+    'record_failure at the ceiling produces a terminal job (next_attempt_at NULL)'
+);
+SELECT is(
+    (public.account_deletion_acquire_lease('worker-ex2', 60, 100)->>'found'),
+    'false',
+    'exhausted jobs are never claimed automatically again'
+);
+SELECT is(
+    (public.account_deletion_has_tombstone(repeat('5', 64))->>'exists'),
+    'true',
+    'exhausted tombstone stays blocking'
+);
+
+-- record_retry at the ceiling also becomes a terminal failed job.
+INSERT INTO public.account_deletion_jobs (
+    operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+    status, attempts, next_attempt_at
+) VALUES (
+    '66666666-6666-6666-6666-666666666666'::uuid, 'adl-exhaust2',
+    repeat('7', 64), repeat('8', 64), 'pending', 99, clock_timestamp()
+);
+SELECT is(
+    (public.account_deletion_acquire_lease('worker-ex4', 60, 100)->>'attempts')::integer,
+    100,
+    'the retry boundary claim reaches the ceiling'
+);
+SELECT is(
+    (public.account_deletion_record_retry(
+        (SELECT job_id FROM public.account_deletion_jobs
+          WHERE user_ref_hmac_sha256 = repeat('7', 64)),
+        'worker-ex4')->>'error_code'),
+    'attempts_exhausted',
+    'record_retry at the ceiling becomes a terminal attempts_exhausted failure'
+);
+SELECT is(
+    (public.account_deletion_acquire_lease('worker-ex5', 60, 100)->>'found'),
+    'false',
+    'exhausted retry job is never claimed automatically again'
+);
+
+-- Resuming an expired lease of the LAST attempt does not consume a new
+-- attempt: attempts never exceeds the ceiling.
+UPDATE public.account_deletion_jobs
+SET status = 'processing',
+    lease_owner = 'worker-ex6',
+    lease_expires_at = now() - interval '1 second'
+WHERE user_ref_hmac_sha256 = repeat('7', 64);
+SELECT is(
+    (public.account_deletion_acquire_lease('worker-ex7', 60, 100)->>'attempts')::integer,
+    100,
+    'resuming an expired last-attempt lease keeps attempts at the ceiling'
+);
+
+-- =================================================================
+-- 11. Retention of completed tombstones
+-- =================================================================
 -- Retention: a recent completed tombstone is retained; an old completed
 -- tombstone is removed; active/failed jobs are never removed by age.
 SELECT is(

--- a/supabase/tests/database/08_account_deletion_ledger.test.sql
+++ b/supabase/tests/database/08_account_deletion_ledger.test.sql
@@ -1,0 +1,600 @@
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgtap;
+SELECT plan(114);
+
+-- =================================================================
+-- 1. Table exists with the exact columns
+-- =================================================================
+SELECT has_table('public', 'account_deletion_jobs', 'account_deletion_jobs exists');
+
+SELECT is(
+    (SELECT array_agg(attname ORDER BY attnum)::text
+       FROM pg_attribute
+      WHERE attrelid = 'public.account_deletion_jobs'::regclass
+        AND attnum > 0
+        AND NOT attisdropped),
+    ARRAY[
+        'job_id', 'operation_id', 'user_id', 'user_ref_hmac_sha256',
+        'intent_fingerprint_sha256', 'status', 'attempts', 'lease_owner',
+        'lease_expires_at', 'next_attempt_at', 'db_purged_at', 'error_code',
+        'requested_at', 'updated_at', 'completed_at'
+    ]::text,
+    'account_deletion_jobs has the exact column set'
+);
+
+-- =================================================================
+-- 2. Exact constraints
+-- =================================================================
+SELECT is(
+    (SELECT array_agg(conname ORDER BY conname)::text
+       FROM pg_constraint
+      WHERE conrelid = 'public.account_deletion_jobs'::regclass),
+    ARRAY[
+        'account_deletion_jobs_attempts_check',
+        'account_deletion_jobs_completed_at_state_check',
+        'account_deletion_jobs_db_purged_state_check',
+        'account_deletion_jobs_error_code_check',
+        'account_deletion_jobs_failed_error_check',
+        'account_deletion_jobs_fingerprint_check',
+        'account_deletion_jobs_idempotency_key',
+        'account_deletion_jobs_lease_owner_check',
+        'account_deletion_jobs_lease_pair_check',
+        'account_deletion_jobs_lease_state_check',
+        'account_deletion_jobs_pkey',
+        'account_deletion_jobs_status_check',
+        'account_deletion_jobs_user_id_check',
+        'account_deletion_jobs_user_id_state_check',
+        'account_deletion_jobs_user_ref_check'
+    ]::text,
+    'account_deletion_jobs has the exact constraint set'
+);
+
+-- =================================================================
+-- 3. Required indexes
+-- =================================================================
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'account_deletion_jobs_status_next_attempt_idx'
+    ),
+    'account_deletion_jobs_status_next_attempt_idx exists'
+);
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'account_deletion_jobs_user_ref_idx'
+    ),
+    'account_deletion_jobs_user_ref_idx exists'
+);
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'account_deletion_jobs_completed_at_idx'
+    ),
+    'account_deletion_jobs_completed_at_idx exists'
+);
+
+-- =================================================================
+-- 4. No FK to profiles
+-- =================================================================
+SELECT is(
+    (SELECT count(*)::integer
+       FROM pg_constraint con
+       JOIN pg_class rel ON rel.oid = con.conrelid
+       JOIN pg_namespace n ON n.oid = rel.relnamespace
+      WHERE n.nspname = 'public'
+        AND rel.relname = 'account_deletion_jobs'
+        AND con.contype = 'f'
+        AND con.confrelid = 'public.profiles'::regclass),
+    0,
+    'account_deletion_jobs has no FK to profiles'
+);
+
+-- =================================================================
+-- 5/6/7. RLS, FORCE RLS, zero policies
+-- =================================================================
+SELECT ok(
+    (SELECT relrowsecurity FROM pg_class WHERE oid = 'public.account_deletion_jobs'::regclass),
+    'RLS is enabled on account_deletion_jobs'
+);
+SELECT ok(
+    (SELECT relforcerowsecurity FROM pg_class WHERE oid = 'public.account_deletion_jobs'::regclass),
+    'FORCE RLS is enabled on account_deletion_jobs'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM pg_policies
+      WHERE schemaname = 'public' AND tablename = 'account_deletion_jobs'),
+    0,
+    'account_deletion_jobs has zero policies'
+);
+
+-- =================================================================
+-- 8. No runtime role has direct table access
+-- =================================================================
+SELECT ok(
+    NOT has_table_privilege('service_role', 'public.account_deletion_jobs',
+        'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'),
+    'service_role has no table privileges'
+);
+SELECT ok(
+    NOT has_table_privilege('anon', 'public.account_deletion_jobs',
+        'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'),
+    'anon has no table privileges'
+);
+SELECT ok(
+    NOT has_table_privilege('authenticated', 'public.account_deletion_jobs',
+        'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'),
+    'authenticated has no table privileges'
+);
+SELECT ok(
+    NOT has_table_privilege('public', 'public.account_deletion_jobs',
+        'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'),
+    'PUBLIC has no table privileges'
+);
+
+-- =================================================================
+-- 9/10. RPC grants exact; internal helpers not exposed
+-- =================================================================
+-- Runtime RPCs: exist, SECURITY DEFINER, search_path = '', service_role
+-- only. One ok() per RPC per property via unnest.
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public' AND p.proname = rpc
+    ),
+    format('%s exists', rpc)
+) FROM unnest(ARRAY[
+    'account_deletion_request', 'account_deletion_has_tombstone',
+    'account_deletion_acquire_lease', 'account_deletion_purge',
+    'account_deletion_record_failure', 'account_deletion_record_retry',
+    'account_deletion_finalize', 'account_deletion_purge_completed'
+]) AS rpc;
+
+SELECT ok(
+    (SELECT prosecdef FROM pg_proc WHERE oid = format('public.%s(%s)', rpc, sig)::regprocedure),
+    format('%s is SECURITY DEFINER', rpc)
+) FROM (VALUES
+    ('account_deletion_request', 'text, text, uuid, text'),
+    ('account_deletion_has_tombstone', 'text'),
+    ('account_deletion_acquire_lease', 'text, integer, integer'),
+    ('account_deletion_purge', 'uuid, text, text'),
+    ('account_deletion_record_failure', 'uuid, text, text'),
+    ('account_deletion_record_retry', 'uuid, text'),
+    ('account_deletion_finalize', 'uuid, text'),
+    ('account_deletion_purge_completed', 'timestamptz, integer')
+) AS t(rpc, sig);
+
+SELECT ok(
+    (SELECT p.proconfig @> ARRAY['search_path=""'] FROM pg_proc p WHERE p.oid = format('public.%s(%s)', rpc, sig)::regprocedure),
+    format('%s has an empty search_path', rpc)
+) FROM (VALUES
+    ('account_deletion_request', 'text, text, uuid, text'),
+    ('account_deletion_has_tombstone', 'text'),
+    ('account_deletion_acquire_lease', 'text, integer, integer'),
+    ('account_deletion_purge', 'uuid, text, text'),
+    ('account_deletion_record_failure', 'uuid, text, text'),
+    ('account_deletion_record_retry', 'uuid, text'),
+    ('account_deletion_finalize', 'uuid, text'),
+    ('account_deletion_purge_completed', 'timestamptz, integer')
+) AS t(rpc, sig);
+
+SELECT ok(
+    has_function_privilege('service_role', format('public.%s(%s)', rpc, sig), 'EXECUTE'),
+    format('service_role can execute %s', rpc)
+) FROM (VALUES
+    ('account_deletion_request', 'text, text, uuid, text'),
+    ('account_deletion_has_tombstone', 'text'),
+    ('account_deletion_acquire_lease', 'text, integer, integer'),
+    ('account_deletion_purge', 'uuid, text, text'),
+    ('account_deletion_record_failure', 'uuid, text, text'),
+    ('account_deletion_record_retry', 'uuid, text'),
+    ('account_deletion_finalize', 'uuid, text'),
+    ('account_deletion_purge_completed', 'timestamptz, integer')
+) AS t(rpc, sig);
+
+SELECT ok(
+    NOT has_function_privilege('anon', format('public.%s(%s)', rpc, sig), 'EXECUTE'),
+    format('anon cannot execute %s', rpc)
+) FROM (VALUES
+    ('account_deletion_request', 'text, text, uuid, text'),
+    ('account_deletion_has_tombstone', 'text'),
+    ('account_deletion_acquire_lease', 'text, integer, integer'),
+    ('account_deletion_purge', 'uuid, text, text'),
+    ('account_deletion_record_failure', 'uuid, text, text'),
+    ('account_deletion_record_retry', 'uuid, text'),
+    ('account_deletion_finalize', 'uuid, text'),
+    ('account_deletion_purge_completed', 'timestamptz, integer')
+) AS t(rpc, sig);
+
+SELECT ok(
+    NOT has_function_privilege('authenticated', format('public.%s(%s)', rpc, sig), 'EXECUTE'),
+    format('authenticated cannot execute %s', rpc)
+) FROM (VALUES
+    ('account_deletion_request', 'text, text, uuid, text'),
+    ('account_deletion_has_tombstone', 'text'),
+    ('account_deletion_acquire_lease', 'text, integer, integer'),
+    ('account_deletion_purge', 'uuid, text, text'),
+    ('account_deletion_record_failure', 'uuid, text, text'),
+    ('account_deletion_record_retry', 'uuid, text'),
+    ('account_deletion_finalize', 'uuid, text'),
+    ('account_deletion_purge_completed', 'timestamptz, integer')
+) AS t(rpc, sig);
+
+SELECT ok(
+    NOT has_function_privilege('public', format('public.%s(%s)', rpc, sig), 'EXECUTE'),
+    format('PUBLIC cannot execute %s', rpc)
+) FROM (VALUES
+    ('account_deletion_request', 'text, text, uuid, text'),
+    ('account_deletion_has_tombstone', 'text'),
+    ('account_deletion_acquire_lease', 'text, integer, integer'),
+    ('account_deletion_purge', 'uuid, text, text'),
+    ('account_deletion_record_failure', 'uuid, text, text'),
+    ('account_deletion_record_retry', 'uuid, text'),
+    ('account_deletion_finalize', 'uuid, text'),
+    ('account_deletion_purge_completed', 'timestamptz, integer')
+) AS t(rpc, sig);
+
+-- Internal helpers exist but carry NO runtime grants.
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public' AND p.proname = helper
+    ),
+    format('%s exists', helper)
+) FROM unnest(ARRAY[
+    'account_deletion_validation_error',
+    'account_deletion_assert_owner',
+    'account_deletion_intent_fingerprint_sha256'
+]) AS helper;
+
+SELECT ok(
+    NOT has_function_privilege('service_role', format('public.%s(%s)', helper, sig), 'EXECUTE'),
+    format('service_role cannot execute internal %s', helper)
+) FROM (VALUES
+    ('account_deletion_validation_error', 'text, text, uuid, text'),
+    ('account_deletion_assert_owner', 'uuid, text'),
+    ('account_deletion_intent_fingerprint_sha256', 'jsonb')
+) AS t(helper, sig);
+
+SELECT ok(
+    NOT has_function_privilege('public', format('public.%s(%s)', helper, sig), 'EXECUTE'),
+    format('PUBLIC cannot execute internal %s', helper)
+) FROM (VALUES
+    ('account_deletion_validation_error', 'text, text, uuid, text'),
+    ('account_deletion_assert_owner', 'uuid, text'),
+    ('account_deletion_intent_fingerprint_sha256', 'jsonb')
+) AS t(helper, sig);
+
+-- =================================================================
+-- 11/12/13/14. Constraints reject incoherent states and bad values
+-- =================================================================
+-- pending must not carry a lease
+SELECT throws_ok(
+    'INSERT INTO public.account_deletion_jobs
+        (operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+         status, lease_owner, lease_expires_at)
+     VALUES (gen_random_uuid(), ''u-1'', repeat(''a'', 64), repeat(''b'', 64),
+         ''pending'', ''worker-1'', now() + interval ''1 minute'')',
+    NULL, NULL,
+    'pending with a lease is rejected'
+);
+-- processing must carry a lease
+SELECT throws_ok(
+    'INSERT INTO public.account_deletion_jobs
+        (operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256, status)
+     VALUES (gen_random_uuid(), ''u-1'', repeat(''a'', 64), repeat(''b'', 64), ''processing'')',
+    NULL, NULL,
+    'processing without a lease is rejected'
+);
+-- lease owner without expiry is rejected
+SELECT throws_ok(
+    'INSERT INTO public.account_deletion_jobs
+        (operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+         status, lease_owner)
+     VALUES (gen_random_uuid(), ''u-1'', repeat(''a'', 64), repeat(''b'', 64),
+         ''processing'', ''worker-1'')',
+    NULL, NULL,
+    'lease owner without expiry is rejected'
+);
+-- completed requires db_purged_at and completed_at
+SELECT throws_ok(
+    'INSERT INTO public.account_deletion_jobs
+        (operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+         status, completed_at)
+     VALUES (gen_random_uuid(), ''u-1'', repeat(''a'', 64), repeat(''b'', 64),
+         ''completed'', now())',
+    NULL, NULL,
+    'completed without db_purged_at is rejected'
+);
+-- completed must not preserve the raw user_id
+SELECT throws_ok(
+    'INSERT INTO public.account_deletion_jobs
+        (operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+         status, db_purged_at, completed_at)
+     VALUES (gen_random_uuid(), ''u-1'', repeat(''a'', 64), repeat(''b'', 64),
+         ''completed'', now(), now())',
+    NULL, NULL,
+    'completed with a raw user_id is rejected (identity minimization)'
+);
+-- failed requires a sanitized error_code
+SELECT throws_ok(
+    'INSERT INTO public.account_deletion_jobs
+        (operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256, status)
+     VALUES (gen_random_uuid(), ''u-1'', repeat(''a'', 64), repeat(''b'', 64), ''failed'')',
+    NULL, NULL,
+    'failed without error_code is rejected'
+);
+-- attempts can never be negative
+SELECT throws_ok(
+    'INSERT INTO public.account_deletion_jobs
+        (operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+         status, attempts)
+     VALUES (gen_random_uuid(), ''u-1'', repeat(''a'', 64), repeat(''b'', 64),
+         ''pending'', -1)',
+    NULL, NULL,
+    'negative attempts are rejected'
+);
+-- unknown status is rejected
+SELECT throws_ok(
+    'INSERT INTO public.account_deletion_jobs
+        (operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256, status)
+     VALUES (gen_random_uuid(), ''u-1'', repeat(''a'', 64), repeat(''b'', 64), ''exploded'')',
+    NULL, NULL,
+    'unknown status is rejected'
+);
+-- lease_owner must match the strict allowlist
+SELECT throws_ok(
+    'INSERT INTO public.account_deletion_jobs
+        (operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+         status, lease_owner, lease_expires_at)
+     VALUES (gen_random_uuid(), ''u-1'', repeat(''a'', 64), repeat(''b'', 64),
+         ''processing'', ''bad owner!!'', now() + interval ''1 minute'')',
+    NULL, NULL,
+    'lease_owner outside the allowlist is rejected'
+);
+-- error_code must match the strict allowlist
+SELECT throws_ok(
+    'INSERT INTO public.account_deletion_jobs
+        (operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+         status, error_code)
+     VALUES (gen_random_uuid(), ''u-1'', repeat(''a'', 64), repeat(''b'', 64),
+         ''failed'', ''Bad Code'')',
+    NULL, NULL,
+    'error_code outside the allowlist is rejected'
+);
+-- invalid HMAC reference is rejected
+SELECT throws_ok(
+    'INSERT INTO public.account_deletion_jobs
+        (operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256, status)
+     VALUES (gen_random_uuid(), ''u-1'', ''not-hex'', repeat(''b'', 64), ''pending'')',
+    NULL, NULL,
+    'invalid user_ref_hmac_sha256 is rejected'
+);
+-- invalid intent fingerprint is rejected
+SELECT throws_ok(
+    'INSERT INTO public.account_deletion_jobs
+        (operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256, status)
+     VALUES (gen_random_uuid(), ''u-1'', repeat(''a'', 64), ''XYZ'', ''pending'')',
+    NULL, NULL,
+    'invalid intent_fingerprint_sha256 is rejected'
+);
+-- empty/whitespace user_id is rejected while active
+SELECT throws_ok(
+    'INSERT INTO public.account_deletion_jobs
+        (operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256, status)
+     VALUES (gen_random_uuid(), ''   '', repeat(''a'', 64), repeat(''b'', 64), ''pending'')',
+    NULL, NULL,
+    'whitespace user_id is rejected'
+);
+-- duplicate (ref, operation_id) is rejected by the idempotency key
+SELECT throws_ok(
+    'INSERT INTO public.account_deletion_jobs
+        (operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256, status)
+     VALUES (''11111111-1111-1111-1111-111111111111''::uuid, ''u-1'',
+         repeat(''a'', 64), repeat(''b'', 64), ''pending''),
+        (''11111111-1111-1111-1111-111111111111''::uuid, ''u-2'',
+         repeat(''a'', 64), repeat(''b'', 64), ''pending'')',
+    NULL, NULL,
+    'duplicate (ref, operation_id) is rejected (idempotency key)'
+);
+
+-- =================================================================
+-- Functional flow: request -> replay -> conflict -> claim -> purge ->
+-- finalize -> retention
+-- =================================================================
+INSERT INTO public.profiles (user_id, persona_config, user_profile,
+    relationship_state, emotional_state, revision)
+VALUES (
+    'adl-pgtap', 'persona', '{}'::jsonb,
+    '{"schema_version":1,"trust":0.5,"affection":0.3,"tension":0.0,"triggers":[],"timestamp":1700000000.0}'::jsonb,
+    '{"schema_version":1,"pleasure":0.0,"arousal":0.0,"dominance":0.0,"libido":0.0,"aggression":0.0,"connection":0.5,"energy":0.8,"tension":0.0,"coping_mode":"HEALTHY","timestamp":1700000000.0}'::jsonb,
+    1
+);
+INSERT INTO public.chat_logs (user_id, role, content)
+VALUES ('adl-pgtap', 'user', 'hi'), ('adl-pgtap', 'assistant', 'hello');
+INSERT INTO public.memories (user_id, content, metadata)
+VALUES ('adl-pgtap', 'memory', '{}'::jsonb);
+INSERT INTO public.admission_reservations
+    (user_id, request_id, message_hmac_sha256, network_hmac_sha256, estimated_units)
+VALUES ('adl-pgtap', gen_random_uuid(), repeat('a', 64), repeat('b', 64), 10);
+INSERT INTO public.privacy_operations
+    (user_id, operation_id, operation, operation_payload_sha256, status, result)
+VALUES ('adl-pgtap', gen_random_uuid(), 'delete_history', repeat('c', 64), 'applied', '{}'::jsonb);
+
+-- A valid, coherent job is accepted.
+INSERT INTO public.account_deletion_jobs (
+    operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+    status, attempts, next_attempt_at
+) VALUES (
+    '22222222-2222-2222-2222-222222222222'::uuid, 'adl-pgtap',
+    repeat('d', 64), repeat('e', 64), 'pending', 0, clock_timestamp()
+);
+
+-- Request RPC: replay returns the existing job; divergent fingerprint
+-- conflicts; tombstone lookup works.
+SELECT is(
+    (public.account_deletion_request('adl-pgtap', repeat('d', 64),
+        '22222222-2222-2222-2222-222222222222'::uuid, repeat('e', 64))->>'status'),
+    'replay',
+    'request replays the same ref+operation_id+fingerprint'
+);
+SELECT is(
+    (public.account_deletion_request('adl-pgtap', repeat('d', 64),
+        '22222222-2222-2222-2222-222222222222'::uuid, repeat('f', 64))->'error'->>'code'),
+    'operation_conflict',
+    'divergent fingerprint produces a structured conflict'
+);
+SELECT is(
+    (public.account_deletion_has_tombstone(repeat('d', 64))->>'exists'),
+    'true',
+    'tombstone lookup reports the blocking job'
+);
+
+-- Claim: first claim wins; a second claim finds nothing.
+SELECT is(
+    (public.account_deletion_acquire_lease('worker-pg', 60, 100)->>'found'),
+    'true',
+    'first claim acquires the job'
+);
+SELECT is(
+    (public.account_deletion_acquire_lease('worker-pg2', 60, 100)->>'found'),
+    'false',
+    'second concurrent claim finds no eligible job'
+);
+
+-- Old worker without the lease cannot purge (fails closed, sanitized).
+SELECT throws_ok(
+    'SELECT public.account_deletion_purge(
+        (SELECT job_id FROM public.account_deletion_jobs
+          WHERE user_ref_hmac_sha256 = repeat(''d'', 64)),
+        ''not-the-owner'', repeat(''e'', 64))',
+    'P0001', 'persistence error',
+    'purge from a non-owner fails closed with a persistence error'
+);
+
+-- Owner purges: every table of the user is removed in one transaction.
+SELECT is(
+    (public.account_deletion_purge(
+        (SELECT job_id FROM public.account_deletion_jobs
+          WHERE user_ref_hmac_sha256 = repeat('d', 64)),
+        'worker-pg', repeat('e', 64))->>'status'),
+    'purged',
+    'owner purge completes'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.chat_logs WHERE user_id = 'adl-pgtap'),
+    0,
+    'chat_logs purged'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.memories WHERE user_id = 'adl-pgtap'),
+    0,
+    'memories purged'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.admission_reservations WHERE user_id = 'adl-pgtap'),
+    0,
+    'admission_reservations purged'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.privacy_operations WHERE user_id = 'adl-pgtap'),
+    0,
+    'privacy_operations purged'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.profiles WHERE user_id = 'adl-pgtap'),
+    0,
+    'profiles purged (tombstone survives)'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.account_deletion_jobs
+      WHERE user_ref_hmac_sha256 = repeat('d', 64)),
+    1,
+    'tombstone survives the profiles purge'
+);
+
+-- Repeated purge after the data is gone is a safe replay.
+SELECT is(
+    (public.account_deletion_purge(
+        (SELECT job_id FROM public.account_deletion_jobs
+          WHERE user_ref_hmac_sha256 = repeat('d', 64)),
+        'worker-pg', repeat('e', 64))->>'status'),
+    'already_purged',
+    'repeated purge on an empty database is a safe replay'
+);
+
+-- Finalize minimizes identity: user_id becomes NULL, ref persists.
+SELECT is(
+    (public.account_deletion_finalize(
+        (SELECT job_id FROM public.account_deletion_jobs
+          WHERE user_ref_hmac_sha256 = repeat('d', 64)),
+        'worker-pg')->>'status'),
+    'completed',
+    'finalize completes the job'
+);
+SELECT is(
+    (SELECT user_id IS NULL FROM public.account_deletion_jobs
+      WHERE user_ref_hmac_sha256 = repeat('d', 64)),
+    true,
+    'completed job minimizes the raw user_id to NULL'
+);
+SELECT is(
+    (SELECT count(*)::integer FROM public.account_deletion_jobs
+      WHERE user_ref_hmac_sha256 = repeat('d', 64)
+        AND status = 'completed'),
+    1,
+    'completed tombstone keeps the sanitized HMAC reference'
+);
+SELECT is(
+    (public.account_deletion_has_tombstone(repeat('d', 64))->>'status'),
+    'completed',
+    'tombstone lookup still works after completion'
+);
+
+-- Retention: a recent completed tombstone is retained; an old completed
+-- tombstone is removed; active/failed jobs are never removed by age.
+SELECT is(
+    public.account_deletion_purge_completed(now() - interval '10 days', 10),
+    0,
+    'completed tombstone younger than the horizon is retained'
+);
+
+-- An old completed tombstone (identity already minimized) is eligible.
+INSERT INTO public.account_deletion_jobs (
+    operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+    status, attempts, db_purged_at, completed_at, next_attempt_at,
+    requested_at, updated_at
+) VALUES (
+    '44444444-4444-4444-4444-444444444444'::uuid, NULL,
+    repeat('9', 64), repeat('8', 64), 'completed', 1,
+    now() - interval '45 days', now() - interval '45 days',
+    now() - interval '45 days', now() - interval '45 days',
+    now() - interval '45 days'
+);
+SELECT is(
+    public.account_deletion_purge_completed(now() - interval '40 days', 10),
+    1,
+    'completed tombstone older than the horizon is removed'
+);
+
+-- Active/failed jobs are never removed by age.
+INSERT INTO public.account_deletion_jobs (
+    operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+    status, attempts, error_code, next_attempt_at, requested_at, updated_at
+) VALUES (
+    '33333333-3333-3333-3333-333333333333'::uuid, 'adl-active',
+    repeat('1', 64), repeat('2', 64), 'failed', 3, 'auth_unavailable',
+    now() - interval '40 days', now() - interval '40 days', now() - interval '40 days'
+);
+SELECT is(
+    public.account_deletion_purge_completed(now() + interval '1 day', 10),
+    0,
+    'failed jobs are never removed by age'
+);
+
+SELECT finish();
+ROLLBACK;

--- a/supabase/tests/database/08_account_deletion_ledger.test.sql
+++ b/supabase/tests/database/08_account_deletion_ledger.test.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 CREATE EXTENSION IF NOT EXISTS pgtap;
-SELECT plan(125);
+SELECT plan(140);
 
 -- =================================================================
 -- 1. Table exists with the exact columns
@@ -589,10 +589,15 @@ SELECT is(
 -- =================================================================
 -- 10. Attempts exhaustion (deterministic terminal state)
 -- =================================================================
--- The ceiling is 100. A job at 99 may be claimed once more (the last
--- allowed claim); record_failure at the ceiling makes it TERMINAL
--- (next_attempt_at NULL); the claim never selects exhausted jobs and the
--- tombstone stays blocking.
+-- The ceiling is 100. A job below the ceiling may be claimed (the last
+-- allowed claim reaches 100); record_failure/record_retry at the ceiling
+-- make it TERMINAL (next_attempt_at NULL); an expired processing lease AT
+-- the ceiling is terminalized in place (never handed to another worker);
+-- the claim never selects exhausted jobs; the tombstone stays blocking;
+-- other eligible jobs still progress (no starvation); schema states
+-- above the ceiling are rejected.
+
+-- --- 10.1 record_failure at the ceiling -> terminal ---
 INSERT INTO public.account_deletion_jobs (
     operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
     status, attempts, next_attempt_at
@@ -600,7 +605,6 @@ INSERT INTO public.account_deletion_jobs (
     '55555555-5555-5555-5555-555555555555'::uuid, 'adl-exhaust',
     repeat('5', 64), repeat('6', 64), 'pending', 99, clock_timestamp()
 );
-
 SELECT is(
     (public.account_deletion_acquire_lease('worker-ex', 60, 100)->>'attempts')::integer,
     100,
@@ -625,7 +629,7 @@ SELECT is(
     'exhausted tombstone stays blocking'
 );
 
--- record_retry at the ceiling also becomes a terminal failed job.
+-- --- 10.2 record_retry at the ceiling -> terminal attempts_exhausted ---
 INSERT INTO public.account_deletion_jobs (
     operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
     status, attempts, next_attempt_at
@@ -652,17 +656,142 @@ SELECT is(
     'exhausted retry job is never claimed automatically again'
 );
 
--- Resuming an expired lease of the LAST attempt does not consume a new
--- attempt: attempts never exceeds the ceiling.
-UPDATE public.account_deletion_jobs
-SET status = 'processing',
-    lease_owner = 'worker-ex6',
-    lease_expires_at = now() - interval '1 second'
-WHERE user_ref_hmac_sha256 = repeat('7', 64);
+-- --- 10.3 Expired processing lease BELOW the ceiling is recoverable ---
+-- (attempts 99 -> the recovery consumes the next attempt, reaching 100).
+INSERT INTO public.account_deletion_jobs (
+    operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+    status, attempts, lease_owner, lease_expires_at, next_attempt_at
+) VALUES (
+    '77777777-7777-7777-7777-777777777777'::uuid, 'adl-recover',
+    repeat('a0', 32), repeat('b0', 32), 'processing', 99,
+    'worker-dead', now() - interval '1 second', now() - interval '1 second'
+);
 SELECT is(
-    (public.account_deletion_acquire_lease('worker-ex7', 60, 100)->>'attempts')::integer,
+    (public.account_deletion_acquire_lease('worker-ex8', 60, 100)->>'attempts')::integer,
     100,
-    'resuming an expired last-attempt lease keeps attempts at the ceiling'
+    'expired lease below the ceiling is recovered and reaches the ceiling'
+);
+SELECT is(
+    (public.account_deletion_acquire_lease('worker-ex9', 60, 100)->>'found'),
+    'false',
+    'after recovery the job is processing at the ceiling: no new claim'
+);
+
+-- --- 10.4 Expired processing lease AT the ceiling is terminalized ---
+-- The job (now processing at 100, lease held by worker-ex8) expires
+-- without record_failure/record_retry: the next claim must NOT deliver it
+-- to another worker; it is terminalized (failed, attempts_exhausted,
+-- lease cleared, next_attempt_at NULL) and db_purged_at is preserved.
+UPDATE public.account_deletion_jobs
+SET lease_expires_at = now() - interval '1 second'
+WHERE user_ref_hmac_sha256 = repeat('a0', 32);
+SELECT is(
+    (public.account_deletion_acquire_lease('worker-ex10', 60, 100)->>'found'),
+    'false',
+    'expired lease at the ceiling is never handed to another worker'
+);
+SELECT is(
+    (SELECT status FROM public.account_deletion_jobs
+      WHERE user_ref_hmac_sha256 = repeat('a0', 32)),
+    'failed',
+    'expired ceiling lease job is terminalized to failed'
+);
+SELECT is(
+    (SELECT error_code FROM public.account_deletion_jobs
+      WHERE user_ref_hmac_sha256 = repeat('a0', 32)),
+    'attempts_exhausted',
+    'terminalized job carries attempts_exhausted'
+);
+SELECT is(
+    (SELECT lease_owner IS NULL AND lease_expires_at IS NULL
+       FROM public.account_deletion_jobs
+      WHERE user_ref_hmac_sha256 = repeat('a0', 32)),
+    true,
+    'terminalized job lease is cleared'
+);
+SELECT is(
+    (SELECT next_attempt_at IS NULL FROM public.account_deletion_jobs
+      WHERE user_ref_hmac_sha256 = repeat('a0', 32)),
+    true,
+    'terminalized job has no next attempt'
+);
+SELECT is(
+    (SELECT db_purged_at IS NOT NULL FROM public.account_deletion_jobs
+      WHERE user_ref_hmac_sha256 = repeat('a0', 32)),
+    false,
+    'terminalized job without prior purge keeps db_purged_at empty'
+);
+SELECT is(
+    (public.account_deletion_has_tombstone(repeat('a0', 32))->>'exists'),
+    'true',
+    'terminalized tombstone stays blocking'
+);
+SELECT is(
+    (public.account_deletion_acquire_lease('worker-ex11', 60, 100)->>'found'),
+    'false',
+    'a new poll never re-acquires the terminalized job'
+);
+
+-- --- 10.5 Terminalization preserves db_purged_at when already set ---
+INSERT INTO public.account_deletion_jobs (
+    operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+    status, attempts, lease_owner, lease_expires_at, next_attempt_at,
+    db_purged_at
+) VALUES (
+    '88888888-8888-8888-8888-888888888888'::uuid, 'adl-purged-ex',
+    repeat('c0', 32), repeat('d0', 32), 'processing', 100,
+    'worker-dead2', now() - interval '1 second', now() - interval '1 second',
+    now() - interval '2 hours'
+);
+SELECT is(
+    (public.account_deletion_acquire_lease('worker-ex12', 60, 100)->>'found'),
+    'false',
+    'expired ceiling lease with db_purged_at is never handed to another worker'
+);
+SELECT is(
+    (SELECT db_purged_at IS NOT NULL FROM public.account_deletion_jobs
+      WHERE user_ref_hmac_sha256 = repeat('c0', 32)),
+    true,
+    'terminalization preserves db_purged_at'
+);
+SELECT is(
+    (SELECT status FROM public.account_deletion_jobs
+      WHERE user_ref_hmac_sha256 = repeat('c0', 32)),
+    'failed',
+    'db_purged_at job is terminalized to failed'
+);
+
+-- --- 10.6 No starvation: another eligible job still progresses ---
+-- The terminalized jobs above are skipped; a new eligible pending job is
+-- claimed in the same poll.
+INSERT INTO public.account_deletion_jobs (
+    operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+    status, attempts, next_attempt_at
+) VALUES (
+    '99999999-9999-9999-9999-999999999999'::uuid, 'adl-starvation',
+    repeat('e0', 32), repeat('f0', 32), 'pending', 0, clock_timestamp()
+);
+SELECT is(
+    (public.account_deletion_acquire_lease('worker-ex13', 60, 100)->>'user_id'),
+    'adl-starvation',
+    'an eligible job is claimed even when exhausted jobs were terminalized'
+);
+
+-- --- 10.7 Schema rejects attempts above the ceiling ---
+SELECT throws_ok(
+    'INSERT INTO public.account_deletion_jobs
+        (operation_id, user_id, user_ref_hmac_sha256, intent_fingerprint_sha256,
+         status, attempts)
+     VALUES (gen_random_uuid(), ''u-1'', repeat(''a'', 64), repeat(''b'', 64),
+         ''pending'', 101)',
+    NULL, NULL,
+    'attempts above the ceiling are rejected by the schema'
+);
+SELECT throws_ok(
+    'UPDATE public.account_deletion_jobs SET attempts = 101
+      WHERE user_ref_hmac_sha256 = repeat(''e0'', 32)',
+    NULL, NULL,
+    'updates above the ceiling are rejected by the schema'
 );
 
 -- =================================================================


### PR DESCRIPTION
Closes #324

## 1. Causa raiz

Excluir uma conta cruza PostgreSQL e Supabase Auth, e não existe transação distribuída que torne as duas etapas atomicamente equivalentes. A arquitetura obrigatória implementada é: (1) registrar um tombstone durável, (2) apagar os dados PostgreSQL em uma única transação, (3) deixar a exclusão do Auth user para a #325 (somente após o commit confirmado), (4) permitir retry seguro após crash. O tombstone sobrevive à exclusão de `profiles` (sem FK para `profiles`).

## 2. Schema final

`public.account_deletion_jobs` (migration nova `20260810120000_account_deletion_ledger.sql`, fail-closed):

`job_id uuid PK`, `operation_id uuid`, `user_id text NULL`, `user_ref_hmac_sha256 text`, `intent_fingerprint_sha256 text`, `status text`, `attempts integer`, `lease_owner text`, `lease_expires_at timestamptz`, `next_attempt_at timestamptz`, `db_purged_at timestamptz`, `error_code text`, `requested_at`, `updated_at`, `completed_at`.

- RLS + FORCE RLS, zero policies, nenhum grant de tabela (nem `service_role`).
- UNIQUE `(user_ref_hmac_sha256, operation_id)` como chave de idempotência.
- Índices: `(status, next_attempt_at)`, `(user_ref_hmac_sha256, requested_at DESC)`, parcial `(completed_at) WHERE status='completed'`.

## 3. Máquina de estados

`pending -> processing -> (failed | retry para pending) -> processing -> completed`

Constraints que impedem estados incoerentes: somente `processing` carrega lease; `pending`/`completed`/`failed` nunca; `completed` exige `db_purged_at` + `completed_at` e `user_id` NULL; `failed` exige `error_code` sanitizado; `attempts >= 0`; allowlists estritas para `lease_owner` e `error_code`.

## 4. RPCs e grants

Oito RPCs de runtime (`SECURITY DEFINER`, `SET search_path = ''`, EXECUTE somente `service_role`, revogadas de PUBLIC/anon/authenticated, sem SQL dinâmico, sem raw exception text): `account_deletion_request`, `account_deletion_has_tombstone`, `account_deletion_acquire_lease`, `account_deletion_purge`, `account_deletion_record_failure`, `account_deletion_record_retry`, `account_deletion_finalize`, `account_deletion_purge_completed`. Helpers internos (`account_deletion_validation_error`, `account_deletion_assert_owner`, `account_deletion_intent_fingerprint_sha256`) sem grants de runtime.

## 5. Estratégia de lease

Claim com `SELECT ... FOR UPDATE SKIP LOCKED` (mecanismo transacional real, nunca lock process-local): duas workers nunca possuem o mesmo job. Lease expira (recuperação de worker morta); toda RPC de job revalida ownership (worker + lease não expirada), então worker antiga não finaliza após perder o lease. Retries representados no banco: `attempts`, `next_attempt_at`, `record_failure` (backoff 30s..1h derivado de attempts), `record_retry`.

## 6. Ordem exata do purge

Uma transação, mesma trava por usuário de `commit_turn` (`pg_advisory_xact_lock(hashtextextended(user_id, 0))`), ordem FK-safe analisada das migrations (sem assumir cascade): `outbox_events` → `turn_requests` → `archival_extractions` → `memories` → `chat_logs` → `admission_reservations` → `privacy_operations` → `profiles` (último). O job/tombstone nunca é removido pelo purge.

## 7. Rollback / idempotência

`db_purged_at` só se torna não nulo na mesma transação que concluiu o purge; qualquer falha faz rollback integral (testado com trigger artificial no meio do purge). Purge repetido em banco vazio (crash pós-commit, antes do Auth) é replay seguro (`already_purged`, `db_purged_at` autoritativo; nenhum delete depende do registro existir).

## 8. HMAC / minimização

Referência persistente = HMAC-SHA256 lowercase hex 64, gerada server-side, domínio próprio `account-deletion` (nunca correlacionável com `USER_REFERENCE_DOMAIN`). `user_id` bruto presente apenas enquanto o job está ativo; `completed` minimiza para NULL.

## 9. Política de retenção

`account_deletion_purge_completed`: 30 dias, batch limitado (1..1000), somente `completed`, cutoff clampado pelo banco (`LEAST(p_cutoff, clock_timestamp() - 30d)` — relógio adiantado nunca antecipa). `pending`/`processing`/`failed` nunca são removidos por idade. Sem scheduler novo.

## 10/11. Testes executados e resultados reais (HEAD final, CI verde)

- pgTAP `08_account_deletion_ledger.test.sql`: **140/140** (suite completa: Files=8, Tests=734, Result: PASS) — inclui exaustão de attempts, `db_purged_at` preservado em `pending`/`failed`, terminalização de lease expirado NO TETO (nunca entregue a outro worker), sem starvation, e schema rejeita attempts > 100.
- Integração real `test_account_deletion_integration.py`: **17 passed** — inclui `test_failure_after_purge_preserves_marker_and_retries_safely`, `test_attempts_exhaustion_is_terminal_and_tombstone_preserved` e `test_expired_ceiling_lease_is_terminalized_not_reclaimed`.
- Python unit `test_account_deletion.py`: **29 passed** (parsers estritos, retry exausto `attempts_exhausted`, UUID/HMAC/fingerprint inválidos, bool em int, identidade divergente sem eco, malformado fail-closed, import puro, nada de segredo em exceção/caplog).
- Legacy upgrade `test_account_deletion_legacy.py`: **2 passed** (upgrade válido preserva dados + cenário inválido de drift → 23514, nada instalado, não registrado, dados intactos).
- Preflight `test_account_deletion_preflight.py`: **9 passed** (8 tabelas obrigatórias removidas → 23514 + drift de objeto próprio `account_deletion_assert_owner` → 23514, nada instalado, migration não registrada).
- Suite unitária backend (CI-equivalente, com ignores): **2524 passed**.
- CI no HEAD `848496a`: backend 2524 passed, database 29m19s (pgTAP 734 PASS, integração 17, legacy 2, preflight 9, retenção 3+7 sem regressão), frontend e docker pass.

## 12. HEAD final

`848496a` (branch `feat/account-deletion-ledger`, base `main` = `e30e13f`). Inclui as correções das duas auditorias do mantenedor:
1. `db_purged_at` preservado em retry/falha pós-purge;
2. drift gate completo com `account_deletion_assert_owner` + testes negativos reais (preflight e legacy);
3. teto determinístico de 100 tentativas com estado terminal `failed`/`next_attempt_at NULL`;
4. leases expirados NO TETO são terminalizados no lugar (nunca entregues a outro worker), com loop que continua a varredura (sem starvation), e `account_deletion_jobs_attempts_check <= 100` alinhada ao teto real.

## 13. Riscos residuais reais

- A atomicidade PostgreSQL + Supabase Auth não existe; a fronteira é documentada e o `db_purged_at` é o marcador autoritativo. A #325 deve confirmar o commit antes do Auth delete e chamar `finalize`.
- A retenção de tombstones completados expõe a RPC `account_deletion_purge_completed`, mas o runner de retenção existente (#316) ainda não a invoca; o worker da #325 (ou um passo de cleanup futuro) deve chamá-la.
- O `has_tombstone` cobre a referência server-derived; o gate HTTP (#326) é quem fará a consulta antes de servir operações.
- Fora de escopo (não implementado aqui, conforme autorizado): endpoint HTTP, Supabase Auth Admin, worker/CLI, frontend, soft-delete/undo, exportação, Redis, scheduler.

## CI

Aguardando os jobs (backend, frontend, docker, database com pgTAP + integração real + preflight/legacy) verdes no mesmo HEAD antes de qualquer conclusão de merge.
