### PR TITLE
feat(desktop): validar pywebview como shell desktop Linux da Katherine (#334)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ The project is divided into two main components:
    > **Production:** Use `python -m backend.serve` instead.
    > See [Production Containment](docs/operations/production-containment.md).
 
+### Desktop Shell (Linux)
+
+```bash
+python -m backend.desktop.app
+```
+
+Opens the production frontend build in a native GTK window (WebKitGTK)
+via `file://` — no HTTP server. See
+[Desktop Shell no Linux](docs/operations/desktop-shell-linux.md).
+
 ### Frontend
 
 1. Navigate to the `frontend` directory:

--- a/backend/desktop/__init__.py
+++ b/backend/desktop/__init__.py
@@ -1,0 +1,7 @@
+"""Desktop shell for Katherine (pywebview proof, #334).
+
+This package hosts the minimal Linux desktop shell used to validate
+pywebview as the desktop base. It contains no domain logic: the backend
+core remains importable and testable without a display, and importing
+anything here never opens a window by itself.
+"""

--- a/backend/desktop/api.py
+++ b/backend/desktop/api.py
@@ -1,14 +1,23 @@
-"""Minimal, allowlisted Desktop API exposed to the pywebview frontend (#334).
+"""Minimal, allowlisted Desktop bridge exposed to the pywebview frontend (#334).
 
 Design rules enforced here and covered by ``test_desktop_api.py``:
 
+* The object actually handed to pywebview's ``js_api`` is
+  :class:`DesktopBridge`, a *facade* over :class:`DesktopApi`. The facade
+  guarantees that **no exposed method ever raises**: every call returns
+  plain JSON-serializable data. pywebview (6.2.1) wraps uncaught
+  exceptions from ``js_api`` methods into a JavaScript ``Error`` carrying
+  ``message``/``name``/``stack``; the facade makes that path unreachable
+  by construction, returning sanitized structured payloads instead.
 * The exposed surface is an explicit allowlist (``DESKTOP_API_METHODS``).
   This proof deliberately exposes exactly one method: ``health()``.
-* Every method returns plain JSON-serializable data. Internal objects,
-  modules, settings, clients, or engines are never handed to JS.
-* Every method validates its input. Invalid input raises
-  :class:`DesktopApiError` carrying a *sanitized*, structured payload:
-  no tracebacks, no types, no paths, no environment details leak to the UI.
+  pywebview walks ``dir(obj)`` and exposes *every public attribute*, so
+  the facade keeps only allowlisted, bound wrappers public. Anything
+  else lives on ``DesktopApi`` (never passed to ``js_api``) or in module
+  functions.
+* Every method validates its input. Invalid input returns a *sanitized*,
+  structured payload: no tracebacks, no types, no paths, no environment
+  details leak to the UI.
 * The module is import-pure: no side effects, no environment reads, no
   pywebview import. Window concerns live in :mod:`backend.desktop.app`.
 """
@@ -29,12 +38,18 @@ DESKTOP_API_VERSION = 1
 _ERROR_INVALID_INPUT = "invalid_input"
 _ERROR_INTERNAL = "internal_error"
 
+#: Messages are deliberately generic and free of internal detail.
+_MSG_UNKNOWN_METHOD = "Unknown method."
+_MSG_INTERNAL = "The desktop bridge failed to complete the request."
+_MSG_UNEXPECTED_RESPONSE = "Unexpected bridge response."
+
 
 class DesktopApiError(Exception):
-    """Sanitized, structured error surfaced to the JS side.
+    """Sanitized, structured error condition inside the bridge.
 
-    The payload is the only thing the UI ever sees: ``code`` plus a
-    human-readable ``message`` that contains no internal detail.
+    Never crosses the JS boundary as an exception: the facade converts it
+    into its ``payload`` dict. The payload carries a stable ``code`` plus
+    a human-readable ``message`` that contains no internal detail.
     """
 
     def __init__(self, code: str, message: str) -> None:
@@ -43,12 +58,13 @@ class DesktopApiError(Exception):
 
 
 class DesktopApi:
-    """Explicit, allowlisted API object handed to pywebview's ``js_api``.
+    """Implementation of the allowlisted methods (no ``js_api`` sanitization).
 
-    pywebview exposes **every public attribute** of this object to
-    JavaScript, so the class must stay minimal by construction: anything
-    public becomes bridge surface. The tests assert the public surface
-    equals ``DESKTOP_API_METHODS`` exactly.
+    This class holds the actual behavior. It is deliberately *not* passed
+    to pywebview: methods may raise :class:`DesktopApiError` for invalid
+    input; the :class:`DesktopBridge` facade turns that into data.
+    Keeping implementation apart from the exposed facade also keeps the
+    ``js_api`` surface provably equal to ``DESKTOP_API_METHODS``.
     """
 
     def health(self, *args: Any) -> dict[str, Any]:
@@ -67,33 +83,63 @@ class DesktopApi:
         return {"ok": True, "api_version": DESKTOP_API_VERSION}
 
 
-def safe_call(api: DesktopApi, method_name: str, *args: Any) -> dict[str, Any]:
-    """Guard used by the shell layer to sanitize unexpected failures.
+class DesktopBridge:
+    """The object actually delivered to pywebview's ``js_api`` (#334).
 
-    Valid, allowlisted calls are forwarded. Unknown methods, invalid
-    arguments, and unexpected internal failures all become a sanitized,
-    structured error payload — never a traceback in the UI.
+    Hard boundary guarantees:
 
-    This stays in the module (not on the API object) precisely so it is
-    not exposed to JavaScript: pywebview only exposes public members of
-    the ``js_api`` instance.
+    * Only the allowlisted wrappers created in ``__init__`` are public
+      (and therefore exposed by pywebview's ``get_functions`` walk).
+    * Each wrapper can never raise: invalid input, unexpected internal
+      failures, and non-dict results all collapse into a sanitized,
+      structured error payload. pywebview's exception-to-JS-``Error``
+      path (which would carry ``stack``) is unreachable for this object.
+    * There is no generic dispatch: no ``__getattr__``, no
+      ``__call__``, no attribute passthrough. Calling an allowlisted
+      method with bad input returns data, never an exception.
     """
-    if method_name not in DESKTOP_API_METHODS or not hasattr(api, method_name):
-        return {"ok": False, "code": _ERROR_INVALID_INPUT, "message": "Unknown method."}
-    try:
-        result = getattr(api, method_name)(*args)
-    except DesktopApiError as err:
-        return err.payload
-    except Exception:  # noqa: BLE001 (boundary: never leak internals to JS)
-        return {
-            "ok": False,
-            "code": _ERROR_INTERNAL,
-            "message": "The desktop bridge failed to complete the request.",
+
+    def __init__(self, api: DesktopApi | None = None) -> None:
+        # Bind private wrappers; deliberately not using types.MethodType on
+        # module-level functions to keep them out of the public surface.
+        self._api = api if api is not None else DesktopApi()
+        self._handlers = {
+            "health": self._api.health,
         }
-    if not isinstance(result, dict):
-        return {
-            "ok": False,
-            "code": _ERROR_INTERNAL,
-            "message": "Unexpected bridge response.",
-        }
-    return result
+        # Sanity: the allowlist and the bound surface must match exactly,
+        # at construction time (fail fast in dev/test, never in JS).
+        if tuple(self._handlers) != DESKTOP_API_METHODS:
+            raise RuntimeError("desktop bridge surface out of sync")  # pragma: no cover
+
+    # -- allowlisted public surface (exposed to JS) ----------------------
+
+    def health(self, *args: Any) -> dict[str, Any]:
+        """Sanitized wrapper for ``DesktopApi.health``; never raises."""
+        return self._invoke("health", args)
+
+    # -- boundary internals (never exposed: underscore-prefixed) ---------
+
+    def _invoke(self, method: str, args: tuple[Any, ...]) -> dict[str, Any]:
+        handler = self._handlers.get(method)
+        if handler is None:
+            return {"ok": False, "code": _ERROR_INVALID_INPUT, "message": _MSG_UNKNOWN_METHOD}
+        try:
+            result = handler(*args)
+        except DesktopApiError as err:
+            return err.payload
+        except Exception:  # noqa: BLE001 (boundary: never leak internals to JS)
+            return {"ok": False, "code": _ERROR_INTERNAL, "message": _MSG_INTERNAL}
+        if not isinstance(result, dict):
+            return {"ok": False, "code": _ERROR_INTERNAL, "message": _MSG_UNEXPECTED_RESPONSE}
+        return result
+
+
+def make_js_api() -> DesktopBridge:
+    """Build the sanitized bridge object to pass as ``js_api=`` (#334).
+
+    This is the single construction path used by the shell entrypoint;
+    tests assert that ``run_desktop_shell`` hands exactly this kind of
+    object to pywebview, so the sanitized facade is the *real* boundary
+    (not an auxiliary helper disconnected from the exposed path).
+    """
+    return DesktopBridge(DesktopApi())

--- a/backend/desktop/api.py
+++ b/backend/desktop/api.py
@@ -1,0 +1,99 @@
+"""Minimal, allowlisted Desktop API exposed to the pywebview frontend (#334).
+
+Design rules enforced here and covered by ``test_desktop_api.py``:
+
+* The exposed surface is an explicit allowlist (``DESKTOP_API_METHODS``).
+  This proof deliberately exposes exactly one method: ``health()``.
+* Every method returns plain JSON-serializable data. Internal objects,
+  modules, settings, clients, or engines are never handed to JS.
+* Every method validates its input. Invalid input raises
+  :class:`DesktopApiError` carrying a *sanitized*, structured payload:
+  no tracebacks, no types, no paths, no environment details leak to the UI.
+* The module is import-pure: no side effects, no environment reads, no
+  pywebview import. Window concerns live in :mod:`backend.desktop.app`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: The one and only public surface of the desktop bridge for this proof.
+#: Adding a method here is a deliberate, reviewable decision.
+DESKTOP_API_METHODS: tuple[str, ...] = ("health",)
+
+#: Version of the desktop bridge contract. The frontend can feature-check
+#: against this single integer instead of sniffing for methods.
+DESKTOP_API_VERSION = 1
+
+#: Public error codes. Structured, stable, safe to show in the UI.
+_ERROR_INVALID_INPUT = "invalid_input"
+_ERROR_INTERNAL = "internal_error"
+
+
+class DesktopApiError(Exception):
+    """Sanitized, structured error surfaced to the JS side.
+
+    The payload is the only thing the UI ever sees: ``code`` plus a
+    human-readable ``message`` that contains no internal detail.
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.payload: dict[str, Any] = {"ok": False, "code": code, "message": message}
+
+
+class DesktopApi:
+    """Explicit, allowlisted API object handed to pywebview's ``js_api``.
+
+    pywebview exposes **every public attribute** of this object to
+    JavaScript, so the class must stay minimal by construction: anything
+    public becomes bridge surface. The tests assert the public surface
+    equals ``DESKTOP_API_METHODS`` exactly.
+    """
+
+    def health(self, *args: Any) -> dict[str, Any]:
+        """Round-trip proof of the JS ↔ Python bridge.
+
+        Returns a stable, structured payload so the frontend can verify
+        the bridge works without depending on any domain behavior.
+
+        Takes no arguments: stray JS-side arguments are rejected with a
+        sanitized ``invalid_input`` error instead of being ignored.
+        """
+        if args:
+            raise DesktopApiError(
+                _ERROR_INVALID_INPUT, "health() takes no arguments."
+            )
+        return {"ok": True, "api_version": DESKTOP_API_VERSION}
+
+
+def safe_call(api: DesktopApi, method_name: str, *args: Any) -> dict[str, Any]:
+    """Guard used by the shell layer to sanitize unexpected failures.
+
+    Valid, allowlisted calls are forwarded. Unknown methods, invalid
+    arguments, and unexpected internal failures all become a sanitized,
+    structured error payload — never a traceback in the UI.
+
+    This stays in the module (not on the API object) precisely so it is
+    not exposed to JavaScript: pywebview only exposes public members of
+    the ``js_api`` instance.
+    """
+    if method_name not in DESKTOP_API_METHODS or not hasattr(api, method_name):
+        return {"ok": False, "code": _ERROR_INVALID_INPUT, "message": "Unknown method."}
+    try:
+        result = getattr(api, method_name)(*args)
+    except DesktopApiError as err:
+        return err.payload
+    except Exception:  # noqa: BLE001 (boundary: never leak internals to JS)
+        return {
+            "ok": False,
+            "code": _ERROR_INTERNAL,
+            "message": "The desktop bridge failed to complete the request.",
+        }
+    if not isinstance(result, dict):
+        return {
+            "ok": False,
+            "code": _ERROR_INTERNAL,
+            "message": "Unexpected bridge response.",
+        }
+    return result

--- a/backend/desktop/app.py
+++ b/backend/desktop/app.py
@@ -1,0 +1,86 @@
+"""Desktop entrypoint: opens the Katherine window via pywebview (#334).
+
+Responsibilities (deliberately tiny):
+
+1. resolve the local frontend build (explicit failure if missing);
+2. build the allowlisted Desktop API;
+3. open one pywebview window pointed at the local build via ``file://``;
+4. block until the window closes, then return cleanly.
+
+Not here (on purpose): no domain logic, no ConversationEngine, no
+backend server, no HTTP hosting of the UI, no background services.
+
+Lifecycle notes:
+* No threads, sockets, servers, or ports are created by this shell.
+* Shutdown is the window close: ``webview.start()`` returns and the
+  process exits normally through the caller. No ``os._exit``, no kills.
+* Navigation policy: the window loads only the local build; this module
+  never exposes a "navigate to arbitrary URL" path, so remote content
+  cannot reach the privileged bridge.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import webview
+
+from backend.desktop.api import DESKTOP_API_METHODS, DesktopApi
+from backend.desktop.build_resolver import (
+    BuildResolutionError,
+    DesktopBuildConfig,
+    resolve_frontend_build,
+)
+
+_WINDOW_TITLE = "Katherine"
+_WINDOW_SIZE = (1280, 800)
+
+
+def _repo_root() -> Path:
+    """Repository root derived from this file's location (no env, no cwd)."""
+    return Path(__file__).resolve().parents[2]
+
+
+def run_desktop_shell(frontend_root: Path | None = None) -> int:
+    """Open the desktop window and block until it is closed.
+
+    Returns 0 on clean close. Raises :class:`BuildResolutionError` (or
+    ``ValueError`` for an invalid root) *before* any window is created,
+    so startup failures are explicit and safe to print.
+    """
+    root = frontend_root if frontend_root is not None else _repo_root() / "frontend"
+    config = DesktopBuildConfig(frontend_root=root)
+    build = resolve_frontend_build(config)
+
+    api = DesktopApi()
+    webview.create_window(
+        title=_WINDOW_TITLE,
+        url=build.index_html.as_uri(),
+        js_api=api,
+        width=_WINDOW_SIZE[0],
+        height=_WINDOW_SIZE[1],
+    )
+    webview.start()
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Console entrypoint: ``python -m backend.desktop.app``.
+
+    Prints a sanitized, actionable message on predictable startup errors
+    (missing build, invalid root) and returns a non-zero exit code.
+    Never falls back to opening anything else.
+    """
+    try:
+        return run_desktop_shell()
+    except BuildResolutionError as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 2
+    except ValueError as err:
+        print(f"error: invalid desktop configuration: {err}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/desktop/app.py
+++ b/backend/desktop/app.py
@@ -3,9 +3,10 @@
 Responsibilities (deliberately tiny):
 
 1. resolve the local frontend build (explicit failure if missing);
-2. build the allowlisted Desktop API;
+2. build the sanitized, allowlisted desktop bridge (``make_js_api``);
 3. open one pywebview window pointed at the local build via ``file://``;
-4. block until the window closes, then return cleanly.
+4. enforce the navigation policy below;
+5. block until the window closes, then return cleanly.
 
 Not here (on purpose): no domain logic, no ConversationEngine, no
 backend server, no HTTP hosting of the UI, no background services.
@@ -14,27 +15,61 @@ Lifecycle notes:
 * No threads, sockets, servers, or ports are created by this shell.
 * Shutdown is the window close: ``webview.start()`` returns and the
   process exits normally through the caller. No ``os._exit``, no kills.
-* Navigation policy: the window loads only the local build; this module
-  never exposes a "navigate to arbitrary URL" path, so remote content
-  cannot reach the privileged bridge.
+
+Navigation policy (remote content must never gain the privileged bridge)
+---------------------------------------------------------------------------
+
+pywebview injects ``window.pywebview`` into *whatever document the
+webview loaded last* (WebKitGTK re-injects on every ``load-changed`` /
+FINISHED). Loading ``file://`` initially is therefore not enough: a
+same-window ``location`` change (link click, ``window.location = ...``)
+would hand ``window.pywebview.api`` to remote content.
+
+This module enforces two independent, local layers:
+
+1. **Revert navigation** — a ``loaded`` event handler checks the window
+   URL; if it is no longer the local build, it navigates back
+   immediately. The remote document may exist transiently, but cannot
+   be interacted with and does not persist.
+2. **Fail-closed bridge** — the ``js_api`` object checks the URL on
+   *every* call. If the current window URL is not the local build,
+   calls return a sanitized ``bridge_unavailable`` payload instead of
+   executing. Even in the race window before the revert completes,
+   remote code cannot invoke Python through the bridge.
+
+Both layers are simple and local (no proxy, no HTTP server, no extra
+process) and covered by ``backend/tests/test_desktop_navigation.py``
+plus the reproducible smoke in ``scripts/desktop_smoke.py``.
 """
 
 from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Any, Callable
+from urllib.parse import urlsplit
 
 import webview
 
-from backend.desktop.api import DESKTOP_API_METHODS, DesktopApi
+from backend.desktop.api import DESKTOP_API_METHODS, DesktopApiError, make_js_api
 from backend.desktop.build_resolver import (
     BuildResolutionError,
     DesktopBuildConfig,
+    ResolvedBuild,
     resolve_frontend_build,
 )
 
 _WINDOW_TITLE = "Katherine"
 _WINDOW_SIZE = (1280, 800)
+
+#: Actionable hint reused for a missing smoke page inside the build.
+_BUILD_HINT = "Run 'npm run build' in the frontend/ directory first."
+
+#: Public error code used when the bridge refuses to serve a non-local page.
+ERROR_BRIDGE_UNAVAILABLE = "bridge_unavailable"
+
+_MSG_BRIDGE_UNAVAILABLE = "Desktop bridge is not available for this page."
+_MSG_INTERNAL = "The desktop bridge failed to complete the request."
 
 
 def _repo_root() -> Path:
@@ -42,25 +77,229 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
-def run_desktop_shell(frontend_root: Path | None = None) -> int:
+def is_local_build_url(url: str | None, build: ResolvedBuild) -> bool:
+    """Return True iff ``url`` points inside the resolved local build.
+
+    Structural check (not string-prefix based): the URL must be
+    ``file://`` with an empty host, no query string and no fragment, and
+    its path must resolve (lexically, no filesystem access) inside the
+    build's ``dist`` directory or be the ``index.html`` itself. Pure
+    predicate: no network, no filesystem access, never raises.
+    """
+    if not url or not url.startswith("file://"):
+        return False
+    try:
+        split = urlsplit(url)
+    except ValueError:  # pragma: no cover - defensive: malformed URLs
+        return False
+    if split.scheme != "file" or split.netloc:
+        return False
+    if split.query or split.fragment:
+        return False
+    dist_dir = build.dist_dir
+    index_html = build.index_html
+    if split.path == index_html.as_posix():
+        return True
+    candidate = Path(split.path)
+    try:
+        candidate.relative_to(dist_dir)
+    except ValueError:
+        return False
+    # Reject lexical traversal: any ``..``/``.`` segment means the URL
+    # does not literally point inside dist (e.g. ``dist/../x.html``).
+    # Raw ``split.path`` is used: ``Path`` would normalize the ``..``
+    # segments away and defeat this check.
+    segments = split.path.split("/")
+    if ".." in segments or "." in segments:
+        return False
+    return split.path.startswith(dist_dir.as_posix() + "/")
+
+
+def _get_url_safely(get_url: Callable[[], str | None]) -> str | None:
+    """Call ``get_url()`` defensively; None on any failure."""
+    try:
+        return get_url()
+    except Exception:  # noqa: BLE001 (policy layer must never crash the shell)
+        return None
+
+
+class BuildTrust:
+    """The URL of the last *completed, local* load (#334, review B2).
+
+    Why this exists (race found during validation): WebKitGTK's
+    ``get_uri()`` reflects the most recent load that *started*, not the
+    document that is actually alive. During the revert navigation
+    (remote → local) there is a window where ``get_uri()`` is already
+    the local ``file://`` URL while the **remote document is still
+    alive** and could invoke the bridge. A URL check alone would pass
+    in that window.
+
+    The trust model closes it: only a URL whose load *completed* as a
+    local build page (committed by the ``loaded`` handler, which also
+    reverts non-local pages) may serve bridge calls, and the current
+    URL must still equal that committed URL. Any in-flight navigation
+    (remote or back) leaves the two out of sync, so the bridge refuses.
+
+    Thread-safety: ``loaded`` handlers run on the GUI thread; bridge
+    calls arrive on worker threads (WebKit dispatch). A simple lock
+    guards the committed value.
+    """
+
+    def __init__(self, build: ResolvedBuild) -> None:
+        import threading
+
+        self._build = build
+        self._lock = threading.Lock()
+        self._committed: str | None = None
+
+    def commit_if_local(self, url: str | None) -> bool:
+        """Commit ``url`` as trusted iff it is a local build page.
+
+        Called from the ``loaded`` handler (load completed). Returns
+        True when the URL was committed as trusted.
+        """
+        if not is_local_build_url(url, self._build):
+            with self._lock:
+                self._committed = None
+            return False
+        with self._lock:
+            self._committed = url
+        return True
+
+    def is_trusted(self, current_url: str | None) -> bool:
+        """True iff ``current_url`` is exactly the committed local URL.
+
+        Any in-flight navigation (remote page alive while a revert load
+        already started, or a local page still loading) fails this
+        check, so the bridge fails closed.
+        """
+        with self._lock:
+            committed = self._committed
+        if committed is None:
+            return False
+        return current_url == committed and is_local_build_url(current_url, self._build)
+
+
+class LocalBuildBridge:
+    """``js_api`` facade that fails closed outside the local build (#334).
+
+    Wraps the sanitized :class:`~backend.desktop.api.DesktopBridge` with
+    the navigation policy: every call first verifies that the window is
+    still showing the trusted local build page (see :class:`BuildTrust`).
+    If not, the call returns a sanitized ``bridge_unavailable`` payload —
+    remote content never reaches the underlying Python methods, including
+    during the revert race window (remote document alive while the
+    revert load already changed ``get_uri()``).
+
+    The public surface stays exactly ``DESKTOP_API_METHODS`` (pywebview
+    exposes every public attribute), and no public method ever raises
+    (pywebview would convert exceptions into JS ``Error`` objects
+    carrying stacktrace information).
+    """
+
+    def __init__(
+        self,
+        bridge: Any,
+        build: ResolvedBuild,
+        get_url: Callable[[], str | None],
+        trust: BuildTrust | None = None,
+    ) -> None:
+        # ``bridge`` is the sanitized facade from make_js_api(); typed Any
+        # to keep this layer decoupled from the concrete facade class.
+        self._bridge = bridge
+        self._build = build
+        self._get_url = get_url
+        self._trust = trust if trust is not None else BuildTrust(build)
+
+    def health(self, *args: Any) -> dict[str, Any]:
+        """Allowlisted round-trip, local-build-only; never raises."""
+        url = _get_url_safely(self._get_url)
+        if not (
+            is_local_build_url(url, self._build) and self._trust.is_trusted(url)
+        ):
+            return {
+                "ok": False,
+                "code": ERROR_BRIDGE_UNAVAILABLE,
+                "message": _MSG_BRIDGE_UNAVAILABLE,
+            }
+        try:
+            result = self._bridge.health(*args)
+        except DesktopApiError as err:
+            return err.payload
+        except Exception:  # noqa: BLE001 (boundary: never leak internals to JS)
+            return {"ok": False, "code": "internal_error", "message": _MSG_INTERNAL}
+        if not isinstance(result, dict):
+            return {"ok": False, "code": "internal_error", "message": _MSG_INTERNAL}
+        return result
+
+
+def run_desktop_shell(
+    frontend_root: Path | None = None,
+    *,
+    html_name: str = "index.html",
+) -> int:
     """Open the desktop window and block until it is closed.
 
     Returns 0 on clean close. Raises :class:`BuildResolutionError` (or
     ``ValueError`` for an invalid root) *before* any window is created,
     so startup failures are explicit and safe to print.
+
+    ``html_name`` selects which page inside the resolved build opens
+    first. Production uses the default ``index.html``; the reproducible
+    smoke (#334, review B3) opens ``desktop-smoke.html`` which mounts
+    the real ChatWindow. The page must exist inside ``dist`` (the
+    resolver still validates the build root), and the navigation
+    policy treats every page inside ``dist`` as local build content.
     """
     root = frontend_root if frontend_root is not None else _repo_root() / "frontend"
     config = DesktopBuildConfig(frontend_root=root)
     build = resolve_frontend_build(config)
 
-    api = DesktopApi()
-    webview.create_window(
+    entry_html = build.dist_dir / html_name
+    if not entry_html.is_file():
+        raise BuildResolutionError(
+            f"Frontend page {html_name!r} not found in the build. " + _BUILD_HINT
+        )
+
+    # ``create_window`` returns the Window synchronously, before
+    # ``webview.start()``; the holder is populated right after creation so
+    # the URL guard can query it. The bridge is delivered at creation time
+    # (js_api=), never reassigned afterwards.
+    window_holder: list[Any] = []
+    trust = BuildTrust(build)
+
+    def _current_url() -> str | None:
+        if not window_holder:
+            return None
+        return _get_url_safely(window_holder[0].get_current_url)
+
+    js_api = LocalBuildBridge(make_js_api(), build, _current_url, trust)
+
+    window = webview.create_window(
         title=_WINDOW_TITLE,
-        url=build.index_html.as_uri(),
-        js_api=api,
+        url=entry_html.as_uri(),
+        js_api=js_api,
         width=_WINDOW_SIZE[0],
         height=_WINDOW_SIZE[1],
     )
+    window_holder.append(window)
+
+    # Policy layer 1: on every completed load, commit local pages as
+    # trusted and revert non-local navigation back to the build. The
+    # commit happens after the revert decision: a remote page never
+    # becomes trusted, and the bridge (which requires the committed
+    # URL to match the current one) stays closed during the revert.
+    def _on_loaded() -> None:
+        url = _get_url_safely(window.get_current_url)
+        if is_local_build_url(url, build):
+            trust.commit_if_local(url)
+        else:
+            # Navigate back to the local build; the remote page is
+            # transient and the fail-closed bridge covered the race.
+            window.load_url(entry_html.as_uri())
+
+    window.events.loaded += _on_loaded
+
     webview.start()
     return 0
 

--- a/backend/desktop/app.py
+++ b/backend/desktop/app.py
@@ -28,18 +28,31 @@ would hand ``window.pywebview.api`` to remote content.
 This module enforces two independent, local layers:
 
 1. **Revert navigation** — a ``loaded`` event handler checks the window
-   URL; if it is no longer the local build, it navigates back
-   immediately. The remote document may exist transiently, but cannot
-   be interacted with and does not persist.
+   URL; if it is no longer the local build, it *revokes the trust
+   first* (:meth:`BuildTrust.revoke`) and then navigates back to the
+   entry. The remote document may exist transiently, but cannot be
+   interacted with and does not persist.
 2. **Fail-closed bridge** — the ``js_api`` object checks the URL on
-   *every* call. If the current window URL is not the local build,
-   calls return a sanitized ``bridge_unavailable`` payload instead of
-   executing. Even in the race window before the revert completes,
+   *every* call. A call is served only when the current URL is exactly
+   the URL of the last *completed and committed* local load. Any
+   in-flight navigation — remote, or the revert itself, even when
+   ``get_uri()`` already shows the local entry URL again — leaves the
+   bridge closed. Even in the race window before the revert completes,
    remote code cannot invoke Python through the bridge.
 
 Both layers are simple and local (no proxy, no HTTP server, no extra
 process) and covered by ``backend/tests/test_desktop_navigation.py``
 plus the reproducible smoke in ``scripts/desktop_smoke.py``.
+
+Why the trust must be *revoked* before the revert navigation
+(reviewer follow-up on the same-URL window): WebKitGTK's ``get_uri()``
+reflects the load that *started*. When the revert navigates back to
+the very same ``entry_html`` the window opened with, ``get_uri()``
+returns the previously committed URL while the **remote document is
+still the live document**. URL equality therefore proves neither
+document identity nor load completion; the only thing that may
+re-open the bridge is the ``loaded`` event of the *new* local load
+committing again.
 """
 
 from __future__ import annotations
@@ -137,8 +150,18 @@ class BuildTrust:
     The trust model closes it: only a URL whose load *completed* as a
     local build page (committed by the ``loaded`` handler, which also
     reverts non-local pages) may serve bridge calls, and the current
-    URL must still equal that committed URL. Any in-flight navigation
-    (remote or back) leaves the two out of sync, so the bridge refuses.
+    URL must still equal that committed URL.
+
+    **The same-URL window** (reviewer follow-up): the revert navigates
+    back to the very ``entry_html`` the window opened with. Because
+    ``get_uri()`` flips as soon as that load starts, ``current_url ==
+    committed`` is TRUE again while the remote document is still the
+    live document. URL equality proves neither identity nor
+    completion, so the trust is *revoked* (:meth:`revoke`) the moment
+    a non-local load is reported — BEFORE the revert navigation is
+    issued — and only the ``loaded`` event of the new local load
+    (a fresh commit) may re-open the bridge. There is no state in
+    which an in-flight navigation (remote or revert) serves a call.
 
     Thread-safety: ``loaded`` handlers run on the GUI thread; bridge
     calls arrive on worker threads (WebKit dispatch). A simple lock
@@ -166,12 +189,27 @@ class BuildTrust:
             self._committed = url
         return True
 
+    def revoke(self) -> None:
+        """Drop the committed trust immediately.
+
+        Called the moment a non-local load is reported, BEFORE any
+        revert ``load_url()`` is issued: from that instant until the
+        new local load completes and is committed again, every bridge
+        call fails closed — including calls that arrive while
+        ``get_uri()`` already reads the local entry URL (the revert
+        load started, the remote document may still be alive).
+        """
+        with self._lock:
+            self._committed = None
+
     def is_trusted(self, current_url: str | None) -> bool:
         """True iff ``current_url`` is exactly the committed local URL.
 
-        Any in-flight navigation (remote page alive while a revert load
-        already started, or a local page still loading) fails this
-        check, so the bridge fails closed.
+        The commit only exists between a *completed* local load and
+        the next revocation, so any in-flight navigation (remote page
+        alive while a revert load already started — even to the same
+        URL — or a local page still loading) fails this check and the
+        bridge fails closed.
         """
         with self._lock:
             committed = self._committed
@@ -233,6 +271,71 @@ class LocalBuildBridge:
         return result
 
 
+class NavigationPolicy:
+    """The ``loaded``-handler logic, extracted to be testable (#334).
+
+    Contract (all transitions explicit, no timing assumptions):
+
+    * local load completed → commit the URL as trusted;
+    * non-local load reported → revoke the trust FIRST, then issue the
+      revert ``load_url`` to the entry page;
+    * while the revert is in flight (``get_uri()`` may already read the
+      same entry URL) → the trust stays revoked, so the bridge stays
+      closed;
+    * new local load completed → the ``loaded`` event commits again and
+      the bridge re-opens.
+
+    The object is deliberately passive: no polling, no threads, no
+    timers. It acts only when the window fires ``loaded``.
+    """
+
+    def __init__(
+        self, window: Any, build: ResolvedBuild, entry_uri: str, trust: BuildTrust
+    ) -> None:
+        self._window = window
+        self._build = build
+        self._entry_uri = entry_uri
+        self._trust = trust
+
+    def on_loaded(self) -> None:
+        """Handle one ``loaded`` event (a load completed in the window)."""
+        url = _get_url_safely(self._window.get_current_url)
+        if is_local_build_url(url, self._build):
+            self._trust.commit_if_local(url)
+        else:
+            # Non-local document reported: drop the trust BEFORE the
+            # revert navigation starts. From this instant the bridge is
+            # closed for every caller, including one that arrives while
+            # get_uri() already reads the same entry URL again (the
+            # revert load started, the remote document may still be
+            # the live document).
+            self._trust.revoke()
+            self._window.load_url(self._entry_uri)
+
+
+def make_navigation_policy(
+    window: Any,
+    build: ResolvedBuild,
+    *,
+    entry_uri: str | None = None,
+    trust: BuildTrust | None = None,
+) -> NavigationPolicy:
+    """Build the :class:`NavigationPolicy` for a shell window.
+
+    ``entry_uri`` defaults to ``build.index_html.as_uri()`` (the shell
+    entry; production passes the page it opened, e.g. the smoke page).
+    ``trust`` defaults to a fresh :class:`BuildTrust`; production
+    passes the one the bridge shares so both layers stay in sync.
+    """
+    resolved_entry = entry_uri if entry_uri is not None else build.index_html.as_uri()
+    return NavigationPolicy(
+        window=window,
+        build=build,
+        entry_uri=resolved_entry,
+        trust=trust if trust is not None else BuildTrust(build),
+    )
+
+
 def run_desktop_shell(
     frontend_root: Path | None = None,
     *,
@@ -285,20 +388,18 @@ def run_desktop_shell(
     window_holder.append(window)
 
     # Policy layer 1: on every completed load, commit local pages as
-    # trusted and revert non-local navigation back to the build. The
-    # commit happens after the revert decision: a remote page never
-    # becomes trusted, and the bridge (which requires the committed
-    # URL to match the current one) stays closed during the revert.
-    def _on_loaded() -> None:
-        url = _get_url_safely(window.get_current_url)
-        if is_local_build_url(url, build):
-            trust.commit_if_local(url)
-        else:
-            # Navigate back to the local build; the remote page is
-            # transient and the fail-closed bridge covered the race.
-            window.load_url(entry_html.as_uri())
-
-    window.events.loaded += _on_loaded
+    # trusted and revert non-local navigation back to the build. A
+    # non-local load REVOKES the trust before the revert ``load_url``
+    # is issued, so the bridge stays closed for the whole revert —
+    # including the window where get_uri() already reads the same
+    # entry URL while the remote document is still the live one.
+    policy = make_navigation_policy(
+        window=window,
+        build=build,
+        entry_uri=entry_html.as_uri(),
+        trust=trust,
+    )
+    window.events.loaded += policy.on_loaded
 
     webview.start()
     return 0

--- a/backend/desktop/build_resolver.py
+++ b/backend/desktop/build_resolver.py
@@ -1,0 +1,72 @@
+"""Frontend build resolution for the desktop shell (#334).
+
+The desktop entrypoint loads the *real* Vite build output
+(``frontend/dist``) — never a throwaway page. Resolution:
+
+* is driven by an explicit, constrained config (no caller-supplied path
+  strings, no environment expansion, so path traversal is structurally
+  impossible);
+* fails explicitly with an actionable message when the build is missing;
+* performs no filesystem writes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+#: Actionable hint shown when the build is absent.
+_BUILD_HINT = "Run 'npm run build' in the frontend/ directory first."
+
+
+class BuildResolutionError(Exception):
+    """Raised when the frontend build is missing or incomplete.
+
+    The message is safe to display: it names the relative build directory
+    and the fix, never absolute local paths.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class DesktopBuildConfig:
+    """Constrained configuration for build resolution.
+
+    ``frontend_root`` must be an existing directory (validated here, so
+    resolution can never operate on a guessed or injected path).
+    """
+
+    frontend_root: Path
+
+    def __post_init__(self) -> None:
+        if not self.frontend_root.is_dir():
+            raise ValueError("frontend_root must be an existing directory")
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedBuild:
+    """Absolute, verified locations of the built frontend."""
+
+    dist_dir: Path
+    index_html: Path
+
+
+def resolve_frontend_build(config: DesktopBuildConfig) -> ResolvedBuild:
+    """Resolve and validate the local Vite build for the desktop shell.
+
+    Raises :class:`BuildResolutionError` with an actionable, sanitized
+    message when the build does not exist or is incomplete. There is no
+    silent fallback: the caller must fail visibly.
+    """
+    dist_dir = config.frontend_root / "dist"
+    index_html = dist_dir / "index.html"
+
+    if not dist_dir.is_dir():
+        raise BuildResolutionError(
+            "Frontend build not found at frontend/dist. " + _BUILD_HINT
+        )
+    if not index_html.is_file():
+        raise BuildResolutionError(
+            "Frontend build is incomplete (index.html missing). " + _BUILD_HINT
+        )
+
+    return ResolvedBuild(dist_dir=dist_dir, index_html=index_html)

--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -7,3 +7,4 @@ supabase==2.31.0
 sentence-transformers==5.6.0
 pydantic==2.13.4
 torch==2.13.0+cpu
+pywebview==6.2.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,6 +17,8 @@ anyio==4.14.1
     #   groq
     #   httpx
     #   starlette
+bottle==0.13.4
+    # via pywebview
 certifi==2026.6.17
     # via
     #   httpcore
@@ -113,6 +115,8 @@ postgrest==2.31.0
     # via supabase
 propcache==0.5.2
     # via yarl
+proxy-tools==0.1.0
+    # via pywebview
 pycparser==3.0
     # via cffi
 pydantic==2.13.4
@@ -131,6 +135,8 @@ pygments==2.20.0
 pyjwt[crypto]==2.13.0
     # via supabase-auth
 python-dotenv==1.2.2
+    # via -r backend/requirements.in
+pywebview==6.2.1
     # via -r backend/requirements.in
 pyyaml==6.0.3
     # via
@@ -195,6 +201,7 @@ typing-extensions==4.16.0
     #   huggingface-hub
     #   pydantic
     #   pydantic-core
+    #   pywebview
     #   realtime
     #   sentence-transformers
     #   starlette

--- a/backend/tests/test_desktop_api.py
+++ b/backend/tests/test_desktop_api.py
@@ -1,0 +1,109 @@
+"""Tests for the minimal Desktop API exposed to the pywebview shell (#334).
+
+Contract under test:
+
+* ``health()`` returns a stable, structured, JSON-serializable payload;
+* the API surface is an explicit allowlist (no generic object exposure);
+* every exposed method validates input and rejects invalid values with a
+  sanitized, structured error (no tracebacks, no internal details);
+* importing the module has no side effects (no window, no threads, no env
+  reads at import time).
+
+These tests run headless: they never create a pywebview window.
+"""
+
+from __future__ import annotations
+
+import json
+
+import backend.desktop.api as desktop_api_module
+from backend.desktop.api import DESKTOP_API_METHODS, DesktopApi, DesktopApiError
+
+
+class TestHealthContract:
+    def test_health_returns_ok_payload_with_api_version(self) -> None:
+        api = DesktopApi()
+        payload = api.health()
+        assert payload["ok"] is True
+        assert payload["api_version"] == 1
+        # Payload must be JSON-serializable as-is (bridge returns plain data).
+        json.dumps(payload)
+
+    def test_health_is_deterministic(self) -> None:
+        first = DesktopApi().health()
+        second = DesktopApi().health()
+        assert first == second
+
+
+class TestAllowlistedSurface:
+    def test_exposed_methods_are_exactly_the_allowlist(self) -> None:
+        api = DesktopApi()
+        public = [name for name in dir(api) if not name.startswith("_")]
+        assert sorted(public) == sorted(DESKTOP_API_METHODS)
+
+    def test_allowlist_contains_only_health(self) -> None:
+        # Deliberately minimal: this proof must not grow a chat API.
+        assert DESKTOP_API_METHODS == ("health",)
+
+    def test_api_exposes_no_generic_objects(self) -> None:
+        # The bridge must never hand internal objects/modules to JS.
+        api = DesktopApi()
+        assert not hasattr(api, "engine")
+        assert not hasattr(api, "supabase")
+        assert not hasattr(api, "settings")
+        assert not hasattr(api, "backend")
+        for name in DESKTOP_API_METHODS:
+            result = getattr(api, name)()
+            assert isinstance(result, dict)
+            assert all(isinstance(k, str) for k in result)
+
+
+class TestInputValidation:
+    def test_health_rejects_arguments(self) -> None:
+        # JS may pass stray arguments; anything unexpected is rejected
+        # instead of being silently ignored.
+        api = DesktopApi()
+        try:
+            api.health("unexpected")  # type: ignore[arg-type]
+        except DesktopApiError as err:
+            assert err.payload["code"] == "invalid_input"
+            assert "unexpected" not in json.dumps(err.payload)
+        else:
+            raise AssertionError("health() must reject unexpected arguments")
+
+    def test_error_payload_is_sanitized(self) -> None:
+        # A failed call must surface a structured error without leaking
+        # types, reprs, paths, or environment details.
+        try:
+            DesktopApi().health(None)  # type: ignore[arg-type]
+        except DesktopApiError as err:
+            serialized = json.dumps(err.payload)
+            assert "<" not in serialized  # no repr markers
+            assert "NoneType" not in serialized
+            assert "Traceback" not in serialized
+
+
+class TestImportPurity:
+    def test_importing_desktop_api_has_no_side_effects(self, monkeypatch) -> None:
+        # Import must not read the environment, start threads, or touch
+        # pywebview: the module stays importable/testable without display.
+        monkeypatch.setenv("KATHERINE_PROBE", "1")
+        import importlib
+
+        importlib.reload(desktop_api_module)
+        # No env read at import time is asserted by the fact that the
+        # module does not fail or cache anything env-dependent; behavior
+        # below must be identical regardless of environment.
+        assert DesktopApi().health()["ok"] is True
+
+    def test_desktop_api_does_not_import_webview(self) -> None:
+        # api.py must not depend on pywebview: window concerns live in
+        # the entrypoint, keeping this module GUI-free.
+        import sys
+
+        assert "webview" not in sys.modules or not any(
+            "backend.desktop.api" in str(m) and getattr(m, "webview", None)
+            for m in []
+        )
+        source = (desktop_api_module.__file__ or "")
+        assert source  # module has a real file

--- a/backend/tests/test_desktop_api.py
+++ b/backend/tests/test_desktop_api.py
@@ -1,45 +1,128 @@
-"""Tests for the minimal Desktop API exposed to the pywebview shell (#334).
+"""Tests for the sanitized desktop bridge delivered to pywebview (#334).
 
-Contract under test:
+Contract under test (review blocker B1): the object *actually handed to
+pywebview's ``js_api``* sanitizes every call — the tests exercise the
+real boundary object (``make_js_api()`` / ``LocalBuildBridge``), not an
+auxiliary helper disconnected from the exposed path.
 
 * ``health()`` returns a stable, structured, JSON-serializable payload;
-* the API surface is an explicit allowlist (no generic object exposure);
-* every exposed method validates input and rejects invalid values with a
-  sanitized, structured error (no tracebacks, no internal details);
-* importing the module has no side effects (no window, no threads, no env
-  reads at import time).
+* the exposed surface is an explicit allowlist and matches exactly what
+  pywebview's ``get_functions`` walk would expose (no extra attributes);
+* no exposed method ever raises: pywebview 6.2.1 converts uncaught
+  ``js_api`` exceptions into a JS ``Error`` carrying ``message``/``name``
+  /``stack``; the bridge makes that path unreachable, returning
+  sanitized structured payloads instead;
+* invalid input is rejected with sanitized errors (no tracebacks, no
+  internal details), both on the facade and through the full
+  navigation-policy wrapper;
+* importing the module has no side effects (no window, no threads, no
+  env reads at import time).
 
 These tests run headless: they never create a pywebview window.
 """
 
 from __future__ import annotations
 
+import inspect
 import json
+from pathlib import Path
 
 import backend.desktop.api as desktop_api_module
-from backend.desktop.api import DESKTOP_API_METHODS, DesktopApi, DesktopApiError
+from backend.desktop.api import (
+    DESKTOP_API_METHODS,
+    DESKTOP_API_VERSION,
+    DesktopApi,
+    DesktopApiError,
+    make_js_api,
+)
+from backend.desktop.app import LocalBuildBridge, is_local_build_url
+from backend.desktop.build_resolver import ResolvedBuild
+
+
+def _make_build(tmp_path: Path) -> ResolvedBuild:
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("<html></html>", encoding="utf-8")
+    return ResolvedBuild(dist_dir=dist, index_html=dist / "index.html")
+
+
+def _pywebview_exposed_names(obj: object) -> set[str]:
+    """Mirror pywebview's ``get_functions`` public-attribute walk."""
+    return {name for name in dir(obj) if not name.startswith("_")}
 
 
 class TestHealthContract:
     def test_health_returns_ok_payload_with_api_version(self) -> None:
-        api = DesktopApi()
-        payload = api.health()
-        assert payload["ok"] is True
-        assert payload["api_version"] == 1
+        bridge = make_js_api()
+        payload = bridge.health()
+        assert payload == {"ok": True, "api_version": DESKTOP_API_VERSION}
         # Payload must be JSON-serializable as-is (bridge returns plain data).
         json.dumps(payload)
 
     def test_health_is_deterministic(self) -> None:
-        first = DesktopApi().health()
-        second = DesktopApi().health()
-        assert first == second
+        assert make_js_api().health() == make_js_api().health()
 
 
-class TestAllowlistedSurface:
+class TestRealBoundarySanitization:
+    """The object given to ``js_api`` must sanitize, never raise."""
+
     def test_exposed_methods_are_exactly_the_allowlist(self) -> None:
-        api = DesktopApi()
-        public = [name for name in dir(api) if not name.startswith("_")]
-        assert sorted(public) == sorted(DESKTOP_API_METHODS)
+        # pywebview exposes every public attribute; the facade must keep
+        # the exposed surface equal to the allowlist and nothing else.
+        bridge = make_js_api()
+        assert _pywebview_exposed_names(bridge) == set(DESKTOP_API_METHODS)
+
+    def test_local_build_bridge_exposes_only_health(self, tmp_path: Path) -> None:
+        build = _make_build(tmp_path)
+        url = build.index_html.as_uri()
+        wrapper = LocalBuildBridge(make_js_api(), build, lambda: url)
+        assert _pywebview_exposed_names(wrapper) == {"health"}
+
+    def test_bridge_health_never_raises_on_invalid_input(self) -> None:
+        # pywebview would convert an exception into a JS Error with a
+        # stacktrace; the facade returns data instead.
+        bridge = make_js_api()
+        result = bridge.health("unexpected")  # type: ignore[arg-type]
+        assert result == {
+            "ok": False,
+            "code": "invalid_input",
+            "message": "health() takes no arguments.",
+        }
+
+    def test_invalid_input_payload_is_sanitized(self) -> None:
+        result = make_js_api().health(None)  # type: ignore[arg-type]
+        serialized = json.dumps(result)
+        assert "NoneType" not in serialized
+        assert "Traceback" not in serialized
+        assert "<" not in serialized  # no repr markers
+
+    def test_implementation_errors_collapse_to_sanitized_internal_error(
+        self, tmp_path: Path
+    ) -> None:
+        # Simulate an unexpected bug inside the implementation: the
+        # facade must still return data, never raise (pywebview would
+        # leak a JS Error with stacktrace otherwise).
+        build = _make_build(tmp_path)
+
+        class FakeBridge:
+            def health(self, *args: object) -> dict[str, object]:
+                raise RuntimeError("secret internal detail /path/to/x")
+
+        from backend.desktop.app import BuildTrust
+
+        trust = BuildTrust(build)
+        trust.commit_if_local(build.index_html.as_uri())
+        wrapper = LocalBuildBridge(
+            FakeBridge(), build, lambda: build.index_html.as_uri(), trust
+        )
+        result = wrapper.health()
+        assert result["ok"] is False
+        assert result["code"] == "internal_error"
+        serialized = json.dumps(result)
+        assert "secret" not in serialized
+        assert "/path/to/x" not in serialized
+        assert "Traceback" not in serialized
+        assert "RuntimeError" not in serialized
 
     def test_allowlist_contains_only_health(self) -> None:
         # Deliberately minimal: this proof must not grow a chat API.
@@ -47,21 +130,21 @@ class TestAllowlistedSurface:
 
     def test_api_exposes_no_generic_objects(self) -> None:
         # The bridge must never hand internal objects/modules to JS.
-        api = DesktopApi()
-        assert not hasattr(api, "engine")
-        assert not hasattr(api, "supabase")
-        assert not hasattr(api, "settings")
-        assert not hasattr(api, "backend")
-        for name in DESKTOP_API_METHODS:
-            result = getattr(api, name)()
-            assert isinstance(result, dict)
-            assert all(isinstance(k, str) for k in result)
+        bridge = make_js_api()
+        for banned in ("engine", "supabase", "settings", "backend", "api"):
+            assert not hasattr(bridge, banned), f"bridge must not expose {banned!r}"
+        result = bridge.health()
+        assert isinstance(result, dict)
+        assert all(isinstance(k, str) for k in result)
+
+    def test_make_js_api_returns_fresh_object_each_call(self) -> None:
+        assert make_js_api() is not make_js_api()
 
 
-class TestInputValidation:
-    def test_health_rejects_arguments(self) -> None:
-        # JS may pass stray arguments; anything unexpected is rejected
-        # instead of being silently ignored.
+class TestDesktopApiImplementation:
+    """The implementation class may raise; the facade converts to data."""
+
+    def test_implementation_health_rejects_arguments(self) -> None:
         api = DesktopApi()
         try:
             api.health("unexpected")  # type: ignore[arg-type]
@@ -71,14 +154,12 @@ class TestInputValidation:
         else:
             raise AssertionError("health() must reject unexpected arguments")
 
-    def test_error_payload_is_sanitized(self) -> None:
-        # A failed call must surface a structured error without leaking
-        # types, reprs, paths, or environment details.
+    def test_implementation_error_payload_is_sanitized(self) -> None:
         try:
             DesktopApi().health(None)  # type: ignore[arg-type]
         except DesktopApiError as err:
             serialized = json.dumps(err.payload)
-            assert "<" not in serialized  # no repr markers
+            assert "<" not in serialized
             assert "NoneType" not in serialized
             assert "Traceback" not in serialized
 
@@ -91,19 +172,18 @@ class TestImportPurity:
         import importlib
 
         importlib.reload(desktop_api_module)
-        # No env read at import time is asserted by the fact that the
-        # module does not fail or cache anything env-dependent; behavior
-        # below must be identical regardless of environment.
-        assert DesktopApi().health()["ok"] is True
+        assert make_js_api().health()["ok"] is True
 
     def test_desktop_api_does_not_import_webview(self) -> None:
         # api.py must not depend on pywebview: window concerns live in
         # the entrypoint, keeping this module GUI-free.
-        import sys
+        source = Path(desktop_api_module.__file__).read_text(encoding="utf-8")
+        assert "import webview" not in source
+        assert "from webview" not in source
 
-        assert "webview" not in sys.modules or not any(
-            "backend.desktop.api" in str(m) and getattr(m, "webview", None)
-            for m in []
-        )
-        source = (desktop_api_module.__file__ or "")
-        assert source  # module has a real file
+    def test_health_signature_takes_no_named_parameters(self) -> None:
+        # pywebview inspects parameter names to build the JS proxy;
+        # *args-only keeps the surface stable and simple.
+        bridge = make_js_api()
+        params = inspect.signature(bridge.health).parameters
+        assert all(p.kind is p.VAR_POSITIONAL for p in params.values())

--- a/backend/tests/test_desktop_build_resolver.py
+++ b/backend/tests/test_desktop_build_resolver.py
@@ -1,0 +1,90 @@
+"""Tests for frontend build resolution used by the desktop shell (#334).
+
+The desktop entrypoint loads the *real* Vite build (frontend/dist), never a
+throwaway page. Resolution must:
+
+* find a valid build (index.html + assets) and return its absolute path;
+* fail explicitly and safely when the build is missing (no silent fallback);
+* accept only an explicit, constrained configuration: no arbitrary path
+* inputs, no path traversal, no environment-expanded user paths.
+
+Runs headless; resolution is pure path logic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.desktop.build_resolver import (
+    BuildResolutionError,
+    DesktopBuildConfig,
+    resolve_frontend_build,
+)
+
+
+def _make_valid_build(root: Path) -> Path:
+    dist = root / "frontend" / "dist"
+    dist.mkdir(parents=True)
+    (dist / "index.html").write_text("<html><body>build</body></html>", encoding="utf-8")
+    (dist / "assets").mkdir()
+    (dist / "assets" / "index.js").write_text("console.log('build')", encoding="utf-8")
+    return dist
+
+
+class TestValidBuildResolution:
+    def test_resolves_real_vite_build(self, tmp_path: Path) -> None:
+        _make_valid_build(tmp_path)
+        config = DesktopBuildConfig(frontend_root=tmp_path / "frontend")
+        resolved = resolve_frontend_build(config)
+        assert resolved.index_html == tmp_path / "frontend" / "dist" / "index.html"
+        assert resolved.index_html.is_file()
+        assert resolved.dist_dir.is_dir()
+
+    def test_resolution_is_pure_no_filesystem_writes(self, tmp_path: Path) -> None:
+        before = sorted(str(p) for p in tmp_path.rglob("*"))
+        _make_valid_build(tmp_path)
+        config = DesktopBuildConfig(frontend_root=tmp_path / "frontend")
+        resolve_frontend_build(config)
+        after = sorted(str(p) for p in tmp_path.rglob("*"))
+        assert before or after  # sanity
+        assert not any("desktop" in p for p in after if p not in before)
+
+
+class TestMissingBuildFailsExplicitly:
+    def test_missing_dist_fails_with_clear_message(self, tmp_path: Path) -> None:
+        (tmp_path / "frontend").mkdir()
+        config = DesktopBuildConfig(frontend_root=tmp_path / "frontend")
+        with pytest.raises(BuildResolutionError) as excinfo:
+            resolve_frontend_build(config)
+        # The error must tell the developer what to run — actionable.
+        message = str(excinfo.value)
+        assert "npm" in message and "build" in message
+        # No absolute local path leakage in the public message.
+        assert "home" not in message.lower() or "frontend" in message.lower()
+
+    def test_missing_index_html_fails(self, tmp_path: Path) -> None:
+        dist = tmp_path / "frontend" / "dist"
+        dist.mkdir(parents=True)
+        config = DesktopBuildConfig(frontend_root=tmp_path / "frontend")
+        with pytest.raises(BuildResolutionError):
+            resolve_frontend_build(config)
+
+
+class TestConfigValidation:
+    def test_config_rejects_non_local_root(self, tmp_path: Path) -> None:
+        # Configuration must be explicit and constrained: frontend_root
+        # must exist and be a directory.
+        with pytest.raises(ValueError):
+            DesktopBuildConfig(frontend_root=tmp_path / "does-not-exist")
+
+    def test_no_path_input_in_resolution(self, tmp_path: Path) -> None:
+        # resolve_frontend_build takes no path strings from callers: the
+        # only input is the constrained config, so traversal is
+        # structurally impossible.
+        _make_valid_build(tmp_path)
+        config = DesktopBuildConfig(frontend_root=tmp_path / "frontend")
+        resolved = resolve_frontend_build(config)
+        assert resolved.dist_dir == config.frontend_root / "dist"
+        assert resolved.dist_dir.is_relative_to(config.frontend_root)

--- a/backend/tests/test_desktop_navigation.py
+++ b/backend/tests/test_desktop_navigation.py
@@ -149,15 +149,13 @@ class TestBridgeFailsClosedOutsideLocalBuild:
         assert wrapper.health()["code"] == ERROR_BRIDGE_UNAVAILABLE
 
     def test_revert_race_local_uri_remote_doc_is_refused(self, tmp_path: Path) -> None:
-        # The exact race found during validation: get_uri() already
-        # returned the local file:// URL (revert load started) while the
-        # remote document is still alive. The committed URL is still the
-        # previous local page — but the URL CHANGED (same path is fine
-        # here: identical URL means no in-flight navigation is visible;
-        # a revert to the same entry URL is indistinguishable from the
-        # committed page, which is safe: the remote doc died when the
-        # revert completed and the local page re-commits on loaded).
-        # The dangerous case is a DIFFERENT local URL racing: refused.
+        # The race found during validation: get_uri() already returned a
+        # local file:// URL (revert load started) while the remote document
+        # is still alive. The committed URL is the previous local page and
+        # the current URL is a DIFFERENT local one, so they disagree — the
+        # mismatch alone refuses. (The harder variant — same URL — is
+        # covered by TestRevertToSameEntryUrl: URL equality must not be
+        # trusted as proof that the local load completed.)
         build = _make_build(tmp_path)
         index_uri = build.index_html.as_uri()
         asset_uri = "file://" + build.dist_dir.as_posix() + "/other.html"
@@ -319,3 +317,318 @@ class TestLoadedHandlerRevertsNavigation:
         _, recorded = self._run_with_stubbed_webview(monkeypatch, tmp_path, "https://example.com/")
         js_api = recorded["create_window_kwargs"]["js_api"]
         assert js_api.health()["code"] == ERROR_BRIDGE_UNAVAILABLE
+
+
+class TestRevertToSameEntryUrl:
+    """The REAL revert race: same entry URL, not a different local one.
+
+    WebKitGTK's ``get_uri()`` reflects the load that *started*. During
+    the revert (remote detected → ``load_url(entry_html)``), the URL can
+    already read the SAME ``file://`` entry while the **remote document
+    is still alive** and the new local load has NOT completed. URL
+    equality between ``current_url`` and the previously committed URL
+    proves neither document identity nor load completion, so a trust
+    model based only on that equality serves the bridge to the remote
+    document. These tests model the machine of states directly:
+
+    * entry local committed → navigation to remote detected → trust
+      REVOKED (before any revert load_url);
+    * revert started, ``get_uri()`` flipped back to the SAME entry URL,
+      new local load NOT completed → bridge still refused;
+    * new local load completed (loaded event, new commit) → bridge
+      serves again.
+
+    Each state is driven through the same functions the real wiring
+    uses; nothing here depends on WebKitGTK timing.
+    """
+
+    # ---- State machine modeled exactly (same entry URL) --------------
+
+    def test_remote_detected_revokes_trust_before_revert_starts(
+        self, tmp_path: Path
+    ) -> None:
+        # Immediately when a loaded event reports a non-local URL, the
+        # trust must be revoked — BEFORE any load_url() navigation back
+        # begins (the old handler kept the commit alive across the
+        # revert, which is what made the same-URL window dangerous).
+        build = _make_build(tmp_path)
+        entry_uri = build.index_html.as_uri()
+        trust = BuildTrust(build)
+        assert trust.commit_if_local(entry_uri) is True
+
+        # Records the trust state at the exact moment the revert
+        # navigation is issued (inside load_url).
+        trust_at_revert: list[bool] = []
+
+        class _Window(_FakeWindowForPolicy):
+            def load_url(self, url: str) -> None:
+                trust_at_revert.append(trust.is_trusted(entry_uri))
+                super().load_url(url)
+
+        window = _Window(entry_uri)
+        window.show("https://example.com/")  # loaded event: remote URL
+        machine = desktop_app_module.make_navigation_policy(
+            window=window, build=build, entry_uri=entry_uri, trust=trust
+        )
+        machine.on_loaded()
+
+        # Revoked BEFORE the revert navigation was issued...
+        assert trust_at_revert == [False]
+        # ...and stays revoked for every URL, including the entry.
+        assert trust.is_trusted(entry_uri) is False
+        assert trust.is_trusted("https://example.com/") is False
+        assert window.load_url_calls == [entry_uri]
+
+    def test_same_url_while_new_local_load_incomplete_keeps_bridge_refused(
+        self, tmp_path: Path
+    ) -> None:
+        # The heart of the race: after the revert load_url() to the SAME
+        # entry_html, get_uri() already returns that same file:// URL
+        # while the remote document is still alive and the new local
+        # load has not completed. A trust model that only compares URLs
+        # would reopen the bridge here — health() must still refuse.
+        build = _make_build(tmp_path)
+        entry_uri = build.index_html.as_uri()
+        trust = BuildTrust(build)
+        assert trust.commit_if_local(entry_uri) is True
+
+        # The loaded event reports the REMOTE document; the policy
+        # revokes and issues the revert.
+        window = _FakeWindowForPolicy("https://example.com/")
+        machine = desktop_app_module.make_navigation_policy(
+            window=window, build=build, entry_uri=entry_uri, trust=trust
+        )
+        machine.on_loaded()
+        assert window.load_url_calls == [entry_uri]
+
+        # Revert started: get_uri() has flipped back to the SAME entry
+        # URL while the remote document is still alive and the new
+        # local load has NOT fired its loaded event yet.
+        window.show(entry_uri)
+        assert window.get_current_url() == entry_uri
+        bridge = LocalBuildBridge(
+            make_js_api(), build, window.get_current_url, trust
+        )
+        assert bridge.health()["code"] == ERROR_BRIDGE_UNAVAILABLE
+
+        # Only after the new local load completes (loaded event → new
+        # commit) may the bridge serve again — same URL, new state.
+        machine.on_loaded()
+        assert bridge.health() == {"ok": True, "api_version": 1}
+
+    def test_bridge_reopens_only_after_new_local_load_completes(
+        self, tmp_path: Path
+    ) -> None:
+        # Full loop: commit → remote detected (revoke) → revert to the
+        # same entry URL (URL already flipped, still refused) → new
+        # local load COMPLETES (loaded event) → bridge serves again.
+        build = _make_build(tmp_path)
+        entry_uri = build.index_html.as_uri()
+        trust = BuildTrust(build)
+        assert trust.commit_if_local(entry_uri) is True
+
+        window = _FakeWindowForPolicy(entry_uri)
+        machine = desktop_app_module.make_navigation_policy(
+            window=window, build=build, entry_uri=entry_uri, trust=trust
+        )
+
+        # 1) Remote detected: trust revoked before the revert.
+        window.show("https://example.com/")
+        machine.on_loaded()
+        assert trust.is_trusted(entry_uri) is False
+
+        # 2) Revert started: URL flipped back to the same entry while the
+        #    remote document is still alive; the bridge keeps refusing.
+        window.show(entry_uri)
+        bridge = LocalBuildBridge(make_js_api(), build, window.get_current_url, trust)
+        assert bridge.health()["code"] == ERROR_BRIDGE_UNAVAILABLE
+
+        # 3) New local load completes: the loaded event re-commits and
+        #    the bridge serves again.
+        machine.on_loaded()
+        assert bridge.health() == {"ok": True, "api_version": 1}
+
+    def test_revert_navigates_to_the_entry_url(self, tmp_path: Path) -> None:
+        # The revert load goes back to the same entry_html the shell
+        # opened (as_uri()), never anywhere else.
+        build = _make_build(tmp_path)
+        entry_uri = build.index_html.as_uri()
+        window = _FakeWindowForPolicy(entry_uri)
+        machine = desktop_app_module.make_navigation_policy(
+            window=window, build=build, entry_uri=entry_uri
+        )
+        window.show("https://example.com/")
+        machine.on_loaded()
+        assert window.load_url_calls == [entry_uri]
+
+    # ---- Handler wiring (stubbed webview, real run_desktop_shell) ----
+
+    def test_run_desktop_shell_wires_policy_with_revoke(self, monkeypatch, tmp_path: Path) -> None:
+        # run_desktop_shell must install a loaded handler that (a) serves
+        # the committed local page, (b) revokes the trust the moment a
+        # remote load is reported and reverts, (c) keeps the bridge
+        # closed while the revert load has flipped get_uri() back to the
+        # SAME entry URL but the new local load has not completed, and
+        # (d) re-opens only after the new local load completed.
+        recorded = _run_shell_with_scripted_urls(monkeypatch, tmp_path)
+        # (a) initial local load: bridge serves.
+        assert recorded["health_after_first_load"]["ok"] is True
+        # (b) remote loaded event: revert issued to the entry URL...
+        assert recorded["load_url_calls"] == [
+            (tmp_path / "dist" / "index.html").resolve().as_uri()
+        ]
+        # ...and the bridge refuses the remote document.
+        assert (
+            recorded["health_after_remote_loaded"]["code"] == ERROR_BRIDGE_UNAVAILABLE
+        )
+        # (c) mid-revert: SAME entry URL visible, new load incomplete —
+        # the bridge must STILL refuse (this is the race being closed).
+        assert recorded["health_mid_revert"]["code"] == ERROR_BRIDGE_UNAVAILABLE
+        # (d) new local load completed: bridge serves again.
+        assert recorded["health_after_reload"]["ok"] is True
+
+
+class _FakeWindowForPolicy:
+    """Minimal window double for the policy machine tests.
+
+    ``show(url)`` scripts what ``get_current_url()`` returns (modeling
+    WebKitGTK's get_uri flipping as loads start), and records
+    ``load_url`` calls.
+    """
+
+    def __init__(self, initial_url: str) -> None:
+        self._current = initial_url
+        self.load_url_calls: list[str] = []
+
+    def get_current_url(self) -> str | None:
+        return self._current
+
+    def show(self, url: str) -> None:
+        self._current = url
+
+    def load_url(self, url: str) -> None:
+        self.load_url_calls.append(url)
+
+
+def _run_shell_with_scripted_urls(monkeypatch, tmp_path: Path) -> dict:
+    """Drive ``run_desktop_shell`` through the same-URL revert race.
+
+    The stubbed window scripts the exact WebKitGTK behavior of the race:
+    (1) initial local load completes; (2) a remote document loads;
+    (3) the shell reverts and get_uri() flips to the SAME entry URL
+    while the new local load is still incomplete — a bridge call made
+    at that moment must be refused; (4) the new local load completes
+    and the bridge serves again.
+
+    ``webview.start()`` plays the role of the GTK main loop: it fires
+    the registered ``loaded`` handlers at each scripted step (the real
+    GTK backend fires them from ``load_changed``/FINISHED).
+    """
+    dist = tmp_path / "dist"
+    dist.mkdir(exist_ok=True)
+    (dist / "index.html").write_text("<html></html>", encoding="utf-8")
+    entry_uri = (dist / "index.html").resolve().as_uri()
+    remote_uri = "https://example.com/"
+
+    recorded: dict = {
+        "health_after_first_load": None,
+        "health_mid_revert": None,
+        "health_after_remote_loaded": None,
+        "health_after_reload": None,
+        "load_url_calls": [],
+    }
+
+    class FakeLoadedEvent:
+        def __init__(self) -> None:
+            self.handlers: list = []
+
+        def __iadd__(self, handler):
+            self.handlers.append(handler)
+            return self
+
+    class FakeEvents:
+        def __init__(self) -> None:
+            self.loaded = FakeLoadedEvent()
+
+    class FakeWindow:
+        """Scripts get_current_url() as WebKitGTK does during the race.
+
+        State machine: the window shows one document at a time;
+        ``load_url`` starts a navigation whose URL is visible
+        immediately (get_uri reflects the load that STARTED) but whose
+        ``loaded`` event only fires later, when the harness lets the
+        main loop run (``finish_loads()``).
+        """
+
+        def __init__(self, **kwargs) -> None:
+            self._kwargs = kwargs
+            self.events = FakeEvents()
+            self._current: str | None = None
+            self._pending_load: str | None = None
+            self.js_api = kwargs.get("js_api")
+
+        def get_current_url(self) -> str | None:
+            return self._current
+
+        def load_url(self, url: str) -> None:
+            recorded["load_url_calls"].append(url)
+            self._pending_load = url
+            # WebKitGTK: get_uri() flips as soon as the load starts,
+            # even though the previous (remote) document is still the
+            # live document until the new load completes.
+            self._current = url
+
+        def fire_loaded(self) -> None:
+            for handler in list(self.events.loaded.handlers):
+                handler()
+
+        def finish_loads(self) -> None:
+            if self._pending_load is not None:
+                self._pending_load = None
+                self.fire_loaded()
+
+        def navigate(self, url: str) -> None:
+            # A same-window navigation not issued by the shell (e.g. a
+            # link click or location assignment in the page).
+            self._current = url
+            self.fire_loaded()
+
+        def health(self) -> dict:
+            return self.js_api.health()
+
+    window_holder: list = []
+
+    def _create_window(**kwargs):
+        window = FakeWindow(**kwargs)
+        window_holder.append(window)
+        return window
+
+    def _start():
+        win = window_holder[0]
+        # 1) The initial local load completes (loaded fires, commit).
+        win._current = entry_uri
+        win.fire_loaded()
+        recorded["health_after_first_load"] = win.health()
+        # 2) Same-window navigation to a remote document; its load
+        #    completes (loaded fires with the remote URL) → the shell
+        #    must revoke the trust and issue the revert.
+        win.navigate(remote_uri)
+        recorded["health_after_remote_loaded"] = win.health()
+        # 3) Mid-revert: load_url(entry) already flipped get_uri() to
+        #    the SAME entry URL while the remote document is still the
+        #    live document and the new local load has NOT completed.
+        #    A bridge call made right now must be refused.
+        recorded["health_mid_revert"] = win.health()
+        # 4) The new local load completes (loaded fires) → commit →
+        #    the bridge serves the local document again.
+        win.finish_loads()
+        recorded["health_after_reload"] = win.health()
+
+    fake_webview = types.SimpleNamespace(
+        create_window=_create_window,
+        start=_start,
+    )
+    monkeypatch.setattr(desktop_app_module, "webview", fake_webview)
+
+    desktop_app_module.run_desktop_shell(frontend_root=tmp_path)
+    return recorded

--- a/backend/tests/test_desktop_navigation.py
+++ b/backend/tests/test_desktop_navigation.py
@@ -1,0 +1,321 @@
+"""Navigation policy tests for the desktop shell (#334, review B2).
+
+Loading ``file://`` initially is not enough to keep the privileged
+bridge away from remote content: pywebview injects
+``window.pywebview`` into whatever document loaded last, and a
+same-window navigation (link click, ``window.location = ...``) would
+hand the bridge to a remote page.
+
+Contract under test (the two local policy layers in
+``backend/desktop/app.py``):
+
+1. ``is_local_build_url`` — the structural predicate deciding which
+   URLs count as "the local build" (exact index, inside dist, no
+   traversal, no query/fragment, file scheme with empty host);
+2. ``LocalBuildBridge`` — the ``js_api`` object fails closed: when the
+   window is not showing the local build, calls return a sanitized
+   ``bridge_unavailable`` payload instead of executing;
+3. the ``loaded`` handler wiring — ``run_desktop_shell`` registers a
+   handler that reverts navigation away from the build (verified with a
+   stubbed ``webview`` module: no window is ever created here).
+
+All tests are headless: no pywebview window is created.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import backend.desktop.app as desktop_app_module
+from backend.desktop.api import make_js_api
+from backend.desktop.app import (
+    ERROR_BRIDGE_UNAVAILABLE,
+    BuildTrust,
+    LocalBuildBridge,
+    is_local_build_url,
+)
+from backend.desktop.build_resolver import ResolvedBuild
+
+
+def _make_build(tmp_path: Path) -> ResolvedBuild:
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("<html></html>", encoding="utf-8")
+    return ResolvedBuild(dist_dir=dist, index_html=dist / "index.html")
+
+
+class TestIsLocalBuildUrl:
+    def test_accepts_the_index_html_uri(self, tmp_path: Path) -> None:
+        build = _make_build(tmp_path)
+        assert is_local_build_url(build.index_html.as_uri(), build) is True
+
+    def test_accepts_assets_inside_dist(self, tmp_path: Path) -> None:
+        build = _make_build(tmp_path)
+        asset = "file://" + build.dist_dir.as_posix() + "/assets/app.js"
+        assert is_local_build_url(asset, build) is True
+
+    def test_rejects_traversal_out_of_dist(self, tmp_path: Path) -> None:
+        build = _make_build(tmp_path)
+        traversal = "file://" + build.dist_dir.as_posix() + "/../secret.html"
+        assert is_local_build_url(traversal, build) is False
+
+    def test_rejects_traversal_that_resolves_back_inside(self, tmp_path: Path) -> None:
+        # ``dist/../dist/app.js`` resolves to a file inside dist, but the
+        # URL contains ``..`` segments and must not be considered local.
+        build = _make_build(tmp_path)
+        sneaky = "file://" + build.dist_dir.as_posix() + "/../dist/app.js"
+        assert is_local_build_url(sneaky, build) is False
+
+    def test_rejects_dot_segments(self, tmp_path: Path) -> None:
+        build = _make_build(tmp_path)
+        dotted = "file://" + build.dist_dir.as_posix() + "/./app.js"
+        assert is_local_build_url(dotted, build) is False
+
+    def test_rejects_remote_http_url(self, tmp_path: Path) -> None:
+        build = _make_build(tmp_path)
+        assert is_local_build_url("https://example.com/", build) is False
+        assert is_local_build_url("http://127.0.0.1:8080/", build) is False
+
+    def test_rejects_file_url_outside_dist(self, tmp_path: Path) -> None:
+        build = _make_build(tmp_path)
+        assert is_local_build_url("file:///etc/passwd", build) is False
+
+    def test_rejects_file_url_with_host(self, tmp_path: Path) -> None:
+        build = _make_build(tmp_path)
+        with_host = "file://localhost" + build.index_html.as_posix()
+        assert is_local_build_url(with_host, build) is False
+
+    def test_rejects_query_and_fragment(self, tmp_path: Path) -> None:
+        build = _make_build(tmp_path)
+        assert is_local_build_url(build.index_html.as_uri() + "?x=1", build) is False
+        assert is_local_build_url(build.index_html.as_uri() + "#frag", build) is False
+
+    def test_rejects_missing_and_empty(self, tmp_path: Path) -> None:
+        build = _make_build(tmp_path)
+        assert is_local_build_url(None, build) is False
+        assert is_local_build_url("", build) is False
+
+    def test_never_raises_on_malformed_url(self, tmp_path: Path) -> None:
+        build = _make_build(tmp_path)
+        for bad in ("file://[::1", "file://%zz", "::::", "file:"):
+            assert is_local_build_url(bad, build) is False
+
+
+class TestBridgeFailsClosedOutsideLocalBuild:
+    """Remote pages must never invoke Python through the bridge."""
+
+    def _bridge_for(self, build: ResolvedBuild, url: str | None, trusted: bool = False):
+        trust = BuildTrust(build)
+        if trusted:
+            trust.commit_if_local(url)
+        return LocalBuildBridge(make_js_api(), build, lambda: url, trust)
+
+    def test_local_url_receives_the_health_payload(self, tmp_path: Path) -> None:
+        build = _make_build(tmp_path)
+        url = build.index_html.as_uri()
+        # The loaded handler committed this local page as trusted.
+        wrapper = self._bridge_for(build, url, trusted=True)
+        assert wrapper.health() == {"ok": True, "api_version": 1}
+
+    def test_local_url_before_commit_is_refused(self, tmp_path: Path) -> None:
+        # Trust is only granted after the loaded handler commits the
+        # page; an in-flight local load (not yet committed) fails closed.
+        build = _make_build(tmp_path)
+        url = build.index_html.as_uri()
+        wrapper = self._bridge_for(build, url, trusted=False)
+        assert wrapper.health()["code"] == ERROR_BRIDGE_UNAVAILABLE
+
+    def test_remote_url_gets_sanitized_unavailable_payload(self, tmp_path: Path) -> None:
+        build = _make_build(tmp_path)
+        wrapper = self._bridge_for(build, "https://example.com/", trusted=False)
+        result = wrapper.health()
+        assert result == {
+            "ok": False,
+            "code": ERROR_BRIDGE_UNAVAILABLE,
+            "message": "Desktop bridge is not available for this page.",
+        }
+
+    def test_remote_url_with_stale_local_commit_is_refused(self, tmp_path: Path) -> None:
+        # The revert race: a local page was committed, then the window
+        # navigated remote while the doc is still alive. The URL no
+        # longer matches the committed one — refuse.
+        build = _make_build(tmp_path)
+        local = build.index_html.as_uri()
+        wrapper = self._bridge_for(build, "https://example.com/")
+        wrapper._trust.commit_if_local(local)  # type: ignore[reportPrivateUsage]
+        assert wrapper.health()["code"] == ERROR_BRIDGE_UNAVAILABLE
+
+    def test_revert_race_local_uri_remote_doc_is_refused(self, tmp_path: Path) -> None:
+        # The exact race found during validation: get_uri() already
+        # returned the local file:// URL (revert load started) while the
+        # remote document is still alive. The committed URL is still the
+        # previous local page — but the URL CHANGED (same path is fine
+        # here: identical URL means no in-flight navigation is visible;
+        # a revert to the same entry URL is indistinguishable from the
+        # committed page, which is safe: the remote doc died when the
+        # revert completed and the local page re-commits on loaded).
+        # The dangerous case is a DIFFERENT local URL racing: refused.
+        build = _make_build(tmp_path)
+        index_uri = build.index_html.as_uri()
+        asset_uri = "file://" + build.dist_dir.as_posix() + "/other.html"
+        (build.dist_dir / "other.html").write_text("<html></html>", encoding="utf-8")
+        trust = BuildTrust(build)
+        trust.commit_if_local(index_uri)
+        wrapper = LocalBuildBridge(make_js_api(), build, lambda: asset_uri, trust)
+        assert wrapper.health()["code"] == ERROR_BRIDGE_UNAVAILABLE
+
+    def test_file_url_outside_dist_is_refused(self, tmp_path: Path) -> None:
+        build = _make_build(tmp_path)
+        wrapper = self._bridge_for(build, "file:///etc/passwd")
+        assert wrapper.health()["code"] == ERROR_BRIDGE_UNAVAILABLE
+
+    def test_traversal_url_is_refused(self, tmp_path: Path) -> None:
+        build = _make_build(tmp_path)
+        traversal = "file://" + build.dist_dir.as_posix() + "/../evil.html"
+        wrapper = self._bridge_for(build, traversal)
+        assert wrapper.health()["code"] == ERROR_BRIDGE_UNAVAILABLE
+
+    def test_unavailable_payload_is_sanitized(self, tmp_path: Path) -> None:
+        build = _make_build(tmp_path)
+        wrapper = self._bridge_for(build, "https://attacker.example/")
+        serialized = json.dumps(wrapper.health())
+        assert "Traceback" not in serialized
+        assert "attacker" not in serialized
+
+    def test_url_lookup_failure_fails_closed(self, tmp_path: Path) -> None:
+        # If get_current_url raises, the bridge must refuse to serve —
+        # never fall back to "assume local".
+        build = _make_build(tmp_path)
+
+        def _raising() -> str | None:
+            raise RuntimeError("boom")
+
+        wrapper = LocalBuildBridge(make_js_api(), build, _raising)
+        assert wrapper.health()["code"] == ERROR_BRIDGE_UNAVAILABLE
+
+    def test_remote_page_cannot_probe_with_arguments(self, tmp_path: Path) -> None:
+        # Even a hostile caller passing stray arguments only ever gets
+        # the sanitized unavailable payload (no method executes).
+        build = _make_build(tmp_path)
+        wrapper = self._bridge_for(build, "https://example.com/")
+        assert wrapper.health("anything")["code"] == ERROR_BRIDGE_UNAVAILABLE
+
+
+class TestLoadedHandlerRevertsNavigation:
+    """``run_desktop_shell`` must wire a revert-on-loaded handler."""
+
+    def _run_with_stubbed_webview(
+        self, monkeypatch, tmp_path: Path, current_url_after_load: str | None
+    ):
+        """Run ``run_desktop_shell`` with a stubbed ``webview`` module.
+
+        Returns recorded calls. No real window is created: the stub
+        captures everything ``run_desktop_shell`` does, then fires the
+        registered ``loaded`` handlers exactly like WebKitGTK would when
+        the document finishes loading. The stub is patched onto the
+        already-imported ``backend.desktop.app`` module so its local
+        ``webview`` reference is replaced too.
+        """
+        # Build must resolve: create a minimal dist first.
+        dist = tmp_path / "dist"
+        dist.mkdir(exist_ok=True)
+        (dist / "index.html").write_text("<html></html>", encoding="utf-8")
+
+        recorded: dict = {
+            "create_window_kwargs": None,
+            "start_called": False,
+            "load_url_calls": [],
+        }
+
+        class FakeLoadedEvent:
+            def __init__(self) -> None:
+                self.handlers: list = []
+
+            def __iadd__(self, handler):
+                self.handlers.append(handler)
+                return self
+
+        class FakeEvents:
+            def __init__(self) -> None:
+                self.loaded = FakeLoadedEvent()
+
+        class FakeWindow:
+            def __init__(self, **kwargs) -> None:
+                self._kwargs = kwargs
+                self.events = FakeEvents()
+                recorded["create_window_kwargs"] = kwargs
+
+            def get_current_url(self) -> str | None:
+                return current_url_after_load
+
+            def load_url(self, url: str) -> None:
+                recorded["load_url_calls"].append(url)
+
+        window_holder: list = []
+
+        def _create_window(**kwargs):
+            window = FakeWindow(**kwargs)
+            window_holder.append(window)
+            return window
+
+        def _start():
+            recorded["start_called"] = True
+            # Fire the loaded handlers like the real shell would when the
+            # document finishes loading.
+            for window in window_holder:
+                for handler in list(window.events.loaded.handlers):
+                    handler()
+
+        fake_webview = types.SimpleNamespace(
+            create_window=_create_window,
+            start=_start,
+        )
+        monkeypatch.setattr(desktop_app_module, "webview", fake_webview)
+
+        exit_code = desktop_app_module.run_desktop_shell(frontend_root=tmp_path)
+        return exit_code, recorded
+
+    def test_js_api_is_the_fail_closed_wrapper(self, monkeypatch, tmp_path: Path) -> None:
+        exit_code, recorded = self._run_with_stubbed_webview(monkeypatch, tmp_path, None)
+        assert exit_code == 0
+        js_api = recorded["create_window_kwargs"]["js_api"]
+        assert isinstance(js_api, LocalBuildBridge)
+        # Wrapper exposes exactly the allowlisted surface.
+        public = [name for name in dir(js_api) if not name.startswith("_")]
+        assert public == ["health"]
+
+    def test_window_url_is_the_local_build(self, monkeypatch, tmp_path: Path) -> None:
+        _, recorded = self._run_with_stubbed_webview(monkeypatch, tmp_path, None)
+        dist = (tmp_path / "dist").resolve()
+        assert recorded["create_window_kwargs"]["url"] == (dist / "index.html").as_uri()
+
+    def test_loaded_navigation_to_remote_is_reverted(self, monkeypatch, tmp_path: Path) -> None:
+        # Simulate the window having navigated away when ``loaded`` fires:
+        # the handler must call load_url back to the local build.
+        dist = (tmp_path / "dist").resolve()
+        expected_uri = (dist / "index.html").as_uri()
+        # Two runs to cover the wiring: one navigation to remote (revert)
+        _, recorded = self._run_with_stubbed_webview(monkeypatch, tmp_path, "https://example.com/")
+        assert recorded["load_url_calls"] == [expected_uri]
+
+    def test_loaded_navigation_staying_local_is_not_reverted(self, monkeypatch, tmp_path: Path) -> None:
+        dist = (tmp_path / "dist").resolve()
+        local_uri = (dist / "index.html").as_uri()
+        _, recorded = self._run_with_stubbed_webview(monkeypatch, tmp_path, local_uri)
+        assert recorded["load_url_calls"] == []
+
+    def test_js_api_health_local_roundtrip_via_wrapper(self, monkeypatch, tmp_path: Path) -> None:
+        dist = (tmp_path / "dist").resolve()
+        local_uri = (dist / "index.html").as_uri()
+        _, recorded = self._run_with_stubbed_webview(monkeypatch, tmp_path, local_uri)
+        js_api = recorded["create_window_kwargs"]["js_api"]
+        assert js_api.health() == {"ok": True, "api_version": 1}
+
+    def test_js_api_health_remote_via_wrapper(self, monkeypatch, tmp_path: Path) -> None:
+        self._run_with_stubbed_webview(monkeypatch, tmp_path, "https://example.com/")
+        _, recorded = self._run_with_stubbed_webview(monkeypatch, tmp_path, "https://example.com/")
+        js_api = recorded["create_window_kwargs"]["js_api"]
+        assert js_api.health()["code"] == ERROR_BRIDGE_UNAVAILABLE

--- a/backend/tests/test_desktop_security.py
+++ b/backend/tests/test_desktop_security.py
@@ -5,12 +5,17 @@ reached by remote content and that the shell adds no servers/processes:
 
 * the window URL is always a local ``file://`` URI derived from the
   resolved build — never an arbitrary caller-supplied URL;
-* the module exposes no generic navigation to the JS side (the API
-  allowlist stays the only surface);
+* the object delivered to ``js_api`` is the sanitized facade and its
+  exposed surface is exactly the allowlist (no generic dispatch, no
+  extra attributes pywebview would expose);
 * no ``http(s)`` hosting is introduced: the entrypoint imports FastAPI
   nowhere and binds no sockets (import purity + grep-level evidence);
 * banned capabilities (eval/exec/subprocess/shell/webbrowser/open) are
   absent from the desktop package.
+
+Behavioral sanitization/fail-closed tests live in
+``test_desktop_api.py`` and ``test_desktop_navigation.py``; this module
+keeps the structural (AST/source-level) guarantees.
 """
 
 from __future__ import annotations
@@ -19,7 +24,7 @@ import ast
 from pathlib import Path
 
 import backend.desktop.app as desktop_app_module
-from backend.desktop.api import DESKTOP_API_METHODS, DesktopApi, safe_call
+from backend.desktop.api import DESKTOP_API_METHODS, make_js_api
 
 _DESKTOP_DIR = Path(desktop_app_module.__file__).parent
 _PY_SOURCES = sorted(_DESKTOP_DIR.glob("*.py"))
@@ -51,19 +56,29 @@ class TestLocalOnlyWindowUrl:
 class TestNoBridgeForRemoteContent:
     def test_allowlist_remains_the_only_js_surface(self) -> None:
         # Any future navigation feature must go through review: today the
-        # exposed surface is exactly health, and safe_call refuses anything
-        # else with a sanitized error.
+        # exposed surface is exactly health, and the real boundary object
+        # (make_js_api()) exposes nothing else. There is no generic
+        # dispatch: calling a non-allowlisted name is structurally
+        # impossible (pywebview only proxies real attributes).
         assert DESKTOP_API_METHODS == ("health",)
-        assert safe_call(DesktopApi(), "navigate", "https://example.com") == {
-            "ok": False,
-            "code": "invalid_input",
-            "message": "Unknown method.",
-        }
-        assert safe_call(DesktopApi(), "eval", "1+1")["code"] == "invalid_input"
+        bridge = make_js_api()
+        public = sorted(name for name in dir(bridge) if not name.startswith("_"))
+        assert public == ["health"]
+
+    def test_bridge_has_no_generic_dispatch_or_passthrough(self) -> None:
+        # The facade must not add __getattr__/__call__/passthrough that
+        # could turn attribute access into generic execution.
+        bridge = make_js_api()
+        assert "__getattr__" not in vars(type(bridge))
+        assert "__call__" not in vars(type(bridge))
+        # And no dynamic attribute exposure beyond the allowlist.
+        assert not hasattr(bridge, "navigate")
+        assert not hasattr(bridge, "eval")
+        assert not hasattr(bridge, "api")
 
     def test_desktop_api_has_no_file_or_shell_capabilities(self) -> None:
-        # The API object handed to JS has no file/shell/process surface.
-        api = DesktopApi()
+        # The object handed to JS has no file/shell/process surface.
+        bridge = make_js_api()
         for banned in (
             "open",
             "read",
@@ -76,7 +91,7 @@ class TestNoBridgeForRemoteContent:
             "env",
             "navigate",
         ):
-            assert not hasattr(api, banned), f"bridge must not expose {banned!r}"
+            assert not hasattr(bridge, banned), f"bridge must not expose {banned!r}"
 
 
 class TestNoHttpHosting:

--- a/backend/tests/test_desktop_security.py
+++ b/backend/tests/test_desktop_security.py
@@ -1,0 +1,129 @@
+"""Security boundary tests for the desktop shell (#334).
+
+Structural, headless assertions that the privileged bridge cannot be
+reached by remote content and that the shell adds no servers/processes:
+
+* the window URL is always a local ``file://`` URI derived from the
+  resolved build — never an arbitrary caller-supplied URL;
+* the module exposes no generic navigation to the JS side (the API
+  allowlist stays the only surface);
+* no ``http(s)`` hosting is introduced: the entrypoint imports FastAPI
+  nowhere and binds no sockets (import purity + grep-level evidence);
+* banned capabilities (eval/exec/subprocess/shell/webbrowser/open) are
+  absent from the desktop package.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import backend.desktop.app as desktop_app_module
+from backend.desktop.api import DESKTOP_API_METHODS, DesktopApi, safe_call
+
+_DESKTOP_DIR = Path(desktop_app_module.__file__).parent
+_PY_SOURCES = sorted(_DESKTOP_DIR.glob("*.py"))
+
+
+class TestLocalOnlyWindowUrl:
+    def test_window_url_is_derived_from_resolved_build(self, tmp_path: Path) -> None:
+        # run_desktop_shell accepts no URL of any kind: the only input is
+        # the frontend root, and the URL is always the resolved local
+        # index.html converted with as_uri().
+        import inspect
+
+        signature = inspect.signature(desktop_app_module.run_desktop_shell)
+        assert "url" not in signature.parameters
+        assert "frontend_root" in signature.parameters
+
+    def test_built_uri_points_into_dist(self, tmp_path: Path) -> None:
+        dist = tmp_path / "frontend" / "dist"
+        dist.mkdir(parents=True)
+        (dist / "index.html").write_text("<html></html>", encoding="utf-8")
+        from backend.desktop.build_resolver import DesktopBuildConfig, resolve_frontend_build
+
+        build = resolve_frontend_build(DesktopBuildConfig(frontend_root=tmp_path / "frontend"))
+        uri = build.index_html.as_uri()
+        assert uri.startswith("file://")
+        assert "dist" in uri
+
+
+class TestNoBridgeForRemoteContent:
+    def test_allowlist_remains_the_only_js_surface(self) -> None:
+        # Any future navigation feature must go through review: today the
+        # exposed surface is exactly health, and safe_call refuses anything
+        # else with a sanitized error.
+        assert DESKTOP_API_METHODS == ("health",)
+        assert safe_call(DesktopApi(), "navigate", "https://example.com") == {
+            "ok": False,
+            "code": "invalid_input",
+            "message": "Unknown method.",
+        }
+        assert safe_call(DesktopApi(), "eval", "1+1")["code"] == "invalid_input"
+
+    def test_desktop_api_has_no_file_or_shell_capabilities(self) -> None:
+        # The API object handed to JS has no file/shell/process surface.
+        api = DesktopApi()
+        for banned in (
+            "open",
+            "read",
+            "write",
+            "execute",
+            "shell",
+            "subprocess",
+            "system",
+            "import",
+            "env",
+            "navigate",
+        ):
+            assert not hasattr(api, banned), f"bridge must not expose {banned!r}"
+
+
+class TestNoHttpHosting:
+    def test_entrypoint_does_not_start_any_server(self) -> None:
+        # The shell must host the packaged UI locally via file://; it may
+        # not spin FastAPI/Uvicorn/Vite just to serve static assets.
+        import sys
+
+        assert "uvicorn" not in sys.modules
+        # backend.main stays import-free in this process unless a test
+        # imported it; the structural point is the entrypoint source.
+        source = _DESKTOP_DIR.joinpath("app.py").read_text(encoding="utf-8")
+        for banned in ("uvicorn", "fastapi", "TestServer", "http.server", "0.0.0.0", "localhost:"):
+            assert banned not in source, f"desktop shell must not reference {banned!r}"
+
+
+class TestBannedCapabilities:
+    def test_no_eval_exec_subprocess_or_open_in_desktop_package(self) -> None:
+        banned_calls = {"eval", "exec", "system", "popen", "run", "Popen"}
+        banned_imports = {"subprocess", "os", "shutil", "webbrowser"}
+        for path in _PY_SOURCES:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        assert alias.name.split(".")[0] not in banned_imports, (
+                            f"{path.name}: forbidden import {alias.name}"
+                        )
+                if isinstance(node, ast.ImportFrom):
+                    root = (node.module or "").split(".")[0]
+                    assert root not in banned_imports, (
+                        f"{path.name}: forbidden import from {node.module}"
+                    )
+                if isinstance(node, ast.Call):
+                    func = node.func
+                    name = getattr(func, "attr", None) or getattr(func, "id", None)
+                    assert name not in banned_calls, (
+                        f"{path.name}: forbidden call {name}()"
+                    )
+
+    def test_no_string_url_literals_in_desktop_package(self) -> None:
+        # No http(s) URLs may appear in the desktop package: the window
+        # only ever loads the local build.
+        for path in _PY_SOURCES:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                    assert not node.value.startswith(("http://", "https://")), (
+                        f"{path.name}: unexpected URL literal {node.value!r}"
+                    )

--- a/docs/operations/desktop-shell-linux.md
+++ b/docs/operations/desktop-shell-linux.md
@@ -69,12 +69,25 @@ Sucesso: todas as linhas `[PASS]` e `SMOKE_OK` no final.
 ### Nota sobre o check "remote navigation"
 
 O documento remoto vive por uma janela curta (o handler `loaded` o
-reverte imediatamente). O smoke aceita qualquer resultado seguro:
-a chamada remota foi recusada com o payload sanitizado
-`bridge_unavailable`, o documento morreu antes de obter a bridge
-(nenhuma chamada chegou ao Python), ou a chamada morreu junto com o
-documento (nenhum payload foi entregue). O único resultado que falha
-é um payload bem-sucedido entregue a conteúdo remoto.
+reverte imediatamente). O smoke prova o isolamento em três estágios:
+
+- **A** — página remota carregada normalmente: `health()` recusada
+  (recusa executada no próprio handler `loaded`, a testemunha
+  autoritária);
+- **B** — revert emitido para a MESMA URL do entry: no instante em que
+  o `load_url` do revert é chamado (documento remoto ainda vivo, novo
+  load local ainda não completou, `get_uri()` já vai ler a mesma URL
+  `file://`), `health()` continua recusada — igualdade de URL não
+  reabre a bridge;
+- **C** — novo load local completou: a bridge volta a servir o
+  documento local.
+
+O probe in-vivo (armado dentro do documento remoto vivo) é mantido
+como evidência extra best-effort: disparar ou não depende do timing do
+WebKitGTK (o doc remoto muitas vezes morre antes da injeção, o que em
+si é um resultado seguro — nada foi entregue). A prova determinística
+da máquina de estados same-URL (todas as transições do trust) está em
+`backend/tests/test_desktop_navigation.py::TestRevertToSameEntryUrl`.
 
 ## Medidas (Ubuntu 24.04, WebKitGTK, headless via Xvfb)
 
@@ -90,10 +103,16 @@ documento (nenhum payload foi entregue). O único resultado que falha
    (`health`) com erros sanitizados; nenhum método exposto levanta.
 2. `LocalBuildBridge` (app.py) só serve chamadas quando a página atual
    é exatamente a URL local cujo load **completou** (trust commitido
-   no evento `loaded`). Durante qualquer navegação em curso —
-   remota, ou o próprio revert — a bridge recusa (`bridge_unavailable`).
-3. Navegação para fora do build é revertida pelo handler `loaded`.
+   no evento `loaded`).
+3. Navegação para fora do build é detectada no handler `loaded`, que
+   **revoga o trust (`BuildTrust.revoke()`) ANTES de emitir o
+   `load_url` de retorno**. Durante qualquer navegação em curso —
+   remota, ou o próprio revert, inclusive quando `get_uri()` já voltou
+   a ler a mesma URL do entry — a bridge recusa (`bridge_unavailable`),
+   porque igualdade de URL não comprova nem identidade do documento
+   nem conclusão do load. Somente o evento `loaded` do novo load
+   local (novo commit) reabre a bridge.
 
 Detalhes e racional da corrida revert (get_uri reflete o load
 iniciado, não o documento vivo) estão em comentários no
-`backend/desktop/app.py` (classe `BuildTrust`).
+`backend/desktop/app.py` (classes `BuildTrust` e `NavigationPolicy`).

--- a/docs/operations/desktop-shell-linux.md
+++ b/docs/operations/desktop-shell-linux.md
@@ -78,9 +78,10 @@ documento (nenhum payload foi entregue). O único resultado que falha
 
 ## Medidas (Ubuntu 24.04, WebKitGTK, headless via Xvfb)
 
-- Startup até página carregada: ~550-650ms
-- RSS idle: ~175MB (pico durante load: ~200MB)
-- CPU idle: 1-2% (0% em steady state)
+- Startup até página carregada: ~550-650ms (do início do processo,
+  incluindo resolução do build; janela do webview apenas: ~260-450ms)
+- RSS idle: ~180-184MB; pico (VmHWM): ~183MB
+- CPU: 1-2% durante o load; 0% em steady state (10s de amostragem)
 - Processos: 1 (nenhum servidor/worker extra)
 
 ## Modelo de confiança da bridge (resumo)

--- a/docs/operations/desktop-shell-linux.md
+++ b/docs/operations/desktop-shell-linux.md
@@ -1,0 +1,98 @@
+# Desktop Shell no Linux (pywebview + WebKitGTK)
+
+> Issue #334 — validação do pywebview como shell desktop Linux. Este
+> documento descreve como executar o shell localmente no Linux, suas
+> dependências de sistema e como reproduzir a validação (smoke).
+
+## Visão geral
+
+O shell desktop é uma janela nativa GTK (via `pywebview`) hospedando o
+build de produção do frontend (Vite) direto por `file://`. Não existe
+servidor HTTP para a UI: nenhum processo extra, nenhuma porta, nenhum
+loopback. O único canal entre a página e o Python é a bridge
+`js_api` do pywebview (ver `backend/desktop/app.py`).
+
+- Entrada de produção: `python -m backend.desktop.app`
+- Entrada de smoke: `python scripts/desktop_smoke.py` (abre
+  `dist/desktop-smoke.html`, que monta a `ChatWindow` real)
+
+## Dependências de sistema (Linux)
+
+O backend GTK do pywebview precisa do stack GObject/WebKit via PyGObject:
+
+- **PyGObject ≥ 3.48** (o venv usa `--system-site-packages` no Ubuntu
+  24.04; o PyGObject do sistema é usado, ele não é instalável via pip
+  sem build deps nativos)
+- WebKit2GTK 4.1 (`libwebkit2gtk-4.1-0`, `libwebkit2gtk-4.1-dev` ao
+  construir PyGObject)
+- GTK 3 e GLib (`libgtk-3-0`, `libglib2.0-0`)
+- Xvfb para execução headless (apenas validação/CI):
+  `xvfb-run -a -s "-screen 0 1280x800x24"`
+
+Instalação recomendada do lado Python (requirements.in já inclui):
+
+```
+pywebview[gtk]
+```
+
+O extra `[gtk]` garante a seleção do backend GTK no Linux. Sem
+display (`$DISPLAY` vazio) o shell não sobe — esse é um erro
+explícito, não um fallback silencioso.
+
+## Reproduzir a validação (smoke)
+
+O smoke abre a janela real em `file://` e verifica, com probes
+`evaluate_js`:
+
+1. resolução do build (dist + página de smoke);
+2. janela carrega o build local via `file://`;
+3. a **chat UI real** renderiza (header, input, send, empty state);
+4. round-trip JS→Python→JS (`health()`);
+5. o badge "desktop v1" do ChatHeader (round-trip visível na UI);
+6. input inválido é rejeitado com erro sanitizado;
+7. navegação remota (`https://example.com/`) é revertida para o build;
+8. a bridge recusa chamadas com a janela em URL remota (fail-closed);
+9. nenhum servidor HTTP escuta no processo (nenhuma porta);
+10. fechar a janela encerra o shell (recursos liberados).
+
+```bash
+# build do frontend (produz dist/index.html e dist/desktop-smoke.html)
+cd frontend && npm ci && npm run build && cd ..
+
+# smoke headless
+xvfb-run -a -s "-screen 0 1280x800x24" \
+  ../.venv/bin/python scripts/desktop_smoke.py
+```
+
+Sucesso: todas as linhas `[PASS]` e `SMOKE_OK` no final.
+
+### Nota sobre o check "remote navigation"
+
+O documento remoto vive por uma janela curta (o handler `loaded` o
+reverte imediatamente). O smoke aceita qualquer resultado seguro:
+a chamada remota foi recusada com o payload sanitizado
+`bridge_unavailable`, o documento morreu antes de obter a bridge
+(nenhuma chamada chegou ao Python), ou a chamada morreu junto com o
+documento (nenhum payload foi entregue). O único resultado que falha
+é um payload bem-sucedido entregue a conteúdo remoto.
+
+## Medidas (Ubuntu 24.04, WebKitGTK, headless via Xvfb)
+
+- Startup até página carregada: ~550-650ms
+- RSS idle: ~175MB (pico durante load: ~200MB)
+- CPU idle: 1-2% (0% em steady state)
+- Processos: 1 (nenhum servidor/worker extra)
+
+## Modelo de confiança da bridge (resumo)
+
+1. `make_js_api()` (api.py) entrega só a allowlist `DESKTOP_API_METHODS`
+   (`health`) com erros sanitizados; nenhum método exposto levanta.
+2. `LocalBuildBridge` (app.py) só serve chamadas quando a página atual
+   é exatamente a URL local cujo load **completou** (trust commitido
+   no evento `loaded`). Durante qualquer navegação em curso —
+   remota, ou o próprio revert — a bridge recusa (`bridge_unavailable`).
+3. Navegação para fora do build é revertida pelo handler `loaded`.
+
+Detalhes e racional da corrida revert (get_uri reflete o load
+iniciado, não o documento vivo) estão em comentários no
+`backend/desktop/app.py` (classe `BuildTrust`).

--- a/docs/operations/desktop-shell-linux.md
+++ b/docs/operations/desktop-shell-linux.md
@@ -77,7 +77,7 @@ cd frontend && npm ci && npm run build && cd ..
 
 # smoke headless
 xvfb-run -a -s "-screen 0 1280x800x24" \
-  ../.venv/bin/python scripts/desktop_smoke.py
+  .venv/bin/python scripts/desktop_smoke.py
 ```
 
 Sucesso: todas as linhas `[PASS]` e `SMOKE_OK` no final.

--- a/docs/operations/desktop-shell-linux.md
+++ b/docs/operations/desktop-shell-linux.md
@@ -40,15 +40,20 @@ estão disponíveis; o extra `[gtk]` do pip (que traria
 reproduzível do ambiente validado:
 
 ```bash
-sudo apt install python3-gi gir1.2-webkit2-4.1 libgtk-3-0 xvfb
+sudo apt install python3-gi gir1.2-webkit2-4.1 libgtk-3-0 xvfb python3.12-venv
 # venv com acesso aos pacotes Python do sistema (python3-gi):
 python3 -m venv .venv --system-site-packages
 source .venv/bin/activate
 pip install -r backend/requirements.txt   # instala pywebview==6.2.1 (sem extra)
+# alternativa com uv (reproduzida): 
+#   uv venv .venv --system-site-packages --python /usr/bin/python3.12
+#   uv pip install -r backend/requirements.txt --index-strategy unsafe-best-match
+#   (--index-strategy por causa do --extra-index-url do torch no lock)
 ```
 
-Sem display (`$DISPLAY` vazio) o shell não sobe — esse é um erro
-explícito, não um fallback silencioso.
+Sem display (`$DISPLAY` vazio) o shell termina com exit code 1 e um
+`Gtk-WARNING: cannot open display` no stderr — sem fallback
+silencioso; a mensagem vem do GTK, não do shell.
 
 ## Reproduzir a validação (smoke)
 

--- a/docs/operations/desktop-shell-linux.md
+++ b/docs/operations/desktop-shell-linux.md
@@ -18,25 +18,36 @@ loopback. O único canal entre a página e o Python é a bridge
 
 ## Dependências de sistema (Linux)
 
-O backend GTK do pywebview precisa do stack GObject/WebKit via PyGObject:
+O backend GTK do pywebview precisa do stack GObject/WebKit via PyGObject.
+O ambiente validado usa o PyGObject do **sistema**, não do pip:
 
-- **PyGObject ≥ 3.48** (o venv usa `--system-site-packages` no Ubuntu
-  24.04; o PyGObject do sistema é usado, ele não é instalável via pip
-  sem build deps nativos)
-- WebKit2GTK 4.1 (`libwebkit2gtk-4.1-0`, `libwebkit2gtk-4.1-dev` ao
-  construir PyGObject)
-- GTK 3 e GLib (`libgtk-3-0`, `libglib2.0-0`)
+- **PyGObject ≥ 3.48** — no Ubuntu 24.04 vem do pacote `python3-gi`
+  (validado com 3.48.2). Ele não é instalável via pip sem build deps
+  nativos e **não** faz parte do `requirements.in`/lock: a venv é
+  criada com `--system-site-packages` e o importa de
+  `/usr/lib/python3/dist-packages`.
+- WebKit2GTK 4.1 (`libwebkit2gtk-4.1-0`; validado com 2.52.3 no
+  Ubuntu 24.04) — typelib `gir1.2-webkit2-4.1`.
+- GTK 3 e GLib (`libgtk-3-0`, `libglib2.0-0`).
 - Xvfb para execução headless (apenas validação/CI):
-  `xvfb-run -a -s "-screen 0 1280x800x24"`
+  `xvfb-run -a -s "-screen 0 1280x800x24"`.
 
-Instalação recomendada do lado Python (requirements.in já inclui):
+Instalação do lado Python: o `requirements.in` trava `pywebview==6.2.1`
+(**sem** o extra `[gtk]`). O backend GTK é selecionado automaticamente
+pelo pywebview no Linux quando o PyGObject do sistema e o WebKitGTK
+estão disponíveis; o extra `[gtk]` do pip (que traria
+`PyGObject==3.50.0` do PyPI) **não** é usado nem validado. Instalação
+reproduzível do ambiente validado:
 
+```bash
+sudo apt install python3-gi gir1.2-webkit2-4.1 libgtk-3-0 xvfb
+# venv com acesso aos pacotes Python do sistema (python3-gi):
+python3 -m venv .venv --system-site-packages
+source .venv/bin/activate
+pip install -r backend/requirements.txt   # instala pywebview==6.2.1 (sem extra)
 ```
-pywebview[gtk]
-```
 
-O extra `[gtk]` garante a seleção do backend GTK no Linux. Sem
-display (`$DISPLAY` vazio) o shell não sobe — esse é um erro
+Sem display (`$DISPLAY` vazio) o shell não sobe — esse é um erro
 explícito, não um fallback silencioso.
 
 ## Reproduzir a validação (smoke)
@@ -93,8 +104,12 @@ da máquina de estados same-URL (todas as transições do trust) está em
 
 - Startup até página carregada: ~550-650ms (do início do processo,
   incluindo resolução do build; janela do webview apenas: ~260-450ms)
-- RSS idle: ~180-184MB; pico (VmHWM): ~183MB
-- CPU: 1-2% durante o load; 0% em steady state (10s de amostragem)
+- RSS idle: ~190MB estável (190148-190528 kB em amostragem de 2s por
+  14s de janela viva); pico (VmHWM): ~190.5MB idle, ~195MB no smoke
+  completo (194832-195316 kB em 4 runs, inclui a fase de navegação
+  remota)
+- CPU: 1-2% durante o load; **0% em steady state** (5 amostras de 2s
+  consecutivas a 0% com a janela viva)
 - Processos: 1 (nenhum servidor/worker extra)
 
 ## Modelo de confiança da bridge (resumo)

--- a/frontend/desktop-smoke.html
+++ b/frontend/desktop-smoke.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Katherine – Desktop Smoke (#334)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/desktopSmokeEntry.jsx"></script>
+  </body>
+</html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,14 @@ function App() {
     const [session, setSession] = useState(null);
 
     useEffect(() => {
+        // Without a Supabase client (e.g. desktop shell build without
+        // web credentials, #334) there is no session to observe: show
+        // the auth screen instead of crashing on null.auth.
+        if (!supabase) {
+            setSession(null);
+            return;
+        }
+
         supabase.auth.getSession().then(({ data: { session } }) => {
             setSession(session);
         });

--- a/frontend/src/desktopSmokeEntry.jsx
+++ b/frontend/src/desktopSmokeEntry.jsx
@@ -1,0 +1,29 @@
+/**
+ * Smoke entry for the desktop shell validation (#334, review B3).
+ *
+ * Purpose: give the reproducible smoke (`scripts/desktop_smoke.py`) a
+ * target that renders the **real chat UI** (the same `ChatWindow` used
+ * by the web app, with the same header/input/message components and the
+ * desktop bridge badge) inside the pywebview shell.
+ *
+ * This is a smoke-only entry: it is NOT part of the web application
+ * (index.html does not reference it), never reaches production users,
+ * and mounts no fake auth state. The web app keeps its own App/Chat flow
+ * untouched; the shell's production entry stays index.html.
+ *
+ * Why a separate entry: the production shell build intentionally has no
+ * Supabase credentials, so `App` shows the (expected) DesktopNotice.
+ * The #334 acceptance "chat UI renders without external server" needs
+ * the real chat components mounted in the shell — this entry does
+ * exactly that, without faking production auth.
+ */
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import ChatWindow from './features/chat/components/ChatWindow.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+    <React.StrictMode>
+        <ChatWindow />
+    </React.StrictMode>,
+);

--- a/frontend/src/features/auth/AuthPage.jsx
+++ b/frontend/src/features/auth/AuthPage.jsx
@@ -1,69 +1,95 @@
-import React from 'react';
 import { Auth } from '@supabase/auth-ui-react';
 import { ThemeSupa } from '@supabase/auth-ui-shared';
 import { supabase } from '../../lib/supabaseClient';
 
-const AuthPage = () => {
-    return (
-        <div className="min-h-screen bg-[#0a0a0a] flex items-center justify-center p-4">
-            <div className="w-full max-w-md bg-[#1a1a1a] p-8 rounded-2xl shadow-2xl border border-white/5">
-                <div className="text-center mb-8">
-                    <h1 className="text-3xl font-light text-white mb-2 tracking-wide">Katherine</h1>
-                    <p className="text-white/40 text-sm">Sua companheira emocional</p>
-                </div>
-
-                <Auth
-                    supabaseClient={supabase}
-                    appearance={{
-                        theme: ThemeSupa,
-                        variables: {
-                            default: {
-                                colors: {
-                                    brand: '#ffffff',
-                                    brandAccent: '#e5e5e5',
-                                    inputBackground: '#262626',
-                                    inputText: '#ffffff',
-                                    inputBorder: '#404040',
-                                    inputLabelText: '#a3a3a3',
-                                },
-                                radii: {
-                                    borderRadiusButton: '8px',
-                                    inputBorderRadius: '8px',
-                                },
-                            },
-                        },
-                        className: {
-                            button: 'font-normal',
-                            input: 'font-light',
-                        }
-                    }}
-                    providers={[]}
-                    theme="dark"
-                    localization={{
-                        variables: {
-                            sign_in: {
-                                email_label: 'Email',
-                                password_label: 'Senha',
-                                button_label: 'Entrar',
-                                loading_button_label: 'Entrando...',
-                                email_input_placeholder: 'Seu email',
-                                password_input_placeholder: 'Sua senha',
-                                link_text: 'Já tem uma conta? Entre',
-                            },
-                            sign_up: {
-                                email_label: 'Email',
-                                password_label: 'Senha',
-                                button_label: 'Criar conta',
-                                loading_button_label: 'Criando conta...',
-                                email_input_placeholder: 'Seu email',
-                                password_input_placeholder: 'Sua senha',
-                                link_text: 'Não tem uma conta? Cadastre-se',
-                            },
-                        },
-                    }}
-                />
+const Shell = ({ children }) => (
+    <div className="min-h-screen bg-[#0a0a0a] flex items-center justify-center p-4">
+        <div className="w-full max-w-md bg-[#1a1a1a] p-8 rounded-2xl shadow-2xl border border-white/5">
+            <div className="text-center mb-8">
+                <h1 className="text-3xl font-light text-white mb-2 tracking-wide">Katherine</h1>
+                <p className="text-white/40 text-sm">Sua companheira emocional</p>
             </div>
+            {children}
         </div>
+    </div>
+);
+
+const DesktopNotice = () => (
+    <Shell>
+        <div className="space-y-4 text-center">
+            <p className="text-white/70 text-sm leading-relaxed">
+                Modo desktop local: a autenticação web não está configurada
+                neste ambiente.
+            </p>
+            <p className="text-white/40 text-xs leading-relaxed">
+                A interface carregou a partir do build local (file://), sem
+                servidor HTTP. Este aviso é esperado em builds sem credenciais
+                Supabase (#334).
+            </p>
+        </div>
+    </Shell>
+);
+
+const AuthPage = () => {
+    // Without Supabase credentials (desktop shell, #334) the auth-ui
+    // component would crash on null.auth, so render a local notice.
+    if (!supabase) {
+        return <DesktopNotice />;
+    }
+
+    return (
+        <Shell>
+            <Auth
+                supabaseClient={supabase}
+                appearance={{
+                    theme: ThemeSupa,
+                    variables: {
+                        default: {
+                            colors: {
+                                brand: '#ffffff',
+                                brandAccent: '#e5e5e5',
+                                inputBackground: '#262626',
+                                inputText: '#ffffff',
+                                inputBorder: '#404040',
+                                inputLabelText: '#a3a3a3',
+                            },
+                            radii: {
+                                borderRadiusButton: '8px',
+                                inputBorderRadius: '8px',
+                            },
+                        },
+                    },
+                    className: {
+                        button: 'font-normal',
+                        input: 'font-light',
+                    }
+                }}
+                providers={[]}
+                theme="dark"
+                localization={{
+                    variables: {
+                        sign_in: {
+                            email_label: 'Email',
+                            password_label: 'Senha',
+                            button_label: 'Entrar',
+                            loading_button_label: 'Entrando...',
+                            email_input_placeholder: 'Seu email',
+                            password_input_placeholder: 'Sua senha',
+                            link_text: 'Já tem uma conta? Entre',
+                        },
+                        sign_up: {
+                            email_label: 'Email',
+                            password_label: 'Senha',
+                            button_label: 'Criar conta',
+                            loading_button_label: 'Criando conta...',
+                            email_input_placeholder: 'Seu email',
+                            password_input_placeholder: 'Sua senha',
+                            link_text: 'Não tem uma conta? Cadastre-se',
+                        },
+                    },
+                }}
+            />
+        </Shell>
     );
 };
 

--- a/frontend/src/features/auth/AuthPage.jsx
+++ b/frontend/src/features/auth/AuthPage.jsx
@@ -1,6 +1,7 @@
 import { Auth } from '@supabase/auth-ui-react';
 import { ThemeSupa } from '@supabase/auth-ui-shared';
 import { supabase } from '../../lib/supabaseClient';
+import { isDesktopShell } from '../../lib/runtimeMode';
 
 const Shell = ({ children }) => (
     <div className="min-h-screen bg-[#0a0a0a] flex items-center justify-center p-4">
@@ -23,20 +24,44 @@ const DesktopNotice = () => (
             </p>
             <p className="text-white/40 text-xs leading-relaxed">
                 A interface carregou a partir do build local (file://), sem
-                servidor HTTP. Este aviso é esperado em builds sem credenciais
-                Supabase (#334).
+                servidor HTTP. Este aviso é esperado no shell desktop (#334).
+            </p>
+        </div>
+    </Shell>
+);
+
+const WebConfigNotice = () => (
+    <Shell>
+        <div className="space-y-4 text-center">
+            <p className="text-white/70 text-sm leading-relaxed">
+                A autenticação não está configurada nesta implantação web.
+            </p>
+            <p className="text-white/40 text-xs leading-relaxed">
+                As variáveis VITE_SUPABASE_URL e VITE_SUPABASE_ANON_KEY
+                precisam estar presentes no build web. Este aviso indica
+                uma configuração faltando, não o modo desktop (#334).
             </p>
         </div>
     </Shell>
 );
 
 const AuthPage = () => {
-    // Without Supabase credentials (desktop shell, #334) the auth-ui
-    // component would crash on null.auth, so render a local notice.
-    if (!supabase) {
+    // The desktop shell (positively detected via the pywebview bridge
+    // global, not via missing credentials — see lib/runtimeMode.js)
+    // cannot use the web auth flow, so it renders a local notice.
+    // A web deployment without credentials is still `web`: it renders
+    // a web configuration notice, never the desktop notice (#334, B4).
+    if (isDesktopShell()) {
         return <DesktopNotice />;
     }
 
+    // Web mode: the auth component requires a configured Supabase
+    // client. A misconfigured deploy (missing credentials) must surface
+    // a clear configuration message instead of crashing on null.auth —
+    // and it must never masquerade as the desktop shell.
+    if (!supabase) {
+        return <WebConfigNotice />;
+    }
     return (
         <Shell>
             <Auth

--- a/frontend/src/features/chat/components/ChatHeader.jsx
+++ b/frontend/src/features/chat/components/ChatHeader.jsx
@@ -1,11 +1,27 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Eraser, Check, X } from 'lucide-react';
+import { checkDesktopHealth } from '../../../lib/desktopBridge';
 
 const ChatHeader = ({ clearScreen }) => {
     const [showConfirm, setShowConfirm] = useState(false);
     const clearButtonRef = useRef(null);
     const prevShowConfirm = useRef(showConfirm);
     const [shouldFocusClearButton, setShouldFocusClearButton] = useState(false);
+    const [desktopBridge, setDesktopBridge] = useState(null);
+
+    useEffect(() => {
+        // Desktop shell probe (#334): shows the JS->Python->JS round trip.
+        // Stays null (hidden) in web mode; never blocks the UI.
+        let active = true;
+        checkDesktopHealth().then((health) => {
+            if (active) {
+                setDesktopBridge(health);
+            }
+        });
+        return () => {
+            active = false;
+        };
+    }, []);
 
     useEffect(() => {
         // Focus restoration when confirmation closes
@@ -41,8 +57,19 @@ const ChatHeader = ({ clearScreen }) => {
 
     return (
         <header className="flex-shrink-0 h-16 border-b border-gray-800 flex items-center justify-between px-4 md:px-8 bg-gray-900 z-10">
-            <div className="font-semibold text-lg tracking-tight text-white">
-                Katherine <span className="text-gray-500 font-normal">– SoulMate</span>
+            <div className="flex items-center gap-3">
+                <div className="font-semibold text-lg tracking-tight text-white">
+                    Katherine <span className="text-gray-500 font-normal">– SoulMate</span>
+                </div>
+                {desktopBridge && (
+                    <span
+                        data-testid="desktop-bridge-indicator"
+                        title="Desktop bridge (pywebview) round trip: OK"
+                        className="text-xs text-green-400/80 border border-green-400/30 rounded-full px-2 py-0.5"
+                    >
+                        desktop v{desktopBridge.api_version}
+                    </span>
+                )}
             </div>
 
             {showConfirm ? (

--- a/frontend/src/lib/desktopBridge.js
+++ b/frontend/src/lib/desktopBridge.js
@@ -1,0 +1,75 @@
+/**
+ * Minimal, explicit desktop bridge client (#334).
+ *
+ * The desktop shell (pywebview) injects `window.pywebview.api` with an
+ * allowlisted surface (currently: `health()`). This module is the only
+ * place the frontend is allowed to touch it, so the contract stays
+ * auditable in one file.
+ *
+ * Rules:
+ * - Never trust the bridge blindly: presence and payload shape are
+ *   validated before callers see anything.
+ * - Returns `null` when not running inside the desktop shell (normal
+ *   web mode is unaffected and never waits for the bridge).
+ * - Structured errors from the bridge are passed through as-is; the
+ *   bridge guarantees they are sanitized (no tracebacks/paths).
+ */
+
+const BRIDGE_READY_TIMEOUT_MS = 5000;
+
+/**
+ * Wait (bounded) for the pywebview bridge, then call `health()`.
+ *
+ * `targetWindow` is injectable for tests; production callers omit it and
+ * the real `window` is used.
+ *
+ * @returns {Promise<{ok: boolean, api_version: number} | null>}
+ *   The sanitized health payload, or null when the desktop bridge is
+ *   unavailable (web mode, timeout, invalid payload).
+ */
+export async function checkDesktopHealth(targetWindow) {
+    const scope = targetWindow ?? (typeof window !== 'undefined' ? window : undefined);
+    if (!scope || !scope.pywebview) {
+        return null;
+    }
+
+    const pywebview = scope.pywebview;
+    try {
+        await waitForBridgeReady(scope, pywebview);
+
+        if (typeof pywebview.api?.health !== 'function') {
+            return null;
+        }
+
+        const payload = await pywebview.api.health();
+        if (
+            payload &&
+            typeof payload === 'object' &&
+            payload.ok === true &&
+            typeof payload.api_version === 'number'
+        ) {
+            return { ok: true, api_version: payload.api_version };
+        }
+        return null;
+    } catch {
+        // Bridge failures must never break the web experience.
+        return null;
+    }
+}
+
+function waitForBridgeReady(scope, pywebview) {
+    if (pywebview.api) {
+        return Promise.resolve();
+    }
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('timeout')), BRIDGE_READY_TIMEOUT_MS);
+        scope.addEventListener(
+            'pywebviewready',
+            () => {
+                clearTimeout(timer);
+                resolve();
+            },
+            { once: true },
+        );
+    });
+}

--- a/frontend/src/lib/runtimeMode.js
+++ b/frontend/src/lib/runtimeMode.js
@@ -1,0 +1,58 @@
+/**
+ * Explicit runtime mode detection (#334, review blocker B4).
+ *
+ * Web mode must never be confused with the desktop shell merely because
+ * Supabase credentials are absent. The mode is a *positive* detection:
+ *
+ * - `desktop`: running inside the pywebview shell — the bridge global
+ *   `window.pywebview` exists AND the bundle was built without web
+ *   credentials. The shell is the only place `window.pywebview` is
+ *   injected, so this cannot trigger in a regular browser.
+ * - `web-dev`: `import.meta.env.DEV` is true (Vite dev/preview server).
+ * - `web`: a normal production web deployment (with credentials).
+ *
+ * Every consumer branches on this explicit mode instead of guessing from
+ * "credentials are missing", which would silently treat a misconfigured
+ * web deploy as a desktop build.
+ */
+
+/**
+ * Detect the runtime mode from explicit signals only.
+ *
+ * `targetWindow` is injectable for tests; production callers omit it and
+ * the real `window` is used.
+ *
+ * @returns {'desktop' | 'web-dev' | 'web'}
+ */
+export function detectRuntimeMode(targetWindow) {
+    const scope = targetWindow ?? (typeof window !== 'undefined' ? window : undefined);
+
+    // The pywebview bridge global is injected only by the desktop shell.
+    // `window.pywebview` in a plain browser is not a thing (the shell's
+    // injected script is the only creator), so presence here is a
+    // positive shell signal, independent of credentials.
+    const hasShellGlobal = Boolean(scope?.pywebview);
+
+    if (hasShellGlobal) {
+        return 'desktop';
+    }
+
+    // Vite dev/preview server: explicit build-time flag, not a guess
+    // from missing credentials.
+    if (import.meta.env?.DEV) {
+        return 'web-dev';
+    }
+
+    return 'web';
+}
+
+/**
+ * True only inside the pywebview desktop shell.
+ *
+ * Uses the same positive detection as `detectRuntimeMode`: a web page
+ * without credentials is NOT "desktop" — it is still `web` (or
+ * `web-dev`), and must not show shell-only behavior.
+ */
+export function isDesktopShell(targetWindow) {
+    return detectRuntimeMode(targetWindow) === 'desktop';
+}

--- a/frontend/src/lib/supabaseClient.js
+++ b/frontend/src/lib/supabaseClient.js
@@ -1,20 +1,24 @@
-/* global process */
 import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = import.meta.env?.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env?.VITE_SUPABASE_ANON_KEY;
 
-// Fail fast only when a Vite dev/preview server is expected to have the
-// configuration (web development). Production builds may run without
-// variables (e.g. the desktop shell loading the bundle via file://, #334):
-// there the app must still boot to its auth screen instead of crashing.
+// Web development (Vite dev/preview server) is expected to carry the
+// configuration: `import.meta.env.DEV` is a build-time flag injected by
+// Vite, not a guess. Missing credentials there is a misconfiguration
+// and must fail fast.
+//
+// A production *web* deploy with missing credentials is a deployment
+// error, but the bundle must still boot: it renders the web auth page
+// (which will surface the auth failure) — it must NOT be treated as the
+// desktop shell. Mode detection lives in `lib/runtimeMode.js` and never
+// depends on "credentials are missing" (#334, review B4).
 if (!supabaseUrl || !supabaseAnonKey) {
-    const isViteServer = typeof process !== 'undefined' && process.env?.NODE_ENV === 'development';
-    if (isViteServer) {
+    if (import.meta.env?.DEV) {
         throw new Error('Missing Supabase environment variables');
     }
 }
 
-export const supabase = (supabaseUrl && supabaseAnonKey) 
-    ? createClient(supabaseUrl, supabaseAnonKey) 
+export const supabase = (supabaseUrl && supabaseAnonKey)
+    ? createClient(supabaseUrl, supabaseAnonKey)
     : null;

--- a/frontend/src/lib/supabaseClient.js
+++ b/frontend/src/lib/supabaseClient.js
@@ -4,8 +4,13 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = import.meta.env?.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env?.VITE_SUPABASE_ANON_KEY;
 
+// Fail fast only when a Vite dev/preview server is expected to have the
+// configuration (web development). Production builds may run without
+// variables (e.g. the desktop shell loading the bundle via file://, #334):
+// there the app must still boot to its auth screen instead of crashing.
 if (!supabaseUrl || !supabaseAnonKey) {
-    if (process.env.NODE_ENV !== 'test') {
+    const isViteServer = typeof process !== 'undefined' && process.env?.NODE_ENV === 'development';
+    if (isViteServer) {
         throw new Error('Missing Supabase environment variables');
     }
 }

--- a/frontend/tests/authPage.test.jsx
+++ b/frontend/tests/authPage.test.jsx
@@ -1,0 +1,99 @@
+/**
+ * AuthPage runtime mode tests (#334, review blocker B4).
+ *
+ * The auth page must branch on the *explicit* runtime mode, never on
+ * "credentials are missing" (which would confuse a misconfigured web
+ * deploy with the desktop shell):
+ *
+ * - web (production, no shell global): renders the Supabase auth
+ *   component; when credentials are missing it shows the web config
+ *   notice — never the desktop notice;
+ * - web-dev (Vite dev): same as web (mode detection is covered in
+ *   runtimeMode.test.js);
+ * - desktop shell (window.pywebview present): renders the local
+ *   desktop notice (no web auth in the shell).
+ *
+ * Vitest/jsdom tests: `window.pywebview` presence drives the branch.
+ */
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+// AuthPage imports supabaseClient (module-level) — for the web-with-
+// credentials case we need a non-null client. vi.mock factories are
+// hoisted above imports, so the state must live on a stable holder
+// object that each test mutates.
+const supabaseState = { supabase: null };
+vi.mock('../src/lib/supabaseClient', () => ({
+    get supabase() {
+        return supabaseState.supabase;
+    },
+}));
+
+// Keep auth-ui out of these tests: rendering the real Auth component
+// is unnecessary for the mode-branch contract (and drags network mocks).
+vi.mock('@supabase/auth-ui-react', () => ({
+    Auth: () => <div data-testid="web-auth-component" />,
+}));
+vi.mock('@supabase/auth-ui-shared', () => ({ ThemeSupa: {} }));
+
+// Import after mocks are registered.
+import AuthPage from '../src/features/auth/AuthPage';
+
+function setWindow({ pywebview } = {}) {
+    if (pywebview === undefined) {
+        delete window.pywebview;
+    } else {
+        window.pywebview = pywebview;
+    }
+}
+
+describe('AuthPage runtime mode branches (#334 B4)', () => {
+    afterEach(() => {
+        cleanup();
+        setWindow({});
+    });
+
+    it('desktop shell (window.pywebview present) renders the desktop notice', () => {
+        setWindow({ pywebview: { api: {} } });
+        render(<AuthPage />);
+        expect(screen.getByText(/Modo desktop local/i)).toBeInTheDocument();
+        expect(screen.queryByTestId('web-auth-component')).toBeNull();
+    });
+
+    it('web without credentials renders the web config notice, never the desktop one', () => {
+        // Core B4 regression: missing credentials in web mode must NOT
+        // show "desktop" behavior.
+        supabaseState.supabase = null;
+        setWindow({});
+        render(<AuthPage />);
+        expect(
+            screen.getByText(/autenticação não está configurada nesta implantação web/i)
+        ).toBeInTheDocument();
+        expect(screen.queryByText(/Modo desktop local/i)).toBeNull();
+        expect(screen.queryByTestId('web-auth-component')).toBeNull();
+    });
+
+    it('web with credentials renders the Supabase auth component', () => {
+        supabaseState.supabase = {
+            auth: { getSession: async () => ({ data: { session: null } }) },
+        };
+        setWindow({});
+        render(<AuthPage />);
+        expect(screen.getByTestId('web-auth-component')).toBeInTheDocument();
+        expect(screen.queryByText(/Modo desktop local/i)).toBeNull();
+    });
+
+    it('desktop shell keeps the desktop notice even if credentials exist', () => {
+        // The shell wins over credentials: presence of window.pywebview
+        // is the desktop signal, not the absence of credentials.
+        supabaseState.supabase = {
+            auth: { getSession: async () => ({ data: { session: null } }) },
+        };
+        setWindow({ pywebview: { api: {} } });
+        render(<AuthPage />);
+        expect(screen.getByText(/Modo desktop local/i)).toBeInTheDocument();
+        expect(screen.queryByTestId('web-auth-component')).toBeNull();
+    });
+});

--- a/frontend/tests/desktopBridge.test.js
+++ b/frontend/tests/desktopBridge.test.js
@@ -1,0 +1,102 @@
+/**
+ * Tests for the desktop bridge client (#334).
+ *
+ * Node-native tests (no DOM): validate the contract rules —
+ * null outside the shell, payload validation inside it, bounded wait.
+ * The window object is injected explicitly (no global mutation).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { checkDesktopHealth } from '../src/lib/desktopBridge.js';
+
+function makeWindow({ pywebview } = {}) {
+    const window = {
+        addEventListener: () => {},
+    };
+    if (pywebview !== undefined) {
+        window.pywebview = pywebview;
+    }
+    return window;
+}
+
+test('returns null when window.pywebview is absent (web mode)', async () => {
+    assert.equal(await checkDesktopHealth(makeWindow()), null);
+});
+
+test('returns null when window is undefined (SSR/edge)', async () => {
+    assert.equal(await checkDesktopHealth(undefined), null);
+});
+
+test('returns null when api.health is missing', async () => {
+    const window = makeWindow({ pywebview: { api: {} } });
+    assert.equal(await checkDesktopHealth(window), null);
+});
+
+test('returns health payload for a valid bridge', async () => {
+    const window = makeWindow({
+        pywebview: {
+            api: {
+                health: async () => ({ ok: true, api_version: 1 }),
+            },
+        },
+    });
+    assert.deepEqual(await checkDesktopHealth(window), { ok: true, api_version: 1 });
+});
+
+test('rejects payload with wrong shape (ok !== true)', async () => {
+    const window = makeWindow({
+        pywebview: {
+            api: {
+                health: async () => ({ ok: false, api_version: 1 }),
+            },
+        },
+    });
+    assert.equal(await checkDesktopHealth(window), null);
+});
+
+test('rejects payload with non-number api_version', async () => {
+    const window = makeWindow({
+        pywebview: {
+            api: {
+                health: async () => ({ ok: true, api_version: '1' }),
+            },
+        },
+    });
+    assert.equal(await checkDesktopHealth(window), null);
+});
+
+test('bridge rejection (sanitized error) maps to null', async () => {
+    const window = makeWindow({
+        pywebview: {
+            api: {
+                health: async () => {
+                    throw { ok: false, code: 'internal_error', message: 'x' };
+                },
+            },
+        },
+    });
+    assert.equal(await checkDesktopHealth(window), null);
+});
+
+test('waits for pywebviewready when api is not yet exposed', async () => {
+    let resolveReady;
+    const window = {
+        addEventListener: (name, fn) => {
+            if (name === 'pywebviewready') {
+                resolveReady = fn;
+            }
+        },
+        pywebview: {
+            api: undefined,
+        },
+    };
+    const pending = checkDesktopHealth(window);
+    // Simulate the shell finishing bridge setup.
+    window.pywebview.api = {
+        health: async () => ({ ok: true, api_version: 1 }),
+    };
+    resolveReady();
+    assert.deepEqual(await pending, { ok: true, api_version: 1 });
+});

--- a/frontend/tests/runtimeMode.test.js
+++ b/frontend/tests/runtimeMode.test.js
@@ -1,0 +1,47 @@
+/**
+ * Tests for explicit runtime mode detection (#334, review B4).
+ *
+ * Web mode must never be confused with the desktop shell merely because
+ * credentials are absent. Mode is detected from explicit signals:
+ * - `desktop`: `window.pywebview` present (only the shell injects it)
+ * - `web-dev`: `import.meta.env.DEV` (build-time flag)
+ * - `web`: everything else (production web)
+ *
+ * Node-native tests (no DOM): the window object is injected explicitly.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { detectRuntimeMode, isDesktopShell } from '../src/lib/runtimeMode.js';
+
+test('desktop shell is detected positively via window.pywebview', () => {
+    const shellWindow = { pywebview: { api: {} } };
+    assert.equal(detectRuntimeMode(shellWindow), 'desktop');
+    assert.equal(isDesktopShell(shellWindow), true);
+});
+
+test('web browser without the shell global is web, even without credentials', () => {
+    // The core B4 regression: missing credentials alone must NOT imply
+    // desktop. A plain window (no pywebview global) is web mode.
+    assert.equal(detectRuntimeMode({}), 'web');
+    assert.equal(isDesktopShell({}), false);
+});
+
+test('undefined window (SSR/edge) is web, not desktop', () => {
+    assert.equal(detectRuntimeMode(undefined), 'web');
+    assert.equal(isDesktopShell(undefined), false);
+});
+
+test('window with pywebview: null is not a shell signal', () => {
+    // Falsy pywebview (null) must not count as the shell global.
+    assert.equal(detectRuntimeMode({ pywebview: null }), 'web');
+    assert.equal(detectRuntimeMode({ pywebview: undefined }), 'web');
+});
+
+test('injection: explicit windows drive detection (no global mutation)', () => {
+    const plain = {};
+    const shell = { pywebview: {} };
+    assert.equal(isDesktopShell(plain), false);
+    assert.equal(isDesktopShell(shell), true);
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -8,6 +8,18 @@ export default defineConfig({
     // (desktop shell via pywebview, #334). Server/preview modes are
     // unaffected: relative paths resolve identically there.
     base: './',
+    // Second build entry: the desktop smoke page (#334, review B3).
+    // It mounts the REAL ChatWindow (no fake auth) for the reproducible
+    // shell validation; index.html (the web app + production shell
+    // entry) is unchanged by this input.
+    build: {
+        rollupOptions: {
+            input: {
+                main: 'index.html',
+                desktopSmoke: 'desktop-smoke.html',
+            },
+        },
+    },
     server: {
         port: 3000,
     }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,6 +4,10 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [react()],
+    // Relative asset paths so the production build also loads from file://
+    // (desktop shell via pywebview, #334). Server/preview modes are
+    // unaffected: relative paths resolve identically there.
+    base: './',
     server: {
         port: 3000,
     }

--- a/scripts/desktop_smoke.py
+++ b/scripts/desktop_smoke.py
@@ -24,9 +24,18 @@ What this smoke proves (issue #334 validation items):
    (``[data-testid="desktop-bridge-indicator"]``) appears;
 4. invalid input is rejected by the bridge (sanitized error payload,
    no exception, no stacktrace);
-5. remote content does NOT receive the privileged bridge: after a
-   same-window navigation to a remote URL, the bridge fails closed
-   and the shell reverts to the local build;
+5. remote content does NOT receive the privileged bridge, proven in
+   three stages: (A) a normally loaded remote page is refused;
+   (B) during the revert to the SAME entry URL — while the remote
+   document is still the live document and the new local load has
+   not completed — the bridge stays closed; (C) after the new local
+   load completes, the bridge serves the local document again. An
+   in-vivo probe inside the remote document is kept as best-effort
+   additional evidence (its outcome depends on WebKitGTK timing:
+   the remote document is often destroyed before pywebview could be
+   injected there, which is itself a safe outcome). The deterministic
+   same-URL state machine proof lives in
+   ``backend/tests/test_desktop_navigation.py::TestRevertToSameEntryUrl``;
 6. closing the window ends the shell cleanly (no leftover threads);
 7. no HTTP server is listening for the UI.
 
@@ -274,10 +283,58 @@ def run_smoke() -> tuple[bool, list[str]]:
     remote_urls_seen: list[str] = []  # URLs captured on loaded events
     remote_direct_ref: list[object] = []  # js_api.health() called in-handler while remote
     in_vivo_ref: list[object] = []  # probe result collected inside the remote doc
+    mid_revert_ref: list[dict] = []  # stage B: health() probed as the revert load starts
 
     def create_and_record(**kwargs):
         window = original_create(**kwargs)
         window_holder.append(window)
+
+        # Deterministic mid-revert evidence (stage B): wrap load_url so
+        # that, at the exact moment the revert navigation is issued
+        # (get_uri() flips to the SAME entry file:// URL while the
+        # remote document is still the live document and the new local
+        # load has NOT completed), a bridge call is made through the
+        # exact object JS would reach. It must be refused.
+        original_load_url = window.load_url
+        entry_uri = kwargs.get("url")
+
+        def _load_url_probe(url: str):
+            # Stage B (deterministic): fires at the instant the shell
+            # issues the revert navigation (inside load_url, BEFORE the
+            # load starts). At this moment the previous document (the
+            # remote page) is still the live document and the new local
+            # load has not completed. The probe calls health() on the
+            # exact object a JS call from that live document would
+            # reach; it must be refused. (Once the load starts,
+            # get_uri() flips to the same entry URL — WebKitGTK shows
+            # the load that STARTED — so a probe made after
+            # original_load_url() would see the flipped URL; the call
+            # is deliberately made BEFORE it, with the live document
+            # still remote, which is the attacker-relevant moment.)
+            if (
+                url == entry_uri
+                and str(url).startswith("file://")
+            ):
+                current = None
+                try:
+                    current = window.get_current_url()
+                except Exception:  # noqa: BLE001 (evidence only)
+                    current = None
+                if current != entry_uri:
+                    js_api_obj = _get_js_api(window)
+                    if js_api_obj is not None:
+                        try:
+                            mid_revert_ref.append(
+                                {
+                                    "reverting_from": current,
+                                    "health": js_api_obj.health(),
+                                }
+                            )
+                        except Exception:  # noqa: BLE001 (evidence only)
+                            pass
+            return original_load_url(url)
+
+        window.load_url = _load_url_probe  # type: ignore[method-assign]
 
         def _record_loaded():
             try:
@@ -405,31 +462,35 @@ def run_smoke() -> tuple[bool, list[str]]:
             # 5. Remote navigation: the bridge must fail closed for the
             #    remote document AND the shell must revert to the build.
             #
-            #    Evidence strategy (deterministic): polling
-            #    get_current_url() can miss the ENTIRE remote window —
-            #    the revert (triggered by the loaded event) sometimes
-            #    completes before the first poll when the network is
-            #    fast. So the evidence comes from the loaded handler
-            #    itself (registered in create_and_record): it sees the
-            #    remote URL, arms the in-vivo probe inside the live
-            #    remote document, and the direct refusal is executed in
-            #    that same handler — the exact moment the window is
-            #    provably remote.
+            #    Evidence, staged (reviewer follow-up on the same-URL
+            #    revert race):
+            #    A. remote page normally loaded -> health() refuses
+            #       (witnessed and executed inside the loaded handler,
+            #       the same event the revert logic runs on — polling
+            #       get_current_url() can miss the whole remote window
+            #       when the network is fast);
+            #    B. revert issued to the SAME entry URL: the load_url
+            #       wrapper probes health() at the instant the revert is
+            #       issued, with the remote document still the live
+            #       document and the new local load NOT completed (the
+            #       exact window where get_uri() equality would reopen a
+            #       naive URL-comparison bridge) -> must refuse;
+            #    C. after the new local load completed -> health()
+            #       serves the local document again.
             #
-            #    Safe outcomes (all fail-closed):
-            #    (i)  in-vivo refusal: the remote doc obtained a
-            #         working bridge and health() returned the
-            #         sanitized bridge_unavailable payload;
-            #    (ii) never-bridged: the remote doc died before
-            #         pywebview was usable there — probe never fired
-            #         or the call died with the doc (no payload
-            #         delivered);
-            #    (iii) direct refusal: js_api.health() invoked while
-            #          the window is remote (from the loaded handler)
-            #          returned bridge_unavailable.
+            #    The in-vivo probe (armed inside the live remote
+            #    document) stays as best-effort extra evidence: whether
+            #    it fires depends on WebKitGTK timing (the remote doc is
+            #    often destroyed before pywebview is injected there,
+            #    which is a safe outcome — nothing was delivered).
+            #    The deterministic proof of the same-URL state machine
+            #    is the test suite (TestRevertToSameEntryUrl), not this
+            #    smoke: the smoke proves the wiring in a real WebKitGTK
+            #    process; the tests prove every transition of the trust
+            #    machine.
             #
-            #    The ONLY failing outcome is a successful health()
-            #    payload delivered to remote content.
+            #    The ONLY failing outcome for A/B/C is a successful
+            #    health() payload delivered to remote content.
             remote_in_vivo = None
             remote_direct = None
 
@@ -450,7 +511,9 @@ def run_smoke() -> tuple[bool, list[str]]:
             # and executed js_api.health() while the window was
             # provably remote; remote_direct_ref holds that result.
 
-            # Wait for the revert to land back on the local build.
+            # Wait for the revert to land back on the local build and
+            # its load to COMPLETE (loaded fires for the new local
+            # document, which re-commits the trust).
             deadline = time.time() + 20
             reverted = False
             while time.time() < deadline:
@@ -473,9 +536,11 @@ def run_smoke() -> tuple[bool, list[str]]:
                 f"urls_seen={[u[:60] for u in remote_urls_seen[:3]]}",
             )
 
-            # Direct refusal: the in-handler call executes with the
-            # window provably remote. The result is stored in
-            # remote_direct_ref (list filled by the handler).
+            # Direct refusal (stage A): the loaded handler recorded that
+            # the window really showed a remote URL (remote_urls_seen is
+            # the authoritative witness — same event the revert used)
+            # and executed js_api.health() while the window was provably
+            # remote; remote_direct_ref holds that result.
             remote_direct = remote_direct_ref[-1] if remote_direct_ref else None
             direct_ok = bool(
                 remote_direct
@@ -483,9 +548,35 @@ def run_smoke() -> tuple[bool, list[str]]:
                 and remote_direct.get("code") == "bridge_unavailable"
             )
             report.check(
-                "js_api refuses calls while window is remote (direct path)",
+                "A: remote page normally loaded -> bridge refuses (direct path)",
                 direct_ok,
                 json.dumps(remote_direct)[:200] if remote_direct else "no result",
+            )
+
+            # Mid-revert (stage B, deterministic): when the shell issued
+            # the revert load_url(entry) — the SAME file:// URL the
+            # window opened with — the previous (remote) document was
+            # still the live document and the new local load had NOT
+            # completed. The probe called health() at that instant; it
+            # must be refused. This is the same-URL race window: URL
+            # equality must not re-open the bridge.
+            mid_revert = mid_revert_ref[-1] if mid_revert_ref else None
+            mid_revert_ok = bool(
+                mid_revert
+                and isinstance(mid_revert.get("health"), dict)
+                and mid_revert["health"].get("ok") is False
+                and mid_revert["health"].get("code") == "bridge_unavailable"
+                and str(mid_revert.get("reverting_from", "")).startswith("https://")
+            )
+            report.check(
+                "B: revert issued to SAME entry URL, new local load incomplete -> bridge still closed",
+                mid_revert_ok,
+                (
+                    f"reverting_from={str(mid_revert.get('reverting_from'))[:60]!r} "
+                    f"health={json.dumps(mid_revert.get('health'))[:120]}"
+                    if mid_revert
+                    else "revert never observed through load_url (no stage-B evidence)"
+                ),
             )
 
             # In-vivo: the probe armed inside the remote document. If
@@ -522,13 +613,33 @@ def run_smoke() -> tuple[bool, list[str]]:
             )
             never_bridge_ok = never_delivered and direct_ok
             report.check(
-                "bridge failed closed for remote content (in-vivo probe)",
+                "in-vivo (best-effort): remote doc never receives a working bridge",
                 in_vivo_ok or never_bridge_ok,
                 (
                     json.dumps(remote_in_vivo)[:200]
                     if remote_in_vivo
                     else "remote doc destroyed before any bridge call (no result)"
                 ),
+            )
+
+            # Stage C: after the new local load completed, the bridge
+            # must serve the local document again (same entry URL, new
+            # completed load → re-committed trust).
+            js_api_after = _get_js_api(window)
+            after_reload = None
+            if js_api_after is not None:
+                try:
+                    after_reload = js_api_after.health()
+                except Exception:  # noqa: BLE001 (evidence only)
+                    after_reload = None
+            report.check(
+                "C: new local load completed -> bridge serves again",
+                bool(
+                    after_reload
+                    and after_reload.get("ok") is True
+                    and after_reload.get("api_version") == 1
+                ),
+                json.dumps(after_reload)[:200] if after_reload else "no result",
             )
 
             # 6. No HTTP server for the UI in this process.

--- a/scripts/desktop_smoke.py
+++ b/scripts/desktop_smoke.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python3
+"""Reproducible smoke test for the Katherine desktop shell (#334).
+
+Run it headless (it never touches the user's visible screen):
+
+    xvfb-run -a -s "-screen 0 1280x800x24" \
+        .venv/bin/python scripts/desktop_smoke.py
+
+Requirements (documented in README "Desktop shell (Linux)"):
+- a built frontend (``npm run build`` in ``frontend/``; produces
+  ``frontend/dist`` including ``desktop-smoke.html``);
+- pywebview with the GTK (WebKitGTK) backend;
+- a virtual display (Xvfb) when running without a GUI session.
+
+What this smoke proves (issue #334 validation items):
+1. the app opens on Linux from the local frontend build (file://, no
+   HTTP server);
+2. the REAL chat UI renders inside the shell (ChatHeader, message
+   list, input area) without any external server and without faking
+   production auth — the smoke entry mounts the same ChatWindow used
+   by the web app;
+3. the JS -> Python -> JS round trip works: ``window.pywebview.api
+   .health()`` returns the structured payload and the ChatHeader badge
+   (``[data-testid="desktop-bridge-indicator"]``) appears;
+4. invalid input is rejected by the bridge (sanitized error payload,
+   no exception, no stacktrace);
+5. remote content does NOT receive the privileged bridge: after a
+   same-window navigation to a remote URL, the bridge fails closed
+   and the shell reverts to the local build;
+6. closing the window ends the shell cleanly (no leftover threads);
+7. no HTTP server is listening for the UI.
+
+Threading model: pywebview requires the GTK main loop on the main
+thread, so ``webview.start()`` runs on the main thread and the probes
+run on a worker thread. WebKitGTK's ``evaluate_js`` dispatches work to
+the GTK main loop via ``glib.idle_add`` and blocks the caller on a
+semaphore, making it safe to call from the worker thread.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+SMOKE_PAGE = "desktop-smoke.html"
+
+#: Probes evaluated inside the page (must return JSON-serializable data).
+_PROBE_CHAT_UI = """
+(() => {
+  const header = document.querySelector('header');
+  const input = document.querySelector('textarea[aria-label="Sua mensagem"]');
+  const send = document.querySelector('button[aria-label="Enviar mensagem (Enter)"]');
+  const empty = document.body.innerText.includes('Comece uma conversa');
+  return {
+    hasHeader: Boolean(header),
+    hasInput: Boolean(input),
+    hasSendButton: Boolean(send),
+    hasEmptyState: Boolean(empty),
+    headerText: header ? header.innerText.slice(0, 120) : null,
+    viewport: { w: window.innerWidth, h: window.innerHeight },
+  };
+})()
+"""
+
+_PROBE_HEALTH_ROUNDTRIP = """
+(() => {
+  window.__smokeHealth = 'pending';
+  (async () => {
+    const deadline = Date.now() + 8000;
+    while (!(window.pywebview && window.pywebview.api)) {
+      if (Date.now() > deadline) { window.__smokeHealth = { ready: false }; return; }
+      await new Promise(r => setTimeout(r, 100));
+    }
+    try {
+      window.__smokeHealth = await window.pywebview.api.health();
+    } catch (e) {
+      window.__smokeHealth = { threw: true };
+    }
+  })();
+  return 'started';
+})()
+"""
+
+_PROBE_COLLECT_HEALTH = "(() => window.__smokeHealth)()"
+
+_PROBE_INVALID_INPUT = """
+(() => {
+  window.__smokeInvalid = 'pending';
+  (async () => {
+    try {
+      window.__smokeInvalid = await window.pywebview.api.health('unexpected-argument');
+    } catch (e) {
+      window.__smokeInvalid = { threw: true };
+    }
+  })();
+  return 'started';
+})()
+"""
+
+_PROBE_COLLECT_INVALID = "(() => window.__smokeInvalid)()"
+
+_PROBE_NAVIGATE_REMOTE = """
+(() => {
+  // Same-window navigation to remote content, exactly like a link
+  // click or location assignment would do. The remote document gets
+  // probed separately while it is active (fail-closed proof).
+  window.location.assign('https://example.com/');
+  return { navigating: true };
+})()
+"""
+
+# Armed INSIDE the remote document (via evaluate_js while it is
+# alive). If the shell re-injects pywebview into the remote doc, the
+# listener fires as REMOTE content and records the outcome. If the
+# revert destroys the doc first, the collector never sees a result —
+# which itself proves the remote page never obtained a bridge.
+_PROBE_ARM_IN_REMOTE_DOC = """
+(() => {
+  window.__smokeRemoteHealth = 'pending';
+  const fire = () => {
+    if (window.__smokeRemoteHealth !== 'pending') return;
+    (async () => {
+      try {
+        const r = await window.pywebview.api.health();
+        window.__smokeRemoteHealth = { refused: r && r.ok === false, code: r ? r.code : null };
+      } catch (e) {
+        window.__smokeRemoteHealth = { refused: false, threw: true };
+      }
+    })();
+  };
+  if (window.pywebview && window.pywebview.api) { fire(); return { armed: true }; }
+  window.addEventListener('pywebviewready', fire);
+  return { armed: true, waiting: true };
+})()
+"""
+
+_PROBE_BADGE = """
+(() => {
+  const badge = document.querySelector('[data-testid="desktop-bridge-indicator"]');
+  return badge ? { text: badge.innerText } : null;
+})()
+"""
+
+
+def _listening_ports(pid: int) -> list[int]:
+    """Return TCP ports listening for this PID (empty on failure)."""
+    try:
+        out = subprocess.run(
+            ["ss", "-ltnp"], check=True, capture_output=True, text=True
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    ports: list[int] = []
+    for line in out.splitlines():
+        if f"pid={pid}" not in line:
+            continue
+        for tok in line.split():
+            if tok.startswith(("127.0.0.1:", "0.0.0.0:", "[::]:")):
+                try:
+                    ports.append(int(tok.rsplit(":", 1)[1]))
+                except ValueError:
+                    pass
+    return ports
+
+
+def _poll_probe(window, collect_script: str, timeout: float) -> object | None:
+    """Poll an async probe's result until it is deposited on window.
+
+    The async probes store their eventual value on a ``window.__smoke*``
+    key (starting as the string ``'pending'``). This helper polls the
+    synchronous collect script until the value stops being ``'pending'``
+    or the timeout elapses.
+    """
+    deadline = time.time() + timeout
+    result = None
+    while time.time() < deadline:
+        result = window.evaluate_js(collect_script)
+        if result != "pending" and result is not None:
+            return result
+        time.sleep(0.25)
+    return result if result != "pending" else None
+
+
+def _get_js_api(window):
+    """Return the ``js_api`` object the shell delivered at creation.
+
+    pywebview's Window keeps it on ``window._js_api`` (core attribute,
+    set at creation). This is the exact object a JS
+    ``window.pywebview.api.health()`` call would reach, so invoking
+    ``health()`` on it directly reproduces the JS→Python path
+    deterministically (used for the direct refusal check while the
+    window is remote).
+    """
+    return getattr(window, "_js_api", None)
+
+
+class SmokeReport:
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+        self.ok = True
+
+    def check(self, name: str, ok: bool, detail: str = "") -> bool:
+        status = "PASS" if ok else "FAIL"
+        line = f"[{status}] {name}" + (f" — {detail}" if detail else "")
+        print(line)
+        self.lines.append(line)
+        if not ok:
+            self.ok = False
+        return ok
+
+    def info(self, text: str) -> None:
+        print(f"[INFO] {text}")
+        self.lines.append(f"[INFO] {text}")
+
+
+def run_smoke() -> tuple[bool, list[str]]:
+    import webview
+
+    from backend.desktop.app import run_desktop_shell
+    from backend.desktop.build_resolver import (
+        BuildResolutionError,
+        DesktopBuildConfig,
+        resolve_frontend_build,
+    )
+
+    report = SmokeReport()
+
+    # 0. Build must exist (with the smoke page).
+    try:
+        build = resolve_frontend_build(
+            DesktopBuildConfig(frontend_root=REPO_ROOT / "frontend")
+        )
+        if not (build.dist_dir / SMOKE_PAGE).is_file():
+            report.check(
+                "frontend build includes desktop-smoke.html",
+                False,
+                "run 'npm run build' in frontend/ (the smoke page is a build input)",
+            )
+            return report.ok, report.lines
+        report.check("frontend build resolved (dist + smoke page)", True)
+    except BuildResolutionError as err:
+        report.check("frontend build resolved", False, str(err))
+        return report.ok, report.lines
+
+    display = os.environ.get("DISPLAY", "")
+    report.check(
+        "DISPLAY available for WebKitGTK",
+        bool(display),
+        f"DISPLAY={display!r} (use xvfb-run for headless runs)",
+    )
+
+    window_holder: list = []
+    loaded = threading.Event()
+    worker_error: list[str] = []
+    worker = threading.Event()  # worker finished
+
+    startup_started = time.perf_counter()
+
+    original_create = webview.create_window
+
+    def create_and_record(**kwargs):
+        window = original_create(**kwargs)
+        window_holder.append(window)
+        window.events.loaded += loaded.set
+        return window
+
+    webview.create_window = create_and_record  # type: ignore[assignment]
+
+    # Worker thread runs the probes (evaluate_js is threadsafe on GTK:
+    # glib.idle_add + semaphore). The main thread runs webview.start().
+    def probe_worker() -> None:
+        try:
+            if not loaded.wait(timeout=30):
+                worker_error.append("timeout waiting for page load")
+                worker.set()
+                return
+
+            window = window_holder[0]
+            startup_ms = (time.perf_counter() - startup_started) * 1000
+            report.info(f"startup to loaded page: {startup_ms:.0f}ms")
+
+            url = window.get_current_url() or ""
+            report.check(
+                "window loaded the local build via file://",
+                url.startswith("file://"),
+                url[:120],
+            )
+
+            # 2. Real chat UI renders.
+            chat = window.evaluate_js(_PROBE_CHAT_UI)
+            chat_ok = bool(
+                chat
+                and chat.get("hasHeader")
+                and chat.get("hasInput")
+                and chat.get("hasSendButton")
+            )
+            report.check(
+                "real chat UI renders in the shell (header/input/send)",
+                chat_ok,
+                json.dumps(chat)[:300] if chat else "no result",
+            )
+            report.check(
+                "chat empty state visible",
+                bool(chat and chat.get("hasEmptyState")),
+            )
+
+            # 3. Bridge round trip (async probe + polling collect).
+            window.evaluate_js(_PROBE_HEALTH_ROUNDTRIP)
+            health = _poll_probe(window, _PROBE_COLLECT_HEALTH, timeout=10)
+            report.check(
+                "health() round trip JS->Python->JS",
+                bool(
+                    health
+                    and isinstance(health, dict)
+                    and health.get("ok") is True
+                    and health.get("api_version") == 1
+                ),
+                json.dumps(health)[:200] if health else "no result",
+            )
+
+            # Badge appears in the real ChatHeader after the round trip.
+            badge = None
+            deadline = time.time() + 10
+            while time.time() < deadline:
+                badge = window.evaluate_js(_PROBE_BADGE)
+                if badge:
+                    break
+                time.sleep(0.3)
+            report.check(
+                "ChatHeader desktop badge (round trip visible in chat UI)",
+                bool(badge and "desktop" in str(badge.get("text", ""))),
+                json.dumps(badge)[:120] if badge else "badge not found",
+            )
+
+            # 4. Invalid input rejected with sanitized error.
+            window.evaluate_js(_PROBE_INVALID_INPUT)
+            invalid = _poll_probe(window, _PROBE_COLLECT_INVALID, timeout=10)
+            invalid_ok = bool(
+                invalid
+                and invalid.get("ok") is False
+                and invalid.get("code") == "invalid_input"
+                and "Traceback" not in json.dumps(invalid)
+                and "unexpected-argument" not in json.dumps(invalid)
+            )
+            report.check(
+                "invalid input rejected with sanitized error",
+                invalid_ok,
+                json.dumps(invalid)[:200] if invalid else "no result",
+            )
+
+            # 5. Remote navigation: the bridge must fail closed for the
+            #    remote document AND the shell must revert to the build.
+            #
+            #    This block is timing-sensitive (the remote document
+            #    lives briefly before the revert destroys it), so it
+            #    tolerates jitter and accepts the safe outcomes:
+            #
+            #    (i)  in-vivo refusal: the remote doc obtained a
+            #         working bridge and health() returned the
+            #         sanitized bridge_unavailable payload;
+            #    (ii) never-bridged: the remote doc was destroyed
+            #         before pywebview was usable there (no call ever
+            #         reached Python) — no result, or a throw caused
+            #         by the document dying mid-call;
+            #    (iii) direct refusal: with the window observed at a
+            #         remote URL, the exact js_api object a JS call
+            #         would reach refuses (deterministic JS→Python
+            #         path).
+            #
+            #    The ONLY failing outcome is a successful health()
+            #    payload delivered to remote content.
+            remote_in_vivo = None
+            remote_direct = None
+            remote_alive = False
+
+            for _attempt in range(3):
+                window.evaluate_js(_PROBE_NAVIGATE_REMOTE)
+
+                # Deterministic direct probe: while the window shows
+                # the remote URL, invoke the SAME js_api object the
+                # remote page would use (the exact JS→Python path).
+                # NOTE: get_current_url() can still show the local
+                # file:// URL for a few ms after location.assign():
+                # only treat the window as remote once https:// is
+                # actually visible.
+                deadline = time.time() + 15
+                remote_alive = False
+                while time.time() < deadline:
+                    current = window.get_current_url() or ""
+                    if current.startswith("https://"):
+                        remote_alive = True
+                        js_api_obj = _get_js_api(window)
+                        if js_api_obj is not None:
+                            remote_direct = js_api_obj.health()
+                        break
+                    time.sleep(0.05)
+
+                if remote_alive:
+                    break
+                # Navigation did not make a remote URL observable in
+                # time (slow network / GTK scheduling): wait for the
+                # revert to settle and retry the navigation.
+                time.sleep(1.0)
+
+            # In-vivo probe: arm the listener INSIDE the remote
+            # document while it is alive. If the shell re-injects
+            # pywebview there, the listener calls health() as remote
+            # content and stores the outcome on the remote window
+            # object (which dies with the document — collect fast).
+            if remote_alive:
+                try:
+                    window.evaluate_js(_PROBE_ARM_IN_REMOTE_DOC)
+                except Exception:  # noqa: BLE001 (doc may already be gone)
+                    pass
+                sub_deadline = time.time() + 3
+                while time.time() < sub_deadline:
+                    try:
+                        remote_in_vivo = window.evaluate_js(
+                            "(() => window.__smokeRemoteHealth)()"
+                        )
+                    except Exception:  # noqa: BLE001 (doc died mid-call)
+                        remote_in_vivo = None
+                        break
+                    if remote_in_vivo and remote_in_vivo != "pending":
+                        break
+                    # Only stop early once the remote doc is truly
+                    # gone (URL changed away from https): the revert
+                    # destroyed it before the probe could fire.
+                    current = window.get_current_url() or ""
+                    if not current.startswith("https://"):
+                        break
+                    time.sleep(0.1)
+
+            # Wait for the revert to land back on the local build.
+            deadline = time.time() + 20
+            reverted = False
+            while time.time() < deadline:
+                current = window.get_current_url() or ""
+                if current.startswith("file://"):
+                    reverted = True
+                    break
+                time.sleep(0.2)
+            report.check(
+                "remote navigation reverted to local build",
+                reverted,
+                f"current_url={str(window.get_current_url())[:80]!r}",
+            )
+
+            direct_ok = bool(
+                remote_direct
+                and remote_direct.get("ok") is False
+                and remote_direct.get("code") == "bridge_unavailable"
+            )
+            report.check(
+                "js_api refuses calls while window is remote (direct path)",
+                direct_ok,
+                json.dumps(remote_direct)[:200] if remote_direct else "no result",
+            )
+
+            in_vivo_ok = bool(
+                remote_in_vivo
+                and remote_in_vivo.get("refused") is True
+                and remote_in_vivo.get("code") == "bridge_unavailable"
+            )
+            # Safe alternative outcomes, none of which delivers a
+            # successful payload to remote content:
+            #   * no result at all (doc destroyed before the probe
+            #     fired — the remote page never obtained a bridge);
+            #   * the collect threw because the doc died mid-call
+            #     (remote_in_vivo is None after the exception);
+            #   * the probe fired but the call itself threw inside the
+            #     dying document ({refused: false, threw: true}) — the
+            #     payload was never delivered.
+            never_delivered = (
+                remote_in_vivo is None
+                or bool(remote_in_vivo.get("threw"))
+            )
+            never_bridge_ok = never_delivered and direct_ok
+            report.check(
+                "bridge failed closed for remote content (in-vivo probe)",
+                in_vivo_ok or never_bridge_ok,
+                (
+                    json.dumps(remote_in_vivo)[:200]
+                    if remote_in_vivo
+                    else "remote doc destroyed before any bridge call (no result)"
+                ),
+            )
+
+            # 6. No HTTP server for the UI in this process.
+            ports = _listening_ports(os.getpid())
+            report.check(
+                "no HTTP server listening for the UI",
+                not ports,
+                f"ports={ports}",
+            )
+
+            # 7. Closing the window ends the shell cleanly (checked by
+            # the main thread after webview.start() returns).
+        except Exception as exc:  # noqa: BLE001 (report and bail out)
+            worker_error.append(f"{type(exc).__name__}: {exc}")
+        finally:
+            worker.set()
+            # Close the window from the worker if it is still open.
+            try:
+                if window_holder:
+                    window_holder[0].destroy()
+            except Exception:  # noqa: BLE001 (best-effort cleanup)
+                pass
+
+    probe_thread = threading.Thread(target=probe_worker, daemon=True)
+    probe_thread.start()
+
+    try:
+        run_desktop_shell(html_name=SMOKE_PAGE)  # blocks on main thread
+    finally:
+        webview.create_window = original_create  # type: ignore[assignment]
+
+    probe_thread.join(timeout=15)
+
+    if worker_error:
+        report.check("probe worker completed without errors", False, "; ".join(worker_error))
+    else:
+        report.check("probe worker completed without errors", True)
+
+    report.check(
+        "closing the window ends the shell (webview.start returned)",
+        True,
+    )
+
+    return report.ok, report.lines
+
+
+def main() -> int:
+    print("Katherine desktop shell smoke (#334)")
+    print(f"repo: {REPO_ROOT}")
+    print(f"python: {sys.version.split()[0]}\n")
+    ok, _ = run_smoke()
+    print()
+    print("SMOKE_OK" if ok else "SMOKE_FAILED")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/desktop_smoke.py
+++ b/scripts/desktop_smoke.py
@@ -267,10 +267,55 @@ def run_smoke() -> tuple[bool, list[str]]:
 
     original_create = webview.create_window
 
+    # Evidence captured by the loaded handler itself (the same event
+    # the revert logic runs on — it ALWAYS sees the remote URL, while
+    # polling get_current_url() can miss the whole remote window when
+    # the network is fast: the revert completes before the first poll).
+    remote_urls_seen: list[str] = []  # URLs captured on loaded events
+    remote_direct_ref: list[object] = []  # js_api.health() called in-handler while remote
+    in_vivo_ref: list[object] = []  # probe result collected inside the remote doc
+
     def create_and_record(**kwargs):
         window = original_create(**kwargs)
         window_holder.append(window)
-        window.events.loaded += loaded.set
+
+        def _record_loaded():
+            try:
+                url = window.get_current_url() or ""
+            except Exception:  # noqa: BLE001 (evidence only)
+                url = ""
+            if url.startswith("https://"):
+                remote_urls_seen.append(url)
+                # Deterministic direct refusal, executed at the exact
+                # moment the window is provably remote: invoke the same
+                # js_api object a JS call from this remote page would
+                # reach. Fail-closed must refuse it here.
+                try:
+                    js_api_obj = _get_js_api(window)
+                    if js_api_obj is not None:
+                        remote_direct_ref.append(js_api_obj.health())
+                except Exception:  # noqa: BLE001 (evidence only)
+                    pass
+                # Arm the in-vivo probe INSIDE the live remote document
+                # and immediately collect what it stores: this is the
+                # only moment the remote doc is guaranteed alive. If
+                # pywebview is (re)injected there, the listener calls
+                # health() as remote content; otherwise the value
+                # stays 'pending'/absent (no payload delivered).
+                try:
+                    in_vivo_ref.append(
+                        window.evaluate_js(_PROBE_ARM_IN_REMOTE_DOC)
+                    )
+                    in_vivo_ref.append(
+                        window.evaluate_js(
+                            "(() => window.__smokeRemoteHealth)()"
+                        )
+                    )
+                except Exception:  # noqa: BLE001 (doc may already be dying)
+                    pass
+            loaded.set()
+
+        window.events.loaded += _record_loaded
         return window
 
     webview.create_window = create_and_record  # type: ignore[assignment]
@@ -360,85 +405,50 @@ def run_smoke() -> tuple[bool, list[str]]:
             # 5. Remote navigation: the bridge must fail closed for the
             #    remote document AND the shell must revert to the build.
             #
-            #    This block is timing-sensitive (the remote document
-            #    lives briefly before the revert destroys it), so it
-            #    tolerates jitter and accepts the safe outcomes:
+            #    Evidence strategy (deterministic): polling
+            #    get_current_url() can miss the ENTIRE remote window —
+            #    the revert (triggered by the loaded event) sometimes
+            #    completes before the first poll when the network is
+            #    fast. So the evidence comes from the loaded handler
+            #    itself (registered in create_and_record): it sees the
+            #    remote URL, arms the in-vivo probe inside the live
+            #    remote document, and the direct refusal is executed in
+            #    that same handler — the exact moment the window is
+            #    provably remote.
             #
+            #    Safe outcomes (all fail-closed):
             #    (i)  in-vivo refusal: the remote doc obtained a
             #         working bridge and health() returned the
             #         sanitized bridge_unavailable payload;
-            #    (ii) never-bridged: the remote doc was destroyed
-            #         before pywebview was usable there (no call ever
-            #         reached Python) — no result, or a throw caused
-            #         by the document dying mid-call;
-            #    (iii) direct refusal: with the window observed at a
-            #         remote URL, the exact js_api object a JS call
-            #         would reach refuses (deterministic JS→Python
-            #         path).
+            #    (ii) never-bridged: the remote doc died before
+            #         pywebview was usable there — probe never fired
+            #         or the call died with the doc (no payload
+            #         delivered);
+            #    (iii) direct refusal: js_api.health() invoked while
+            #          the window is remote (from the loaded handler)
+            #          returned bridge_unavailable.
             #
             #    The ONLY failing outcome is a successful health()
             #    payload delivered to remote content.
             remote_in_vivo = None
             remote_direct = None
-            remote_alive = False
 
-            for _attempt in range(3):
-                window.evaluate_js(_PROBE_NAVIGATE_REMOTE)
+            window.evaluate_js(_PROBE_NAVIGATE_REMOTE)
 
-                # Deterministic direct probe: while the window shows
-                # the remote URL, invoke the SAME js_api object the
-                # remote page would use (the exact JS→Python path).
-                # NOTE: get_current_url() can still show the local
-                # file:// URL for a few ms after location.assign():
-                # only treat the window as remote once https:// is
-                # actually visible.
-                deadline = time.time() + 15
-                remote_alive = False
-                while time.time() < deadline:
-                    current = window.get_current_url() or ""
-                    if current.startswith("https://"):
-                        remote_alive = True
-                        js_api_obj = _get_js_api(window)
-                        if js_api_obj is not None:
-                            remote_direct = js_api_obj.health()
-                        break
-                    time.sleep(0.05)
-
-                if remote_alive:
+            # The revert is triggered by the shell's loaded handler;
+            # give it time to fire and then settle back on the build.
+            deadline = time.time() + 20
+            while time.time() < deadline:
+                current = window.get_current_url() or ""
+                if current.startswith("file://") and remote_urls_seen:
                     break
-                # Navigation did not make a remote URL observable in
-                # time (slow network / GTK scheduling): wait for the
-                # revert to settle and retry the navigation.
-                time.sleep(1.0)
+                time.sleep(0.2)
 
-            # In-vivo probe: arm the listener INSIDE the remote
-            # document while it is alive. If the shell re-injects
-            # pywebview there, the listener calls health() as remote
-            # content and stores the outcome on the remote window
-            # object (which dies with the document — collect fast).
-            if remote_alive:
-                try:
-                    window.evaluate_js(_PROBE_ARM_IN_REMOTE_DOC)
-                except Exception:  # noqa: BLE001 (doc may already be gone)
-                    pass
-                sub_deadline = time.time() + 3
-                while time.time() < sub_deadline:
-                    try:
-                        remote_in_vivo = window.evaluate_js(
-                            "(() => window.__smokeRemoteHealth)()"
-                        )
-                    except Exception:  # noqa: BLE001 (doc died mid-call)
-                        remote_in_vivo = None
-                        break
-                    if remote_in_vivo and remote_in_vivo != "pending":
-                        break
-                    # Only stop early once the remote doc is truly
-                    # gone (URL changed away from https): the revert
-                    # destroyed it before the probe could fire.
-                    current = window.get_current_url() or ""
-                    if not current.startswith("https://"):
-                        break
-                    time.sleep(0.1)
+            # Direct refusal: the loaded handler recorded that the
+            # window really showed a remote URL (remote_urls_seen is
+            # the authoritative witness — same event the revert used)
+            # and executed js_api.health() while the window was
+            # provably remote; remote_direct_ref holds that result.
 
             # Wait for the revert to land back on the local build.
             deadline = time.time() + 20
@@ -455,6 +465,18 @@ def run_smoke() -> tuple[bool, list[str]]:
                 f"current_url={str(window.get_current_url())[:80]!r}",
             )
 
+            # The remote window was provably alive: the loaded handler
+            # (the same event the revert logic uses) witnessed it.
+            report.check(
+                "remote navigation reached a remote document (witnessed by loaded handler)",
+                bool(remote_urls_seen),
+                f"urls_seen={[u[:60] for u in remote_urls_seen[:3]]}",
+            )
+
+            # Direct refusal: the in-handler call executes with the
+            # window provably remote. The result is stored in
+            # remote_direct_ref (list filled by the handler).
+            remote_direct = remote_direct_ref[-1] if remote_direct_ref else None
             direct_ok = bool(
                 remote_direct
                 and remote_direct.get("ok") is False
@@ -465,6 +487,20 @@ def run_smoke() -> tuple[bool, list[str]]:
                 direct_ok,
                 json.dumps(remote_direct)[:200] if remote_direct else "no result",
             )
+
+            # In-vivo: the probe armed inside the remote document. If
+            # pywebview was injected there, health() was called as
+            # remote content; the outcome was collected by the loaded
+            # handler itself (the doc dies with its window object, so
+            # it had to be read before the doc died). The arm call
+            # returns {armed: true}; the collect returns the stored
+            # outcome — take the LAST collected value, skipping the
+            # arm result dicts.
+            remote_in_vivo = None
+            for value in reversed(in_vivo_ref):
+                if isinstance(value, dict) and "armed" not in value:
+                    remote_in_vivo = value
+                    break
 
             in_vivo_ok = bool(
                 remote_in_vivo


### PR DESCRIPTION
## Problema

A issue #334 pede a validação do **pywebview como shell desktop Linux da Katherine**: provar que a UI real (build Vite) pode rodar numa janela nativa, com bridge Python controlada, **sem servidor HTTP para a UI**, aditiva apenas, sem lógica de domínio.

Além da prova arquitetural, o smoke inicial expôs um bug real de frontend: em builds de produção sem credenciais Supabase, o `@supabase/auth-ui-react` crashava com `TypeError: null is not an object (evaluating 't.auth')` — o `AuthPage` passava `supabase=null` incondicionalmente e a janela ficava branca. O guard antigo em `supabaseClient.js` (baseado em `process.env.NODE_ENV`) é dead code no bundle de produção, porque o Vite substitui a expressão em tempo de build.

## Solução

Prova arquitetural mínima em `backend/desktop/` (novo, isolado, aditivo):

- **`api.py`** — bridge allowlistada exposta via `js_api`: superfície é exatamente `("health",)`, tudo público vira bridge por construção (pywebview expõe todos os atributos públicos). Erros são estruturados e sanitizados (`DesktopApiError` + `safe_call`): nunca vazam traceback, tipos, paths ou detalhes internos. Import puro: sem efeitos, sem leitura de ambiente, sem importar pywebview.
- **`build_resolver.py`** — resolução explícita e restrita de `frontend/dist`: config validada (diretório existente), sem strings de path do caller, sem expansão de ambiente (path traversal estruturalmente impossível), falha explicitamente com mensagem acionável se o build não existir, zero writes.
- **`app.py`** — entrypoint mínimo: resolve build → cria janela 1280x800 apontando para `index.html` via `file://` → bloqueia até fechar. Sem servidores, threads, sockets, portas ou lógica de domínio. Nunca aceita URL arbitrária.

Frontend (aditivo, modo web intacto):

- **`desktopBridge.js`** — único lugar que toca `window.pywebview`: espera limitada (5s) por `pywebviewready`, valida shape do payload, retorna `null` fora do shell (web mode nunca espera a bridge).
- **`ChatHeader.jsx`** — badge não-bloqueante `desktop v1` com o round trip JS→Python→JS, visível só dentro do shell.
- **`AuthPage.jsx`** — sem cliente Supabase, renderiza `DesktopNotice` local (aviso de modo desktop, pt-BR) em vez de crashar; `Shell` extraído preserva o visual original.
- **`supabaseClient.js`/`App.jsx`** — fail fast só sob o Vite dev server (`import.meta` é avaliado pelo próprio Vite, guard sobrevive ao build de produção); builds sem credenciais bootam até a tela de auth.
- **`vite.config.js`** — `base: './'` para o build carregar via `file://`.

## Bridge

- Superfície: `health()` → `{"ok": true, "api_version": 1}`. Sem `eval`/`exec`/`shell`/`fs`/`secrets`/`navigate` — coberto por testes que leem o AST do pacote.
- Toda entrada é validada; toda saída é JSON-serializable plain data; erros internos viram `{"ok": false, "code": "internal_error", "message": ...}` sanitizado.
- Trust por load, não por URL: `BuildTrust` começa revogado; só o evento `loaded` **local** (WebKitGTK `FINISHED`) o (re)estabelece. Igualdade de URL **não** é evidência de identidade nem de conclusão de load — `get_uri()` reflete o load iniciado, não o vivo. O revert de navegação remota chama `revoke()` **antes** de `load_url` (não depois), então o documento remoto ainda vivo encontra `bridge_unavailable` mesmo se o `get_uri()` já voltou a apontar para o `file://` local. Cobertura determinística em `TestRevertToSameEntryUrl` (mesmo `entry_html`, 5 testes).

## Lifecycle

- Startup: `python -m backend.desktop.app` (sem args). Sem build → exit 2 com mensagem acionável.
- Shutdown = fechar a janela: `webview.start()` retorna e o processo sai normalmente. Sem `os._exit`, sem kills, sem handlers escondidos.
- Zero threads/sockets/portas criados pelo shell.

## Segurança

- Allowlist como única superfície JS (testado: `safe_call("navigate", url)` → `Unknown method.`).
- URL sempre derivada do build resolvido (`as_uri()` de `dist/index.html`), nunca input do caller.
- Política de navegação (`NavigationPolicy`): qualquer destino não idêntico ao build local é revertido, com `BuildTrust.revoke()` emitido **antes** do `load_url` do revert. O documento remoto vivo encontra `bridge_unavailable` — igualdade de URL não é tratada como evidência de identidade (o `get_uri()` do WebKitGTK reflete o load iniciado, não o vivo). Cobertura: `TestRevertToSameEntryUrl` (mesmo `entry_html`, 5 testes) + smoke A/B/C com probe determinístico no instante do revert.
- Scan do pacote: sem `eval`, `exec`, `subprocess`, `shell`, `webbrowser`, `open`, sem literais de URL string.
- Sem HTTP hosting artificial da UI; erros sanitizados; nenhuma credencial envolvida (o shell é offline por design).

## Dependências

- `pywebview==6.2.1` adicionada a `backend/requirements.in`; locks regenerados via pip-compile (adiciona `bottle` e `proxy-tools` como transitivas). `pip check` OK.
- Deps de sistema (não travadas pelo pip): `gir1.2-webkit2-4.1` (WebKitGTK), `python3-gi`. Documentadas como requisito Linux do shell.

## Validação

- Backend: 61 testes desktop (api, resolver, segurança, navegação com o trust model por load). Suíte replica do job de CI: **2635 passed** (mesmos 17 ignores do CI). A correção da race do revert same-URL foi validada por TDD: os 5 testes novos falham contra o head anterior (verificado por stash round-trip) e passam no fix.
- Frontend: 102 testes node + 60 de componentes passam; lint e build (`npm run build`) verdes.
- `python -m compileall -q backend` OK.
- Smoke headless em **Xvfb** (display virtual, sem tocar a tela do usuário), 16 checks **[PASS]** → `SMOKE_OK`: build resolvido, janela carregando o build local via `file://`, **chat UI real renderizando no shell** (header/input/send + empty state via `evaluate_js`), round-trip JS→Python→JS (`health()`), badge `desktop v1` no ChatHeader, input inválido com erro sanitizado, navegação remota revertida com testemunha `urls_seen=['https://example.com/']`, **fail-closed da bridge nos estágios A/B/C** (A: recusa direta no handler `loaded`; B: probe determinístico no instante do revert same-URL, `reverting_from='https://example.com/'` → `bridge_unavailable`; C: bridge volta a servir após o novo load local), in-vivo best-effort, nenhum servidor HTTP escutando, e fechar a janela encerra o shell. Nota honesta: o probe in-vivo depende do timing do WebKitGTK (doc remoto costuma morrer antes da injeção) e é evidência extra, não prova; a prova determinística da máquina de estados same-URL é `TestRevertToSameEntryUrl`.
- Pixel analysis (remontada): ~99.2% pixels escuros, 0.04% branco — tela branca eliminada.

## Recursos (medições honestas, Xvfb, smoke atual)

Medições re-executadas no head atual (Ubuntu 24.04 + WebKitGTK, `desktop-smoke.html` com a ChatWindow real montada):

- Smoke completo: **~2.0-2.2s** por run, RSS pico (VmHWM) **~195MB** (194832-195316 kB em 4 runs, inclui a fase de navegação remota).
- Janela idle viva (harness separado, 14s de amostragem): RSS estável **~190MB** (190148-190528 kB), CPU **0% em steady state** (5 amostras de 2s consecutivas a 0%; 1-2% apenas durante o load).
- Processos: **1** (nenhum servidor/worker extra).

## Limitações

- Prova arquitetural apenas: sem credenciais no shell desktop (a tela de auth existe e não crasha — `AuthPage` renderiza `DesktopNotice` local sem cliente Supabase), sem conversas reais, sem backend de domínio.
- WebKitGTK é o único backend validado (Linux); outros backends do pywebview fora de escopo.
- Setup validado e **reproduzido de ponta a ponta em venv fresh** (Ubuntu 24.04): `pywebview==6.2.1` do lock (sem extra `[gtk]`) + PyGObject/WebKitGTK do sistema (`python3-gi`, `gir1.2-webkit2-4.1`) via venv `--system-site-packages` (requer `python3.12-venv` para `python3 -m venv`; alternativa uv documentada com `--index-strategy unsafe-best-match` pelo `--extra-index-url` do torch no lock). Na venv fresh: smoke 17/17 **[PASS]** + **SMOKE_OK** e os 61 testes desktop passam. Sem `$DISPLAY`: exit 1 + `Gtk-WARNING` do GTK (sem fallback). Detalhes em `docs/operations/desktop-shell-linux.md`.
- Artefato conhecido de ferramenta: `xwd` sobre Xvfb entrega framebuffer com shift horizontal (bug da captura, não do app; medições de geometria via DOM foram feitas por `evaluate_js`).

## Fora de escopo (explicitamente)

- Empacotamento/installer, ícone, .desktop, AppImage.
- Auth nativa/desktop, keyring, persistência de sessão no shell.
- Qualquer item das issues #335+, #326/#329/#330.

Closes #334



