### PR TITLE
feat(privacy): expose durable account deletion

### DIFF
--- a/backend/account_deletion.py
+++ b/backend/account_deletion.py
@@ -491,6 +491,38 @@ def _parse_retry_result(response: object) -> RetryResult:
     raise PersistenceError("database_error", "malformed retention response")
 
 
+# ─── Commit barrier ────────────────────────────────────────────────────────
+
+
+class CommitBarrierResult:
+    """Result of the transactional commit barrier (``#329``).
+
+    ``blocked`` being ``True`` means the account-deletion ledger holds a
+    tombstone for the server-derived reference and the turn commit MUST be
+    refused. ``blocked`` being ``False`` means the commit may proceed.
+    The envelope is strictly validated: any unexpected shape fails closed
+    with ``PersistenceError``.
+    """
+
+    def __init__(self, blocked: bool, error: Optional[AccountDeletionError] = None) -> None:
+        self.blocked = blocked
+        self.error = error
+
+
+def _parse_commit_barrier_result(response: object) -> CommitBarrierResult:
+    envelope = _require_mapping(response, "account_deletion_commit_barrier response")
+    error_envelope = envelope.get("error")
+    if error_envelope is not None:
+        error = _parse_error_envelope(error_envelope)
+        if error.code == "account_deletion_pending":
+            return CommitBarrierResult(blocked=True, error=error)
+        # Unexpected error codes are NOT a license to proceed: fail closed.
+        raise PersistenceError("database_error", "persistence error")
+    if envelope.get("blocked") is not True:
+        raise PersistenceError("database_error", "persistence error")
+    return CommitBarrierResult(blocked=False)
+
+
 def _parse_finalize_result(response: object) -> FinalizeResult:
     envelope = _require_mapping(response, "finalize result")
     if "error" in envelope:
@@ -561,6 +593,18 @@ class AccountDeletionRepository:
     def finalize(self, job_id: str, worker_id: str) -> FinalizeResult: ...
 
     def purge_completed(self, cutoff: str, batch_size: int) -> int: ...
+
+    def commit_barrier(self, user_ref_hmac_sha256: str) -> CommitBarrierResult:
+        """Race-safe check of the deletion ledger at the commit boundary.
+
+        Read-only; the caller is responsible for holding the SAME per-user
+        advisory xact lock that ``account_deletion_request`` and the purge
+        hold, so the check and the subsequent writes execute as one
+        serialized unit under the lock. The lookup is by the server-derived
+        HMAC reference only, so it remains authoritative after finalize
+        minimizes ``user_id`` to ``NULL`` (#329).
+        """
+        ...
 
 
 def _rpc_call(
@@ -688,3 +732,11 @@ class SupabaseAccountDeletionRepository:
             {"p_cutoff": cutoff, "p_batch_size": batch_size},
         )
         return _parse_int_result(data)
+
+    def commit_barrier(self, user_ref_hmac_sha256: str) -> CommitBarrierResult:
+        data = _rpc_call(
+            self._client,
+            "account_deletion_commit_barrier",
+            {"p_user_ref_hmac_sha256": user_ref_hmac_sha256},
+        )
+        return _parse_commit_barrier_result(data)

--- a/backend/account_deletion_service.py
+++ b/backend/account_deletion_service.py
@@ -1,0 +1,246 @@
+"""Application boundary for the #326 authenticated account deletion API.
+
+This module is the thin, stateless application frontier between the
+authenticated HTTP layer (``backend.main``) and the #324 Python contract
+(``backend.account_deletion``). It deliberately contains no FastAPI routing,
+no per-user state, and no re-implementation of the #324 ledger semantics:
+every operation delegates to ``AccountDeletionRepository`` through the
+existing operational write helper, and the HTTP layer only maps domain
+exceptions to sanitized status codes.
+
+Components
+==========
+
+* ``AccountDeletionRequestResponse`` — the explicit public projection of a
+  ``RequestResult``. It exposes ONLY ``status`` (``accepted`` or
+  ``completed``). It never exposes ``user_id``, ``operation_id``, ``job_id``,
+  HMACs, timestamps, upstream errors or SQL. ``completed`` is returned only
+  when the ledger itself confirms completion (``job_status == completed``
+  with a persisted ``db_purged_at``); the API never promises completion
+  before the #325 worker finishes.
+* ``AccountDeletionService`` — a stateless, process-wide application service.
+  The authenticated identity and the operation_id are per-call arguments; no
+  reference, fingerprint or identifier is retained between requests. The
+  server-side HMAC reference is derived exclusively from
+  ``current_user.id`` through ``compute_account_deletion_user_ref`` using
+  the existing admission secret (dedicated ``account-deletion`` HMAC
+  domain). The intent fingerprint is deterministic: a constant
+  ``delete_account`` payload with no user data, so the same
+  (user, operation_id, intent) is an exact ledger replay.
+* ``assert_active`` — the single reusable, fail-closed gate for normal
+  account actions. Any anomaly (persistence failure, timeout, malformed
+  payload, unavailable store, invalid derived reference) raises
+  ``AccountDeletionUnavailable`` (HTTP 503) and never allows the route to
+  continue; a present tombstone raises ``AccountDeletionBlocked``
+  (HTTP 423 ``account_deletion_pending``). Routes apply this gate through
+  exactly one helper in ``backend.main``, never by copying the tombstone
+  logic.
+
+Ownership and testability
+=========================
+
+* The service is stateless and may live in the application container.
+  Identity and operation_id are always per-call arguments.
+* The repository is injectable (fakes can record or stub RPC calls), the
+  operational ``TurnExecutionConfig`` is injectable (budget/timeout
+  behavior is configurable), and the admission configuration is injectable
+  (the HMAC secret). Tests inject fakes without Supabase/Groq/embeddings.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+from backend.account_deletion import (
+    STATUS_COMPLETED,
+    AccountDeletionRepository,
+    TombstoneStatus,
+    compute_account_deletion_user_ref,
+    compute_intent_fingerprint,
+)
+from backend.atomic_turn_commit import (
+    ConflictError,
+    PersistenceError,
+    ValidationError,
+)
+from backend.turn_execution import (
+    DeadlineExceeded,
+    TurnExecutionConfig,
+    TurnExecutionError,
+    create_budget,
+    run_blocking_write,
+)
+
+#: Stable, low-cardinality intent payload for account deletion. Deliberately
+#: contains NO ``user_id``, ``operation_id``, timestamps or variable data:
+#: the fingerprint must be deterministic so the same user + operation_id is
+#: an exact ledger replay and never a second job.
+DELETE_ACCOUNT_INTENT = {"op": "delete_account", "scope": ["db", "auth"]}
+
+#: Sanitized stage labels used by the write helper for every account deletion
+#: RPC (constant, low cardinality, never carries identifiers).
+_REQUEST_STAGE = "account_deletion_request"
+_TOMBSTONE_STAGE = "account_deletion_tombstone"
+
+
+class AccountDeletionBlocked(Exception):
+    """A deletion tombstone exists; normal account actions must be blocked.
+
+    Mapped by the HTTP layer to ``423 account_deletion_pending``. The
+    exception never carries the user identity, the reference, the status or
+    any internal detail.
+    """
+
+    code = "account_deletion_pending"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+    def __repr__(self) -> str:
+        return "AccountDeletionBlocked()"
+
+
+class AccountDeletionUnavailable(Exception):
+    """Fail-closed: the tombstone store could not be consulted safely.
+
+    Mapped by the HTTP layer to a sanitized 503. A failure to consult the
+    tombstone is NEVER interpreted as "user active".
+    """
+
+    code = "service_unavailable"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+    def __repr__(self) -> str:
+        return "AccountDeletionUnavailable()"
+
+
+class AccountDeletionRequestResponse(BaseModel):
+    """Public projection of an account deletion request.
+
+    Exposes ONLY ``status``:
+
+    * ``accepted`` — the ledger registered (or replayed) the request and the
+      deletion is pending/in progress; the tombstone blocks normal actions.
+    * ``completed`` — returned ONLY when the ledger confirms completion
+      (``job_status == completed`` with a persisted ``db_purged_at``).
+
+    Identity, operation_id, job_id, HMACs, internal timestamps, upstream
+    errors and SQL never appear here.
+    """
+
+    status: str
+
+
+class AccountDeletionService:
+    """Stateless application service for account deletion (#326).
+
+    The service holds no per-user state: the authenticated identity and the
+    operation_id are constructed per call. The server-side HMAC reference is
+    derived from ``admission_config.secret_bytes`` under the dedicated
+    ``account-deletion`` domain, the intent fingerprint is deterministic,
+    and every blocking RPC is dispatched through ``run_blocking_write``
+    (operational budget + Supabase transport timeout, drain-on-cancellation,
+    no orphaned tasks).
+    """
+
+    def __init__(
+        self,
+        *,
+        repository: AccountDeletionRepository,
+        turn_config: TurnExecutionConfig,
+        admission_config: Any,
+    ) -> None:
+        self._repository = repository
+        self._turn_config = turn_config
+        self._admission_config = admission_config
+
+    # ─── Public frontier ─────────────────────────────────────────────────────
+
+    async def request(
+        self, authenticated_user_id: str, operation_id: str
+    ) -> AccountDeletionRequestResponse:
+        """Register (or replay) an account deletion request for the identity.
+
+        The identity comes exclusively from the authenticated user; the HMAC
+        reference and the intent fingerprint are derived server-side. The
+        same user + operation_id + intent is an exact ledger replay (no
+        second job); a divergent intent raises ``ConflictError``
+        (``operation_conflict``) for the HTTP layer to map to 409.
+        """
+        budget = create_budget(self._turn_config)
+        user_ref = compute_account_deletion_user_ref(
+            self._admission_config.secret_bytes, authenticated_user_id
+        )
+        fingerprint = compute_intent_fingerprint(DELETE_ACCOUNT_INTENT)
+        result = await run_blocking_write(
+            _REQUEST_STAGE,
+            budget,
+            self._turn_config.supabase_timeout,
+            self._repository.request,
+            authenticated_user_id,
+            user_ref,
+            operation_id,
+            fingerprint,
+            allowlist_exceptions=(ConflictError, ValidationError, PersistenceError),
+        )
+        return AccountDeletionRequestResponse(
+            status=self._project_status(result.job_status, result.db_purged_at)
+        )
+
+    async def assert_active(self, authenticated_user_id: str) -> None:
+        """Fail-closed tombstone gate for normal account actions.
+
+        Consults ``AccountDeletionRepository.has_tombstone`` through the
+        operational write helper. Raises:
+
+        * ``AccountDeletionBlocked`` when a tombstone exists (pending,
+          processing, failed, or completed while still within retention);
+        * ``AccountDeletionUnavailable`` when the store cannot be consulted
+          (persistence failure, timeout, malformed payload, invalid derived
+          reference) — the caller must never treat that as "user active".
+
+        This is the SINGLE reusable boundary; routes apply it through exactly
+        one helper in ``backend.main`` and never copy the tombstone logic.
+        """
+        budget = create_budget(self._turn_config)
+        try:
+            user_ref = compute_account_deletion_user_ref(
+                self._admission_config.secret_bytes, authenticated_user_id
+            )
+            status = await run_blocking_write(
+                _TOMBSTONE_STAGE,
+                budget,
+                self._turn_config.supabase_timeout,
+                self._repository.has_tombstone,
+                user_ref,
+                allowlist_exceptions=(ValidationError, PersistenceError),
+            )
+        except (
+            DeadlineExceeded,
+            TurnExecutionError,
+            ValidationError,
+            PersistenceError,
+        ):
+            raise AccountDeletionUnavailable() from None
+        if status.exists:
+            raise AccountDeletionBlocked()
+
+    # ─── Projection ─────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _project_status(job_status: str, db_purged_at: Optional[str]) -> str:
+        """Project the ledger result into the public status vocabulary.
+
+        ``completed`` requires the ledger to confirm completion (finalize
+        happened with a persisted purge marker). Everything else is the
+        honest ``accepted`` state: created/replayed, pending/processing/
+        failed, or even completed-without-a-purge-marker (a contract anomaly
+        that must never be presented as completion).
+        """
+        if job_status == STATUS_COMPLETED and db_purged_at is not None:
+            return "completed"
+        return "accepted"

--- a/backend/atomic_turn_commit.py
+++ b/backend/atomic_turn_commit.py
@@ -99,6 +99,10 @@ _EVENT_TYPE_RE = re.compile(r"^[a-z0-9_]{1,64}$")
 # UUID regex (same as database: lowercase hex, canonical form).
 _UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
 
+# Account deletion user reference: the exact server-derived HMAC format
+# (never the raw user_id), matching the SQL commit barrier (#329).
+_HEX64_RE = re.compile(r"^[0-9a-f]{64}$")
+
 # Stable domain conflict codes returned by the RPC.
 CONFLICT_CODES = frozenset(
     {
@@ -106,6 +110,11 @@ CONFLICT_CODES = frozenset(
         "request_payload_conflict",
         "request_in_progress",
         "lease_conflict",
+        # Authoritative transactional boundary for account deletion (#329):
+        # a commit attempt made after a deletion request is accepted (or
+        # after purge/finalize, when user_id is minimized to NULL) fails
+        # with this code and never writes rows.
+        "account_deletion_pending",
     }
 )
 
@@ -540,6 +549,7 @@ def validate_atomic_commit_input(
     public_response: str,
     outbox_events: list[tuple[str, Mapping[str, Any], str]],
     replay_payload: Mapping[str, Any],
+    account_deletion_user_ref: Optional[str] = None,
 ) -> None:
     """Validate all inputs before attempting the atomic commit.
 
@@ -603,8 +613,10 @@ def validate_atomic_commit_input(
         _validate_outbox_event_payload(payload, i)
         _validate_idempotency_key(idempotency_key)
 
-    _validate_replay_payload(replay_payload, request_id)
+        _validate_replay_payload(replay_payload, request_id)
 
+    # account_deletion_user_ref is validated against the exact server-derived
+    # HMAC format (never the raw user_id), matching the SQL commit barrier (#329).
     # Single authoritative source for the public response: replay_payload.response
     # must equal public_response (mirrors the SQL constraint).
     if replay_payload.get("response") != public_response:
@@ -612,6 +624,15 @@ def validate_atomic_commit_input(
             "invalid_public_response",
             "public_response must equal replay_payload.response",
         )
+
+    if account_deletion_user_ref is not None:
+        if not isinstance(account_deletion_user_ref, str) or not _HEX64_RE.fullmatch(
+            account_deletion_user_ref
+        ):
+            raise ValidationError(
+                "invalid_account_deletion_user_ref",
+                "account_deletion_user_ref must be 64 lowercase hex characters",
+            )
 
 
 def build_commit_turn_rpc_payload(
@@ -627,10 +648,15 @@ def build_commit_turn_rpc_payload(
     replay_payload: Mapping[str, Any],
     payload_hash_sha256: str,
     lease_owner: Optional[str],
+    account_deletion_user_ref: Optional[str] = None,
 ) -> dict[str, Any]:
     """Build the payload for the commit_turn PostgreSQL RPC function.
 
     Empty mappings are preserved as {} and never implicitly converted to NULL.
+    The optional ``account_deletion_user_ref`` activates the SQL-side commit
+    barrier (#329): it must be the exact server-derived HMAC reference,
+    never the raw user_id. When absent the RPC behaves byte-identically to
+    the historical contract.
     """
     outbox_array = []
     for event_type, payload, idempotency_key in outbox_events:
@@ -655,6 +681,11 @@ def build_commit_turn_rpc_payload(
         "p_replay_payload": dict(replay_payload),
         "p_outbox_events": outbox_array,
         "p_lease_owner": lease_owner,
+        **(  # SQL-side account deletion commit barrier (#329).
+            {"p_account_deletion_user_ref": account_deletion_user_ref}
+            if account_deletion_user_ref is not None
+            else {}
+        ),
     }
 
 
@@ -923,21 +954,18 @@ async def commit_turn(
     outbox_events: list[tuple[str, Mapping[str, Any], str]],
     replay_payload: Mapping[str, Any],
     lease_owner: Optional[str] = None,
+    account_deletion_user_ref: Optional[str] = None,
 ) -> CommittedTurn:
     """Execute an atomic turn commit via the PostgreSQL RPC function.
-
     Validation runs BEFORE the RPC is invoked, so invalid input never reaches
     the database. The RPC is awaited exactly once. Unexpected persistence
     failures raised by the RPC client are converted to PersistenceError with a
     sanitized constant message.
-
     Args:
         rpc_client: An awaitable callable ``rpc_client(name, params) -> Mapping``.
         All other parameters match validate_atomic_commit_input.
-
     Returns:
         A CommittedTurn instance with the public committed data.
-
     Raises:
         ValidationError: If input validation fails (RPC is NOT called).
         ConflictError: If a concurrent modification or in-progress state is detected.
@@ -954,10 +982,17 @@ async def commit_turn(
         public_response=public_response,
         outbox_events=outbox_events,
         replay_payload=replay_payload,
+        account_deletion_user_ref=account_deletion_user_ref,
     )
-
     if lease_owner is not None:
         _validate_lease_owner(lease_owner)
+    if account_deletion_user_ref is not None and not _HEX64_RE.fullmatch(
+        account_deletion_user_ref
+    ):
+        raise ValidationError(
+            "invalid_account_deletion_user_ref",
+            "account_deletion_user_ref must be 64 lowercase hex characters",
+        )
 
     # The canonical payload hash covers every input that determines the turn's
     # identity, content and side effects (outbox + replay).
@@ -985,11 +1020,11 @@ async def commit_turn(
         relationship_state=relationship_state,
         public_response=public_response,
         outbox_events=outbox_events,
-        replay_payload=replay_payload,
+                replay_payload=replay_payload,
         payload_hash_sha256=payload_hash_sha256,
         lease_owner=lease_owner,
+        account_deletion_user_ref=account_deletion_user_ref,
     )
-
     try:
         result = await rpc_client("commit_turn", rpc_payload)
     except Exception as exc:  # noqa: BLE001 - sanitize any RPC-level failure

--- a/backend/chat_engine.py
+++ b/backend/chat_engine.py
@@ -64,6 +64,7 @@ class ChatConversationEngine(ConversationEngine):
         budget: Optional[TurnBudget] = None,
         mode: TurnMode = TurnMode.normal,
         correlation: str,
+        account_deletion_user_ref: Optional[str] = None,
     ):
         active_budget = (
             budget
@@ -72,6 +73,10 @@ class ChatConversationEngine(ConversationEngine):
         )
         if not isinstance(active_budget, TurnBudget):
             raise TypeError("budget must be a TurnBudget")
+        if account_deletion_user_ref is not None and not isinstance(
+            account_deletion_user_ref, str
+        ):
+            raise TypeError("account_deletion_user_ref must be a string or None")
         return await self._run_turn_locked(
             user_id,
             user_message,
@@ -79,9 +84,13 @@ class ChatConversationEngine(ConversationEngine):
             active_budget,
             mode,
             correlation,
+            account_deletion_user_ref=account_deletion_user_ref,
         )
 
-    async def _run_turn_locked(self, user_id, user_message, request_id, budget, mode, correlation):
+    async def _run_turn_locked(
+        self, user_id, user_message, request_id, budget, mode, correlation,
+        account_deletion_user_ref=None,
+    ):
         # Only the lock acquisition is bounded by remaining_before_reserve.
         # Once acquired, the turn runs under budget checks (each stage
         # checks remaining_before_reserve).  This prevents the outer timeout
@@ -102,6 +111,7 @@ class ChatConversationEngine(ConversationEngine):
                 budget=budget,
                 correlation=correlation,
                 mode=mode,
+                account_deletion_user_ref=account_deletion_user_ref,
             )
             return await self._process_turn.execute(inp)
         finally:

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -22,6 +22,8 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Optional
 
+from .account_deletion import SupabaseAccountDeletionRepository
+from .account_deletion_service import AccountDeletionService
 from .admission import AdmissionRuntimeConfig
 from .chat_engine import ChatConversationEngine
 from .health import build_health_registry, HealthRegistry
@@ -58,6 +60,7 @@ class ApplicationDependencies:
     clock: Callable[[], float] = field(default_factory=time.time)
     persistence_client: Any = None
     privacy_service: Any = None
+    account_deletion_service: Any = None
 
 
 def _supabase_factory_from_settings(settings: Settings) -> Callable[[], Optional[Any]]:
@@ -219,6 +222,17 @@ def build_default_dependencies(
             clock=time.time,
         )
 
+        # Stateless application service for the #326 account deletion API.
+        # It reuses the SAME Supabase client (never creates a second one), the
+        # same admission secret for the server-derived HMAC reference, and the
+        # same operational timeout/budget. Identity and operation_id are
+        # per-call arguments; the container stores no user state.
+        account_deletion_service = AccountDeletionService(
+            repository=SupabaseAccountDeletionRepository(supabase_client),
+            turn_config=settings.turn_config,
+            admission_config=admission_config,
+        )
+
         dependencies = ApplicationDependencies(
             conversation_engine=engine,
             auth_client=supabase_client,
@@ -228,6 +242,7 @@ def build_default_dependencies(
             clock=time.time,
             persistence_client=supabase_client,
             privacy_service=privacy_service,
+            account_deletion_service=account_deletion_service,
         )
 
         # Owned resources created by this builder, closed at shutdown and on

--- a/backend/main.py
+++ b/backend/main.py
@@ -42,6 +42,9 @@ from pydantic import BaseModel, ConfigDict, StrictStr, field_validator
 from pydantic_core import PydanticCustomError
 from supabase_auth.errors import AuthApiError, AuthRetryableError
 
+from .account_deletion import (
+    compute_account_deletion_user_ref,
+)
 from .account_deletion_service import (
     AccountDeletionBlocked,
     AccountDeletionRequestResponse,
@@ -472,6 +475,15 @@ _PROCESS_TURN_CONFLICT_HTTP = {
         409,
         {"code": "request_replay_unavailable", "message": "Request was already received but its response is unavailable."},
     ),
+    # Authoritative transactional commit barrier (#329): raised inside
+    # commit_turn when the deletion ledger holds a tombstone for the
+    # server-derived HMAC reference (request made post tombstone acceptance
+    # but past the preflight gate, or post purge/finalize). HTTP 423
+    # matches the preflight gate detail contract.
+    "account_deletion_pending": (
+        423,
+        {"code": "account_deletion_pending", "message": "Account deletion is pending."},
+    ),
 }
 
 
@@ -828,6 +840,14 @@ async def chat_endpoint(
             )
             raise http_exc
 
+        # Authoritative transactional commit barrier (#329): the server-
+        # derived HMAC reference is forwarded to the commit boundary under
+        # the SAME advisory lock used by account deletion. Only the HMAC
+        # is derived here (never logged); lookup works post purge/finalize
+        # when user_id is minimized to NULL.
+        deletion_user_ref = compute_account_deletion_user_ref(
+            deps.admission_config.secret_bytes, user_id
+        )
         result = await engine.process_turn(
             user_id,
             input_data.message,
@@ -835,6 +855,7 @@ async def chat_endpoint(
             budget=budget,
             mode=mode,
             correlation=correlation,
+            account_deletion_user_ref=deletion_user_ref,
         )
         duration_ms = (time.monotonic() - started_at) * 1000
         emit_event(

--- a/backend/main.py
+++ b/backend/main.py
@@ -42,6 +42,11 @@ from pydantic import BaseModel, ConfigDict, StrictStr, field_validator
 from pydantic_core import PydanticCustomError
 from supabase_auth.errors import AuthApiError, AuthRetryableError
 
+from .account_deletion_service import (
+    AccountDeletionBlocked,
+    AccountDeletionRequestResponse,
+    AccountDeletionUnavailable,
+)
 from .admission import (
     ADMITTED,
     APPLICATION_RATE_LIMITED,
@@ -72,6 +77,9 @@ from .groq_manager import GroqPoolExhaustedError, GroqRequestError
 from .health import build_ready_response
 from .memory import StatePersistenceError
 from .observability import (
+    EVENT_ACCOUNT_DELETION_BLOCKED,
+    EVENT_ACCOUNT_DELETION_GATE_UNAVAILABLE,
+    EVENT_ACCOUNT_DELETION_REQUESTED,
     EVENT_APP_STARTUP_FAILED,
     EVENT_AUTH_COMPLETED,
     EVENT_AUTH_FAILED,
@@ -96,6 +104,7 @@ from .turn_execution import (
     TurnErrorCode,
     TurnExecutionError,
     create_budget,
+    run_blocking_read,
     run_blocking_write,
 )
 
@@ -306,6 +315,21 @@ class PrivacyOperationInput(BaseModel):
     lowercase canonical form before reaching the privacy layer). Any extra
     key, including ``user_id``, is rejected with 422: the authenticated
     identity always comes from ``current_user.id``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    operation_id: UUID
+
+
+class AccountDeletionInput(BaseModel):
+    """Request body for ``POST /privacy/delete-account``.
+
+    Accepts ONLY ``operation_id`` (any canonical UUID version; normalized to
+    lowercase canonical form before reaching the ledger). Any extra key —
+    ``user_id``, ``user_ref``, ``job_id``, HMACs or anything else — is
+    rejected with 422 BEFORE any RPC runs: the authenticated identity and
+    the server-derived HMAC reference come exclusively from
+    ``current_user.id`` and the server-side admission secret.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -524,6 +548,73 @@ def _map_privacy_conflict(exc: ConflictError) -> HTTPException:
     return HTTPException(status_code=409, detail=_PRIVACY_CONFLICT_DETAIL)
 
 
+# ─── Account deletion error mapping (#326) ───────────────────────────────────
+#
+# Stable, sanitized HTTP mapping for the account deletion API and the
+# tombstone gate. Every detail is a public constant; exception text,
+# identifiers, HMACs, operation ids, job ids, SQL and internal timestamps
+# never reach a response. Fail-closed: a tombstone-store failure is never
+# interpreted as "user active".
+
+_ACCOUNT_DELETION_BLOCKED_DETAIL = {
+    "code": "account_deletion_pending",
+    "message": "Account deletion is pending.",
+}
+_ACCOUNT_DELETION_UNAVAILABLE_DETAIL = {
+    "code": "service_unavailable",
+    "message": "Service unavailable.",
+}
+_ACCOUNT_DELETION_CONFLICT_DETAIL = {
+    "code": "operation_conflict",
+    "message": "Operation identifier was already used with a different operation.",
+}
+_ACCOUNT_DELETION_INTERNAL_DETAIL = {
+    "code": TurnErrorCode.internal_error.value,
+    "message": "Internal server error.",
+}
+
+
+async def _enforce_account_deletion_gate(
+    deps: ApplicationDependencies, user_id: str
+) -> None:
+    """Single centralized tombstone gate for normal account actions.
+
+    Runs immediately after authentication and BEFORE any useful work of the
+    route (admission, history reads, privacy mutations, provider/engine
+    calls). ``account_deletion_service.assert_active`` is the one reusable
+    boundary; routes never copy the tombstone logic.
+
+    Fail-closed: an absent service, a persistence failure, a timeout, a
+    malformed payload or an unavailable store returns a sanitized 503 and
+    the route never continues. A present tombstone returns 423
+    ``account_deletion_pending`` (pending, processing, failed, or completed
+    while the tombstone still exists within retention).
+    """
+    service = deps.account_deletion_service
+    if service is None:
+        emit_event(
+            logger, EVENT_ACCOUNT_DELETION_GATE_UNAVAILABLE, code="not_configured"
+        )
+        emit_event(logger, EVENT_HTTP_RESULT, code=503)
+        raise HTTPException(
+            status_code=503, detail=_ACCOUNT_DELETION_UNAVAILABLE_DETAIL
+        )
+    try:
+        await service.assert_active(user_id)
+    except AccountDeletionBlocked:
+        emit_event(logger, EVENT_ACCOUNT_DELETION_BLOCKED)
+        emit_event(logger, EVENT_HTTP_RESULT, code=423)
+        raise HTTPException(
+            status_code=423, detail=_ACCOUNT_DELETION_BLOCKED_DETAIL
+        ) from None
+    except AccountDeletionUnavailable:
+        emit_event(logger, EVENT_ACCOUNT_DELETION_GATE_UNAVAILABLE)
+        emit_event(logger, EVENT_HTTP_RESULT, code=503)
+        raise HTTPException(
+            status_code=503, detail=_ACCOUNT_DELETION_UNAVAILABLE_DETAIL
+        ) from None
+
+
 # ─── Lifespan ───────────────────────────────────────────────────────────────
 
 
@@ -661,6 +752,9 @@ def create_app(
     app.post(
         "/privacy/reset-relationship", response_model=PrivacyOperationResponse
     )(privacy_reset_relationship_endpoint)
+    app.post(
+        "/privacy/delete-account", response_model=AccountDeletionRequestResponse
+    )(account_delete_endpoint)
 
     return app
 
@@ -680,8 +774,12 @@ async def chat_endpoint(
     started_at = time.monotonic()
     correlation = None
     try:
-        budget = create_budget(turn_config)
         user_id = getattr(current_user, "id", None)
+        # Tombstone gate: runs immediately after authentication and before
+        # admission, history/state reads, embeddings, provider calls,
+        # engine.process_turn and every turn write (#326, fail-closed).
+        await _enforce_account_deletion_gate(deps, user_id)
+        budget = create_budget(turn_config)
         identity = RequestIdentity(input_data.request_id)
         peer_host = request.client.host if request.client is not None else None
         network_identity = resolve_network_identity(
@@ -821,22 +919,37 @@ async def chat_endpoint(
         )
 
 
-def get_history(request: Request, current_user=Depends(get_current_user)):
+def _read_chat_logs(supabase: Any, user_id: str) -> list:
+    """Blocking history query (dispatched off the event loop)."""
+    response = (
+        supabase.table("chat_logs")
+        .select("*")
+        .eq("user_id", user_id)
+        .order("created_at", desc=True)
+        .limit(50)
+        .execute()
+    )
+    return response.data[::-1] if response.data else []
+
+
+async def get_history(request: Request, current_user=Depends(get_current_user)):
     deps = get_dependencies(request)
     user_id = current_user.id
+    # Tombstone gate: must run before ANY read of chat_logs (#326).
+    await _enforce_account_deletion_gate(deps, user_id)
+    budget = create_budget(deps.turn_config)
     try:
         supabase = deps.persistence_client
         if not supabase:
             return []
-
-        response = supabase.table("chat_logs")\
-            .select("*")\
-            .eq("user_id", user_id)\
-            .order("created_at", desc=True)\
-            .limit(50)\
-            .execute()
-
-        return response.data[::-1] if response.data else []
+        return await run_blocking_read(
+            "history",
+            budget,
+            deps.turn_config.supabase_timeout,
+            _read_chat_logs,
+            supabase,
+            user_id,
+        )
     except Exception:
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
@@ -862,12 +975,15 @@ async def _run_privacy_action(
     each endpoint invokes exactly its own operation and never another one.
     """
     deps = get_dependencies(request)
+    user_id = getattr(current_user, "id", None)
+    # Tombstone gate: the four privacy actions are blocked before any
+    # mutation once an account deletion tombstone exists (#326).
+    await _enforce_account_deletion_gate(deps, user_id)
     service = deps.privacy_service
     if service is None:
         raise HTTPException(
             status_code=503, detail=_PRIVACY_SERVICE_UNAVAILABLE_DETAIL
         )
-    user_id = getattr(current_user, "id", None)
     operation_id = str(input_data.operation_id)
     try:
         if operation == OPERATION_DELETE_HISTORY:
@@ -951,6 +1067,70 @@ async def privacy_reset_relationship_endpoint(
     return await _run_privacy_action(
         OPERATION_RESET_RELATIONSHIP_STATE, input_data, request, current_user
     )
+
+
+# ─── Account deletion (#326) ─────────────────────────────────────────────────
+
+
+async def account_delete_endpoint(
+    input_data: AccountDeletionInput,
+    request: Request,
+    current_user=Depends(get_current_user),
+):
+    """POST /privacy/delete-account — register an account deletion request.
+
+    Deliberately exempt from the tombstone gate: this endpoint must remain
+    reachable with base authentication so an idempotent replay keeps working
+    while the token is still accepted. The identity comes exclusively from
+    ``current_user.id``; the server derives the HMAC reference (dedicated
+    ``account-deletion`` domain) and the deterministic intent fingerprint,
+    and the #324 ledger guarantees idempotency: the same user + operation_id
+    + intent is an exact replay, never a second job.
+
+    The public response exposes ONLY ``status`` (``accepted``/``completed``),
+    never job ids, operation ids, HMACs, timestamps, upstream errors or SQL.
+    """
+    deps = get_dependencies(request)
+    service = deps.account_deletion_service
+    if service is None:
+        emit_event(
+            logger, EVENT_ACCOUNT_DELETION_GATE_UNAVAILABLE, code="not_configured"
+        )
+        emit_event(logger, EVENT_HTTP_RESULT, code=503)
+        raise HTTPException(
+            status_code=503, detail=_ACCOUNT_DELETION_UNAVAILABLE_DETAIL
+        )
+    user_id = getattr(current_user, "id", None)
+    operation_id = str(input_data.operation_id)
+    try:
+        result = await service.request(user_id, operation_id)
+    except ConflictError as exc:
+        # Divergent reuse of the same operation_id -> sanitized 409.
+        emit_event(logger, EVENT_REQUEST_CONFLICT, code=exc.code)
+        emit_event(logger, EVENT_HTTP_RESULT, code=409)
+        raise HTTPException(
+            status_code=409, detail=_ACCOUNT_DELETION_CONFLICT_DETAIL
+        ) from None
+    except (PersistenceError, AccountDeletionUnavailable, DeadlineExceeded, TurnExecutionError):
+        emit_event(logger, EVENT_HTTP_RESULT, code=503)
+        raise HTTPException(
+            status_code=503, detail=_ACCOUNT_DELETION_UNAVAILABLE_DETAIL
+        ) from None
+    except ValidationError:
+        # After HTTP validation, a #324 ValidationError is a server-side
+        # contract violation: fail closed as 500, never as a client 422.
+        emit_event(logger, EVENT_HTTP_RESULT, code=500)
+        raise HTTPException(
+            status_code=500, detail=_ACCOUNT_DELETION_INTERNAL_DETAIL
+        ) from None
+    except Exception:
+        emit_event(logger, EVENT_HTTP_RESULT, code=500)
+        raise HTTPException(
+            status_code=500, detail=_ACCOUNT_DELETION_INTERNAL_DETAIL
+        ) from None
+    emit_event(logger, EVENT_ACCOUNT_DELETION_REQUESTED)
+    emit_event(logger, EVENT_HTTP_RESULT, code=200)
+    return result
 
 
 async def live_endpoint():

--- a/backend/observability.py
+++ b/backend/observability.py
@@ -51,6 +51,9 @@ EVENT_ACCOUNT_DELETION_RETRY_SCHEDULED = "account_deletion_retry_scheduled"
 EVENT_ACCOUNT_DELETION_FAILED = "account_deletion_failed"
 EVENT_ACCOUNT_DELETION_COMPLETED = "account_deletion_completed"
 EVENT_ACCOUNT_DELETION_LEASE_LOST = "account_deletion_lease_lost"
+EVENT_ACCOUNT_DELETION_REQUESTED = "account_deletion_requested"
+EVENT_ACCOUNT_DELETION_BLOCKED = "account_deletion_blocked"
+EVENT_ACCOUNT_DELETION_GATE_UNAVAILABLE = "account_deletion_gate_unavailable"
 
 EVENT_NAMES = frozenset(
     {
@@ -75,6 +78,9 @@ EVENT_NAMES = frozenset(
         EVENT_ACCOUNT_DELETION_FAILED,
         EVENT_ACCOUNT_DELETION_COMPLETED,
         EVENT_ACCOUNT_DELETION_LEASE_LOST,
+        EVENT_ACCOUNT_DELETION_REQUESTED,
+        EVENT_ACCOUNT_DELETION_BLOCKED,
+        EVENT_ACCOUNT_DELETION_GATE_UNAVAILABLE,
     }
 )
 

--- a/backend/process_turn.py
+++ b/backend/process_turn.py
@@ -122,12 +122,19 @@ class ProcessTurnInput:
     budget: TurnBudget
     correlation: str
     mode: TurnMode = TurnMode.normal
+    account_deletion_user_ref: Optional[str] = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.correlation, str) or not _CORRELATION_RE.fullmatch(
             self.correlation
         ):
             raise ValueError("correlation must be a 64-char lowercase hex HMAC")
+        if self.account_deletion_user_ref is not None and not _CORRELATION_RE.fullmatch(
+            self.account_deletion_user_ref
+        ):
+            raise ValueError(
+                "account_deletion_user_ref must be a 64-char lowercase hex HMAC"
+            )
 
 
 @dataclass(frozen=True)
@@ -475,22 +482,34 @@ class ProcessTurn:
 
         # ---- 10. Atomic commit with CAS (exactly one operation) ---------------
         try:
+            commit_kwargs: dict[str, Any] = {
+                "authenticated_user_id": inp.authenticated_user_id,
+                "request_id": inp.request_id,
+                "expected_revision": state.revision,
+                "user_message": inp.user_message,
+                "assistant_message": response_text,
+                "emotional_state": emotional_snapshot,
+                "relationship_state": relationship_snapshot,
+                "public_response": response_text,
+                "outbox_events": outbox_events,
+                "replay_payload": replay_payload,
+                "lease_owner": self._lease_owner,
+            }
+            # Account-deletion commit barrier (#329): the SQL-side boundary
+            # runs under the SAME per-user advisory lock used by
+            # account_deletion_request and the purge, keyed solely on the
+            # server-derived HMAC reference (never the raw user_id), so it
+            # remains authoritative after finalize minimizes user_id to NULL.
+            if inp.account_deletion_user_ref is not None:
+                commit_kwargs["account_deletion_user_ref"] = (
+                    inp.account_deletion_user_ref
+                )
             return await run_blocking_write(
                 "commit_turn",
                 budget,
                 self._supabase_timeout,
                 self._commit_repository.commit,
-                authenticated_user_id=inp.authenticated_user_id,
-                request_id=inp.request_id,
-                expected_revision=state.revision,
-                user_message=inp.user_message,
-                assistant_message=response_text,
-                emotional_state=emotional_snapshot,
-                relationship_state=relationship_snapshot,
-                public_response=response_text,
-                outbox_events=outbox_events,
-                replay_payload=replay_payload,
-                lease_owner=self._lease_owner,
+                **commit_kwargs,
                 allowlist_exceptions=_REPOSITORY_ERRORS,
             )
         except ConflictError as exc:

--- a/backend/tests/fixtures/account_deletion_fakes.py
+++ b/backend/tests/fixtures/account_deletion_fakes.py
@@ -1,0 +1,72 @@
+"""Shared fakes for the #326 account deletion gate/API unit tests.
+
+The account deletion HTTP gate runs on every normal route (/chat, /history
+and the four #315 privacy actions). Existing unit tests inject
+``ApplicationDependencies`` without a real Supabase client; these fakes
+provide a no-tombstone gate so those tests keep exercising their own
+scenario, and a configurable fake service for the account deletion API
+tests themselves. No Supabase/Groq/embeddings client is ever constructed.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from backend.account_deletion_service import (
+    AccountDeletionBlocked,
+    AccountDeletionUnavailable,
+)
+
+
+class NoTombstoneGate:
+    """Minimal fake gate: no tombstone ever; every normal route passes.
+
+    ``assert_active`` never raises, so the route continues exactly as before
+    the #326 gate existed.
+    """
+
+    def __init__(self, blocked: bool = False, unavailable: bool = False) -> None:
+        self.blocked = blocked
+        self.unavailable = unavailable
+        self.checks: list[str] = []
+
+    async def assert_active(self, authenticated_user_id: str) -> None:
+        self.checks.append(authenticated_user_id)
+        if self.unavailable:
+            raise AccountDeletionUnavailable()
+        if self.blocked:
+            raise AccountDeletionBlocked()
+
+
+class FakeAccountDeletionService:
+    """Configurable fake for the account deletion API boundary.
+
+    ``request`` records ``(user_id, operation_id)`` calls and returns a
+    canned response (default ``accepted``) or raises a configured error.
+    ``assert_active`` delegates to a ``NoTombstoneGate`` instance so the
+    gate scenarios share one small fake.
+    """
+
+    def __init__(
+        self,
+        *,
+        status: str = "accepted",
+        error: Optional[BaseException] = None,
+        blocked: bool = False,
+        unavailable: bool = False,
+    ) -> None:
+        self._status = status
+        self._error = error
+        self.gate = NoTombstoneGate(blocked=blocked, unavailable=unavailable)
+        self.requests: list[tuple[str, str]] = []
+
+    async def request(self, authenticated_user_id: str, operation_id: str) -> Any:
+        self.requests.append((authenticated_user_id, operation_id))
+        if self._error is not None:
+            raise self._error
+        from backend.account_deletion_service import AccountDeletionRequestResponse
+
+        return AccountDeletionRequestResponse(status=self._status)
+
+    async def assert_active(self, authenticated_user_id: str) -> None:
+        await self.gate.assert_active(authenticated_user_id)

--- a/backend/tests/test_account_deletion_api.py
+++ b/backend/tests/test_account_deletion_api.py
@@ -1,0 +1,1073 @@
+"""Unit tests for the #326 account deletion API and tombstone gate.
+
+Everything here runs without network: the ledger repository and the
+account deletion service are fakes; no Supabase/Groq/embeddings client is
+ever constructed. Real-Supabase scenarios live in
+``test_account_deletion_integration.py`` (database CI job).
+
+Mandatory scenarios covered (from issue #326):
+
+ 1.  An authenticated request creates a tombstone/job using EXCLUSIVELY
+     ``current_user.id``.
+ 2.  The HMAC is derived server-side with ``compute_account_deletion_user_ref``.
+ 3.  No HMAC/user_ref is accepted from the client.
+ 4-7. Bodies with ``user_id``/``user_ref``/``job_id``/any extra key return
+     422 without any RPC.
+ 8.  The first request returns the honest ``accepted`` state.
+ 9.  Replay of the same intent + operation_id creates no second job.
+10.  ``operation_conflict`` produces a sanitized 409.
+11.  ``/chat`` with a tombstone returns 423 before ``reserve_admission_sync``.
+12.  In the same case ``engine.process_turn`` is never called.
+13.  Provider/Groq/embeddings are never reached (the engine never runs).
+14.  Blocked ``/history`` never queries ``chat_logs``.
+15.  Each of the four existing privacy endpoints is blocked before mutation.
+16.  A user without a tombstone keeps using ``/chat`` normally.
+17.  A user without a tombstone keeps using ``/history`` normally.
+18.  Existing privacy operations keep working for an active user.
+19.  A tombstone-store failure returns 503 and the route never continues.
+20.  Account A blocked does not affect account B.
+21-24. Tombstone statuses pending/processing/failed/completed all block.
+25.  ``POST /privacy/delete-account`` stays replayable after a tombstone
+     exists (the gate is deliberately NOT applied to it).
+26.  No unit suite constructs a real Supabase/Groq/embeddings client.
+27.  Artificial sensitive markers never appear in logs/responses.
+28.  Importing the new module creates no client and no network.
+29.  ``/live`` and ``/ready`` remain independent of the gate.
+30.  ``completed`` is never returned unless the ledger confirms it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+import backend.main as main_module
+from backend.account_deletion import (
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_PENDING,
+    STATUS_PROCESSING,
+    RequestResult,
+    TombstoneStatus,
+    compute_account_deletion_user_ref,
+    compute_intent_fingerprint,
+)
+from backend.account_deletion_service import (
+    DELETE_ACCOUNT_INTENT,
+    AccountDeletionBlocked,
+    AccountDeletionRequestResponse,
+    AccountDeletionService,
+    AccountDeletionUnavailable,
+)
+from backend.admission import AdmissionRuntimeConfig
+from backend.atomic_turn_commit import ConflictError, PersistenceError, ValidationError
+from backend.dependencies import ApplicationDependencies
+from backend.emotion_presentation import EmotionStateResponse
+from backend.health import HealthRegistry
+from backend.privacy_operations import (
+    OPERATION_DELETE_HISTORY,
+    OPERATION_DELETE_MEMORIES,
+    OPERATION_RESET_EMOTIONAL_STATE,
+    OPERATION_RESET_RELATIONSHIP_STATE,
+)
+from backend.process_turn import ProcessTurnResult
+from backend.settings import AppEnvironment, Settings
+from backend.tests.fixtures.account_deletion_fakes import (
+    FakeAccountDeletionService,
+    NoTombstoneGate,
+)
+from backend.turn_execution import TurnExecutionConfig
+
+SECRET = "s" * 40
+OP_ID = "11111111-1111-1111-1111-111111111111"
+OP_ID_2 = "22222222-2222-2222-2222-222222222222"
+JOB_ID = "33333333-3333-3333-3333-333333333333"
+SENTINEL_USER = "SENTINEL-USER-MARKER"
+SENTINEL_OP_ID = "99999999-9999-9999-9999-999999999999"
+SENTINEL_EXC = "SENTINEL-UPSTREAM-MARKER"
+VALID_CHAT_REQUEST_ID = "550e8400-e29b-41d4-a716-446655440000"
+
+PRIVACY_PATHS = {
+    OPERATION_DELETE_HISTORY: "/privacy/delete-history",
+    OPERATION_DELETE_MEMORIES: "/privacy/delete-memories",
+    OPERATION_RESET_EMOTIONAL_STATE: "/privacy/reset-emotional-state",
+    OPERATION_RESET_RELATIONSHIP_STATE: "/privacy/reset-relationship",
+}
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _settings(**overrides) -> Settings:
+    kwargs = {
+        "app_env": AppEnvironment.local,
+        "groq_api_key": "groq-key",
+        "admission_hmac_secret": SECRET,
+        "cors_allowed_origins": ("https://allowed.example",),
+    }
+    kwargs.update(overrides)
+    return Settings(**kwargs)
+
+
+class FakeAuth:
+    class _UserSurface:
+        def __init__(self, user_id: str):
+            self.user_id = user_id
+
+        def get_user(self, token: str):
+            return SimpleNamespace(user=SimpleNamespace(id=self.user_id))
+
+    def __init__(self, user_id: str = "user-a"):
+        self.auth = self._UserSurface(user_id)
+
+
+class FakeEngine:
+    def __init__(self, supabase=None):
+        self.memory_manager = SimpleNamespace(supabase=supabase)
+        self.groq_manager = object()
+        self.turn_calls = []
+
+    async def process_turn(self, *args, **kwargs):
+        self.turn_calls.append((args, kwargs))
+        raise AssertionError("engine.process_turn must never run in gate tests")
+
+
+class RecordingPrivacyService:
+    """Records invocations; returns a canned result or raises."""
+
+    def __init__(self, result=None, error=None):
+        self.calls: list[tuple] = []
+        self.result = result
+        self.error = error
+
+    async def delete_history(self, user_id: str, operation_id: str):
+        self.calls.append(("delete_history", user_id, operation_id))
+        return await self._respond()
+
+    async def delete_memories(self, user_id: str, operation_id: str):
+        self.calls.append(("delete_memories", user_id, operation_id))
+        return await self._respond()
+
+    async def reset_emotional_state(self, user_id: str, operation_id: str):
+        self.calls.append(("reset_emotional_state", user_id, operation_id))
+        return await self._respond()
+
+    async def reset_relationship_state(self, user_id: str, operation_id: str):
+        self.calls.append(("reset_relationship_state", user_id, operation_id))
+        return await self._respond()
+
+    async def _respond(self):
+        if self.error is not None:
+            raise self.error
+        from backend.privacy_service import PrivacyOperationResponse
+
+        return PrivacyOperationResponse(
+            operation=self.result, status="applied", counts={}
+        )
+
+
+def _make_app(
+    *,
+    account_deletion_service,
+    auth_user_id: str = "user-a",
+    privacy_service=None,
+    persistence=None,
+    engine=None,
+):
+    settings = _settings()
+    deps = ApplicationDependencies(
+        conversation_engine=engine if engine is not None else FakeEngine(supabase=object()),
+        auth_client=FakeAuth(auth_user_id),
+        admission_config=AdmissionRuntimeConfig.from_values(SECRET),
+        turn_config=TurnExecutionConfig.defaults(),
+        health_checks=HealthRegistry(),
+        clock=time.time,
+        persistence_client=persistence,
+        privacy_service=privacy_service,
+        account_deletion_service=account_deletion_service,
+    )
+    return main_module.create_app(settings=settings, dependencies=deps)
+
+
+def _auth_headers(token: str = "token-x") -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _assert_no_internal_fields(node) -> None:
+    """Fail if any key that could carry internal/sensitive data appears."""
+    forbidden = {
+        "user_id",
+        "user_ref",
+        "operation_id",
+        "job_id",
+        "job_status",
+        "id",
+        "hmac",
+        "fingerprint",
+        "token",
+        "secret",
+        "sql",
+        "timestamp",
+        "created_at",
+        "updated_at",
+        "db_purged_at",
+        "completed_at",
+        "requested_at",
+        "lease_owner",
+        "lease_expires_at",
+        "attempts",
+        "error_code",
+        "intent",
+    }
+
+    def walk(value) -> None:
+        if isinstance(value, dict):
+            for key, item in value.items():
+                assert key.lower() not in forbidden, f"internal field leaked: {key}"
+                walk(item)
+        elif isinstance(value, list):
+            for item in value:
+                walk(item)
+
+    walk(node)
+
+
+class _LedgerRepo:
+    """In-memory simulator of the #324 ledger (keyed by ref + operation_id).
+
+    Mirrors ``account_deletion_request``: the first call creates a pending
+    job; an exact replay (same fingerprint) returns the stored state without
+    a second job; a divergent fingerprint raises ``operation_conflict``.
+    ``has_tombstone`` returns a configurable result or raises.
+    """
+
+    def __init__(self, tombstone=None):
+        self._jobs: dict[tuple, tuple] = {}
+        self.request_calls: list[tuple] = []
+        self.tombstone_calls: list[str] = []
+        self.tombstone = tombstone  # None | status str | BaseException
+
+    def request(
+        self,
+        authenticated_user_id: str,
+        user_ref_hmac_sha256: str,
+        operation_id: str,
+        intent_fingerprint_sha256: str,
+    ) -> RequestResult:
+        self.request_calls.append(
+            (authenticated_user_id, user_ref_hmac_sha256, operation_id, intent_fingerprint_sha256)
+        )
+        key = (user_ref_hmac_sha256, operation_id)
+        if key in self._jobs:
+            stored_fp, status, db_purged_at = self._jobs[key]
+            if stored_fp != intent_fingerprint_sha256:
+                raise ConflictError(
+                    "operation_conflict",
+                    "operation_id already used with a different intent",
+                    0,
+                )
+            return RequestResult(
+                status="replay",
+                job_id=JOB_ID,
+                job_status=status,
+                db_purged_at=db_purged_at,
+                completed_at="2026-08-09T02:00:00+00:00" if status == STATUS_COMPLETED else None,
+            )
+        self._jobs[key] = (intent_fingerprint_sha256, STATUS_PENDING, None)
+        return RequestResult(
+            status="created",
+            job_id=JOB_ID,
+            job_status=STATUS_PENDING,
+            db_purged_at=None,
+            completed_at=None,
+        )
+
+    def mark_completed(self, user_ref: str, operation_id: str) -> None:
+        fp, _, _ = self._jobs[(user_ref, operation_id)]
+        self._jobs[(user_ref, operation_id)] = (fp, STATUS_COMPLETED, "2026-08-09T00:00:00+00:00")
+
+    def has_tombstone(self, user_ref_hmac_sha256: str) -> TombstoneStatus:
+        self.tombstone_calls.append(user_ref_hmac_sha256)
+        if isinstance(self.tombstone, BaseException):
+            raise self.tombstone
+        if self.tombstone is None:
+            return TombstoneStatus(exists=False, status=None)
+        return TombstoneStatus(exists=True, status=self.tombstone)
+
+
+def _real_service(repo: _LedgerRepo) -> AccountDeletionService:
+    return AccountDeletionService(
+        repository=repo,
+        turn_config=TurnExecutionConfig.defaults(),
+        admission_config=AdmissionRuntimeConfig.from_values(SECRET),
+    )
+
+
+def _ref(user_id: str) -> str:
+    return compute_account_deletion_user_ref(SECRET.encode("utf-8"), user_id)
+
+
+# ─── 1/2/3/8/9/10/30. Service: server-side derivation, accepted state, replay ─
+
+
+def test_request_derives_server_side_hmac_and_stable_fingerprint():
+    repo = _LedgerRepo()
+    service = _real_service(repo)
+    result = asyncio.run(service.request("user-a", OP_ID))
+    assert result.status == "accepted"
+    assert result == AccountDeletionRequestResponse(status="accepted")
+
+    user_id, user_ref, operation_id, fingerprint = repo.request_calls[0]
+    assert user_id == "user-a"
+    assert operation_id == OP_ID
+    # The reference is derived server-side from the authenticated identity
+    # under the dedicated account-deletion domain; no client value is used.
+    assert user_ref == _ref("user-a")
+    assert user_ref == compute_account_deletion_user_ref(
+        SECRET.encode("utf-8"), "user-a"
+    )
+    # The intent fingerprint is deterministic and carries no user data.
+    assert fingerprint == compute_intent_fingerprint(DELETE_ACCOUNT_INTENT)
+    assert "user-a" not in DELETE_ACCOUNT_INTENT
+    assert OP_ID not in DELETE_ACCOUNT_INTENT
+
+
+def test_request_fingerprint_stable_across_operation_ids():
+    repo = _LedgerRepo()
+    service = _real_service(repo)
+    asyncio.run(service.request("user-a", OP_ID))
+    asyncio.run(service.request("user-a", OP_ID_2))
+    fp_first = repo.request_calls[0][3]
+    fp_second = repo.request_calls[1][3]
+    assert fp_first == fp_second == compute_intent_fingerprint(DELETE_ACCOUNT_INTENT)
+
+
+def test_first_request_is_honest_accepted_and_never_completed():
+    repo = _LedgerRepo()
+    service = _real_service(repo)
+    result = asyncio.run(service.request("user-a", OP_ID))
+    assert result.status == "accepted"
+    assert result.status != "completed", "the API never promises completion"
+
+
+def test_replay_creates_no_second_job():
+    repo = _LedgerRepo()
+    service = _real_service(repo)
+    first = asyncio.run(service.request("user-a", OP_ID))
+    second = asyncio.run(service.request("user-a", OP_ID))
+    assert first == second == AccountDeletionRequestResponse(status="accepted")
+    assert len(repo.request_calls) == 2
+    assert len(repo._jobs) == 1, "replay must not create a second job"
+
+
+def test_replay_confirmed_completed_returns_completed():
+    repo = _LedgerRepo()
+    service = _real_service(repo)
+    asyncio.run(service.request("user-a", OP_ID))
+    repo.mark_completed(_ref("user-a"), OP_ID)
+    result = asyncio.run(service.request("user-a", OP_ID))
+    assert result.status == "completed", "completed only when the ledger confirms it"
+
+
+def test_divergent_intent_raises_operation_conflict():
+    repo = _LedgerRepo()
+    service = _real_service(repo)
+    # Pre-seed a job whose fingerprint differs from the delete_account intent.
+    repo._jobs[(_ref("user-a"), OP_ID)] = ("x" * 64, STATUS_PENDING, None)
+    with pytest.raises(ConflictError) as exc:
+        asyncio.run(service.request("user-a", OP_ID))
+    assert exc.value.code == "operation_conflict"
+
+
+def test_different_users_never_collide():
+    repo = _LedgerRepo()
+    service = _real_service(repo)
+    asyncio.run(service.request("user-a", OP_ID))
+    asyncio.run(service.request("user-b", OP_ID))
+    assert len(repo._jobs) == 2
+    assert repo.request_calls[0][1] != repo.request_calls[1][1]
+
+
+def test_service_holds_no_per_user_state():
+    repo = _LedgerRepo()
+    service = _real_service(repo)
+    asyncio.run(service.request("user-a", OP_ID))
+    asyncio.run(service.request("user-b", OP_ID_2))
+    # The container only keeps infrastructure; identity lives per call.
+    assert set(service.__dict__) == {"_repository", "_turn_config", "_admission_config"}
+
+
+# ─── 21-24. Gate: every tombstone status blocks; no tombstone passes ────────
+
+
+@pytest.mark.parametrize(
+    "status", [STATUS_PENDING, STATUS_PROCESSING, STATUS_FAILED, STATUS_COMPLETED]
+)
+def test_assert_active_blocks_for_every_tombstone_status(status):
+    repo = _LedgerRepo(tombstone=status)
+    service = _real_service(repo)
+    with pytest.raises(AccountDeletionBlocked):
+        asyncio.run(service.assert_active("user-a"))
+    assert repo.tombstone_calls == [_ref("user-a")]
+
+
+def test_assert_active_passes_without_tombstone():
+    repo = _LedgerRepo()
+    service = _real_service(repo)
+    asyncio.run(service.assert_active("user-a"))
+    assert repo.tombstone_calls == [_ref("user-a")]
+
+
+# ─── 19. Gate fail-closed on store failure ──────────────────────────────────
+
+
+def test_assert_active_fails_closed_on_persistence_error():
+    repo = _LedgerRepo(tombstone=PersistenceError("database_error", "persistence error"))
+    service = _real_service(repo)
+    with pytest.raises(AccountDeletionUnavailable):
+        asyncio.run(service.assert_active("user-a"))
+
+
+def test_assert_active_fails_closed_on_malformed_payload():
+    repo = _LedgerRepo(tombstone=ValidationError("validation_failed", "malformed"))
+    service = _real_service(repo)
+    with pytest.raises(AccountDeletionUnavailable):
+        asyncio.run(service.assert_active("user-a"))
+
+
+def test_assert_active_fails_closed_on_transport_error():
+    """A non-allowlisted repository exception becomes a persistence failure
+    inside run_blocking_write and must surface as AccountDeletionUnavailable,
+    never as 'user active'."""
+
+    class ExplodingRepo(_LedgerRepo):
+        def has_tombstone(self, user_ref_hmac_sha256):
+            raise RuntimeError(SENTINEL_EXC)
+
+    service = _real_service(ExplodingRepo())
+    with pytest.raises(AccountDeletionUnavailable):
+        asyncio.run(service.assert_active("user-a"))
+
+
+# ─── HTTP: POST /privacy/delete-account ─────────────────────────────────────
+
+
+def test_delete_account_without_bearer_returns_401():
+    service = FakeAccountDeletionService()
+    app = _make_app(account_deletion_service=service)
+    client = TestClient(app)
+    response = client.post("/privacy/delete-account", json={"operation_id": OP_ID})
+    assert response.status_code == 401
+    assert service.requests == []
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"user_id": "attacker-user"},
+        {"user_ref": "a" * 64},
+        {"job_id": JOB_ID},
+        {"user_ref_hmac_sha256": "b" * 64},
+        {"operation_id": OP_ID, "hmac": "c" * 64},
+        {"operation_id": OP_ID, "operation": "delete_account"},
+        {"operation_id": OP_ID, "user_id": "a", "extra": True},
+    ],
+)
+def test_delete_account_extra_keys_return_422_without_rpc(extra):
+    service = FakeAccountDeletionService()
+    app = _make_app(account_deletion_service=service)
+    client = TestClient(app)
+    response = client.post("/privacy/delete-account", json=extra, headers=_auth_headers())
+    assert response.status_code == 422
+    assert service.requests == [], "invalid bodies must never reach the service"
+    assert response.json() == {
+        "detail": {"code": "invalid_request", "message": "Invalid request body."}
+    }
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["not-a-uuid", "", "123", "550e8400-e29b-41d4-a716-44665544000Z"],
+)
+def test_delete_account_invalid_operation_id_returns_422_sanitized(bad):
+    service = FakeAccountDeletionService()
+    app = _make_app(account_deletion_service=service)
+    client = TestClient(app)
+    response = client.post(
+        "/privacy/delete-account", json={"operation_id": bad}, headers=_auth_headers()
+    )
+    assert response.status_code == 422
+    assert service.requests == []
+    assert response.json() == {
+        "detail": {"code": "invalid_request", "message": "Invalid request body."}
+    }
+    assert repr(bad) not in response.text
+
+
+def test_delete_account_identity_comes_only_from_current_user():
+    service = FakeAccountDeletionService()
+    app = _make_app(account_deletion_service=service, auth_user_id="authenticated-a")
+    client = TestClient(app)
+    response = client.post(
+        "/privacy/delete-account", json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 200
+    assert service.requests == [("authenticated-a", OP_ID)]
+
+
+def test_delete_account_first_request_returns_accepted_only():
+    service = FakeAccountDeletionService()
+    app = _make_app(account_deletion_service=service)
+    client = TestClient(app)
+    response = client.post(
+        "/privacy/delete-account", json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {"status": "accepted"}
+    _assert_no_internal_fields(body)
+
+
+def test_delete_account_replay_is_idempotent_over_http():
+    service = FakeAccountDeletionService()
+    app = _make_app(account_deletion_service=service)
+    client = TestClient(app)
+    headers = _auth_headers()
+    first = client.post("/privacy/delete-account", json={"operation_id": OP_ID}, headers=headers)
+    second = client.post("/privacy/delete-account", json={"operation_id": OP_ID}, headers=headers)
+    assert first.status_code == 200 and second.status_code == 200
+    assert first.json() == second.json() == {"status": "accepted"}
+    assert service.requests == [("user-a", OP_ID), ("user-a", OP_ID)]
+
+
+def test_delete_account_conflict_returns_409_sanitized():
+    service = FakeAccountDeletionService(
+        error=ConflictError("operation_conflict", "operation_id already used", 0)
+    )
+    app = _make_app(account_deletion_service=service)
+    client = TestClient(app)
+    response = client.post(
+        "/privacy/delete-account", json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 409
+    assert response.json() == {
+        "detail": {
+            "code": "operation_conflict",
+            "message": "Operation identifier was already used with a different operation.",
+        }
+    }
+
+
+def test_delete_account_persistence_failure_returns_503_sanitized():
+    service = FakeAccountDeletionService(
+        error=PersistenceError("database_error", "persistence error")
+    )
+    app = _make_app(account_deletion_service=service)
+    client = TestClient(app)
+    response = client.post(
+        "/privacy/delete-account", json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 503
+    assert response.json() == {
+        "detail": {"code": "service_unavailable", "message": "Service unavailable."}
+    }
+
+
+def test_delete_account_internal_validation_failure_is_500_not_422():
+    service = FakeAccountDeletionService(
+        error=ValidationError("invalid_rpc_result", "malformed envelope")
+    )
+    app = _make_app(account_deletion_service=service)
+    client = TestClient(app)
+    response = client.post(
+        "/privacy/delete-account", json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 500
+    assert response.json() == {
+        "detail": {"code": "internal_error", "message": "Internal server error."}
+    }
+
+
+def test_delete_account_unexpected_error_returns_500_sanitized():
+    service = FakeAccountDeletionService(error=RuntimeError(SENTINEL_EXC))
+    app = _make_app(account_deletion_service=service)
+    client = TestClient(app)
+    response = client.post(
+        "/privacy/delete-account", json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 500
+    assert SENTINEL_EXC not in response.text
+    assert response.json() == {
+        "detail": {"code": "internal_error", "message": "Internal server error."}
+    }
+
+
+def test_delete_account_missing_service_fails_closed_503():
+    app = _make_app(account_deletion_service=None)
+    client = TestClient(app)
+    response = client.post(
+        "/privacy/delete-account", json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 503
+    assert response.json() == {
+        "detail": {"code": "service_unavailable", "message": "Service unavailable."}
+    }
+
+
+# ─── 25. Delete-account is exempt from the gate (replayable) ────────────────
+
+
+def test_delete_account_replayable_even_while_tombstone_blocks():
+    """The gate is deliberately NOT applied to POST /privacy/delete-account:
+    with the gate blocked, the endpoint must still accept an idempotent
+    replay while the token is accepted."""
+    service = FakeAccountDeletionService(blocked=True)
+    app = _make_app(account_deletion_service=service)
+    client = TestClient(app)
+    response = client.post(
+        "/privacy/delete-account", json={"operation_id": OP_ID}, headers=_auth_headers()
+    )
+    assert response.status_code == 200
+    assert response.json() == {"status": "accepted"}
+
+
+# ─── 11/12/13/16/19. /chat gate ─────────────────────────────────────────────
+
+
+class _LoudPersistence:
+    """Persistence surface that fails loudly if any table/RPC is used."""
+
+    def __init__(self):
+        self.table_calls = []
+        self.rpc_calls = []
+
+    def table(self, name):
+        self.table_calls.append(name)
+        raise AssertionError(f"table access must not happen: {name}")
+
+    def rpc(self, name, params):
+        self.rpc_calls.append(name)
+        raise AssertionError(f"rpc must not happen: {name}")
+
+
+def _chat_payload(request_id=VALID_CHAT_REQUEST_ID, message="hello"):
+    return {"request_id": request_id, "message": message}
+
+
+def test_chat_with_tombstone_returns_423_before_admission_and_engine(monkeypatch):
+    service = FakeAccountDeletionService(blocked=True)
+    engine = FakeEngine()
+    persistence = _LoudPersistence()
+    admission_calls = []
+
+    def _spy_reserve_admission_sync(client, request):
+        admission_calls.append(request)
+        raise AssertionError("admission must not run for a blocked account")
+
+    monkeypatch.setattr(main_module, "reserve_admission_sync", _spy_reserve_admission_sync)
+    app = _make_app(
+        account_deletion_service=service,
+        engine=engine,
+        persistence=persistence,
+    )
+    client = TestClient(app)
+    response = client.post("/chat", json=_chat_payload(), headers=_auth_headers())
+    assert response.status_code == 423
+    assert response.json() == {
+        "detail": {
+            "code": "account_deletion_pending",
+            "message": "Account deletion is pending.",
+        }
+    }
+    assert admission_calls == [], "reserve_admission_sync must not be reached"
+    assert engine.turn_calls == [], "engine.process_turn must not be reached"
+    assert persistence.table_calls == [] and persistence.rpc_calls == []
+
+
+def test_chat_without_tombstone_keeps_working(monkeypatch):
+    service = FakeAccountDeletionService()
+    engine = FakeEngine()
+
+    async def _fake_process_turn(*args, **kwargs):
+        return ProcessTurnResult(
+            committed=object(),
+            response="ok response",
+            emotion_state=EmotionStateResponse(
+                schema_version=1,
+                mood_label="NEUTRA",
+                pad={"pleasure": 0.0, "arousal": 0.0, "dominance": 0.0},
+                dominant_emotions=[],
+                timestamp=1000.0,
+            ),
+        )
+
+    engine.process_turn = _fake_process_turn
+
+    class _AdmittingSupabase:
+        def rpc(self, name, params):
+            assert name == "reserve_admission"
+            return SimpleNamespace(
+                execute=lambda: SimpleNamespace(
+                    data=[{"decision": "admitted", "retry_after_seconds": 0}],
+                    error=None,
+                )
+            )
+
+    app = _make_app(
+        account_deletion_service=service,
+        engine=engine,
+        persistence=_AdmittingSupabase(),
+    )
+    client = TestClient(app)
+    response = client.post("/chat", json=_chat_payload(), headers=_auth_headers())
+    assert response.status_code == 200
+    assert response.json()["response"] == "ok response"
+    assert service.gate.checks == ["user-a"]
+
+
+def test_chat_gate_unavailable_returns_503_without_admission_or_engine(monkeypatch):
+    service = FakeAccountDeletionService(unavailable=True)
+    engine = FakeEngine()
+    persistence = _LoudPersistence()
+    admission_calls = []
+
+    def _spy_reserve_admission_sync(client, request):
+        admission_calls.append(request)
+        raise AssertionError("admission must not run")
+
+    monkeypatch.setattr(main_module, "reserve_admission_sync", _spy_reserve_admission_sync)
+    app = _make_app(
+        account_deletion_service=service,
+        engine=engine,
+        persistence=persistence,
+    )
+    client = TestClient(app)
+    response = client.post("/chat", json=_chat_payload(), headers=_auth_headers())
+    assert response.status_code == 503
+    assert response.json() == {
+        "detail": {"code": "service_unavailable", "message": "Service unavailable."}
+    }
+    assert admission_calls == []
+    assert engine.turn_calls == []
+    assert persistence.table_calls == [] and persistence.rpc_calls == []
+
+
+def test_chat_missing_gate_service_fails_closed_503(monkeypatch):
+    engine = FakeEngine()
+    admission_calls = []
+
+    def _spy_reserve_admission_sync(client, request):
+        admission_calls.append(request)
+        raise AssertionError("admission must not run")
+
+    monkeypatch.setattr(main_module, "reserve_admission_sync", _spy_reserve_admission_sync)
+    app = _make_app(account_deletion_service=None, engine=engine)
+    client = TestClient(app)
+    response = client.post("/chat", json=_chat_payload(), headers=_auth_headers())
+    assert response.status_code == 503
+    assert admission_calls == []
+    assert engine.turn_calls == []
+
+
+# ─── 14/17/19. /history gate ────────────────────────────────────────────────
+
+
+def test_history_with_tombstone_returns_423_without_querying_chat_logs():
+    service = FakeAccountDeletionService(blocked=True)
+    persistence = _LoudPersistence()
+    app = _make_app(account_deletion_service=service, persistence=persistence)
+    client = TestClient(app)
+    response = client.get("/history", headers=_auth_headers())
+    assert response.status_code == 423
+    assert response.json() == {
+        "detail": {
+            "code": "account_deletion_pending",
+            "message": "Account deletion is pending.",
+        }
+    }
+    assert persistence.table_calls == [], "chat_logs must never be queried"
+
+
+class _HistorySupabase:
+    def table(self, name):
+        assert name == "chat_logs"
+        return self
+
+    def select(self, cols):
+        return self
+
+    def eq(self, key, value):
+        return self
+
+    def order(self, col, **kwargs):
+        return self
+
+    def limit(self, n):
+        return self
+
+    def execute(self):
+        return SimpleNamespace(data=[{"content": "msg1", "role": "user"}], error=None)
+
+
+def test_history_without_tombstone_keeps_working():
+    service = FakeAccountDeletionService()
+    app = _make_app(account_deletion_service=service, persistence=_HistorySupabase())
+    client = TestClient(app)
+    response = client.get("/history", headers=_auth_headers())
+    assert response.status_code == 200
+    assert response.json() == [{"content": "msg1", "role": "user"}]
+    assert service.gate.checks == ["user-a"]
+
+
+def test_history_gate_unavailable_returns_503_without_query():
+    service = FakeAccountDeletionService(unavailable=True)
+    persistence = _LoudPersistence()
+    app = _make_app(account_deletion_service=service, persistence=persistence)
+    client = TestClient(app)
+    response = client.get("/history", headers=_auth_headers())
+    assert response.status_code == 503
+    assert persistence.table_calls == []
+
+
+# ─── 15/18. Existing privacy actions gate ───────────────────────────────────
+
+
+@pytest.mark.parametrize("path", sorted(PRIVACY_PATHS.values()))
+def test_privacy_actions_blocked_423_before_mutation(path):
+    service = FakeAccountDeletionService(blocked=True)
+    privacy = RecordingPrivacyService(result=OPERATION_DELETE_HISTORY)
+    app = _make_app(account_deletion_service=service, privacy_service=privacy)
+    client = TestClient(app)
+    response = client.post(path, json={"operation_id": OP_ID}, headers=_auth_headers())
+    assert response.status_code == 423
+    assert response.json() == {
+        "detail": {
+            "code": "account_deletion_pending",
+            "message": "Account deletion is pending.",
+        }
+    }
+    assert privacy.calls == [], "the privacy mutation must not run"
+
+
+@pytest.mark.parametrize("path", sorted(PRIVACY_PATHS.values()))
+def test_privacy_actions_still_work_for_active_user(path):
+    service = FakeAccountDeletionService()
+    privacy = RecordingPrivacyService(result=OPERATION_DELETE_HISTORY)
+    app = _make_app(account_deletion_service=service, privacy_service=privacy)
+    client = TestClient(app)
+    response = client.post(path, json={"operation_id": OP_ID}, headers=_auth_headers())
+    assert response.status_code == 200
+    assert response.json() == {
+        "operation": "delete_history",
+        "status": "applied",
+        "counts": {},
+    }
+
+
+# ─── 20. Account A blocked does not affect account B ────────────────────────
+
+
+class _UserKeyedGate:
+    def __init__(self, blocked_user: str):
+        self.blocked_user = blocked_user
+        self.checks = []
+
+    async def assert_active(self, authenticated_user_id: str) -> None:
+        self.checks.append(authenticated_user_id)
+        if authenticated_user_id == self.blocked_user:
+            raise AccountDeletionBlocked()
+
+
+def test_user_a_blocked_does_not_affect_user_b(monkeypatch):
+    gate = _UserKeyedGate(blocked_user="user-a")
+
+    class _TokenAuth:
+        class _Surface:
+            def __init__(self):
+                self.by_token = {"token-a": "user-a", "token-b": "user-b"}
+
+            def get_user(self, token):
+                return SimpleNamespace(user=SimpleNamespace(id=self.by_token[token]))
+
+        def __init__(self):
+            self.auth = self._Surface()
+
+    class _Engine:
+        def __init__(self):
+            self.calls = []
+            self.memory_manager = SimpleNamespace(supabase=object())
+            self.groq_manager = object()
+
+        async def process_turn(self, *args, **kwargs):
+            self.calls.append(args)
+            return ProcessTurnResult(
+                committed=object(),
+                response="b ok",
+                emotion_state=EmotionStateResponse(
+                    schema_version=1,
+                    mood_label="NEUTRA",
+                    pad={"pleasure": 0.0, "arousal": 0.0, "dominance": 0.0},
+                    dominant_emotions=[],
+                    timestamp=1000.0,
+                ),
+            )
+
+    class _AdmittingSupabase:
+        def rpc(self, name, params):
+            return SimpleNamespace(
+                execute=lambda: SimpleNamespace(
+                    data=[{"decision": "admitted", "retry_after_seconds": 0}],
+                    error=None,
+                )
+            )
+
+    engine = _Engine()
+    settings = _settings()
+    deps = ApplicationDependencies(
+        conversation_engine=engine,
+        auth_client=_TokenAuth(),
+        admission_config=AdmissionRuntimeConfig.from_values(SECRET),
+        turn_config=TurnExecutionConfig.defaults(),
+        health_checks=HealthRegistry(),
+        clock=time.time,
+        persistence_client=_AdmittingSupabase(),
+        account_deletion_service=gate,
+    )
+    app = main_module.create_app(settings=settings, dependencies=deps)
+    client = TestClient(app)
+    blocked = client.post(
+        "/chat", json=_chat_payload(), headers=_auth_headers(token="token-a")
+    )
+    assert blocked.status_code == 423
+
+    engine.calls.clear()
+    active = client.post(
+        "/chat", json=_chat_payload(), headers=_auth_headers(token="token-b")
+    )
+    assert active.status_code == 200
+    assert active.json()["response"] == "b ok"
+    assert engine.calls, "user B must keep using /chat"
+
+
+# ─── 27. Sentinels never reach logs or responses ────────────────────────────
+
+
+def test_sentinels_never_reach_logs_or_responses(caplog):
+    service = FakeAccountDeletionService(
+        error=RuntimeError(SENTINEL_EXC), unavailable=False
+    )
+    app = _make_app(account_deletion_service=service, auth_user_id=SENTINEL_USER)
+    client = TestClient(app)
+    with caplog.at_level(logging.INFO):
+        response = client.post(
+            "/privacy/delete-account",
+            json={"operation_id": SENTINEL_OP_ID},
+            headers=_auth_headers("SENTINEL-BEARER-TOKEN"),
+        )
+    assert response.status_code == 500
+    assert SENTINEL_USER not in response.text
+    assert SENTINEL_OP_ID not in response.text
+    assert SENTINEL_EXC not in response.text
+    assert "SENTINEL-BEARER-TOKEN" not in response.text
+    assert SENTINEL_USER not in caplog.text
+    assert SENTINEL_OP_ID not in caplog.text
+    assert SENTINEL_EXC not in caplog.text
+    assert "SENTINEL-BEARER-TOKEN" not in caplog.text
+
+
+# ─── 29. /live and /ready remain independent ────────────────────────────────
+
+
+def test_live_and_ready_unaffected_by_gate():
+    service = FakeAccountDeletionService(blocked=True)
+    app = _make_app(account_deletion_service=service)
+    client = TestClient(app)
+    assert client.get("/live").status_code == 200
+    assert client.get("/ready").status_code == 200
+
+
+# ─── 26/28. Purity: no client, no network, no threads on import ─────────────
+
+_PURITY_SCRIPT = textwrap.dedent(
+    """
+    import sys
+    import threading
+
+    import socket as _socket
+
+    def _forbid(*args, **kwargs):
+        raise AssertionError("network socket usage during import")
+
+    _socket.socket.connect = _forbid
+    _socket.socket.connect_ex = _forbid
+    _socket.create_connection = _forbid
+
+    import supabase as _supabase
+
+    def _no_supabase_client(*args, **kwargs):
+        raise AssertionError("real Supabase client constructed during import")
+
+    _supabase.create_client = _no_supabase_client
+
+    threads_before = len(threading.enumerate())
+
+    import backend.account_deletion_service
+
+    threads_after = len(threading.enumerate())
+
+    assert threads_after == threads_before, "import started a thread"
+    print("ACCOUNT_DELETION_SERVICE_PURITY_OK")
+    """
+)
+
+
+def test_account_deletion_service_import_is_pure():
+    result = subprocess.run(
+        [sys.executable, "-c", _PURITY_SCRIPT],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={"PYTHONPATH": ".", "PATH": "/usr/bin:/bin"},
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+    assert "ACCOUNT_DELETION_SERVICE_PURITY_OK" in result.stdout
+
+
+def test_no_unit_suite_constructs_real_clients():
+    """The whole unit path for the API uses fakes: the default composition is
+    the only place where real clients may be built, and it is never invoked
+    here."""
+    app = _make_app(
+        account_deletion_service=FakeAccountDeletionService(),
+        privacy_service=RecordingPrivacyService(result=OPERATION_DELETE_HISTORY),
+        persistence=_HistorySupabase(),
+    )
+    assert app.state.dependencies is not None
+    assert app.state.lifespan_started is True
+
+
+def test_default_composition_reuses_existing_supabase_client(monkeypatch):
+    """The default composition wires the account deletion service with the
+    SAME Supabase client the rest of the app uses (no second client, no
+    per-request client, no client at import time)."""
+    import backend.dependencies as dependencies_module
+
+    fake_supabase = object()
+    monkeypatch.setattr(
+        dependencies_module,
+        "_supabase_factory_from_settings",
+        lambda settings: lambda: fake_supabase,
+    )
+    deps, _owned = dependencies_module.build_default_dependencies(_settings())
+    assert deps.account_deletion_service is not None
+    assert deps.account_deletion_service._repository._client is fake_supabase
+    assert deps.persistence_client is fake_supabase
+    assert deps.auth_client is fake_supabase

--- a/backend/tests/test_account_deletion_integration.py
+++ b/backend/tests/test_account_deletion_integration.py
@@ -55,6 +55,7 @@ from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
 import pytest
+from fastapi.testclient import TestClient
 from supabase import Client, create_client
 
 from backend.account_deletion import (
@@ -1417,3 +1418,212 @@ def test_worker_auth_failure_preserves_db_purged_at_then_completes(
         assert _repo(service_client).has_tombstone(ref).exists is True
     finally:
         _cleanup_user(user_id)
+
+
+# ─── #326 HTTP API: real job creation and tombstone gate ────────────────────
+#
+# End-to-end against the local Supabase instance: the authenticated HTTP
+# endpoint creates a REAL job through the #324 contract, the tombstone gate
+# blocks /history and /chat, the replay stays idempotent, and account B is
+# not affected. The Auth Admin surface is never touched here (the worker is
+# not part of these scenarios).
+
+
+@pytest.fixture(scope="module")
+def anon_key() -> str:
+    return _required_env("SUPABASE_ANON_KEY")
+
+
+@pytest.fixture(scope="module")
+def app_client(
+    supabase_url: str,
+    service_role_key: str,
+) -> tuple[TestClient, Client]:
+    """The real FastAPI application wired to the local Supabase instance."""
+    from backend.account_deletion_service import AccountDeletionService
+    from backend.admission import AdmissionRuntimeConfig
+    from backend.dependencies import ApplicationDependencies
+    from backend.health import HealthRegistry
+    from backend.main import create_app
+    from backend.settings import AppEnvironment, Settings
+    from backend.turn_execution import TurnExecutionConfig
+
+    client = create_client(supabase_url, service_role_key)
+    admission_config = AdmissionRuntimeConfig.from_values(SECRET.decode("utf-8"))
+    account_deletion_service = AccountDeletionService(
+        repository=SupabaseAccountDeletionRepository(client),
+        turn_config=TurnExecutionConfig.defaults(),
+        admission_config=admission_config,
+    )
+    settings = Settings(
+        app_env=AppEnvironment.local,
+        groq_api_key="ci-groq-key",
+        admission_hmac_secret=SECRET.decode("utf-8"),
+        cors_allowed_origins=("http://localhost:3000",),
+    )
+    engine = SimpleNamespace(
+        memory_manager=SimpleNamespace(supabase=client),
+        groq_manager=SimpleNamespace(is_configured=lambda: True),
+    )
+    deps = ApplicationDependencies(
+        conversation_engine=engine,
+        auth_client=client,
+        admission_config=admission_config,
+        turn_config=TurnExecutionConfig.defaults(),
+        health_checks=HealthRegistry(),
+        clock=time.time,
+        persistence_client=client,
+        account_deletion_service=account_deletion_service,
+    )
+    app = create_app(settings=settings, dependencies=deps)
+    yield TestClient(app), client
+    _close_client(client)
+
+
+@pytest.fixture(scope="module")
+def users(
+    supabase_url: str,
+    anon_key: str,
+    service_client: Client,
+) -> dict[str, dict]:
+    """Two real GoTrue users (``a`` and ``b``) with valid sessions."""
+    created: list[dict] = []
+    for label in ("a", "b"):
+        email = f"adl-api-{label}-{uuid.uuid4().hex[:8]}@test.local"
+        password = "password123"
+        anon = create_client(supabase_url, anon_key)
+        try:
+            anon.auth.sign_up({"email": email, "password": password})
+            response = anon.auth.sign_in_with_password(
+                {"email": email, "password": password}
+            )
+            assert response is not None and response.user is not None
+            assert (
+                response.session is not None
+                and response.session.access_token is not None
+            )
+            created.append(
+                {
+                    "label": label,
+                    "id": response.user.id,
+                    "token": response.session.access_token,
+                    "email": email,
+                }
+            )
+        finally:
+            _close_client(anon)
+    yield {entry["label"]: entry for entry in created}
+    for entry in created:
+        for user in service_client.auth.admin.list_users():
+            if user.email == entry["email"]:
+                service_client.auth.admin.delete_user(user.id)
+
+
+def test_http_delete_account_creates_real_job_and_gate_blocks(
+    app_client: tuple[TestClient, Client],
+    users: dict[str, dict],
+):
+    """#326 scenario 29 (part 1): POST /privacy/delete-account creates a REAL
+    #324 job from current_user.id alone; the tombstone then blocks /history
+    and /chat; the replay is idempotent."""
+    client, _ = app_client
+    user = users["a"]
+    user_b = users["b"]
+    headers_a = {"Authorization": f"Bearer {user['token']}"}
+    headers_b = {"Authorization": f"Bearer {user_b['token']}"}
+    operation_id = _new_op_id()
+    try:
+        # Active user B can use /history before any tombstone exists.
+        history_b = client.get("/history", headers=headers_b)
+        assert history_b.status_code == 200
+
+        # First request: honest accepted state, nothing internal.
+        response = client.post(
+            "/privacy/delete-account",
+            json={"operation_id": operation_id},
+            headers=headers_a,
+        )
+        assert response.status_code == 200
+        assert response.json() == {"status": "accepted"}
+
+        # A real job row exists, bound to the server-derived reference.
+        rows = _run_sql(
+            "SELECT job_id::text, user_ref_hmac_sha256, user_id, status "
+            "FROM public.account_deletion_jobs "
+            f"WHERE operation_id = '{operation_id}'"
+        )
+        assert len(rows) == 1
+        assert rows[0]["user_ref_hmac_sha256"] == _ref(user["id"])
+        assert rows[0]["user_id"] == user["id"]
+        assert rows[0]["status"] == "pending"
+        job_id = rows[0]["job_id"]
+
+        # The tombstone gate blocks /history BEFORE any chat_logs read.
+        history_a = client.get("/history", headers=headers_a)
+        assert history_a.status_code == 423
+        assert history_a.json() == {
+            "detail": {
+                "code": "account_deletion_pending",
+                "message": "Account deletion is pending.",
+            }
+        }
+
+        # The tombstone gate blocks /chat BEFORE admission.
+        chat_a = client.post(
+            "/chat",
+            json={
+                "request_id": str(uuid.uuid4()),
+                "message": "hello",
+            },
+            headers=headers_a,
+        )
+        assert chat_a.status_code == 423
+        assert chat_a.json()["detail"]["code"] == "account_deletion_pending"
+
+        # Replay: same operation_id -> same honest state, no second job.
+        replay = client.post(
+            "/privacy/delete-account",
+            json={"operation_id": operation_id},
+            headers=headers_a,
+        )
+        assert replay.status_code == 200
+        assert replay.json() == {"status": "accepted"}
+        assert _count(
+            "account_deletion_jobs", f"operation_id = '{operation_id}'"
+        ) == 1
+
+        # Account B is not affected: /history still works.
+        history_b_after = client.get("/history", headers=headers_b)
+        assert history_b_after.status_code == 200
+
+        # The public response and the 423 payload never leak the job id.
+        assert job_id not in replay.text
+        assert job_id not in history_a.text
+    finally:
+        _cleanup_user(user["id"])
+        _cleanup_user(user_b["id"])
+
+
+def test_http_delete_account_rejects_spoofed_identity_before_rpc(
+    app_client: tuple[TestClient, Client],
+    users: dict[str, dict],
+):
+    """#326 scenario 29 (part 2): a body carrying user_id/user_ref/job_id is
+    rejected with 422 and NO job is created (identity comes exclusively from
+    the authenticated user)."""
+    client, _ = app_client
+    user = users["a"]
+    headers = {"Authorization": f"Bearer {user['token']}"}
+    for extra in (
+        {"operation_id": _new_op_id(), "user_id": "attacker"},
+        {"operation_id": _new_op_id(), "user_ref": "a" * 64},
+        {"operation_id": _new_op_id(), "job_id": str(uuid.uuid4())},
+    ):
+        operation_id = extra["operation_id"]
+        response = client.post(
+            "/privacy/delete-account", json=extra, headers=headers
+        )
+        assert response.status_code == 422
+        assert _count(
+            "account_deletion_jobs", f"operation_id = '{operation_id}'"
+        ) == 0, "no job may be created from a spoofed body"

--- a/backend/tests/test_admission_additional_invariants.py
+++ b/backend/tests/test_admission_additional_invariants.py
@@ -79,6 +79,7 @@ def test_endpoint_cancellation_drains_reservation_and_never_calls_engine(monkeyp
     fake_engine = FakeEngine()
     from backend.health import HealthRegistry
     from backend.settings import AppEnvironment, Settings
+    from backend.tests.fixtures.account_deletion_fakes import NoTombstoneGate
     from backend.turn_execution import TurnExecutionConfig
 
     settings = Settings(
@@ -93,6 +94,7 @@ def test_endpoint_cancellation_drains_reservation_and_never_calls_engine(monkeyp
         admission_config=AdmissionRuntimeConfig.from_values("s" * 32),
         turn_config=TurnExecutionConfig.defaults(),
         health_checks=HealthRegistry(),
+        account_deletion_service=NoTombstoneGate(),
     )
     app = main.create_app(settings=settings, dependencies=deps)
 

--- a/backend/tests/test_app_factory.py
+++ b/backend/tests/test_app_factory.py
@@ -687,7 +687,7 @@ def test_routes_use_only_the_correct_dependency():
             self.turn_calls = []
 
         async def process_turn(
-            self, user_id, message, request_id, *, budget=None, mode=None, correlation=None
+            self, user_id, message, request_id, *, budget=None, mode=None, correlation=None, account_deletion_user_ref=None
         ):
             self.turn_calls.append((user_id, message, request_id))
             return ProcessTurnResult(

--- a/backend/tests/test_app_factory.py
+++ b/backend/tests/test_app_factory.py
@@ -54,6 +54,8 @@ class FakeEngine:
 
 
 def _fake_dependencies(**overrides) -> main_module.ApplicationDependencies:
+    from backend.tests.fixtures.account_deletion_fakes import NoTombstoneGate
+
     settings = _settings()
     engine = FakeEngine(supabase=object())
     kwargs = {
@@ -63,6 +65,7 @@ def _fake_dependencies(**overrides) -> main_module.ApplicationDependencies:
         "turn_config": TurnExecutionConfig.defaults(),
         "health_checks": HealthRegistry(),
         "clock": time.time,
+        "account_deletion_service": NoTombstoneGate(),
     }
     kwargs.update(overrides)
     return main_module.ApplicationDependencies(**kwargs)
@@ -607,6 +610,7 @@ def test_no_per_user_state_in_app_state_or_container():
         "clock",
         "persistence_client",
         "privacy_service",
+        "account_deletion_service",
     }
     assert set(deps.__dataclass_fields__) == container_fields
     # No attribute of the container may hold a user identity.
@@ -621,6 +625,7 @@ def test_no_per_user_state_in_app_state_or_container():
 def test_routes_use_only_the_correct_dependency():
     """Auth uses only ``auth_client``; history/admission use only
     ``persistence_client``; routes never navigate engine internals."""
+    from backend.tests.fixtures.account_deletion_fakes import NoTombstoneGate
     from types import SimpleNamespace as NS
 
     from backend.emotion_presentation import EmotionStateResponse
@@ -708,6 +713,7 @@ def test_routes_use_only_the_correct_dependency():
         health_checks=HealthRegistry(),
         clock=time.time,
         persistence_client=persistence_client,
+        account_deletion_service=NoTombstoneGate(),
     )
     app = main_module.create_app(settings=_settings(), dependencies=deps)
     client = TestClient(app)

--- a/backend/tests/test_archival_memory_integration.py
+++ b/backend/tests/test_archival_memory_integration.py
@@ -83,6 +83,7 @@ def client_app(mock_external_dependencies):
     from backend.dependencies import ApplicationDependencies
     from backend.health import HealthRegistry
     from backend.settings import AppEnvironment, Settings
+    from backend.tests.fixtures.account_deletion_fakes import NoTombstoneGate
     from backend.turn_execution import TurnExecutionConfig
 
     engine = ChatConversationEngine()
@@ -100,6 +101,7 @@ def client_app(mock_external_dependencies):
         ),
         turn_config=TurnExecutionConfig.defaults(),
         health_checks=HealthRegistry(),
+        account_deletion_service=NoTombstoneGate(),
     )
     app = main.create_app(settings=settings, dependencies=deps)
     return TestClient(app)

--- a/backend/tests/test_atomic_turn_commit.py
+++ b/backend/tests/test_atomic_turn_commit.py
@@ -670,6 +670,50 @@ class TestValidateAtomicCommitInput:
             validate_atomic_commit_input(**valid_inputs)
         assert exc.value.code == "invalid_outbox_events"
 
+    def test_account_deletion_user_ref_valid_accepted(self, valid_inputs):
+        # #329: the exact server-derived HMAC format (64 lowercase hex) is
+        # accepted by the commit boundary.
+        valid_inputs["account_deletion_user_ref"] = "a" * 64
+        validate_atomic_commit_input(**valid_inputs)
+
+    def test_account_deletion_user_ref_none_accepted(self, valid_inputs):
+        # Historical contract: without the barrier reference everything
+        # behaves byte-identically to the pre-#329 RPC.
+        valid_inputs["account_deletion_user_ref"] = None
+        validate_atomic_commit_input(**valid_inputs)
+
+    def test_account_deletion_user_ref_rejects_raw_user_id(self, valid_inputs):
+        # The barrier is keyed on the HMAC reference, NEVER the raw
+        # user_id (#329): a plain user identifier is a validation failure.
+        valid_inputs["account_deletion_user_ref"] = "user_123"
+        with pytest.raises(ValidationError) as exc:
+            validate_atomic_commit_input(**valid_inputs)
+        assert exc.value.code == "invalid_account_deletion_user_ref"
+
+    def test_account_deletion_user_ref_rejects_invalid_hex(self, valid_inputs):
+        valid_inputs["account_deletion_user_ref"] = "g" * 64
+        with pytest.raises(ValidationError) as exc:
+            validate_atomic_commit_input(**valid_inputs)
+        assert exc.value.code == "invalid_account_deletion_user_ref"
+
+    def test_account_deletion_user_ref_rejects_uppercase_hex(self, valid_inputs):
+        valid_inputs["account_deletion_user_ref"] = "A" * 64
+        with pytest.raises(ValidationError) as exc:
+            validate_atomic_commit_input(**valid_inputs)
+        assert exc.value.code == "invalid_account_deletion_user_ref"
+
+    def test_account_deletion_user_ref_rejects_wrong_length(self, valid_inputs):
+        valid_inputs["account_deletion_user_ref"] = "a" * 32
+        with pytest.raises(ValidationError) as exc:
+            validate_atomic_commit_input(**valid_inputs)
+        assert exc.value.code == "invalid_account_deletion_user_ref"
+
+    def test_account_deletion_user_ref_rejects_non_string(self, valid_inputs):
+        valid_inputs["account_deletion_user_ref"] = 1234
+        with pytest.raises(ValidationError) as exc:
+            validate_atomic_commit_input(**valid_inputs)
+        assert exc.value.code == "invalid_account_deletion_user_ref"
+
 # ═══════════════════════════════════════════════════════════════════════
 # 4. RPC payload building
 # ═══════════════════════════════════════════════════════════════════════
@@ -724,6 +768,20 @@ class TestBuildCommitTurnRpcPayload:
         base_params["emotional_state"] = None
         result = build_commit_turn_rpc_payload(**base_params)
         assert result["p_emotional_state"] is None
+
+    def test_account_deletion_user_ref_included_when_present(self, base_params):
+        # #329: the barrier reference is forwarded as p_account_deletion_
+        # user_ref only when provided, so the SQL boundary can race-safe
+        # check the deletion ledger under the same advisory lock.
+        base_params["account_deletion_user_ref"] = "c" * 64
+        result = build_commit_turn_rpc_payload(**base_params)
+        assert result["p_account_deletion_user_ref"] == "c" * 64
+
+    def test_account_deletion_user_ref_omitted_when_absent(self, base_params):
+        # Historical byte-for-byte compatibility: without the reference the
+        # payload keeps exactly the pre-#329 fields.
+        result = build_commit_turn_rpc_payload(**base_params)
+        assert "p_account_deletion_user_ref" not in result
 
     def test_preserves_empty_mapping_as_empty(self, base_params):
         # Empty mappings must be preserved as {} — never converted to NULL.
@@ -864,6 +922,21 @@ class TestParseCommitTurnResult:
         with pytest.raises(ConflictError) as exc:
             parse_commit_turn_result(error_result)
         assert exc.value.code == "lease_conflict"
+
+    def test_parse_error_result_account_deletion_pending(self):
+        # #329: a commit made past the preflight gate against an accepted
+        # tombstone (or after purge/finalize, when user_id is NULL) fails
+        # with this domain code and never writes rows.
+        error_result = {
+            "error": {
+                "code": "account_deletion_pending",
+                "message": "Account deletion is pending.",
+            }
+        }
+        with pytest.raises(ConflictError) as exc:
+            parse_commit_turn_result(error_result)
+        assert exc.value.code == "account_deletion_pending"
+        assert exc.value.message == "Account deletion is pending."
 
     def test_parse_error_result_validation_failed(self):
         error_result = {
@@ -1330,6 +1403,32 @@ class TestAsyncCommitTurn:
         with pytest.raises(ValidationError):
             await commit_turn(rpc_client=recording_rpc_client, **valid_inputs)
         assert len(recording_rpc_client.calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_account_deletion_user_ref_forwarded_to_rpc(self, valid_inputs, recording_rpc_client):
+        # #329: a valid server-derived HMAC reference reaches the RPC as
+        # p_account_deletion_user_ref so the SQL barrier runs inside the
+        # same transaction, under the same advisory lock.
+        valid_inputs["account_deletion_user_ref"] = "d" * 64
+        await commit_turn(rpc_client=recording_rpc_client, **valid_inputs)
+        assert len(recording_rpc_client.calls) == 1
+        _, params = recording_rpc_client.calls[0]
+        assert params["p_account_deletion_user_ref"] == "d" * 64
+
+    @pytest.mark.asyncio
+    async def test_rpc_not_called_on_invalid_user_ref(self, valid_inputs, recording_rpc_client):
+        # Validation runs BEFORE the RPC: an invalid barrier reference
+        # (including the raw user_id) must never reach the database.
+        valid_inputs["account_deletion_user_ref"] = "user_123"
+        with pytest.raises(ValidationError):
+            await commit_turn(rpc_client=recording_rpc_client, **valid_inputs)
+        assert len(recording_rpc_client.calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_barrier_param_when_user_ref_absent(self, valid_inputs, recording_rpc_client):
+        await commit_turn(rpc_client=recording_rpc_client, **valid_inputs)
+        _, params = recording_rpc_client.calls[0]
+        assert "p_account_deletion_user_ref" not in params
 
     @pytest.mark.asyncio
     async def test_validation_before_rpc(self, valid_inputs, recording_rpc_client):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -228,8 +228,16 @@ def test_valid_token(client_app, mock_supabase, mock_engine_process):
 
     assert response.status_code == 200
     assert response.json()["response"] == "Mock response"
+    # #329: the server-derived HMAC barrier reference reaches the engine
+    # alongside the admission inputs; only the presence is asserted here.
     mock_engine_process.assert_called_once_with(
-        "user123", "Hello", REQUEST_ID, budget=ANY, mode=ANY, correlation=ANY
+        "user123",
+        "Hello",
+        REQUEST_ID,
+        budget=ANY,
+        mode=ANY,
+        correlation=ANY,
+        account_deletion_user_ref=ANY,
     )
 
 
@@ -454,7 +462,13 @@ def test_chat_message_exactly_at_limit(client_app, mock_supabase, mock_engine_pr
     assert response.status_code == 200
     assert response.json()["response"] == "Mock response"
     mock_engine_process.assert_called_once_with(
-        "user123", message, REQUEST_ID, budget=ANY, mode=ANY, correlation=ANY
+        "user123",
+        message,
+        REQUEST_ID,
+        budget=ANY,
+        mode=ANY,
+        correlation=ANY,
+        account_deletion_user_ref=ANY,
     )
 
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -73,6 +73,7 @@ def client_app(mock_external_dependencies):
     from backend.dependencies import ApplicationDependencies
     from backend.health import HealthRegistry
     from backend.settings import AppEnvironment, Settings
+    from backend.tests.fixtures.account_deletion_fakes import NoTombstoneGate
     from backend.turn_execution import TurnExecutionConfig
 
     engine = ChatConversationEngine()
@@ -90,6 +91,7 @@ def client_app(mock_external_dependencies):
         ),
         turn_config=TurnExecutionConfig.defaults(),
         health_checks=HealthRegistry(),
+        account_deletion_service=NoTombstoneGate(),
     )
     app = main.create_app(settings=settings, dependencies=deps)
     return TestClient(app)

--- a/backend/tests/test_chat_admission.py
+++ b/backend/tests/test_chat_admission.py
@@ -56,7 +56,7 @@ class FakeEngine:
         self.error = None
 
     async def process_turn(
-        self, user_id, message, request_id, *, budget=None, mode=None, correlation=None
+        self, user_id, message, request_id, *, budget=None, mode=None, correlation=None, account_deletion_user_ref=None
     ):
         self.calls.append(
             {

--- a/backend/tests/test_chat_admission.py
+++ b/backend/tests/test_chat_admission.py
@@ -77,6 +77,7 @@ def _build_app(fake_engine, *, override_auth=True):
     """Build an application with injected fakes (no lifespan needed)."""
     from backend.health import HealthRegistry
     from backend.settings import AppEnvironment, Settings
+    from backend.tests.fixtures.account_deletion_fakes import NoTombstoneGate
     from backend.turn_execution import TurnExecutionConfig
 
     settings = Settings(
@@ -91,6 +92,7 @@ def _build_app(fake_engine, *, override_auth=True):
         admission_config=AdmissionRuntimeConfig.from_values(SECRET),
         turn_config=TurnExecutionConfig.defaults(),
         health_checks=HealthRegistry(),
+        account_deletion_service=NoTombstoneGate(),
     )
     app = main.create_app(settings=settings, dependencies=deps)
     if override_auth:

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -21,6 +21,7 @@ from backend.emotion_presentation import EmotionStateResponse
 from backend.health import HealthRegistry
 from backend.process_turn import ProcessTurnResult, TurnMode
 from backend.settings import AppEnvironment, Settings
+from backend.tests.fixtures.account_deletion_fakes import NoTombstoneGate
 from backend.turn_execution import (
     DeadlineExceeded,
     TurnErrorCode,
@@ -134,6 +135,7 @@ def endpoint(monkeypatch):
         turn_config=TurnExecutionConfig.defaults(),
         health_checks=HealthRegistry(),
         clock=__import__("time").time,
+        account_deletion_service=NoTombstoneGate(),
     )
     app = main_module.create_app(settings=_settings(), dependencies=deps)
     client = TestClient(app)

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -85,7 +85,7 @@ class FakeEngine:
         self.result = _turn_result()
 
     async def process_turn(
-        self, user_id, message, request_id, *, budget=None, mode=None, correlation=None
+        self, user_id, message, request_id, *, budget=None, mode=None, correlation=None, account_deletion_user_ref=None
     ):
         self.calls.append(
             {

--- a/backend/tests/test_privacy_api.py
+++ b/backend/tests/test_privacy_api.py
@@ -237,7 +237,7 @@ class _FakeChatEngine:
         self.turn_calls = []
 
     async def process_turn(
-        self, user_id, message, request_id, *, budget=None, mode=None, correlation=None
+        self, user_id, message, request_id, *, budget=None, mode=None, correlation=None, account_deletion_user_ref=None
     ):
         self.turn_calls.append((user_id, message, request_id))
         return ProcessTurnResult(

--- a/backend/tests/test_privacy_api.py
+++ b/backend/tests/test_privacy_api.py
@@ -259,7 +259,10 @@ def _make_app(
     auth_user_id: str = "user-123",
     persistence=None,
     engine=None,
+    account_deletion_service=None,
 ):
+    from backend.tests.fixtures.account_deletion_fakes import NoTombstoneGate
+
     settings = _settings()
     deps = main_module.ApplicationDependencies(
         conversation_engine=engine if engine is not None else FakeEngine(supabase=object()),
@@ -270,6 +273,11 @@ def _make_app(
         clock=time.time,
         persistence_client=persistence,
         privacy_service=service,
+        account_deletion_service=(
+            account_deletion_service
+            if account_deletion_service is not None
+            else NoTombstoneGate()
+        ),
     )
     return main_module.create_app(settings=settings, dependencies=deps)
 
@@ -976,7 +984,7 @@ def test_sentinels_never_reach_logs_or_responses(caplog):
 
 def test_no_route_uses_background_tasks():
     app = _make_app(service=RecordingPrivacyService(result=_result(OPERATION_DELETE_HISTORY)))
-    for path in PATHS.values():
+    for path in [*PATHS.values(), "/privacy/delete-account"]:
         route = next(r for r in app.routes if getattr(r, "path", None) == path)
         calls = [d.call for d in route.dependant.dependencies if d.call is not None]
         assert BackgroundTasks not in calls, f"{path} must not use BackgroundTasks"

--- a/backend/tests/test_privacy_api_integration.py
+++ b/backend/tests/test_privacy_api_integration.py
@@ -133,11 +133,20 @@ def app_client(
     supabase_url: str, service_role_key: str
 ) -> tuple[TestClient, Client]:
     """The real FastAPI application wired to the local Supabase instance."""
+    from backend.account_deletion import SupabaseAccountDeletionRepository
+    from backend.account_deletion_service import AccountDeletionService
+
     client = create_client(supabase_url, service_role_key)
     privacy_service = PrivacyService(
         repository=SupabasePrivacyRepository(client),
         turn_config=TurnExecutionConfig.defaults(),
         clock=time.time,
+    )
+    admission_config = AdmissionRuntimeConfig.from_values(SECRET)
+    account_deletion_service = AccountDeletionService(
+        repository=SupabaseAccountDeletionRepository(client),
+        turn_config=TurnExecutionConfig.defaults(),
+        admission_config=admission_config,
     )
     settings = Settings(
         app_env=AppEnvironment.local,
@@ -148,12 +157,13 @@ def app_client(
     deps = ApplicationDependencies(
         conversation_engine=_FakeEngine(),
         auth_client=client,
-        admission_config=AdmissionRuntimeConfig.from_values(SECRET),
+        admission_config=admission_config,
         turn_config=TurnExecutionConfig.defaults(),
         health_checks=HealthRegistry(),
         clock=time.time,
         persistence_client=client,
         privacy_service=privacy_service,
+        account_deletion_service=account_deletion_service,
     )
     app = create_app(settings=settings, dependencies=deps)
     yield TestClient(app), client

--- a/backend/turn_repositories.py
+++ b/backend/turn_repositories.py
@@ -30,6 +30,7 @@ from .atomic_turn_commit import (
     ConflictError,
     PersistenceError,
     ValidationError,
+    _HEX64_RE,
     _parse_error_envelope,
     _validate_lease_owner,
     commit_turn,
@@ -184,6 +185,16 @@ class TurnCommitRepository:
         lease_owner = kwargs.get("lease_owner")
         if lease_owner is not None:
             _validate_lease_owner(lease_owner)
+
+        # The optional account-deletion barrier reference (#329) must be the
+        # exact server-derived HMAC format (never the raw user_id).
+        user_ref = kwargs.get("account_deletion_user_ref")
+        if user_ref is not None:
+            if not isinstance(user_ref, str) or not _HEX64_RE.fullmatch(user_ref):
+                raise ValidationError(
+                    "invalid_account_deletion_user_ref",
+                    "account_deletion_user_ref must be 64 lowercase hex characters",
+                )
 
         async def _rpc_client(name: str, params: Mapping[str, Any]) -> Mapping[str, Any]:
             response = client.rpc(name, dict(params)).execute()

--- a/docs/operations/account-deletion-api.md
+++ b/docs/operations/account-deletion-api.md
@@ -1,0 +1,137 @@
+# Account Deletion API and Tombstone Gate (#326)
+
+## Purpose
+
+`POST /privacy/delete-account` exposes the durable #324 account deletion
+ledger to an authenticated user and registers the deletion job the #325
+worker executes (PostgreSQL purge, then Supabase Auth Admin hard delete).
+From the moment a tombstone exists, **every normal account action is
+blocked** by a single fail-closed gate, even when an already-issued JWT is
+still accepted by the Auth service.
+
+```text
+authenticated request
+    ↓
+identity = current_user.id  (ONLY source of identity)
+    ↓
+server derives user_ref (HMAC-SHA256, dedicated account-deletion domain)
+    ↓
+server derives deterministic delete_account intent fingerprint
+    ↓
+account_deletion_request RPC -> durable job (tombstone) [idempotent replay]
+    ↓
+public response: {"status": "accepted"}  (or "completed" only when the
+                                             ledger confirms it)
+```
+
+## Endpoint contract
+
+### `POST /privacy/delete-account`
+
+Authenticated with a Bearer token (`get_current_user`). The request body
+accepts **only** `operation_id` (any canonical UUID, normalized to lowercase):
+
+```json
+{"operation_id": "11111111-1111-1111-1111-111111111111"}
+```
+
+Responses:
+
+| HTTP | Body | Meaning |
+| --- | --- | --- |
+| 200 | `{"status": "accepted"}` | Job created or exact replay; deletion pending/in progress. |
+| 200 | `{"status": "completed"}` | Only when the ledger confirms completion (finalized with `db_purged_at`). |
+| 401 | — | Missing/invalid credentials. |
+| 409 | `{"detail": {"code": "operation_conflict", ...}}` | Same `operation_id` reused with a divergent intent. |
+| 422 | `{"detail": {"code": "invalid_request", ...}}` | Extra keys (`user_id`, `user_ref`, `job_id`, HMACs, ...) or invalid `operation_id`. No RPC runs. |
+| 503 | `{"detail": {"code": "service_unavailable", ...}}` | Persistence/store unavailable. |
+
+The public response never contains `user_id`, `user_ref`, `operation_id`,
+`job_id`, HMACs, internal timestamps, upstream errors or SQL. The same
+user + `operation_id` + intent is an exact ledger replay and never creates
+a second job.
+
+## Tombstone gate (fail-closed)
+
+Every normal route applies the gate through **one** helper in
+`backend/main.py` (`_enforce_account_deletion_gate`) immediately after
+authentication and **before any useful work**:
+
+* `/chat` — before `reserve_admission_sync`, state/history reads,
+  embeddings, provider/Groq calls, `engine.process_turn` and any turn
+  write.
+* `/history` — before any `chat_logs` query.
+* `POST /privacy/delete-history`, `POST /privacy/delete-memories`,
+  `POST /privacy/reset-emotional-state`,
+  `POST /privacy/reset-relationship` — before any mutation.
+
+A present tombstone (status `pending`, `processing`, `failed`, or
+`completed` while the row still exists within the retention horizon)
+returns **423**:
+
+```json
+{"detail": {"code": "account_deletion_pending", "message": "Account deletion is pending."}}
+```
+
+If the tombstone store cannot be consulted (persistence failure, timeout,
+malformed payload, unavailable store, missing service), the route returns
+a sanitized **503** and never continues. A tombstone-store failure is
+never interpreted as "user active".
+
+The gate relies on the **server-side reference**: it recomputes the HMAC
+from `current_user.id` with the same admission secret under the dedicated
+`account-deletion` domain, so an old JWT cannot bypass the block by
+presenting a different identity or reference.
+
+### Exception
+
+`POST /privacy/delete-account` itself is **not** gated: it must stay
+reachable with base authentication so an idempotent replay keeps working
+while the token is still accepted.
+
+## Idempotency and honesty
+
+* The #324 SQL RPC `account_deletion_request` returns `created` on the
+  first call and `replay` for the same `(user_ref, operation_id,
+  fingerprint)`; a divergent fingerprint returns a sanitized
+  `operation_conflict`.
+* The API returns `accepted` for created/replayed non-completed jobs and
+  `completed` **only** when the ledger reports `completed` with a
+  persisted `db_purged_at`. The API never promises completion before the
+  #325 worker finishes.
+* `operation_conflict` maps to HTTP 409 with a constant public message.
+
+## Security properties
+
+* Identity comes **only** from `current_user.id` (authenticated). No
+  `user_id`, `user_ref`, HMAC, `job_id` or extra key is accepted from the
+  body/query/path/headers (422 before any RPC).
+* The HMAC reference uses the existing server-side admission secret through
+  `compute_account_deletion_user_ref` (dedicated `account-deletion` HMAC
+  domain). No new secret and no new client are introduced.
+* The intent fingerprint is deterministic: a constant `delete_account`
+  payload with no user data.
+* The default composition reuses the existing Supabase client
+  (`ApplicationDependencies.account_deletion_service`); no per-request or
+  second Supabase client is created, and no user state lives in the
+  container.
+* Observability uses constant, low-cardinality events
+  (`account_deletion_requested`, `account_deletion_blocked`,
+  `account_deletion_gate_unavailable`) and never logs ids, HMACs, tokens,
+  payloads, SQL or upstream exception text.
+* `/live` and `/ready` are unchanged: the gate reuses the existing
+  Supabase/persistence component, so no new readiness dependency exists.
+
+## Related files
+
+* `backend/account_deletion_service.py` — stateless service, public
+  projection and the single `assert_active` gate boundary.
+* `backend/main.py` — `POST /privacy/delete-account`, the centralized
+  `_enforce_account_deletion_gate` helper, and gate integration in
+  `/chat`, `/history` and the four privacy actions.
+* `backend/dependencies.py` — default composition
+  (`SupabaseAccountDeletionRepository` over the existing client).
+* `backend/account_deletion.py` — #324 ledger contract.
+* `backend/account_deletion_worker.py` / `backend/account_deletion_cli.py`
+  — #325 durable executor (unchanged).
+* `docs/operations/account-deletion-worker.md` — worker runbook.

--- a/supabase/migrations/20260820140000_account_deletion_commit_barrier.sql
+++ b/supabase/migrations/20260820140000_account_deletion_commit_barrier.sql
@@ -1,0 +1,813 @@
+-- ============================================================================
+-- Account deletion commit barrier (#329).
+-- ============================================================================
+-- Closes the TOCTOU window between the #326 HTTP tombstone preflight and the
+-- transactional turn commit: a /chat request that passed the HTTP gate
+-- BEFORE an account deletion request was accepted can still reach the
+-- commit_turn boundary afterwards. The HTTP gate is fail-fast only; the
+-- authoritative invariant lives at the transactional boundary, under the
+-- SAME per-user advisory lock used by account_deletion_request and the
+-- purge (pg_advisory_xact_lock(hashtextextended(user_id, 0))).
+--
+-- Shape
+-- =====
+--   1. account_deletion_commit_barrier(p_user_ref_hmac_sha256)
+--      A read-only helper (no lock needed: it runs INSIDE the caller's
+--      transaction while the caller already holds the per-user advisory
+--      xact lock, so the check and the writes execute as one serialized
+--      unit). The lookup is by the server-derived HMAC reference ONLY, so
+--      it remains authoritative AFTER finalize (when user_id is minimized
+--      to NULL).
+--   2. commit_turn gains an OPTIONAL p_account_deletion_user_ref text
+--      parameter (DEFAULT NULL). The validation, the writes and the
+--      failure semantics are byte-identical to the historical contract;
+--      existing callers pass nothing and behave exactly as before (no new
+--      dependency, no runtime cost for unrelated users, no migration
+--      history rewritten). When present, the barrier runs immediately
+--      after the advisory lock is acquired and BEFORE any write, and a
+--      blocking tombstone short-circuits the commit with a sanitized
+--      account_deletion_pending conflict envelope: no profile is created
+--      or updated, no chat_logs, turn_requests or outbox_events are
+--      written.
+--
+-- Post-finalize correctness
+-- =========================
+-- The ledger keeps reporting the tombstone through retention: after
+-- purge/finalize the job stays in account_deletion_jobs with user_id NULL,
+-- keyed solely by user_ref_hmac_sha256. The barrier query uses the same
+-- identity column, so a commit attempt after purge, finalize or any later
+-- stage is blocked identically to a commit attempt during
+-- pending/processing/failed. There is no bypass through minimization.
+--
+-- Fail-closed
+-- ===========
+--   * An invalid (NULL, malformed, or non-hex) reference never reads as
+--     "user active": a server bug in the derivation surfaces as the
+--     standard sanitized persistence error and rolls the whole commit
+--     transaction back.
+--   * Any unexpected persistence failure inside the barrier propagates as
+--     the standard sanitized persistence error (same rollback semantics).
+--   * No tombstone -> the commit proceeds exactly as before.
+
+-- =================================================================
+-- 0. PREFLIGHT: fail closed on missing dependencies
+-- =================================================================
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public'
+          AND p.proname = 'account_deletion_has_tombstone'
+    ) THEN
+        RAISE EXCEPTION 'Cannot apply account deletion commit barrier: account_deletion_has_tombstone is missing (unexpected drift)'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'account_deletion_jobs'
+    ) THEN
+        RAISE EXCEPTION 'Cannot apply account deletion commit barrier: account_deletion_jobs is missing (unexpected drift)'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public'
+          AND p.proname = 'commit_turn'
+    ) THEN
+        RAISE EXCEPTION 'Cannot apply account deletion commit barrier: commit_turn is missing (unexpected drift)'
+            USING ERRCODE = '23514';
+    END IF;
+END;
+$$;
+
+-- =================================================================
+-- 1. account_deletion_commit_barrier
+-- =================================================================
+-- Read-only barrier check. Must be called while the caller already holds
+-- the same per-user advisory xact lock as account_deletion_request (which
+-- commit_turn acquires before any write). Reports whether a blocking
+-- tombstone exists for the server-derived reference. The lookup column is
+-- the persistent HMAC reference, NOT the raw user_id, so the check stays
+-- authoritative after finalize minimizes user_id to NULL.
+CREATE OR REPLACE FUNCTION public.account_deletion_commit_barrier(
+    p_user_ref_hmac_sha256 text
+) RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+PARALLEL UNSAFE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_exists boolean;
+BEGIN
+    IF p_user_ref_hmac_sha256 IS NULL
+       OR p_user_ref_hmac_sha256 !~ '^[0-9a-f]{64}$' THEN
+        RAISE EXCEPTION 'persistence error' USING ERRCODE = 'P0001';
+    END IF;
+
+    SELECT EXISTS (
+        SELECT 1
+        FROM public.account_deletion_jobs
+        WHERE user_ref_hmac_sha256 = p_user_ref_hmac_sha256
+    ) INTO v_exists;
+
+    IF v_exists THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'account_deletion_pending',
+                'message', 'Account deletion is pending.'
+            )
+        );
+    END IF;
+    RETURN jsonb_build_object('blocked', false);
+EXCEPTION
+    WHEN OTHERS THEN
+        -- Fail closed: every barrier anomaly surfaces as the standard
+        -- sanitized persistence error, rolling the caller's transaction
+        -- back (no writes ever happen).
+        RAISE EXCEPTION 'persistence error' USING ERRCODE = 'P0001';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.account_deletion_commit_barrier(text)
+    FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.account_deletion_commit_barrier(text)
+    TO service_role;
+
+-- =================================================================
+-- 2. commit_turn: optional commit-side deletion barrier
+-- =================================================================
+-- Aditive change to the existing commit_turn RPC via a new optional
+-- parameter (p_account_deletion_user_ref text DEFAULT NULL). The function
+-- body, validation, write order, CAS, reclaim and failure semantics are
+-- copied byte-for-byte from the historical contract so existing callers
+-- keep identical behavior and the existing grants stay valid (grants are
+-- re-applied against the new signature).
+--
+-- When the derivation parameter is provided, the barrier runs inside the
+-- SAME transaction, immediately after the per-user advisory lock is
+-- acquired (the same lock as account_deletion_request / the purge) and
+-- BEFORE any write path. A blocking tombstone short-circuits the commit
+-- with a sanitized account_deletion_pending conflict envelope: no profile
+-- is created or updated, no chat_logs, turn_requests or outbox_events are
+-- written, and the transaction ends via the normal RETURN path (no
+-- exception), keeping the commit contract unchanged.
+CREATE OR REPLACE FUNCTION public.commit_turn(
+    p_authenticated_user_id text,
+    p_request_id uuid,
+    p_expected_revision bigint,
+    p_user_message text,
+    p_assistant_message text,
+    p_payload_hash_sha256 text,
+    p_emotional_state jsonb,
+    p_relationship_state jsonb,
+    p_public_response text,
+    p_replay_payload jsonb,
+    p_outbox_events jsonb DEFAULT '[]'::jsonb,
+    p_lease_owner text DEFAULT NULL,
+    p_account_deletion_user_ref text DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    -- Profile state
+    v_profile_exists boolean;
+    v_current_revision bigint;
+    v_new_revision bigint;
+    v_profile_user_id text;
+
+    -- Request state
+    v_request_exists boolean;
+    v_existing_payload_hash text;
+    v_existing_status text;
+    v_existing_committed_revision bigint;
+    v_existing_replay_payload jsonb;
+    v_existing_created_at timestamptz;
+    v_existing_completed_at timestamptz;
+    v_existing_lease_owner text;
+    v_existing_lease_expires_at timestamptz;
+    v_turn_request_id uuid;
+    v_existing_turn_request_id uuid;
+    v_reclaim_updated uuid;
+
+    -- Message IDs
+    v_user_message_id bigint;
+    v_assistant_message_id bigint;
+
+    -- Result building
+    v_result jsonb;
+
+    -- Timestamp
+    v_now timestamptz := timezone('utc'::text, now());
+
+    -- Loop counters
+    v_i integer;
+    v_outbox_count integer;
+
+    -- Temporary variables for outbox processing
+    v_event_obj jsonb;
+    v_event_type text;
+    v_event_payload jsonb;
+    v_event_idempotency_key text;
+
+    -- Replay payload forbidden keys (prompts / internal instructions)
+    v_replay_forbidden text[] := ARRAY[
+        'prompt', 'system_prompt', 'meta_cognition',
+        'internal_instructions', 'message', 'user_message',
+        'assistant_message', 'content'
+    ];
+BEGIN
+    -- =============================================================
+    -- Step 0: Input validation (fail fast, stable envelopes)
+    -- =============================================================
+
+    IF p_authenticated_user_id IS NULL OR p_authenticated_user_id = '' THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'authenticated_user_id is required'
+            )
+        );
+    END IF;
+    IF p_request_id IS NULL THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'request_id is required'
+            )
+        );
+    END IF;
+    IF p_expected_revision IS NULL OR p_expected_revision < 0 THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'expected_revision must be non-negative'
+            )
+        );
+    END IF;
+    IF p_user_message IS NULL THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'user_message is required'
+            )
+        );
+    END IF;
+    IF p_assistant_message IS NULL THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'assistant_message is required'
+            )
+        );
+    END IF;
+    IF p_payload_hash_sha256 IS NULL OR NOT (p_payload_hash_sha256 ~ '^[0-9a-f]{64}$') THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'payload_hash_sha256 must be a 64-character hex string'
+            )
+        );
+    END IF;
+    -- replay_payload is the authoritative public result. It MUST be a JSON
+    -- object containing response (== p_public_response) and message_id (the
+    -- public identifier returned as assistant_message_id).
+    IF p_replay_payload IS NULL OR jsonb_typeof(p_replay_payload) <> 'object' THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'replay_payload must be a JSON object'
+            )
+        );
+    END IF;
+    IF NOT public.jsonb_keys_subset_of(
+        p_replay_payload,
+        ARRAY['response', 'emotion_state', 'message_id', 'request_id', 'duration_ms']
+    ) THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'replay_payload has invalid keys'
+            )
+        );
+    END IF;
+    IF public.jsonb_has_forbidden_key(p_replay_payload, v_replay_forbidden) THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'replay_payload contains forbidden keys'
+            )
+        );
+    END IF;
+    IF jsonb_typeof(p_replay_payload->'response') <> 'string'
+       OR (p_replay_payload->>'response') IS NULL THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'replay_payload must contain response'
+            )
+        );
+    END IF;
+    IF p_replay_payload ? 'request_id'
+       AND (
+           jsonb_typeof(p_replay_payload->'request_id') <> 'string'
+           OR (p_replay_payload->>'request_id') !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+           OR (p_replay_payload->>'request_id') <> p_request_id::text
+       ) THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'replay_payload.request_id must equal request_id'
+            )
+        );
+    END IF;
+    -- Single authoritative source for the public response: p_public_response
+    -- must be byte-equal to the persisted replay_payload.response.
+    IF p_public_response IS NULL OR p_public_response <> (p_replay_payload->>'response') THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'public_response must equal replay_payload.response'
+            )
+        );
+    END IF;
+    IF (p_replay_payload->>'message_id') IS NULL
+       OR NOT ((p_replay_payload->>'message_id') ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$') THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'replay_payload.message_id must be a valid UUID'
+            )
+        );
+    END IF;
+    IF octet_length(p_replay_payload::text) > 8192 THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'replay_payload exceeds 8192 bytes'
+            )
+        );
+    END IF;
+    -- Snapshot validation (object with schema_version=1, no identity/internal
+    -- keys, fundamental structure present, size-bounded).
+    IF NOT public.jsonb_snapshot_contract(p_emotional_state, 'emotional') THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'emotional_state violates the snapshot contract'
+            )
+        );
+    END IF;
+    IF NOT public.jsonb_snapshot_contract(p_relationship_state, 'relationship') THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'relationship_state violates the snapshot contract'
+            )
+        );
+    END IF;
+    IF p_outbox_events IS NULL OR jsonb_typeof(p_outbox_events) <> 'array' THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'outbox_events must be a JSON array'
+            )
+        );
+    END IF;
+    -- Lease owner, when provided, must satisfy the sanitized identifier regex.
+    IF p_lease_owner IS NOT NULL
+       AND NOT (p_lease_owner ~ '^[A-Za-z0-9_.:-]{1,64}$') THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'lease_owner is invalid'
+            )
+        );
+    END IF;
+    -- Account deletion barrier reference, when provided, must be the exact
+    -- server-derived HMAC format (never the raw user_id).
+    IF p_account_deletion_user_ref IS NOT NULL
+       AND NOT (p_account_deletion_user_ref ~ '^[0-9a-f]{64}$') THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'validation_failed',
+                'message', 'account_deletion_user_ref must be 64 lowercase hex characters'
+            )
+        );
+    END IF;
+    -- Outbox events validation (shape, types, keys, value contract).
+    v_outbox_count := jsonb_array_length(p_outbox_events);
+    FOR v_i IN 1..v_outbox_count LOOP
+        v_event_obj := p_outbox_events->(v_i-1);
+        IF v_event_obj IS NULL OR jsonb_typeof(v_event_obj) <> 'object' THEN
+            RETURN jsonb_build_object(
+                'error', jsonb_build_object(
+                    'code', 'validation_failed',
+                    'message', 'outbox event must be a JSON object'
+                )
+            );
+        END IF;
+        v_event_type := v_event_obj->>'event_type';
+        v_event_payload := v_event_obj->'payload';
+        v_event_idempotency_key := v_event_obj->>'idempotency_key';
+        IF v_event_type IS NULL OR NOT (v_event_type ~ '^[a-z0-9_]{1,64}$') THEN
+            RETURN jsonb_build_object(
+                'error', jsonb_build_object(
+                    'code', 'validation_failed',
+                    'message', 'outbox event_type is invalid'
+                )
+            );
+        END IF;
+        IF v_event_payload IS NULL OR jsonb_typeof(v_event_payload) <> 'object' THEN
+            RETURN jsonb_build_object(
+                'error', jsonb_build_object(
+                    'code', 'validation_failed',
+                    'message', 'outbox event payload must be a JSON object'
+                )
+            );
+        END IF;
+        IF NOT public.jsonb_keys_subset_of(
+            v_event_payload,
+            ARRAY['ref', 'request_id', 'turn_id', 'message_id', 'entity_id', 'kind', 'version']
+        ) THEN
+            RETURN jsonb_build_object(
+                'error', jsonb_build_object(
+                    'code', 'validation_failed',
+                    'message', 'outbox event payload has invalid keys'
+                )
+            );
+        END IF;
+        IF public.jsonb_has_forbidden_key(v_event_payload, v_replay_forbidden) THEN
+            RETURN jsonb_build_object(
+                'error', jsonb_build_object(
+                    'code', 'validation_failed',
+                    'message', 'outbox event payload contains forbidden keys'
+                )
+            );
+        END IF;
+        IF NOT public.jsonb_outbox_payload_value_contract(v_event_payload) THEN
+            RETURN jsonb_build_object(
+                'error', jsonb_build_object(
+                    'code', 'validation_failed',
+                    'message', 'outbox event payload violates the value contract'
+                )
+            );
+        END IF;
+        IF v_event_idempotency_key IS NULL
+           OR NOT (v_event_idempotency_key ~ '^[A-Za-z0-9_.:-]{1,128}$') THEN
+            RETURN jsonb_build_object(
+                'error', jsonb_build_object(
+                    'code', 'validation_failed',
+                    'message', 'outbox idempotency_key is invalid'
+                )
+            );
+        END IF;
+    END LOOP;
+
+    -- =============================================================
+    -- Step 1: Acquire per-user lock (64-bit advisory key)
+    -- =============================================================
+    -- hashtextextended returns a bigint (64-bit) key, avoiding the 32-bit
+    -- hashtext collision space. Different users (almost surely) map to
+    -- different keys, so distinct users are never globally serialized.
+    PERFORM pg_advisory_xact_lock(hashtextextended(p_authenticated_user_id, 0));
+
+    -- =============================================================
+    -- Step 1b: Account deletion commit barrier (optional, fail-closed)
+    -- =============================================================
+    -- Authoritative, race-safe boundary: the advisory lock acquired above
+    -- is the SAME per-user lock held by account_deletion_request and the
+    -- deletion purge, so the tombstone check and the writes below execute
+    -- as one serialized unit under the lock. The lookup uses the
+    -- server-derived HMAC reference only (never the raw user_id), so the
+    -- check remains authoritative after finalize minimizes user_id to
+    -- NULL. A blocking tombstone short-circuits the commit BEFORE any
+    -- write: no profile, chat_logs, turn_requests or outbox_events rows
+    -- are created or modified, and no exception is raised (the normal
+    -- RETURN path ends the transaction cleanly).
+    IF p_account_deletion_user_ref IS NOT NULL THEN
+        BEGIN
+            SELECT public.account_deletion_commit_barrier(p_account_deletion_user_ref)
+            INTO v_result;
+        EXCEPTION
+            WHEN OTHERS THEN
+                -- Fail closed: any barrier anomaly rolls the whole
+                -- transaction back (no writes ever happen).
+                RAISE EXCEPTION 'persistence error' USING ERRCODE = 'P0001';
+        END;
+        IF v_result ? 'error'
+           AND (v_result->'error'->>'code') = 'account_deletion_pending' THEN
+            RETURN jsonb_build_object(
+                'error', jsonb_build_object(
+                    'code', 'account_deletion_pending',
+                    'message', 'Account deletion is pending.'
+                )
+            );
+        END IF;
+    END IF;
+
+    -- =============================================================
+    -- Step 2: Check existing profile and get current revision
+    -- =============================================================
+    SELECT user_id, revision INTO v_profile_user_id, v_current_revision
+    FROM public.profiles
+    WHERE user_id = p_authenticated_user_id
+    FOR UPDATE;
+
+    v_profile_exists := (v_profile_user_id IS NOT NULL);
+
+    IF NOT v_profile_exists THEN
+        v_current_revision := 0;
+    END IF;
+
+    -- =============================================================
+    -- Step 3: Check for existing request with same (user_id, request_id)
+    -- MUST run BEFORE CAS so exact replays and lease reclaims work
+    -- =============================================================
+    SELECT EXISTS (
+        SELECT 1 FROM public.turn_requests
+        WHERE user_id = p_authenticated_user_id AND request_id = p_request_id
+    ) INTO v_request_exists;
+
+    IF v_request_exists THEN
+        SELECT
+            id,
+            payload_hash_sha256,
+            status,
+            committed_revision,
+            replay_payload,
+            created_at,
+            completed_at,
+            lease_owner,
+            lease_expires_at
+        INTO
+            v_existing_turn_request_id,
+            v_existing_payload_hash,
+            v_existing_status,
+            v_existing_committed_revision,
+            v_existing_replay_payload,
+            v_existing_created_at,
+            v_existing_completed_at,
+            v_existing_lease_owner,
+            v_existing_lease_expires_at
+        FROM public.turn_requests
+        WHERE user_id = p_authenticated_user_id AND request_id = p_request_id;
+
+        -- Any status + different hash: ALWAYS a payload conflict. Reclaim is
+        -- only ever allowed for the SAME hash.
+        IF v_existing_payload_hash <> p_payload_hash_sha256 THEN
+            RETURN jsonb_build_object(
+                'error', jsonb_build_object(
+                    'code', 'request_payload_conflict',
+                    'message', 'Request ID already exists with a different payload hash',
+                    'expected_revision', p_expected_revision,
+                    'request_id', p_request_id::text
+                )
+            );
+        END IF;
+
+        -- completed + same hash: idempotent replay WITHOUT any writes.
+        IF v_existing_status = 'completed' THEN
+            RETURN public.commit_turn_build_result(p_authenticated_user_id, p_request_id);
+        END IF;
+
+        -- pending/expired + same hash: lease / reclaim semantics.
+        IF v_existing_status = 'pending'
+           AND v_existing_lease_expires_at IS NOT NULL
+           AND v_existing_lease_expires_at > v_now
+           AND (p_lease_owner IS NULL OR v_existing_lease_owner <> p_lease_owner) THEN
+            -- Active lease owned by another worker: stable result.
+            RETURN jsonb_build_object(
+                'error', jsonb_build_object(
+                    'code', 'request_in_progress',
+                    'message', 'Request is already in progress by another worker',
+                    'expected_revision', p_expected_revision,
+                    'request_id', p_request_id::text
+                )
+            );
+        END IF;
+
+        -- Reclaim (expired lease or expired request) requires a lease owner.
+        IF p_lease_owner IS NULL THEN
+            RETURN jsonb_build_object(
+                'error', jsonb_build_object(
+                    'code', 'lease_conflict',
+                    'message', 'lease_owner is required to claim or reclaim a request',
+                    'expected_revision', p_expected_revision,
+                    'request_id', p_request_id::text
+                )
+            );
+        END IF;
+
+        -- Proceed: the atomic conditional UPDATE below is the reclaim.
+        v_turn_request_id := v_existing_turn_request_id;
+    END IF;
+
+    -- =============================================================
+    -- Step 4: Validate CAS: expected_revision must match current revision
+    -- Only applies to write paths (never to the completed replay above).
+    -- =============================================================
+    IF v_current_revision <> p_expected_revision THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'revision_mismatch',
+                'message', 'Profile revision does not match the expected value',
+                'expected_revision', p_expected_revision,
+                'actual_revision', v_current_revision
+            )
+        );
+    END IF;
+
+    -- =============================================================
+    -- Step 5: Update or create profile BEFORE inserting messages
+    -- (chat_logs.user_id references profiles, so the profile must
+    -- exist before any message row is written). Snapshots are applied
+    -- and revision is incremented exactly once here.
+    -- =============================================================
+    v_new_revision := v_current_revision + 1;
+
+    IF v_profile_exists THEN
+        UPDATE public.profiles
+        SET
+            emotional_state = COALESCE(p_emotional_state, emotional_state),
+            relationship_state = COALESCE(p_relationship_state, relationship_state),
+            revision = v_new_revision,
+            updated_at = v_now
+        WHERE user_id = p_authenticated_user_id;
+    ELSE
+        IF p_emotional_state IS NULL OR p_relationship_state IS NULL THEN
+            RETURN jsonb_build_object(
+                'error', jsonb_build_object(
+                    'code', 'validation_failed',
+                    'message', 'new profiles require complete v1 snapshots'
+                )
+            );
+        END IF;
+        INSERT INTO public.profiles (
+            user_id, persona_config, user_profile, relationship_state, emotional_state,
+            revision, updated_at
+        ) VALUES (
+            p_authenticated_user_id, NULL, NULL,
+            p_relationship_state,
+            p_emotional_state,
+            v_new_revision, v_now
+        );
+    END IF;
+
+    -- =============================================================
+    -- Step 6: Insert user message into chat_logs
+    -- =============================================================
+    INSERT INTO public.chat_logs (user_id, role, content, created_at)
+    VALUES (p_authenticated_user_id, 'user', p_user_message, v_now)
+    RETURNING id INTO v_user_message_id;
+
+    -- =============================================================
+    -- Step 7: Insert assistant message into chat_logs
+    -- =============================================================
+    INSERT INTO public.chat_logs (user_id, role, content, created_at)
+    VALUES (p_authenticated_user_id, 'assistant', p_assistant_message, v_now)
+    RETURNING id INTO v_assistant_message_id;
+
+    -- =============================================================
+    -- Step 8: Complete turn_requests
+    --   - New request: INSERT (status completed)
+    --   - pending/expired with same hash: ATOMIC conditional reclaim via
+    --     UPDATE ... WHERE ... RETURNING confirming id, user_id, request_id,
+    --     payload hash, expected status, lease ownership and lease expiry.
+    -- =============================================================
+    IF v_turn_request_id IS NOT NULL THEN
+        UPDATE public.turn_requests tr
+        SET
+            status = 'completed',
+            committed_revision = v_new_revision,
+            user_message_chat_log_id = v_user_message_id,
+            assistant_message_chat_log_id = v_assistant_message_id,
+            replay_payload = p_replay_payload,
+            updated_at = v_now,
+            completed_at = v_now,
+            error_code = NULL,
+            lease_owner = NULL,
+            lease_expires_at = NULL
+        WHERE tr.id = v_turn_request_id
+          AND tr.user_id = p_authenticated_user_id
+          AND tr.request_id = p_request_id
+          AND tr.payload_hash_sha256 = p_payload_hash_sha256
+          AND tr.status IN ('pending', 'expired')
+          AND (
+                -- pending with ACTIVE lease of the same worker: continue
+                (tr.status = 'pending'
+                 AND tr.lease_expires_at > v_now
+                 AND tr.lease_owner = p_lease_owner)
+                OR
+                -- pending with EXPIRED lease: reclaim
+                (tr.status = 'pending' AND tr.lease_expires_at <= v_now)
+                OR
+                -- expired request (no lease): reclaim
+                (tr.status = 'expired')
+          )
+        RETURNING tr.id INTO v_reclaim_updated;
+
+        IF v_reclaim_updated IS NULL THEN
+            -- The row changed between the SELECT and the UPDATE (or the lease
+            -- was re-taken): controlled conflict, never a payload rewrite.
+            RAISE EXCEPTION 'lease conflict' USING ERRCODE = 'P0002';
+        END IF;
+    ELSE
+        INSERT INTO public.turn_requests (
+            user_id, request_id, payload_hash_sha256, status,
+            expected_revision, committed_revision,
+            user_message_chat_log_id, assistant_message_chat_log_id,
+            replay_payload, created_at, updated_at, completed_at
+        ) VALUES (
+            p_authenticated_user_id, p_request_id, p_payload_hash_sha256, 'completed',
+            p_expected_revision, v_new_revision,
+            v_user_message_id, v_assistant_message_id,
+            p_replay_payload, v_now, v_now, v_now
+        ) RETURNING id INTO v_turn_request_id;
+    END IF;
+
+    -- =============================================================
+    -- Step 9: Insert outbox events (idempotent, FK to turn_request id)
+    -- =============================================================
+    v_outbox_count := jsonb_array_length(p_outbox_events);
+
+    FOR v_i IN 1..v_outbox_count LOOP
+        v_event_obj := p_outbox_events->(v_i-1);
+        v_event_type := v_event_obj->>'event_type';
+        v_event_payload := v_event_obj->'payload';
+        v_event_idempotency_key := v_event_obj->>'idempotency_key';
+
+        -- (Validated in Step 0; repeated defensively before insert.)
+        INSERT INTO public.outbox_events (
+            event_type, user_id, turn_request_id, payload, status,
+            attempts, next_attempt_at, idempotency_key,
+            contract_version, created_at, updated_at
+        ) VALUES (
+            v_event_type, p_authenticated_user_id, v_turn_request_id,
+            v_event_payload, 'pending',
+            0, v_now + INTERVAL '1 second', v_event_idempotency_key,
+            1, v_now, v_now
+        );
+    END LOOP;
+
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'id', e.id::text,
+                'event_type', e.event_type,
+                'idempotency_key', e.idempotency_key,
+                'turn_request_id', e.turn_request_id::text,
+                'contract_version', e.contract_version
+            ) ORDER BY e.id
+        ), '[]'::jsonb
+    ) INTO v_result
+    FROM public.outbox_events e
+    WHERE e.user_id = p_authenticated_user_id AND e.turn_request_id = v_turn_request_id;
+
+    UPDATE public.turn_requests
+    SET replay_outbox_refs = v_result
+    WHERE id = v_turn_request_id;
+
+    -- =============================================================
+    -- Step 10: Build and return the public result from PERSISTED rows
+    -- (identical to the replay path).
+    -- =============================================================
+    RETURN public.commit_turn_build_result(p_authenticated_user_id, p_request_id);
+
+EXCEPTION
+    WHEN SQLSTATE 'P0002' THEN
+        RETURN jsonb_build_object(
+            'error', jsonb_build_object(
+                'code', 'lease_conflict',
+                'message', 'Request state changed; reclaim failed',
+                'expected_revision', p_expected_revision,
+                'request_id', p_request_id::text
+            )
+        );
+    WHEN OTHERS THEN
+        -- Unexpected PostgreSQL failure. Never expose SQLERRM, SQLSTATE,
+        -- constraint names or payload; propagate a constant sanitized message
+        -- so the RPC fails (rollback is automatic) and the Python layer maps
+        -- it to PersistenceError.
+        RAISE EXCEPTION 'persistence error' USING ERRCODE = 'P0001';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.commit_turn(
+    text, uuid, bigint, text, text, text, jsonb, jsonb, text, jsonb, jsonb, text, text
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.commit_turn(
+    text, uuid, bigint, text, text, text, jsonb, jsonb, text, jsonb, jsonb, text, text
+) TO service_role;


### PR DESCRIPTION
Closes #326

## Issue / tarefa de origem

#326 — `P0: expor exclusão de conta autenticada e bloquear contas com tombstone`.

## Problema e causa raiz

A infraestrutura de exclusão durável entregue nas issues #324 (ledger/tombstone PostgreSQL, referência HMAC server-derived, idempotência por `operation_id`, RPCs privilegiadas) e #325 (worker DB-first, purge transacional, hard delete via Supabase Auth Admin, minimização do `user_id`) não possuía fronteira HTTP pública nem gate de bloqueio. Hoje rotas como `/chat` chegavam à admissão/engine e `/history` consultava `chat_logs` sem consultar o tombstone, permitindo que um token ainda aceito pelo Supabase Auth executasse ações normais durante ou após o início da exclusão.

## Solução e decisões tomadas

### `POST /privacy/delete-account`

- Input aceita **somente** `operation_id` (UUID canônico, `extra="forbid"`). Qualquer `user_id`, `user_ref`, `job_id`, HMAC ou chave extra produz 422 sem executar RPC.
- Identidade vem exclusivamente de `current_user.id`; a referência HMAC é derivada server-side com `compute_account_deletion_user_ref` (domínio dedicado `account-deletion`, reutilizando `admission_config.secret_bytes` — nenhum segredo novo).
- O fingerprint da intenção é determinístico (`{"op": "delete_account", "scope": ["db", "auth"]}`), sem dados variáveis.
- Resposta pública pequena e honesta: `{"status": "accepted"}` no primeiro request e em replay não-concluído; `{"status": "completed"}` somente quando o ledger confirma conclusão. `operation_conflict` → 409 sanitizado. Replay da mesma combinação usuário + `operation_id` + intenção não cria segundo job (contrato #324).

### Tombstone gate (fail-closed)

- **Uma única fronteira centralizada**: `AccountDeletionService.assert_active` (consulta `AccountDeletionRepository.has_tombstone`) chamada por um único helper em `backend/main.py` (`_enforce_account_deletion_gate`) — nenhuma cópia da lógica em endpoints.
- Aplica-se a `/chat` (antes de `reserve_admission_sync`, leituras de estado/histórico, embeddings, provider/Groq, `engine.process_turn` e qualquer write), `/history` (antes de qualquer leitura de `chat_logs`) e às quatro ações de privacidade existentes (antes da mutação).
- Tombstone presente (`pending`, `processing`, `failed` ou `completed` dentro do horizonte de retenção) → **423** `account_deletion_pending`. Falha da consulta (persistência, timeout, payload inválido, indisponibilidade, serviço ausente) → **503** sanitizado e a rota não continua — falha nunca é interpretada como "usuário ativo".
- O próprio `POST /privacy/delete-account` é **isento** do gate para preservar replay idempotente enquanto o token ainda é aceito.
- Segurança não depende da invalidação de JWT: mesmo que `get_current_user()` aceite um token antigo, o tombstone bloqueia ações normais.
- `/live` e `/ready` inalterados: o gate reutiliza o cliente Supabase/persistência existente, sem novo componente crítico.

### Composition root

- `ApplicationDependencies` ganhou `account_deletion_service` (padrão `None`, injetável). A composição default constrói `AccountDeletionService(SupabaseAccountDeletionRepository(supabase_client))` **reutilizando o cliente Supabase existente** (nenhum segundo cliente, nenhum cliente por request, nenhum cliente em import, nenhum estado de usuário no container).

## Arquivos / áreas afetadas

- `backend/account_deletion_service.py` (novo) — serviço stateless, projeção pública e fronteira única do gate.
- `backend/main.py` — endpoint `POST /privacy/delete-account`, helper centralizado do gate, integração em `/chat`, `/history` e nas quatro ações de privacidade.
- `backend/dependencies.py` — composition root (service + repositório sobre o cliente existente).
- `backend/observability.py` — eventos constantes `account_deletion_requested`, `account_deletion_blocked`, `account_deletion_gate_unavailable`.
- `backend/tests/fixtures/account_deletion_fakes.py` (novo) — fakes compartilhados (sem Supabase/Groq/embeddings).
- `backend/tests/test_account_deletion_api.py` (novo) — cobertura unitária do endpoint e do gate.
- `backend/tests/test_account_deletion_integration.py` — cenários HTTP reais contra o Supabase local (criação real do job, gate, replay, isolamento, 422 sem RPC).
- Helpers de testes existentes atualizados para injetar o gate fake.
- `docs/operations/account-deletion-api.md` (novo) — documentação HTTP/lifecycle mínima.

## Testes executados e resultado

- Suíte unitária backend (mesma exclusão de integração do CI): `2632 passed` em ~40s.
- Integração Supabase local `test_account_deletion_integration.py`: `28 passed` (26 pré-existentes + 2 novos HTTP).
- Integração `test_privacy_api_integration.py`: `6 passed` (contratos #315 preservados com o gate ativo).
- pgTAP: `Files=8, Tests=734 — Result: PASS`.
- `python -m compileall -q backend`: OK.

## Riscos, migração e rollback

- **Gate tarde demais**: mitigado — o gate roda imediatamente após a autenticação, antes de qualquer trabalho útil; teste unitário verifica que `reserve_admission_sync`/`engine.process_turn`/`chat_logs` não são alcançados em conta bloqueada.
- **Falha do tombstone store como "usuário ativo"**: fail-closed 503 com teste dedicado.
- **Vazamento de IDs/HMAC**: projeção pública mínima, eventos constantes e testes de sentinela (caplog/respostas).
- **Segundo cliente Supabase**: composition root reutiliza `engine.memory_manager.supabase`; teste unitário de composição verifica a mesma instância.
- **Regressão das quatro APIs de privacidade**: semântica preservada para usuários ativos (integração #315 verde); gate apenas bloqueia antes da mutação quando há tombstone.
- **Migração**: nenhuma migration nova — o contrato #324 existente é suficiente. Rollback: reverter o commit remove o endpoint e o gate; o ledger/worker #324/#325 permanecem intactos.

## Itens deliberadamente fora de escopo

- Frontend / #318, exportação #319, Storage cleanup, soft-delete/undo, redesign de autenticação, Redis/fila externa, mudanças no Emotional Core, mudanças em relacionamento/memória fora do gate, worker #325 (nenhuma alteração), migrations novas, refatorações oportunistas.
