### PR TITLE
feat(storage): local SQLite persistence foundation (#335)

### DIFF
--- a/backend/local_storage/__init__.py
+++ b/backend/local_storage/__init__.py
@@ -1,0 +1,70 @@
+"""SQLite local persistence foundation for the Katherine desktop app (#335).
+
+Public contract (the only names importers should rely on):
+
+- ``LocalStorage`` — the store facade: open, migrate, commit a turn
+  atomically, load state/history, replay, privacy operations, trim,
+  backup, metrics, close.
+- ``open_local_storage(path)`` — open (creating if needed) and migrate a
+  database file. The connection lifecycle belongs to the application.
+- ``default_database_path(env)`` — XDG-compliant default location with an
+  injectable environment mapping for tests.
+- ``StorageCorruptError`` — explicit corruption signal; the store is
+  never silently reset.
+
+Design invariants (mirrors the PostgreSQL contract, local-first):
+
+1. **Atomic turn commit.** Messages, profile revision CAS, turn ledger
+   row and outbox rows are written inside one ``BEGIN IMMEDIATE``
+   transaction. Any failure rolls the whole turn back — messages and
+   snapshots can never diverge after a crash.
+2. **Revision CAS.** ``profiles.revision`` is the optimistic-concurrency
+   token: a commit with a stale ``expected_revision`` raises
+   ``ConflictError("revision_mismatch")`` and persists nothing.
+3. **Versioned, ordered, idempotent migrations** recorded in
+   ``schema_migrations``. A migration that fails partially leaves no
+   trace of completion (each migration runs in its own transaction and
+   its version row is only inserted after its DDL succeeds).
+4. **Foreign keys enforced** on every connection; integrity is real,
+   not advisory.
+5. **Explicit durability policy**: WAL journaling + ``synchronous=FULL``
+   (documented in ``docs/architecture/local-sqlite-persistence.md``).
+6. **Serialization policy for the single process**: one writer lock per
+   store; writers take ``BEGIN IMMEDIATE`` before the first write so
+   lock upgrades cannot fail mid-transaction; readers use per-thread
+   connections and WAL gives them a consistent committed snapshot.
+7. **Sanitized errors.** Public errors are stable code+message pairs.
+   SQL text, paths, raw content and driver details never cross the API.
+8. **No cloud imports.** The package imports only stdlib sqlite3/JSON —
+   importing it never pulls Supabase/PostgREST/HTTP stacks.
+
+Removed versus the web schema (each removal documented in the issue
+#335 invariant table): multi-user ``user_id`` columns, RLS, service-role
+grants, distributed advisory locks, identity HMAC, and lease/claim
+machinery (single process ⇒ the writer lock + pending→failed recovery
+policy replace distributed leases).
+"""
+
+from __future__ import annotations
+
+from . import migrations
+from .storage import (
+    ConflictError,
+    LocalStorage,
+    PersistenceError,
+    StorageCorruptError,
+    ValidationError,
+    default_database_path,
+    open_local_storage,
+)
+
+__all__ = [
+    "ConflictError",
+    "LocalStorage",
+    "PersistenceError",
+    "StorageCorruptError",
+    "ValidationError",
+    "default_database_path",
+    "migrations",
+    "open_local_storage",
+]

--- a/backend/local_storage/__init__.py
+++ b/backend/local_storage/__init__.py
@@ -53,6 +53,10 @@ Design invariants (mirrors the PostgreSQL contract, local-first):
 10. **Terminal lifecycle.** After ``close()`` no new connection is
     created and no operation proceeds on any thread; every later call
     fails with the stable sanitized ``PersistenceError("storage_closed")``.
+    Connections stay per-thread (never shared), but are opened with
+    ``check_same_thread=False`` so ``close()`` deterministically closes
+    (no GC reliance) connections other threads created; ``backup_to()``
+    on a closed store fails before creating any file or directory.
 11. **Sanitized errors.** Public errors are stable code+message pairs.
     SQL text, paths, raw content and driver details never cross the API.
 12. **No cloud imports.** The package imports only stdlib sqlite3/JSON —

--- a/backend/local_storage/__init__.py
+++ b/backend/local_storage/__init__.py
@@ -21,22 +21,42 @@ Design invariants (mirrors the PostgreSQL contract, local-first):
 2. **Revision CAS.** ``profiles.revision`` is the optimistic-concurrency
    token: a commit with a stale ``expected_revision`` raises
    ``ConflictError("revision_mismatch")`` and persists nothing.
-3. **Versioned, ordered, idempotent migrations** recorded in
+3. **Request idempotency with payload conflict.** The canonical payload
+   hash covers every determinative input (request id, expected revision,
+   both messages, both snapshots, public response, replay payload,
+   outbox events). The same request id with the same canonical payload
+   replays the committed result without writing; any divergent input
+   raises ``ConflictError("request_payload_conflict")`` without writing
+   anything, and never echoes the payload.
+4. **Validated payloads.** Replay payloads, outbox events and snapshots
+   are validated at the store boundary (``local_storage.contracts``):
+   public allowlists, forbidden keys at any depth, finite canonical JSON,
+   explicit byte bounds, real domain v1 snapshot structure, and the
+   domain-produced neutral v1 snapshot as the only reset payload.
+5. **Real delete_history semantics.** One transaction removes
+   ``chat_logs``, ``turn_requests`` (replay ledger included) and the
+   derived ``outbox_events``; afterwards replay is unavailable. The
+   privacy audit row keeps aggregate counts only.
+6. **Versioned, ordered, idempotent migrations** recorded in
    ``schema_migrations``. A migration that fails partially leaves no
    trace of completion (each migration runs in its own transaction and
    its version row is only inserted after its DDL succeeds).
-4. **Foreign keys enforced** on every connection; integrity is real,
-   not advisory.
-5. **Explicit durability policy**: WAL journaling + ``synchronous=FULL``
+7. **Foreign keys enforced** on every connection; integrity is real,
+   not advisory. Ledger rows cascade to their derived outbox events;
+   turn ledger messages cascade with the ledger on deletion.
+8. **Explicit durability policy**: WAL journaling + ``synchronous=FULL``
    (documented in ``docs/architecture/local-sqlite-persistence.md``).
-6. **Serialization policy for the single process**: one writer lock per
+9. **Serialization policy for the single process**: one writer lock per
    store; writers take ``BEGIN IMMEDIATE`` before the first write so
    lock upgrades cannot fail mid-transaction; readers use per-thread
    connections and WAL gives them a consistent committed snapshot.
-7. **Sanitized errors.** Public errors are stable code+message pairs.
-   SQL text, paths, raw content and driver details never cross the API.
-8. **No cloud imports.** The package imports only stdlib sqlite3/JSON —
-   importing it never pulls Supabase/PostgREST/HTTP stacks.
+10. **Terminal lifecycle.** After ``close()`` no new connection is
+    created and no operation proceeds on any thread; every later call
+    fails with the stable sanitized ``PersistenceError("storage_closed")``.
+11. **Sanitized errors.** Public errors are stable code+message pairs.
+    SQL text, paths, raw content and driver details never cross the API.
+12. **No cloud imports.** The package imports only stdlib sqlite3/JSON —
+    importing it never pulls Supabase/PostgREST/HTTP stacks.
 
 Removed versus the web schema (each removal documented in the issue
 #335 invariant table): multi-user ``user_id`` columns, RLS, service-role

--- a/backend/local_storage/contracts.py
+++ b/backend/local_storage/contracts.py
@@ -1,0 +1,459 @@
+"""Payload contracts for the local SQLite store (#335).
+
+These validators enforce, at the local store boundary, the same invariants
+the PostgreSQL transactional schema enforces for the web runtime
+(``backend.transactional_schema`` / ``backend.atomic_turn_commit``), adapted
+to the single-user desktop context:
+
+- **canonical serialization**: deterministic JSON (sorted keys, compact
+  separators, UTF-8, ``allow_nan=False``) for hashing and storage;
+- **replay payload**: public allowlist, forbidden keys at any depth, finite
+  JSON, explicit byte bound;
+- **outbox events**: shape, event type, idempotency key, payload allowlist,
+  forbidden keys at any depth, value types, finite JSON, explicit byte bound
+  — the outbox carries references, never conversation content;
+- **snapshots**: exact v1 domain structure validated by the real domain
+  models (``EmotionalStateV1`` / ``RelationshipStateV1``), which already
+  reject identity fields, internal content, unknown keys, out-of-range
+  values, non-finite numbers and unbounded size;
+- **neutral snapshots**: the canonical neutral v1 snapshot produced by the
+  domain constructors is the only accepted reset payload.
+
+The module is deliberately local to the storage package: it must not import
+the Supabase/HTTP stack, and importing it never triggers network access.
+Domain models are imported lazily inside functions so importing the package
+contract surface stays cheap and dependency-free.
+
+All errors are stable ``code`` + constant ``message`` pairs (the local
+``ValidationError``): a rejected value, key or payload content is never
+echoed into the error.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Mapping
+
+from .errors import ValidationError
+
+# ---------------------------------------------------------------------------
+# Bounds (mirror the web contract sizes; identical semantics locally)
+# ---------------------------------------------------------------------------
+
+# Maximum serialized payload size in bytes (UTF-8), applied to the replay
+# payload, each outbox event payload, and each snapshot.
+MAX_REPLAY_PAYLOAD_BYTES = 8192
+MAX_OUTBOX_PAYLOAD_BYTES = 256
+MAX_SNAPSHOT_BYTES = 4096
+
+# Outbox event identifiers.
+MAX_IDEMPOTENCY_KEY_LENGTH = 128
+MAX_EVENT_TYPE_LENGTH = 64
+
+# Maximum number of outbox events accepted per turn commit.
+MAX_OUTBOX_EVENTS = 32
+
+# Explicit ASCII regexes (``str.isalnum`` accepts Unicode the web contract
+# rejects; the local contract keeps the same charset).
+_IDEMPOTENCY_KEY_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
+_EVENT_TYPE_RE = re.compile(r"^[a-z0-9_]{1,64}$")
+
+# ---------------------------------------------------------------------------
+# Allowlists and forbidden keys (parity with transactional_schema)
+# ---------------------------------------------------------------------------
+
+# Keys that may never appear inside a stored payload document, at any depth.
+# ``message`` / ``user_message`` / ``assistant_message`` / ``content`` are
+# forbidden so the outbox and replay payloads can never duplicate prompts or
+# conversation content.
+FORBIDDEN_PAYLOAD_KEYS = frozenset(
+    {
+        "prompt",
+        "system_prompt",
+        "meta_cognition",
+        "internal_instructions",
+        "message",
+        "user_message",
+        "assistant_message",
+        "content",
+    }
+)
+
+# Local snapshot forbidden keys: the base forbidden set plus identity fields.
+# Identity is never trusted from JSON documents.
+SNAPSHOT_FORBIDDEN_KEYS = FORBIDDEN_PAYLOAD_KEYS | frozenset(
+    {"user_id", "bond_label"}
+)
+
+# Explicit allowlist of top-level keys for ``turn_requests.replay_payload``.
+# Only public result fields are permitted.
+REPLAY_PAYLOAD_ALLOWED_KEYS = frozenset(
+    {"response", "emotion_state", "message_id", "request_id", "duration_ms"}
+)
+
+# Explicit allowlist of top-level keys for ``outbox_events.payload``.
+# Event payloads carry only stable references and public event metadata.
+OUTBOX_PAYLOAD_ALLOWED_KEYS = frozenset(
+    {"ref", "request_id", "turn_id", "message_id", "entity_id", "kind", "version"}
+)
+
+
+# ---------------------------------------------------------------------------
+# Canonical serialization
+# ---------------------------------------------------------------------------
+
+
+def canonical_json(value: Any) -> str:
+    """Serialize deterministically: sorted keys, compact separators, UTF-8.
+
+    ``allow_nan=False``: ``NaN`` / ``Infinity`` / ``-Infinity`` are rejected
+    (not interoperable JSON; hashing them would break idempotency). Raises
+    the sanitized ``ValidationError`` — the offending value is never echoed.
+    """
+    try:
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    except (TypeError, ValueError):
+        raise ValidationError(
+            "invalid_payload", "payload is not canonical JSON serializable"
+        ) from None
+
+
+def _require_canonical_bytes(value: Any, code: str, max_bytes: int) -> None:
+    """Reject a value that is not finite JSON or exceeds the byte bound.
+
+    Non-finite floats (``NaN`` / ``Infinity``) are rejected with the same
+    stable ``code`` the calling validator uses, so callers see one error
+    contract per payload kind.
+    """
+    try:
+        serialized = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    except (TypeError, ValueError):
+        raise ValidationError(code, "payload is not finite JSON") from None
+    if len(serialized.encode("utf-8")) > max_bytes:
+        raise ValidationError(code, f"payload exceeds {max_bytes} bytes")
+
+
+def _has_forbidden(obj: Any, forbidden: frozenset[str]) -> bool:
+    """Recursively detect any forbidden key at any depth."""
+    if isinstance(obj, Mapping):
+        for key, nested in obj.items():
+            if key in forbidden or _has_forbidden(nested, forbidden):
+                return True
+    elif isinstance(obj, (list, tuple)):
+        for nested in obj:
+            if _has_forbidden(nested, forbidden):
+                return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Replay payload
+# ---------------------------------------------------------------------------
+
+
+def validate_replay_payload(payload: Any) -> Mapping[str, Any]:
+    """Validate the public replay payload of one turn.
+
+    Requirements:
+
+    - must be a ``Mapping``;
+    - only allowlisted public keys;
+    - no forbidden key at any depth (prompts, raw messages, meta-cognition,
+      internal instructions, hidden ``content``);
+    - ``response`` is required and must be a string;
+    - finite JSON within the explicit byte bound.
+    """
+    if not isinstance(payload, Mapping):
+        raise ValidationError("invalid_replay_payload", "replay payload must be a mapping")
+    if _has_forbidden(payload, FORBIDDEN_PAYLOAD_KEYS):
+        raise ValidationError("invalid_replay_payload", "replay payload contains forbidden keys")
+    unknown = set(payload) - REPLAY_PAYLOAD_ALLOWED_KEYS
+    if unknown:
+        raise ValidationError("invalid_replay_payload", "replay payload contains unknown keys")
+    response = payload.get("response")
+    if not isinstance(response, str):
+        raise ValidationError(
+            "invalid_replay_payload", "replay payload requires a string response field"
+        )
+    _require_canonical_bytes(
+        payload, "invalid_replay_payload", MAX_REPLAY_PAYLOAD_BYTES
+    )
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Outbox events
+# ---------------------------------------------------------------------------
+
+
+def _validate_idempotency_key(key: Any, index: int) -> None:
+    if not isinstance(key, str):
+        raise ValidationError("invalid_outbox_events", "idempotency key must be a string")
+    if not _IDEMPOTENCY_KEY_RE.fullmatch(key):
+        raise ValidationError(
+            "invalid_outbox_events", "idempotency key charset or length is invalid"
+        )
+
+
+def _validate_outbox_event(event: Any, index: int) -> tuple[str, Mapping[str, Any], str]:
+    """Validate one outbox event ``(event_type, payload, idempotency_key)``."""
+    if not isinstance(event, (list, tuple)) or len(event) != 3:
+        raise ValidationError(
+            "invalid_outbox_events", f"event {index} must be a triple"
+        )
+    event_type, payload, idempotency_key = event
+    if not isinstance(event_type, str) or not _EVENT_TYPE_RE.fullmatch(event_type):
+        raise ValidationError(
+            "invalid_outbox_events", f"event {index}: event_type charset or length is invalid"
+        )
+    if not isinstance(payload, Mapping):
+        raise ValidationError(
+            "invalid_outbox_events", f"event {index}: payload must be a mapping"
+        )
+    _validate_idempotency_key(idempotency_key, index)
+
+    unknown = set(payload) - OUTBOX_PAYLOAD_ALLOWED_KEYS
+    if unknown:
+        raise ValidationError(
+            "invalid_outbox_events", f"event {index}: payload contains unknown keys"
+        )
+    if _has_forbidden(payload, FORBIDDEN_PAYLOAD_KEYS):
+        raise ValidationError(
+            "invalid_outbox_events", f"event {index}: payload contains forbidden keys"
+        )
+
+    # Value contract: reference/identifier fields are bounded scalar strings
+    # in the explicit ASCII charset; ``version`` is an integer in [1, 1000].
+    # This is what guarantees the outbox carries references, never content.
+    for key, value in payload.items():
+        if key == "version":
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, int)
+                or not 1 <= value <= 1000
+            ):
+                raise ValidationError(
+                    "invalid_outbox_events",
+                    f"event {index}: payload.version must be an integer in 1-1000",
+                )
+        else:
+            if not isinstance(value, str) or not re.fullmatch(
+                r"[A-Za-z0-9_.:-]{1,128}", value
+            ):
+                raise ValidationError(
+                    "invalid_outbox_events",
+                    f"event {index}: payload.{key} must be a bounded ASCII reference string",
+                )
+
+    _require_canonical_bytes(
+        payload, "invalid_outbox_events", MAX_OUTBOX_PAYLOAD_BYTES
+    )
+    return event_type, payload, idempotency_key
+
+
+def validate_outbox_events(
+    events: Any,
+) -> list[tuple[str, Mapping[str, Any], str]]:
+    """Validate the outbox events of one turn commit (shape + payload)."""
+    if events is None:
+        return []
+    if not isinstance(events, (list, tuple)):
+        raise ValidationError("invalid_outbox_events", "outbox events must be a list")
+    if len(events) > MAX_OUTBOX_EVENTS:
+        raise ValidationError(
+            "invalid_outbox_events", f"at most {MAX_OUTBOX_EVENTS} outbox events per turn"
+        )
+    validated = [
+        _validate_outbox_event(event, index) for index, event in enumerate(events)
+    ]
+    keys = [key for _, _, key in validated]
+    if len(keys) != len(set(keys)):
+        raise ValidationError(
+            "invalid_outbox_events", "idempotency keys must be unique within a turn"
+        )
+    return validated
+
+
+# ---------------------------------------------------------------------------
+# Domain snapshots
+# ---------------------------------------------------------------------------
+
+
+def validate_emotional_snapshot(payload: Any) -> Mapping[str, Any]:
+    """Validate an emotional snapshot through the real domain model.
+
+    The domain model rejects unknown keys, missing keys, identity/internal
+    content, out-of-range values, non-finite numbers and bool/str numerics.
+    The byte bound guards unbounded growth. This reuses the single existing
+    definition of a valid v1 snapshot instead of duplicating the rules.
+    """
+    from backend.emotional_domain import EmotionalDomainError, EmotionalStateV1
+
+    if not isinstance(payload, Mapping):
+        raise ValidationError("invalid_emotional_state", "snapshot must be a mapping")
+    if _has_forbidden(payload, SNAPSHOT_FORBIDDEN_KEYS):
+        raise ValidationError(
+            "invalid_emotional_state", "snapshot contains forbidden keys"
+        )
+    _require_canonical_bytes(payload, "invalid_emotional_state", MAX_SNAPSHOT_BYTES)
+    try:
+        EmotionalStateV1.from_dict(dict(payload))
+    except EmotionalDomainError:
+        raise ValidationError(
+            "invalid_emotional_state", "snapshot does not match the v1 domain contract"
+        ) from None
+    return payload
+
+
+def validate_relationship_snapshot(payload: Any) -> Mapping[str, Any]:
+    """Validate a relationship snapshot through the real domain model."""
+    from backend.emotional_domain import EmotionalDomainError
+    from backend.relationship import RelationshipDomainError, RelationshipStateV1
+
+    if not isinstance(payload, Mapping):
+        raise ValidationError("invalid_relationship_state", "snapshot must be a mapping")
+    if _has_forbidden(payload, SNAPSHOT_FORBIDDEN_KEYS):
+        raise ValidationError(
+            "invalid_relationship_state", "snapshot contains forbidden keys"
+        )
+    _require_canonical_bytes(
+        payload, "invalid_relationship_state", MAX_SNAPSHOT_BYTES
+    )
+    try:
+        RelationshipStateV1.from_dict(dict(payload))
+    except (EmotionalDomainError, RelationshipDomainError):
+        raise ValidationError(
+            "invalid_relationship_state",
+            "snapshot does not match the v1 domain contract",
+        ) from None
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Neutral snapshots (canonical reset payloads)
+# ---------------------------------------------------------------------------
+
+
+def validate_neutral_emotional_snapshot(payload: Any) -> Mapping[str, Any]:
+    """Require the canonical neutral v1 emotional snapshot produced by the domain.
+
+    Neutrality is produced, not reimplemented: the expected snapshot is built
+    through ``EmotionalStateV1.neutral`` with the payload's own timestamp and
+    must match exactly. A structurally valid v1 snapshot with non-neutral
+    values is rejected.
+    """
+    from backend.emotional_domain import EmotionalStateV1
+
+    payload = validate_emotional_snapshot(payload)
+    timestamp = payload.get("timestamp")
+    if (
+        isinstance(timestamp, bool)
+        or not isinstance(timestamp, (int, float))
+        or timestamp <= 0
+    ):
+        raise ValidationError(
+            "invalid_reset_payload", "reset snapshot must be the canonical neutral state"
+        )
+    expected = EmotionalStateV1.neutral(timestamp=float(timestamp)).to_dict()
+    if dict(payload) != expected:
+        raise ValidationError(
+            "invalid_reset_payload", "reset snapshot must be the canonical neutral state"
+        )
+    return payload
+
+
+def validate_neutral_relationship_snapshot(payload: Any) -> Mapping[str, Any]:
+    """Require the canonical neutral v1 relationship snapshot produced by the domain."""
+    from backend.relationship import RelationshipStateV1
+
+    payload = validate_relationship_snapshot(payload)
+    timestamp = payload.get("timestamp")
+    if (
+        isinstance(timestamp, bool)
+        or not isinstance(timestamp, (int, float))
+        or timestamp <= 0
+    ):
+        raise ValidationError(
+            "invalid_reset_payload", "reset snapshot must be the canonical neutral state"
+        )
+    expected = RelationshipStateV1.neutral(timestamp=float(timestamp)).to_dict()
+    if dict(payload) != expected:
+        raise ValidationError(
+            "invalid_reset_payload", "reset snapshot must be the canonical neutral state"
+        )
+    return payload
+
+
+def neutral_emotional_snapshot(timestamp: float) -> dict[str, Any]:
+    """Build the canonical neutral v1 emotional snapshot (domain-produced)."""
+    from backend.emotional_domain import EmotionalStateV1
+
+    return EmotionalStateV1.neutral(timestamp=timestamp).to_dict()
+
+
+def neutral_relationship_snapshot(timestamp: float) -> dict[str, Any]:
+    """Build the canonical neutral v1 relationship snapshot (domain-produced)."""
+    from backend.relationship import RelationshipStateV1
+
+    return RelationshipStateV1.neutral(timestamp=timestamp).to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Canonical commit payload (idempotency hash input)
+# ---------------------------------------------------------------------------
+
+
+def build_canonical_commit_payload(
+    *,
+    request_id: str,
+    expected_revision: int | None,
+    user_message: str,
+    assistant_message: str,
+    emotional_state: Mapping[str, Any],
+    relationship_state: Mapping[str, Any],
+    public_response: str,
+    replay_payload: Mapping[str, Any],
+    outbox_events: list[tuple[str, Mapping[str, Any], str]],
+) -> dict[str, Any]:
+    """Build the canonical payload hashed for ``payload_hash_sha256``.
+
+    Covers every input that determines the turn's identity, content and
+    effects — the same rule the web contract uses (``build_canonical_commit_
+    payload`` in ``backend.atomic_turn_commit``), minus cloud identity fields
+    that do not exist locally.
+    """
+    return {
+        "request_id": request_id,
+        "expected_revision": expected_revision,
+        "user_message": user_message,
+        "assistant_message": assistant_message,
+        "emotional_state": dict(emotional_state),
+        "relationship_state": dict(relationship_state),
+        "public_response": public_response,
+        "replay_payload": dict(replay_payload),
+        "outbox_events": [
+            {"event_type": event_type, "payload": dict(payload), "idempotency_key": key}
+            for event_type, payload, key in outbox_events
+        ],
+    }
+
+
+def canonical_payload_hash(payload: Mapping[str, Any]) -> str:
+    """Compute the canonical SHA-256 hex digest of a payload."""
+    import hashlib
+
+    canonical = canonical_json(payload)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/backend/local_storage/contracts.py
+++ b/backend/local_storage/contracts.py
@@ -43,9 +43,14 @@ from .errors import ValidationError
 
 # Maximum serialized payload size in bytes (UTF-8), applied to the replay
 # payload, each outbox event payload, and each snapshot.
+# The web contract bounds replay_payload and outbox payloads at 8192 bytes
+# (``atomic_turn_commit`` / SQL CHECK). Snapshots have no web byte bound;
+# locally they are bounded at the same 8192 bytes. This comfortably admits
+# every domain-valid snapshot: the largest possible relationship snapshot
+# (32 triggers x 128 chars, ~4.3 KB canonical) validates.
 MAX_REPLAY_PAYLOAD_BYTES = 8192
-MAX_OUTBOX_PAYLOAD_BYTES = 256
-MAX_SNAPSHOT_BYTES = 4096
+MAX_OUTBOX_PAYLOAD_BYTES = 8192
+MAX_SNAPSHOT_BYTES = 8192
 
 # Outbox event identifiers.
 MAX_IDEMPOTENCY_KEY_LENGTH = 128

--- a/backend/local_storage/contracts.py
+++ b/backend/local_storage/contracts.py
@@ -179,6 +179,13 @@ def validate_replay_payload(payload: Any) -> Mapping[str, Any]:
     - no forbidden key at any depth (prompts, raw messages, meta-cognition,
       internal instructions, hidden ``content``);
     - ``response`` is required and must be a string;
+    - ``message_id`` is required (web parity: the replay payload always
+      identifies the committed assistant message). Locally the message id
+      is a SQLite rowid, so an integer or a bounded identifier string is
+      accepted (the web UUID requirement assumes uuid PKs, which the
+      local schema does not use);
+    - ``request_id``, when present, must be a bounded identifier string
+      and callers cross-check it against the enclosing turn request;
     - finite JSON within the explicit byte bound.
     """
     if not isinstance(payload, Mapping):
@@ -193,6 +200,25 @@ def validate_replay_payload(payload: Any) -> Mapping[str, Any]:
         raise ValidationError(
             "invalid_replay_payload", "replay payload requires a string response field"
         )
+    message_id = payload.get("message_id")
+    if isinstance(message_id, bool) or not (
+        isinstance(message_id, int)
+        or (isinstance(message_id, str) and re.fullmatch(r"[A-Za-z0-9_.:-]{1,128}", message_id))
+    ):
+        raise ValidationError(
+            "invalid_replay_payload",
+            "replay payload requires a message_id (integer rowid or bounded identifier)",
+        )
+    if "request_id" in payload:
+        request_id = payload["request_id"]
+        if isinstance(request_id, bool) or not (
+            isinstance(request_id, str)
+            and re.fullmatch(r"[A-Za-z0-9_.:-]{1,128}", request_id)
+        ):
+            raise ValidationError(
+                "invalid_replay_payload",
+                "replay payload request_id must be a bounded identifier string",
+            )
     _require_canonical_bytes(
         payload, "invalid_replay_payload", MAX_REPLAY_PAYLOAD_BYTES
     )

--- a/backend/local_storage/errors.py
+++ b/backend/local_storage/errors.py
@@ -1,0 +1,75 @@
+"""Error contracts for the local storage foundation (#335).
+
+The three stable domain errors mirror the web contract names in
+``backend/atomic_turn_commit.py`` so callers can reuse their existing
+error handling: ``ConflictError`` (concurrent modification), 
+``ValidationError`` (invalid input) and ``PersistenceError`` (unexpected
+store failure, sanitized constant message). ``StorageCorruptError``
+extends ``PersistenceError`` with an explicit corruption code: the store
+is never silently reset (issue #335, test 9).
+
+No exception ever carries SQL text, file paths, driver details, raw
+message content or tracebacks: messages are stable constants.
+"""
+
+from __future__ import annotations
+
+
+class ConflictError(Exception):
+    """Concurrent modification detected (revision CAS mismatch)."""
+
+    __slots__ = ("code", "message", "expected_revision", "actual_revision", "request_id")
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        expected_revision: int,
+        actual_revision: int | None = None,
+        request_id: str | None = None,
+    ) -> None:
+        self.code = code
+        self.message = message
+        self.expected_revision = expected_revision
+        self.actual_revision = actual_revision
+        self.request_id = request_id
+
+    def __str__(self) -> str:
+        return f"{self.code}: {self.message}"
+
+
+class ValidationError(Exception):
+    """Invalid input detected before any write."""
+
+    __slots__ = ("code", "message")
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+
+    def __str__(self) -> str:
+        return f"{self.code}: {self.message}"
+
+
+class PersistenceError(Exception):
+    """Unexpected store failure (sanitized constant message)."""
+
+    __slots__ = ("code", "message")
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+
+    def __str__(self) -> str:
+        return f"{self.code}: {self.message}"
+
+
+class StorageCorruptError(PersistenceError):
+    """The database file is corrupt; recovery is never a silent reset.
+
+    Raised by ``open_local_storage`` when SQLite reports corruption.
+    The corrupted file is left untouched: automatic recreation would
+    destroy the user's data without consent.
+    """
+
+    __slots__ = ()

--- a/backend/local_storage/migrations.py
+++ b/backend/local_storage/migrations.py
@@ -1,0 +1,126 @@
+"""Ordered, versioned SQLite schema migrations (#335).
+
+Each migration is ``(version, sql)`` with a strict positive integer
+version. Migrations are:
+
+- **ordered** — applied strictly in ascending version order;
+- **idempotent to re-run** — applied versions are recorded in
+  ``schema_migrations`` and skipped on later opens;
+- **atomic** — each migration's DDL runs inside one transaction together
+  with the insertion of its version row: a migration that fails in the
+  middle is neither applied nor recorded (SQLite rolls the transaction
+  back). A later open retries it from scratch.
+
+Migrations live in code (a frozen list), not in loose SQL files: no new
+dependency, deterministic ordering, and the exact text is reviewable in
+one place. New schema changes append a new tuple — existing migrations
+are never edited.
+"""
+
+from __future__ import annotations
+
+_SCHEMA_MIGRATIONS_TABLE = """
+create table if not exists schema_migrations (
+    version integer primary key,
+    applied_at text not null default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+"""
+
+#: Migration 1 — the initial local-first schema (single user, no
+#: ``user_id`` columns, no RLS/ACL equivalents: the database file itself
+#: is the trust boundary on the user's own machine).
+_MIGRATION_0001 = """
+create table profiles (
+    id integer primary key check (id = 1),
+    persona_config text,
+    user_profile text not null default '{}',
+    emotional_state text not null default '{}',
+    relationship_state text not null default '{}',
+    revision integer not null default 0 check (revision >= 0),
+    updated_at text not null default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+create table chat_logs (
+    id integer primary key autoincrement,
+    role text not null check (role in ('user', 'assistant')),
+    content text not null,
+    created_at text not null default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+create index chat_logs_created_idx on chat_logs (created_at, id);
+
+create table turn_requests (
+    request_id text primary key,
+    payload_hash_sha256 text not null,
+    status text not null
+        check (status in ('pending', 'completed', 'failed')),
+    expected_revision integer not null default 0,
+    committed_revision integer,
+    user_message_chat_log_id integer,
+    assistant_message_chat_log_id integer,
+    replay_payload text,
+    error_code text,
+    created_at text not null default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at text not null default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    completed_at text,
+    foreign key (user_message_chat_log_id) references chat_logs (id)
+        on delete set null,
+    foreign key (assistant_message_chat_log_id) references chat_logs (id)
+        on delete set null
+);
+create index turn_requests_status_idx on turn_requests (status);
+
+create table outbox_events (
+    id text primary key,
+    event_type text not null,
+    idempotency_key text not null unique,
+    status text not null default 'pending'
+        check (status in ('pending', 'completed', 'dead_letter')),
+    turn_request_id text not null
+        references turn_requests (request_id),
+    payload text not null check (json_valid(payload)),
+    created_at text not null default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    processed_at text
+);
+create index outbox_events_status_idx on outbox_events (status);
+
+create table memories (
+    id integer primary key autoincrement,
+    content text not null,
+    metadata text not null check (json_valid(metadata)),
+    created_at text not null default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+create index memories_created_idx on memories (created_at);
+
+create table privacy_operations (
+    id integer primary key autoincrement,
+    operation text not null
+        check (operation in ('delete_history', 'delete_memories',
+                             'reset_emotional_state', 'reset_relationship_state')),
+    status text not null check (status = 'applied'),
+    result text not null check (json_valid(result)),
+    applied_at text not null default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+"""
+
+#: The ordered migration list. Append-only by convention.
+MIGRATIONS: tuple[tuple[int, str], ...] = (
+    (1, _MIGRATION_0001),
+)
+
+#: SQL that guarantees the bookkeeping table exists before any version
+#: is recorded. Runs outside migration transactions, is itself
+#: idempotent (``if not exists``), and never fails partially.
+BOOTSTRAP_SQL = _SCHEMA_MIGRATIONS_TABLE
+
+
+def pending_versions(applied: set[int]) -> list[int]:
+    """Return the not-yet-applied versions in ascending order."""
+    return [version for version, _ in MIGRATIONS if version not in applied]
+
+
+def migration_sql(version: int) -> str:
+    """Return the SQL of one migration (KeyError for unknown versions)."""
+    for known_version, sql in MIGRATIONS:
+        if known_version == version:
+            return sql
+    raise KeyError(f"unknown migration version: {version}")

--- a/backend/local_storage/migrations.py
+++ b/backend/local_storage/migrations.py
@@ -14,7 +14,10 @@ version. Migrations are:
 Migrations live in code (a frozen list), not in loose SQL files: no new
 dependency, deterministic ordering, and the exact text is reviewable in
 one place. New schema changes append a new tuple — existing migrations
-are never edited.
+are never edited **after merge**. Migration 0001 is still pre-merge on
+this branch, so it is amended in place here (the FKs and the outbox
+uniqueness contract changed for the delete-history privacy semantics
+of issue #335); post-merge, migrations become append-only.
 """
 
 from __future__ import annotations
@@ -63,23 +66,28 @@ create table turn_requests (
     updated_at text not null default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     completed_at text,
     foreign key (user_message_chat_log_id) references chat_logs (id)
-        on delete set null,
+        on delete cascade,
     foreign key (assistant_message_chat_log_id) references chat_logs (id)
-        on delete set null
+        on delete cascade
 );
 create index turn_requests_status_idx on turn_requests (status);
 
 create table outbox_events (
     id text primary key,
     event_type text not null,
-    idempotency_key text not null unique,
+    idempotency_key text not null,
     status text not null default 'pending'
         check (status in ('pending', 'completed', 'dead_letter')),
     turn_request_id text not null
-        references turn_requests (request_id),
+        references turn_requests (request_id)
+        on delete cascade,
     payload text not null check (json_valid(payload)),
     created_at text not null default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-    processed_at text
+    processed_at text,
+    -- Uniqueness is per (idempotency_key, event_type): the same key may
+    -- label distinct event kinds of one turn, while redelivering the
+    -- same event is rejected (matching the commit conflict target).
+    unique (idempotency_key, event_type)
 );
 create index outbox_events_status_idx on outbox_events (status);
 

--- a/backend/local_storage/storage.py
+++ b/backend/local_storage/storage.py
@@ -460,6 +460,15 @@ class LocalStorage:
                 "invalid_public_response",
                 "public_response must equal replay_payload response",
             )
+        # Web parity: a replay payload carrying a request_id must identify
+        # THIS request (the web contract enforces the same cross-check in
+        # _validate_replay_payload; the local id charset differs from the
+        # web UUID, but the consistency rule is identical).
+        if "request_id" in replay_payload and replay_payload["request_id"] != request_id:
+            raise ValidationError(
+                "invalid_replay_payload",
+                "replay payload request_id must equal the enclosing request_id",
+            )
         contracts_module.validate_emotional_snapshot(emotional_state)
         contracts_module.validate_relationship_snapshot(relationship_state)
         validated_outbox = contracts_module.validate_outbox_events(outbox_events)

--- a/backend/local_storage/storage.py
+++ b/backend/local_storage/storage.py
@@ -164,6 +164,53 @@ def _time_now_unix() -> float:
     return _time.time()
 
 
+def _split_sql_statements(sql: str) -> list[str]:
+    """Split a migration into individual statements.
+
+    Handles ``BEGIN ... END`` blocks (trigger bodies) by tracking block
+    depth, plus single/double-quoted strings. Statements are stripped;
+    empty fragments are dropped. A future migration may therefore
+    include triggers with embedded semicolons safely.
+    """
+    statements: list[str] = []
+    current: list[str] = []
+    in_single = False
+    in_double = False
+    depth = 0
+    word: list[str] = []
+    i = 0
+    while i < len(sql):
+        ch = sql[i]
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        if not in_single and not in_double:
+            # track BEGIN/END keywords for trigger bodies
+            if ch.isalpha():
+                word.append(ch)
+            else:
+                joined = "".join(word).upper()
+                if joined == "BEGIN":
+                    depth += 1
+                elif joined == "END" and depth > 0:
+                    depth -= 1
+                word = []
+            if ch == ";" and depth == 0:
+                fragment = "".join(current).strip()
+                if fragment:
+                    statements.append(fragment)
+                current = []
+                i += 1
+                continue
+        current.append(ch)
+        i += 1
+    tail = "".join(current).strip()
+    if tail:
+        statements.append(tail)
+    return statements
+
+
 class LocalStorage:
     """Single-process SQLite store for the Katherine desktop app."""
 
@@ -224,30 +271,36 @@ class LocalStorage:
             raise PersistenceError("storage_unavailable", "persistence error") from None
 
     def _run_migrations(self, conn: sqlite3.Connection) -> None:
+        """Apply pending migrations atomically, version row included.
+
+        ``executescript`` is deliberately avoided: it issues an implicit
+        COMMIT before running, which would let a migration's DDL land
+        without its version row (the failure mode of issue #335 test 8).
+        Instead each migration is split into statements executed one by
+        one inside the same transaction that inserts its version row:
+        either the whole migration + its record commit, or nothing does.
+        """
         with self._lock:
-            conn.execute("BEGIN IMMEDIATE")
-            try:
-                conn.executescript(migrations_module.BOOTSTRAP_SQL)
-                # executescript commits; re-open the transaction explicitly
+            conn.executescript(migrations_module.BOOTSTRAP_SQL)
+            applied_rows = conn.execute(
+                "select version from schema_migrations"
+            ).fetchall()
+            applied = {row[0] for row in applied_rows}
+            for version in migrations_module.pending_versions(applied):
+                sql = migrations_module.migration_sql(version)
                 conn.execute("BEGIN IMMEDIATE")
-                applied_rows = conn.execute(
-                    "select version from schema_migrations"
-                ).fetchall()
-                applied = {row[0] for row in applied_rows}
-                for version in migrations_module.pending_versions(applied):
-                    sql = migrations_module.migration_sql(version)
-                    conn.executescript(sql)
-                    conn.execute(
-                        "BEGIN IMMEDIATE"
-                    )  # executescript auto-committed again
+                try:
+                    for statement in _split_sql_statements(sql):
+                        conn.execute(statement)
                     conn.execute(
                         "insert into schema_migrations (version) values (?)",
                         (version,),
                     )
-                conn.execute("COMMIT")
-            except Exception:
-                conn.execute("ROLLBACK")
-                raise
+                    conn.execute("COMMIT")
+                except Exception:
+                    if conn.in_transaction:
+                        conn.execute("ROLLBACK")
+                    raise
 
     def _recover_interrupted_turns(self, conn: sqlite3.Connection) -> None:
         """Fail-close pending rows left by a crash: never auto-recompute."""
@@ -389,21 +442,20 @@ class LocalStorage:
 
         with self._lock:
             conn = self._connection()
-            conn.execute("BEGIN IMMEDIATE")
-            try:
-                existing = conn.execute(
-                    "select status, committed_revision, user_message_chat_log_id, "
-                    "assistant_message_chat_log_id, replay_payload "
-                    "from turn_requests where request_id = ?",
-                    (request_id,),
-                ).fetchone()
-                if existing is not None and existing[0] == "completed":
-                    committed = self._committed_from_row(
-                        request_id, existing[1], existing[2], existing[3], existing[4]
-                    )
-                    conn.execute("COMMIT")
-                    return committed
+            # Idempotency first, without opening a write transaction.
+            existing = conn.execute(
+                "select status, committed_revision, user_message_chat_log_id, "
+                "assistant_message_chat_log_id, replay_payload "
+                "from turn_requests where request_id = ?",
+                (request_id,),
+            ).fetchone()
+            if existing is not None and existing[0] == "completed":
+                return self._committed_from_row(
+                    request_id, existing[1], existing[2], existing[3], existing[4]
+                )
 
+            try:
+                conn.execute("BEGIN IMMEDIATE")
                 profile_row = conn.execute(
                     "select revision from profiles where id = 1"
                 ).fetchone()
@@ -420,7 +472,6 @@ class LocalStorage:
                         )
                     expected = expected_revision
                 if expected != current_revision:
-                    conn.execute("ROLLBACK")
                     raise ConflictError(
                         "revision_mismatch",
                         "Profile revision changed concurrently.",
@@ -495,16 +546,10 @@ class LocalStorage:
                     )
 
                 conn.execute("COMMIT")
-            except ConflictError:
-                raise
-            except ValidationError:
+            except (ConflictError, ValidationError):
                 if conn.in_transaction:
                     conn.execute("ROLLBACK")
                 raise
-            except sqlite3.IntegrityError:
-                if conn.in_transaction:
-                    conn.execute("ROLLBACK")
-                raise PersistenceError("database_error", "persistence error") from None
             except sqlite3.Error:
                 if conn.in_transaction:
                     conn.execute("ROLLBACK")
@@ -514,14 +559,14 @@ class LocalStorage:
                     conn.execute("ROLLBACK")
                 raise
 
-        return CommittedTurn(
-            request_id=request_id,
-            revision=new_revision,
-            user_message_id=user_message_id,
-            assistant_message_id=assistant_message_id,
-            response=replay_payload.get("response", ""),
-            emotion_state=replay_payload.get("emotion_state", {}),
-        )
+            return CommittedTurn(
+                request_id=request_id,
+                revision=new_revision,
+                user_message_id=user_message_id,
+                assistant_message_id=assistant_message_id,
+                response=replay_payload.get("response", ""),
+                emotion_state=replay_payload.get("emotion_state", {}),
+            )
 
     def _committed_from_row(
         self,

--- a/backend/local_storage/storage.py
+++ b/backend/local_storage/storage.py
@@ -1,0 +1,772 @@
+"""The ``LocalStorage`` facade: atomic turn commit and local persistence.
+
+See the package docstring for the design invariants. This module is the
+implementation core: connection lifecycle, migration runner, the atomic
+turn commit (CAS on ``profiles.revision``), replay, privacy operations,
+retention trims, backup and metrics.
+
+Concurrency policy (single process, no daemon):
+
+- The store owns one ``threading.RLock``. **Every write path** takes the
+  lock and opens its transaction with ``BEGIN IMMEDIATE`` so the write
+  lock is acquired before the first statement (a deferred transaction
+  that upgrades mid-way can fail with SQLITE_BUSY and leave a half-open
+  turn).
+- Each thread gets its own connection (``threading.local``); SQLite
+  connections are not safe to share across threads. With WAL, reader
+  threads always see the last **committed** snapshot.
+- Writes from other *processes* are not part of this contract: the
+  database file belongs to the desktop application process. WAL's
+  busy-timeout still avoids transient reader/writer contention inside
+  the process.
+
+Recovery policy: a ``pending`` turn with no live in-process writer can
+only exist after a crash. On open, every ``pending`` row is moved to
+``failed`` with ``error_code='interrupted'`` inside one transaction:
+replays of an interrupted request return ``request_replay_unavailable``
+(paridade com o contrato web: nunca reexecuta automaticamente).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from . import migrations as migrations_module
+from .errors import (
+    ConflictError,
+    PersistenceError,
+    StorageCorruptError,
+    ValidationError,
+)
+
+#: Application directory name under XDG data home.
+APP_DIR_NAME = "katherine"
+
+#: Database file name.
+DATABASE_FILE_NAME = "katherine.db"
+
+#: Message length bound, mirroring the web contract (memory.MAX_MESSAGE_LENGTH).
+MAX_MESSAGE_LENGTH = 10_000
+
+#: Request id bound (defensive; mirrors the web bounded identifier rule).
+MAX_REQUEST_ID_LENGTH = 128
+
+#: Busy timeout for transient reader/writer contention (milliseconds).
+_BUSY_TIMEOUT_MS = 5_000
+
+_REQUEST_ID_ALLOWED = set(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.:-"
+)
+
+
+# ---------------------------------------------------------------------------
+# Errors live in errors.py; re-export for the package contract.
+# ---------------------------------------------------------------------------
+
+
+def default_database_path(env: Optional[Mapping[str, str]] = None) -> Path:
+    """Resolve the XDG-compliant default database path.
+
+    ``env`` is an injectable environment mapping (defaults to
+    ``os.environ``) so tests never touch the real environment. The
+    parent directories are created with mode 0o700 (private to the
+    user) before returning; failures surface as ``PersistenceError``.
+    """
+    environment = os.environ if env is None else dict(env)
+    data_home = environment.get("XDG_DATA_HOME", "").strip()
+    if data_home:
+        base = Path(data_home)
+    else:
+        home = environment.get("HOME", "").strip()
+        if not home:
+            raise PersistenceError("invalid_environment", "HOME is not set")
+        base = Path(home) / ".local" / "share"
+    path = base / APP_DIR_NAME / DATABASE_FILE_NAME
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    except OSError:
+        raise PersistenceError("storage_unavailable", "persistence error") from None
+    return path
+
+
+@dataclass(frozen=True)
+class LoadedUserState:
+    """Snapshot of the single local profile plus its revision token."""
+
+    revision: int
+    persona_config: Optional[str]
+    user_profile: Mapping[str, Any]
+    emotional_state: Mapping[str, Any]
+    relationship_state: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class CommittedTurn:
+    """Public result of one successful atomic turn commit."""
+
+    request_id: str
+    revision: int
+    user_message_id: int
+    assistant_message_id: int
+    response: str
+    emotion_state: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class ReplayOutcome:
+    """Structured replay lookup result (web contract parity)."""
+
+    status: str
+    committed: Optional[CommittedTurn] = None
+
+
+def _validate_request_id(request_id: Any) -> str:
+    if not isinstance(request_id, str) or not request_id:
+        raise ValidationError("invalid_request_id", "request id must be a non-empty string")
+    if len(request_id) > MAX_REQUEST_ID_LENGTH:
+        raise ValidationError("invalid_request_id", "request id too long")
+    if not all(ch in _REQUEST_ID_ALLOWED for ch in request_id):
+        raise ValidationError("invalid_request_id", "request id has invalid characters")
+    return request_id
+
+
+def _validate_message(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValidationError("empty_message", f"{field} must be a non-empty string")
+    if len(value) > MAX_MESSAGE_LENGTH:
+        raise ValidationError("message_too_long", "message exceeds the maximum length")
+    return value
+
+
+def _canonical_payload_hash(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(
+        payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _now_iso() -> str:
+    import datetime as _dt
+
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+
+
+def _time_now_unix() -> float:
+    import time as _time
+
+    return _time.time()
+
+
+class LocalStorage:
+    """Single-process SQLite store for the Katherine desktop app."""
+
+    def __init__(self, path: Path | str) -> None:
+        self._path = Path(path)
+        self._lock = threading.RLock()
+        self._local = threading.local()
+        self._closed = False
+        self._open_and_migrate()
+
+    # ── Connection management ────────────────────────────────────────────
+
+    def _new_connection(self) -> sqlite3.Connection:
+        try:
+            conn = sqlite3.connect(
+                str(self._path),
+                timeout=_BUSY_TIMEOUT_MS / 1000.0,
+                isolation_level=None,  # explicit transaction control
+            )
+        except sqlite3.Error:
+            raise PersistenceError("storage_unavailable", "persistence error") from None
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=FULL")
+        conn.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MS}")
+        return conn
+
+    def _connection(self) -> sqlite3.Connection:
+        conn = getattr(self._local, "conn", None)
+        if conn is None:
+            conn = self._new_connection()
+            self._local.conn = conn
+        return conn
+
+    def _connection_for_tests_only(self) -> sqlite3.Connection:
+        """Direct connection accessor for tests (never used by the app)."""
+        return self._connection()
+
+    # ── Open / migrate / recovery ────────────────────────────────────────
+
+    def _open_and_migrate(self) -> None:
+        try:
+            self._ensure_parent_dir()
+            conn = self._connection()
+            self._run_migrations(conn)
+            self._recover_interrupted_turns(conn)
+        except sqlite3.DatabaseError as exc:
+            raise StorageCorruptError("corrupt_database", "database error") from None
+        except PersistenceError:
+            raise
+        except sqlite3.Error:
+            raise PersistenceError("storage_unavailable", "persistence error") from None
+
+    def _ensure_parent_dir(self) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        except OSError:
+            raise PersistenceError("storage_unavailable", "persistence error") from None
+
+    def _run_migrations(self, conn: sqlite3.Connection) -> None:
+        with self._lock:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                conn.executescript(migrations_module.BOOTSTRAP_SQL)
+                # executescript commits; re-open the transaction explicitly
+                conn.execute("BEGIN IMMEDIATE")
+                applied_rows = conn.execute(
+                    "select version from schema_migrations"
+                ).fetchall()
+                applied = {row[0] for row in applied_rows}
+                for version in migrations_module.pending_versions(applied):
+                    sql = migrations_module.migration_sql(version)
+                    conn.executescript(sql)
+                    conn.execute(
+                        "BEGIN IMMEDIATE"
+                    )  # executescript auto-committed again
+                    conn.execute(
+                        "insert into schema_migrations (version) values (?)",
+                        (version,),
+                    )
+                conn.execute("COMMIT")
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+
+    def _recover_interrupted_turns(self, conn: sqlite3.Connection) -> None:
+        """Fail-close pending rows left by a crash: never auto-recompute."""
+        with self._lock:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                conn.execute(
+                    "update turn_requests set status = 'failed', "
+                    "error_code = 'interrupted', updated_at = ? "
+                    "where status = 'pending'",
+                    (_now_iso(),),
+                )
+                conn.execute("COMMIT")
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+
+    def schema_version(self) -> int:
+        row = self._connection().execute(
+            "select coalesce(max(version), 0) from schema_migrations"
+        ).fetchone()
+        return int(row[0])
+
+    # ── State load ──────────────────────────────────────────────────────
+
+    def load_user_state(self) -> LoadedUserState:
+        try:
+            row = self._connection().execute(
+                "select revision, persona_config, user_profile, "
+                "emotional_state, relationship_state from profiles where id = 1"
+            ).fetchone()
+        except sqlite3.Error:
+            raise PersistenceError("database_error", "persistence error") from None
+        if row is None:
+            # Missing profile: default in-memory neutral v1 state, revision 0.
+            # Contract parity with the web ``UserStateRepository.load`` — the
+            # caller gets valid v1 snapshots, never empty dicts.
+            from backend.emotional_domain import EmotionalStateV1
+            from backend.relationship import RelationshipStateV1
+
+            timestamp = _time_now_unix()
+            return LoadedUserState(
+                revision=0,
+                persona_config=None,
+                user_profile={},
+                emotional_state=EmotionalStateV1.neutral(timestamp=timestamp).to_dict(),
+                relationship_state=RelationshipStateV1.neutral(
+                    timestamp=timestamp
+                ).to_dict(),
+            )
+        revision, persona, profile, emotional, relationship = row
+        if isinstance(revision, bool) or not isinstance(revision, int) or revision < 0:
+            raise PersistenceError("invalid_state", "persistence error")
+        try:
+            profile_doc = json.loads(profile) if profile else {}
+            emotional_doc = json.loads(emotional) if emotional else {}
+            relationship_doc = json.loads(relationship) if relationship else {}
+        except (json.JSONDecodeError, TypeError):
+            raise PersistenceError("invalid_state", "persistence error") from None
+        if not isinstance(profile_doc, dict):
+            profile_doc = {}
+        if not isinstance(emotional_doc, dict):
+            emotional_doc = {}
+        if not isinstance(relationship_doc, dict):
+            relationship_doc = {}
+        return LoadedUserState(
+            revision=revision,
+            persona_config=persona if isinstance(persona, str) else None,
+            user_profile=profile_doc,
+            emotional_state=emotional_doc,
+            relationship_state=relationship_doc,
+        )
+
+    def load_recent_history(self, limit: int = 10) -> list[dict[str, Any]]:
+        if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 500:
+            raise ValidationError("invalid_limit", "limit must be an int in [1, 500]")
+        try:
+            rows = self._connection().execute(
+                "select id, role, content, created_at from chat_logs "
+                "order by created_at desc, id desc limit ?",
+                (limit,),
+            ).fetchall()
+        except sqlite3.Error:
+            raise PersistenceError("database_error", "persistence error") from None
+        history: list[dict[str, Any]] = []
+        for msg_id, role, content, created_at in rows:
+            if role not in ("user", "assistant"):
+                raise PersistenceError("invalid_state", "persistence error")
+            if not isinstance(content, str) or len(content) > MAX_MESSAGE_LENGTH:
+                raise PersistenceError("invalid_state", "persistence error")
+            history.append(
+                {
+                    "id": msg_id,
+                    "role": role,
+                    "content": content,
+                    "created_at": created_at,
+                }
+            )
+        history.reverse()
+        return history
+
+    # ── Atomic turn commit ───────────────────────────────────────────────
+
+    def commit_turn(
+        self,
+        *,
+        request_id: str,
+        user_message: str,
+        assistant_message: str,
+        emotional_state: Mapping[str, Any],
+        relationship_state: Mapping[str, Any],
+        public_response: str,
+        replay_payload: Mapping[str, Any],
+        outbox_events: list[tuple[str, Mapping[str, Any], str]] | None = None,
+        expected_revision: int | None = None,
+    ) -> CommittedTurn:
+        """Commit one conversation turn as a single atomic unit.
+
+        Steps (all inside ``BEGIN IMMEDIATE`` … ``COMMIT``):
+
+        1. idempotency: an existing **completed** request replays
+           without writing anything;
+        2. insert both chat messages;
+        3. upsert the single profile row with a revision CAS
+           (``WHERE revision = expected``), bumping the revision;
+        4. insert the turn ledger row with the replay payload;
+        5. insert outbox events (unique idempotency keys).
+
+        Any failure between steps rolls the entire turn back: messages
+        and snapshots can never diverge (issue #335, tests 3 and 4).
+        """
+        request_id = _validate_request_id(request_id)
+        user_message = _validate_message(user_message, "user_message")
+        assistant_message = _validate_message(assistant_message, "assistant_message")
+        if not isinstance(replay_payload, Mapping):
+            raise ValidationError("invalid_replay_payload", "replay payload must be a mapping")
+        payload_hash = _canonical_payload_hash(replay_payload)
+        now = _now_iso()
+
+        with self._lock:
+            conn = self._connection()
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                existing = conn.execute(
+                    "select status, committed_revision, user_message_chat_log_id, "
+                    "assistant_message_chat_log_id, replay_payload "
+                    "from turn_requests where request_id = ?",
+                    (request_id,),
+                ).fetchone()
+                if existing is not None and existing[0] == "completed":
+                    committed = self._committed_from_row(
+                        request_id, existing[1], existing[2], existing[3], existing[4]
+                    )
+                    conn.execute("COMMIT")
+                    return committed
+
+                profile_row = conn.execute(
+                    "select revision from profiles where id = 1"
+                ).fetchone()
+                current_revision = profile_row[0] if profile_row else 0
+                if expected_revision is None:
+                    expected = current_revision
+                else:
+                    if isinstance(expected_revision, bool) or not isinstance(
+                        expected_revision, int
+                    ) or expected_revision < 0:
+                        raise ValidationError(
+                            "invalid_expected_revision",
+                            "expected_revision must be a non-negative integer",
+                        )
+                    expected = expected_revision
+                if expected != current_revision:
+                    conn.execute("ROLLBACK")
+                    raise ConflictError(
+                        "revision_mismatch",
+                        "Profile revision changed concurrently.",
+                        expected_revision=expected,
+                        actual_revision=current_revision,
+                        request_id=request_id,
+                    )
+
+                user_cursor = conn.execute(
+                    "insert into chat_logs (role, content, created_at) "
+                    "values ('user', ?, ?)",
+                    (user_message, now),
+                )
+                user_message_id = int(user_cursor.lastrowid)
+                assistant_cursor = conn.execute(
+                    "insert into chat_logs (role, content, created_at) "
+                    "values ('assistant', ?, ?)",
+                    (assistant_message, now),
+                )
+                assistant_message_id = int(assistant_cursor.lastrowid)
+
+                new_revision = current_revision + 1
+                conn.execute(
+                    "insert into profiles (id, emotional_state, relationship_state, "
+                    "revision, updated_at) values (1, ?, ?, ?, ?) "
+                    "on conflict (id) do update set "
+                    "emotional_state = excluded.emotional_state, "
+                    "relationship_state = excluded.relationship_state, "
+                    "revision = excluded.revision, "
+                    "updated_at = excluded.updated_at",
+                    (
+                        _json_dumps(emotional_state),
+                        _json_dumps(relationship_state),
+                        new_revision,
+                        now,
+                    ),
+                )
+
+                conn.execute(
+                    "insert into turn_requests (request_id, payload_hash_sha256, "
+                    "status, expected_revision, committed_revision, "
+                    "user_message_chat_log_id, assistant_message_chat_log_id, "
+                    "replay_payload, completed_at, updated_at) "
+                    "values (?, ?, 'completed', ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        request_id,
+                        payload_hash,
+                        expected,
+                        new_revision,
+                        user_message_id,
+                        assistant_message_id,
+                        _json_dumps(replay_payload),
+                        now,
+                        now,
+                    ),
+                )
+
+                for event_type, payload, idempotency_key in outbox_events or []:
+                    conn.execute(
+                        "insert into outbox_events (id, event_type, "
+                        "idempotency_key, status, turn_request_id, payload, "
+                        "created_at) values (?, ?, ?, 'pending', ?, ?, ?) "
+                        "on conflict (idempotency_key) do nothing",
+                        (
+                            f"{idempotency_key}:{event_type}",
+                            event_type,
+                            idempotency_key,
+                            request_id,
+                            _json_dumps(payload),
+                            now,
+                        ),
+                    )
+
+                conn.execute("COMMIT")
+            except ConflictError:
+                raise
+            except ValidationError:
+                if conn.in_transaction:
+                    conn.execute("ROLLBACK")
+                raise
+            except sqlite3.IntegrityError:
+                if conn.in_transaction:
+                    conn.execute("ROLLBACK")
+                raise PersistenceError("database_error", "persistence error") from None
+            except sqlite3.Error:
+                if conn.in_transaction:
+                    conn.execute("ROLLBACK")
+                raise PersistenceError("database_error", "persistence error") from None
+            except Exception:
+                if conn.in_transaction:
+                    conn.execute("ROLLBACK")
+                raise
+
+        return CommittedTurn(
+            request_id=request_id,
+            revision=new_revision,
+            user_message_id=user_message_id,
+            assistant_message_id=assistant_message_id,
+            response=replay_payload.get("response", ""),
+            emotion_state=replay_payload.get("emotion_state", {}),
+        )
+
+    def _committed_from_row(
+        self,
+        request_id: str,
+        revision: Optional[int],
+        user_message_id: Optional[int],
+        assistant_message_id: Optional[int],
+        replay_payload_text: Optional[str],
+    ) -> CommittedTurn:
+        try:
+            payload = json.loads(replay_payload_text) if replay_payload_text else {}
+        except (json.JSONDecodeError, TypeError):
+            raise PersistenceError("invalid_state", "persistence error") from None
+        if not isinstance(payload, dict):
+            raise PersistenceError("invalid_state", "persistence error")
+        return CommittedTurn(
+            request_id=request_id,
+            revision=int(revision or 0),
+            user_message_id=int(user_message_id or 0),
+            assistant_message_id=int(assistant_message_id or 0),
+            response=payload.get("response", ""),
+            emotion_state=payload.get("emotion_state", {}),
+        )
+
+    # ── Replay ───────────────────────────────────────────────────────────
+
+    def replay(self, request_id: str) -> ReplayOutcome:
+        request_id = _validate_request_id(request_id)
+        try:
+            row = self._connection().execute(
+                "select status, committed_revision, user_message_chat_log_id, "
+                "assistant_message_chat_log_id, replay_payload "
+                "from turn_requests where request_id = ?",
+                (request_id,),
+            ).fetchone()
+        except sqlite3.Error:
+            raise PersistenceError("database_error", "persistence error") from None
+        if row is None:
+            return ReplayOutcome(status="request_replay_unavailable", committed=None)
+        status, revision, user_msg_id, assistant_msg_id, payload_text = row
+        if status == "completed":
+            return ReplayOutcome(
+                status="completed",
+                committed=self._committed_from_row(
+                    request_id, revision, user_msg_id, assistant_msg_id, payload_text
+                ),
+            )
+        if status == "pending":
+            return ReplayOutcome(status="request_in_progress", committed=None)
+        return ReplayOutcome(status="request_replay_unavailable", committed=None)
+
+    # ── Memory ──────────────────────────────────────────────────────────
+
+    def store_memory(self, content: str, metadata: Mapping[str, Any]) -> int:
+        content = _validate_message(content, "memory content")
+        if not isinstance(metadata, Mapping):
+            raise ValidationError("invalid_metadata", "metadata must be a mapping")
+        with self._lock:
+            conn = self._connection()
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                cursor = conn.execute(
+                    "insert into memories (content, metadata, created_at) "
+                    "values (?, ?, ?)",
+                    (content, _json_dumps(metadata), _now_iso()),
+                )
+                conn.execute("COMMIT")
+            except sqlite3.Error:
+                if conn.in_transaction:
+                    conn.execute("ROLLBACK")
+                raise PersistenceError("database_error", "persistence error") from None
+            return int(cursor.lastrowid)
+
+    # ── Privacy operations ──────────────────────────────────────────────
+
+    def delete_history(self) -> dict[str, Any]:
+        return self._privacy_delete(
+            "delete_history",
+            "delete from chat_logs",
+            "deleted_messages",
+            "select count(*) from chat_logs",
+        )
+
+    def delete_memories(self) -> dict[str, Any]:
+        return self._privacy_delete(
+            "delete_memories",
+            "delete from memories",
+            "deleted_memories",
+            "select count(*) from memories",
+        )
+
+    def _privacy_delete(
+        self, operation: str, delete_sql: str, result_key: str, count_sql: str
+    ) -> dict[str, Any]:
+        with self._lock:
+            conn = self._connection()
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                count = conn.execute(count_sql).fetchone()[0]
+                conn.execute(delete_sql)
+                result = {"status": "applied", result_key: int(count)}
+                conn.execute(
+                    "insert into privacy_operations (operation, status, result) "
+                    "values (?, 'applied', ?)",
+                    (operation, _json_dumps(result)),
+                )
+                conn.execute("COMMIT")
+            except sqlite3.Error:
+                if conn.in_transaction:
+                    conn.execute("ROLLBACK")
+                raise PersistenceError("database_error", "persistence error") from None
+        return result
+
+    def reset_emotional_state(self, neutral: Optional[Mapping[str, Any]] = None) -> dict[str, Any]:
+        return self._reset_state_field(
+            "reset_emotional_state", "emotional_state", neutral or {}
+        )
+
+    def reset_relationship_state(self, neutral: Optional[Mapping[str, Any]] = None) -> dict[str, Any]:
+        return self._reset_state_field(
+            "reset_relationship_state", "relationship_state", neutral or {}
+        )
+
+    def _reset_state_field(
+        self, operation: str, field: str, neutral: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        with self._lock:
+            conn = self._connection()
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                conn.execute(
+                    f"update profiles set {field} = ?, updated_at = ? where id = 1",
+                    (_json_dumps(neutral), _now_iso()),
+                )
+                result = {"status": "applied"}
+                conn.execute(
+                    "insert into privacy_operations (operation, status, result) "
+                    "values (?, 'applied', ?)",
+                    (operation, _json_dumps(result)),
+                )
+                conn.execute("COMMIT")
+            except sqlite3.Error:
+                if conn.in_transaction:
+                    conn.execute("ROLLBACK")
+                raise PersistenceError("database_error", "persistence error") from None
+        return result
+
+    # ── Retention ────────────────────────────────────────────────────────
+
+    def trim_history(self, keep_last: int) -> dict[str, Any]:
+        if isinstance(keep_last, bool) or not isinstance(keep_last, int) or keep_last < 0:
+            raise ValidationError("invalid_keep_last", "keep_last must be a non-negative int")
+        with self._lock:
+            conn = self._connection()
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                count = conn.execute("select count(*) from chat_logs").fetchone()[0]
+                conn.execute(
+                    "delete from chat_logs where id not in "
+                    "(select id from chat_logs order by id desc limit ?)",
+                    (keep_last,),
+                )
+                result = {"status": "applied", "remaining": int(min(count, keep_last))}
+                conn.execute("COMMIT")
+            except sqlite3.Error:
+                if conn.in_transaction:
+                    conn.execute("ROLLBACK")
+                raise PersistenceError("database_error", "persistence error") from None
+        return result
+
+    # ── Backup and metrics ──────────────────────────────────────────────
+
+    def backup_to(self, target: Path | str) -> None:
+        """Consistent online backup (never captures half-written state)."""
+        target_path = Path(target)
+        if target_path.exists():
+            raise ValidationError("backup_target_exists", "backup target already exists")
+        try:
+            target_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            dest = sqlite3.connect(str(target_path))
+            try:
+                with self._lock:
+                    self._connection().backup(dest)
+            finally:
+                dest.close()
+        except sqlite3.Error:
+            raise PersistenceError("backup_failed", "persistence error") from None
+        except OSError:
+            raise PersistenceError("backup_failed", "persistence error") from None
+
+    def storage_metrics(self) -> dict[str, Any]:
+        conn = self._connection()
+        try:
+            chat_rows = conn.execute("select count(*) from chat_logs").fetchone()[0]
+            memory_rows = conn.execute("select count(*) from memories").fetchone()[0]
+            turn_rows = conn.execute("select count(*) from turn_requests").fetchone()[0]
+            page_count = conn.execute("PRAGMA page_count").fetchone()[0]
+            page_size = conn.execute("PRAGMA page_size").fetchone()[0]
+            journal_mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        except sqlite3.Error:
+            raise PersistenceError("database_error", "persistence error") from None
+        return {
+            "chat_log_rows": int(chat_rows),
+            "memory_rows": int(memory_rows),
+            "turn_request_rows": int(turn_rows),
+            "page_count": int(page_count),
+            "page_size": int(page_size),
+            "journal_mode": str(journal_mode),
+        }
+
+    # ── Lifecycle ────────────────────────────────────────────────────────
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            conn = getattr(self._local, "conn", None)
+            if conn is not None:
+                try:
+                    conn.close()
+                except sqlite3.Error:
+                    pass
+                self._local.conn = None
+
+
+def _json_dumps(value: Any) -> str:
+    try:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    except (TypeError, ValueError):
+        raise ValidationError("invalid_payload", "payload is not JSON serializable") from None
+
+
+def open_local_storage(path: Path | str) -> LocalStorage:
+    """Open (creating if needed) and migrate a local database.
+
+    Corruption is an explicit ``StorageCorruptError`` — the store is
+    never silently reset. Permission/I-O problems surface as
+    ``PersistenceError`` with a constant sanitized message.
+    """
+    try:
+        return LocalStorage(path)
+    except StorageCorruptError:
+        raise
+    except PersistenceError:
+        raise
+    except Exception:
+        raise PersistenceError("storage_unavailable", "persistence error") from None

--- a/backend/local_storage/storage.py
+++ b/backend/local_storage/storage.py
@@ -227,11 +227,19 @@ class LocalStorage:
     # ── Connection management ────────────────────────────────────────────
 
     def _new_connection(self) -> sqlite3.Connection:
+        # check_same_thread=False: connections stay strictly per-thread
+        # (one thread key -> one connection, never shared), but close()
+        # — which runs on the closing thread — may call conn.close() on
+        # connections other threads created. sqlite3's default thread
+        # affinity would turn that deterministic shutdown into a
+        # ProgrammingError, and swallowing it would leave connections
+        # open (relying on GC) while the docs claim they are closed.
         try:
             conn = sqlite3.connect(
                 str(self._path),
                 timeout=_BUSY_TIMEOUT_MS / 1000.0,
                 isolation_level=None,  # explicit transaction control
+                check_same_thread=False,
             )
         except sqlite3.Error:
             raise PersistenceError("storage_unavailable", "persistence error") from None
@@ -973,22 +981,32 @@ class LocalStorage:
     # ── Backup and metrics ──────────────────────────────────────────────
 
     def backup_to(self, target: Path | str) -> None:
-        """Consistent online backup (never captures half-written state)."""
-        target_path = Path(target)
-        if target_path.exists():
-            raise ValidationError("backup_target_exists", "backup target already exists")
-        try:
-            target_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-            dest = sqlite3.connect(str(target_path))
+        """Consistent online backup (never captures half-written state).
+
+        The closed-store lifecycle gate runs **before** any filesystem
+        effect: a closed store fails with ``storage_closed`` without
+        creating the target directory or an empty ``backup.db``.
+        """
+        with self._lock:
+            if self._closed:
+                raise PersistenceError("storage_closed", "storage is closed")
+            src = self._connection()
+            target_path = Path(target)
+            if target_path.exists():
+                raise ValidationError(
+                    "backup_target_exists", "backup target already exists"
+                )
             try:
-                with self._lock:
-                    self._connection().backup(dest)
-            finally:
-                dest.close()
-        except sqlite3.Error:
-            raise PersistenceError("backup_failed", "persistence error") from None
-        except OSError:
-            raise PersistenceError("backup_failed", "persistence error") from None
+                target_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+                dest = sqlite3.connect(str(target_path))
+                try:
+                    src.backup(dest)
+                finally:
+                    dest.close()
+            except sqlite3.Error:
+                raise PersistenceError("backup_failed", "persistence error") from None
+            except OSError:
+                raise PersistenceError("backup_failed", "persistence error") from None
 
     def storage_metrics(self) -> dict[str, Any]:
         conn = self._connection()

--- a/backend/local_storage/storage.py
+++ b/backend/local_storage/storage.py
@@ -20,6 +20,12 @@ Concurrency policy (single process, no daemon):
   busy-timeout still avoids transient reader/writer contention inside
   the process.
 
+Lifecycle policy (the lifecycle belongs to the application): after
+``close()`` the store is terminal. No new connection is ever created, no
+operation reads or writes silently, and every call — including from
+other threads — fails with the stable sanitized
+``PersistenceError("storage_closed")``.
+
 Recovery policy: a ``pending`` turn with no live in-process writer can
 only exist after a crash. On open, every ``pending`` row is moved to
 ``failed`` with ``error_code='interrupted'`` inside one transaction:
@@ -29,7 +35,6 @@ replays of an interrupted request return ``request_replay_unavailable``
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import sqlite3
@@ -38,6 +43,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
+from . import contracts as contracts_module
 from . import migrations as migrations_module
 from .errors import (
     ConflictError,
@@ -46,7 +52,7 @@ from .errors import (
     ValidationError,
 )
 
-#: Application directory name under XDG data home.
+#: Application Directory name under XDG data home.
 APP_DIR_NAME = "katherine"
 
 #: Database file name.
@@ -145,13 +151,6 @@ def _validate_message(value: Any, field: str) -> str:
     return value
 
 
-def _canonical_payload_hash(payload: Mapping[str, Any]) -> str:
-    canonical = json.dumps(
-        payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
-    )
-    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
-
-
 def _now_iso() -> str:
     import datetime as _dt
 
@@ -217,7 +216,11 @@ class LocalStorage:
     def __init__(self, path: Path | str) -> None:
         self._path = Path(path)
         self._lock = threading.RLock()
-        self._local = threading.local()
+        # Connections are per-thread, but tracked in one registry so
+        # ``close()`` can close every open connection, not only the
+        # caller thread's (the store is a single application-owned
+        # object; its lifecycle is the application's).
+        self._connections: dict[int, sqlite3.Connection] = {}
         self._closed = False
         self._open_and_migrate()
 
@@ -239,11 +242,18 @@ class LocalStorage:
         return conn
 
     def _connection(self) -> sqlite3.Connection:
-        conn = getattr(self._local, "conn", None)
-        if conn is None:
-            conn = self._new_connection()
-            self._local.conn = conn
-        return conn
+        # Lifecycle gate: a closed store never creates or reuses a
+        # connection, on any thread. The check runs inside the same lock
+        # close() takes, so close-then-use races cannot slip through.
+        with self._lock:
+            if self._closed:
+                raise PersistenceError("storage_closed", "storage is closed")
+            thread_key = threading.get_ident()
+            conn = self._connections.get(thread_key)
+            if conn is None:
+                conn = self._new_connection()
+                self._connections[thread_key] = conn
+            return conn
 
     def _connection_for_tests_only(self) -> sqlite3.Connection:
         """Direct connection accessor for tests (never used by the app)."""
@@ -419,15 +429,18 @@ class LocalStorage:
     ) -> CommittedTurn:
         """Commit one conversation turn as a single atomic unit.
 
-        Steps (all inside ``BEGIN IMMEDIATE`` … ``COMMIT``):
+        Steps:
 
-        1. idempotency: an existing **completed** request replays
-           without writing anything;
-        2. insert both chat messages;
-        3. upsert the single profile row with a revision CAS
-           (``WHERE revision = expected``), bumping the revision;
-        4. insert the turn ledger row with the replay payload;
-        5. insert outbox events (unique idempotency keys).
+        1. validate every input against the payload contracts (before any
+           write; ``public_response`` must equal ``replay_payload``
+           [``response``], the single authoritative source);
+        2. idempotency: an existing **completed** request with the SAME
+           canonical payload replays without writing anything; the same
+           ``request_id`` with ANY divergent determinative input raises
+           ``ConflictError("request_payload_conflict")`` without writing;
+        3. inside ``BEGIN IMMEDIATE`` … ``COMMIT``: insert both chat
+           messages, upsert the single profile row with a revision CAS,
+           insert the turn ledger row, insert the outbox events.
 
         Any failure between steps rolls the entire turn back: messages
         and snapshots can never diverge (issue #335, tests 3 and 4).
@@ -435,27 +448,142 @@ class LocalStorage:
         request_id = _validate_request_id(request_id)
         user_message = _validate_message(user_message, "user_message")
         assistant_message = _validate_message(assistant_message, "assistant_message")
-        if not isinstance(replay_payload, Mapping):
-            raise ValidationError("invalid_replay_payload", "replay payload must be a mapping")
-        payload_hash = _canonical_payload_hash(replay_payload)
+        if not isinstance(public_response, str) or not public_response:
+            raise ValidationError(
+                "invalid_public_response", "public_response must be a non-empty string"
+            )
+        if len(public_response) > MAX_MESSAGE_LENGTH:
+            raise ValidationError("message_too_long", "message exceeds the maximum length")
+        replay_payload = contracts_module.validate_replay_payload(replay_payload)
+        if replay_payload.get("response") != public_response:
+            raise ValidationError(
+                "invalid_public_response",
+                "public_response must equal replay_payload response",
+            )
+        contracts_module.validate_emotional_snapshot(emotional_state)
+        contracts_module.validate_relationship_snapshot(relationship_state)
+        validated_outbox = contracts_module.validate_outbox_events(outbox_events)
+        if expected_revision is not None and (
+            isinstance(expected_revision, bool)
+            or not isinstance(expected_revision, int)
+            or expected_revision < 0
+        ):
+            raise ValidationError(
+                "invalid_expected_revision",
+                "expected_revision must be a non-negative integer",
+            )
+
+        canonical_payload = contracts_module.build_canonical_commit_payload(
+            request_id=request_id,
+            expected_revision=expected_revision,
+            user_message=user_message,
+            assistant_message=assistant_message,
+            emotional_state=emotional_state,
+            relationship_state=relationship_state,
+            public_response=public_response,
+            replay_payload=replay_payload,
+            outbox_events=validated_outbox,
+        )
+        payload_hash = contracts_module.canonical_payload_hash(canonical_payload)
         now = _now_iso()
 
         with self._lock:
             conn = self._connection()
             # Idempotency first, without opening a write transaction.
             existing = conn.execute(
-                "select status, committed_revision, user_message_chat_log_id, "
-                "assistant_message_chat_log_id, replay_payload "
+                "select status, payload_hash_sha256, committed_revision, "
+                "user_message_chat_log_id, assistant_message_chat_log_id, "
+                "replay_payload "
                 "from turn_requests where request_id = ?",
                 (request_id,),
             ).fetchone()
-            if existing is not None and existing[0] == "completed":
-                return self._committed_from_row(
-                    request_id, existing[1], existing[2], existing[3], existing[4]
-                )
+            if existing is not None:
+                status, stored_hash = existing[0], existing[1]
+                if status == "completed":
+                    # Same request + same canonical payload → replay the
+                    # committed result. Any divergent determinative input
+                    # is a conflict: the stored hash is compared BEFORE
+                    # replaying, and nothing is ever written on this path.
+                    if stored_hash != payload_hash:
+                        raise ConflictError(
+                            "request_payload_conflict",
+                            "Request id was already completed with a different payload.",
+                            expected_revision=(
+                                expected_revision if expected_revision is not None else 0
+                            ),
+                            actual_revision=None,
+                            request_id=request_id,
+                        )
+                    return self._committed_from_row(
+                        request_id, existing[2], existing[3], existing[4], existing[5]
+                    )
+                if status == "pending":
+                    raise ConflictError(
+                        "request_in_progress",
+                        "Request is already in progress.",
+                        expected_revision=(
+                            expected_revision if expected_revision is not None else 0
+                        ),
+                        actual_revision=None,
+                        request_id=request_id,
+                    )
+                # failed: replay is unavailable, but a retry with the same
+                # canonical payload may proceed as a fresh attempt; a
+                # divergent payload for the same request id is still a
+                # conflict (deterministic rejection, no silent reuse).
+                if stored_hash != payload_hash:
+                    raise ConflictError(
+                        "request_payload_conflict",
+                        "Request id already exists with a different payload.",
+                        expected_revision=(
+                            expected_revision if expected_revision is not None else 0
+                        ),
+                        actual_revision=None,
+                        request_id=request_id,
+                    )
 
             try:
                 conn.execute("BEGIN IMMEDIATE")
+                # Re-read the ledger row inside the write transaction: the
+                # first read ran outside it, and only the writer lock plus
+                # BEGIN IMMEDIATE make the check-then-act atomic.
+                existing = conn.execute(
+                    "select status, payload_hash_sha256, committed_revision, "
+                    "user_message_chat_log_id, assistant_message_chat_log_id, "
+                    "replay_payload "
+                    "from turn_requests where request_id = ?",
+                    (request_id,),
+                ).fetchone()
+                if existing is not None:
+                    status, stored_hash = existing[0], existing[1]
+                    if stored_hash != payload_hash:
+                        conn.execute("ROLLBACK")
+                        raise ConflictError(
+                            "request_payload_conflict",
+                            "Request id was already committed with a different payload.",
+                            expected_revision=(
+                                expected_revision if expected_revision is not None else 0
+                            ),
+                            actual_revision=None,
+                            request_id=request_id,
+                        )
+                    if status == "completed":
+                        conn.execute("ROLLBACK")
+                        return self._committed_from_row(
+                            request_id, existing[2], existing[3], existing[4], existing[5]
+                        )
+                    if status == "pending":
+                        conn.execute("ROLLBACK")
+                        raise ConflictError(
+                            "request_in_progress",
+                            "Request is already in progress.",
+                            expected_revision=(
+                                expected_revision if expected_revision is not None else 0
+                            ),
+                            actual_revision=None,
+                            request_id=request_id,
+                        )
+
                 profile_row = conn.execute(
                     "select revision from profiles where id = 1"
                 ).fetchone()
@@ -463,13 +591,6 @@ class LocalStorage:
                 if expected_revision is None:
                     expected = current_revision
                 else:
-                    if isinstance(expected_revision, bool) or not isinstance(
-                        expected_revision, int
-                    ) or expected_revision < 0:
-                        raise ValidationError(
-                            "invalid_expected_revision",
-                            "expected_revision must be a non-negative integer",
-                        )
                     expected = expected_revision
                 if expected != current_revision:
                     raise ConflictError(
@@ -529,12 +650,12 @@ class LocalStorage:
                     ),
                 )
 
-                for event_type, payload, idempotency_key in outbox_events or []:
+                for event_type, payload, idempotency_key in validated_outbox:
                     conn.execute(
                         "insert into outbox_events (id, event_type, "
                         "idempotency_key, status, turn_request_id, payload, "
                         "created_at) values (?, ?, ?, 'pending', ?, ?, ?) "
-                        "on conflict (idempotency_key) do nothing",
+                        "on conflict (idempotency_key, event_type) do nothing",
                         (
                             f"{idempotency_key}:{event_type}",
                             event_type,
@@ -643,12 +764,61 @@ class LocalStorage:
     # ── Privacy operations ──────────────────────────────────────────────
 
     def delete_history(self) -> dict[str, Any]:
-        return self._privacy_delete(
-            "delete_history",
-            "delete from chat_logs",
-            "deleted_messages",
-            "select count(*) from chat_logs",
-        )
+        """Make the local conversation history unrecoverable, atomically.
+
+        The local history is everything the turn flow persists for those
+        turns: ``chat_logs`` (messages), ``turn_requests`` (the replay
+        ledger, including ``replay_payload``) and the ``outbox_events``
+        derived from them. All three are removed in **one** transaction;
+        the cascade is explicit (outbox → turn request), and the ledger
+        rows are removed together with their messages (no orphaned
+        replay data may survive the user's "delete history").
+
+        The ``privacy_operations`` ledger row is kept for audit, carrying
+        only aggregate counts — no private content.
+        """
+        with self._lock:
+            conn = self._connection()
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                chat_count = conn.execute(
+                    "select count(*) from chat_logs"
+                ).fetchone()[0]
+                turn_count = conn.execute(
+                    "select count(*) from turn_requests"
+                ).fetchone()[0]
+                # Outbox rows cascade with their turn request; count first
+                # because the FK cascade removes them as part of the same
+                # transaction.
+                outbox_count = conn.execute(
+                    "select count(*) from outbox_events"
+                ).fetchone()[0]
+                conn.execute(
+                    "delete from turn_requests"
+                )  # cascades to outbox_events, nulls chat log refs are moot
+                conn.execute("delete from chat_logs")
+                remaining = conn.execute(
+                    "select count(*) from chat_logs"
+                ).fetchone()[0]
+                if remaining != 0:
+                    raise PersistenceError("database_error", "persistence error")
+                result = {
+                    "status": "applied",
+                    "deleted_messages": int(chat_count),
+                    "deleted_turn_requests": int(turn_count),
+                    "deleted_outbox_events": int(outbox_count),
+                }
+                conn.execute(
+                    "insert into privacy_operations (operation, status, result) "
+                    "values ('delete_history', 'applied', ?)",
+                    (_json_dumps(result),),
+                )
+                conn.execute("COMMIT")
+            except sqlite3.Error:
+                if conn.in_transaction:
+                    conn.execute("ROLLBACK")
+                raise PersistenceError("database_error", "persistence error") from None
+        return result
 
     def delete_memories(self) -> dict[str, Any]:
         return self._privacy_delete(
@@ -681,27 +851,81 @@ class LocalStorage:
         return result
 
     def reset_emotional_state(self, neutral: Optional[Mapping[str, Any]] = None) -> dict[str, Any]:
+        """Replace the emotional snapshot with the canonical neutral v1 state.
+
+        The resulting snapshot is the neutral state **produced by the
+        domain** (``EmotionalStateV1.neutral``). When ``neutral`` is
+        supplied it must BE that canonical snapshot (validated by
+        reconstruction through the domain constructor); there is exactly
+        one definition of "neutral". The reset bumps ``profiles.revision``
+        coherently (CAS): a commit prepared on the previous revision
+        fails with ``revision_mismatch`` instead of silently overwriting
+        the reset.
+        """
+        timestamp = _time_now_unix()
+        canonical = contracts_module.neutral_emotional_snapshot(timestamp)
+        if neutral is not None:
+            contracts_module.validate_neutral_emotional_snapshot(neutral)
         return self._reset_state_field(
-            "reset_emotional_state", "emotional_state", neutral or {}
+            "reset_emotional_state", "emotional_state", canonical
         )
 
     def reset_relationship_state(self, neutral: Optional[Mapping[str, Any]] = None) -> dict[str, Any]:
+        """Replace the relationship snapshot with the canonical neutral v1 state.
+
+        Same semantics as ``reset_emotional_state`` with the domain's
+        ``RelationshipStateV1.neutral`` as the single neutral definition.
+        """
+        timestamp = _time_now_unix()
+        canonical = contracts_module.neutral_relationship_snapshot(timestamp)
+        if neutral is not None:
+            contracts_module.validate_neutral_relationship_snapshot(neutral)
         return self._reset_state_field(
-            "reset_relationship_state", "relationship_state", neutral or {}
+            "reset_relationship_state", "relationship_state", canonical
         )
 
     def _reset_state_field(
-        self, operation: str, field: str, neutral: Mapping[str, Any]
+        self, operation: str, field: str, canonical_neutral: Mapping[str, Any]
     ) -> dict[str, Any]:
         with self._lock:
             conn = self._connection()
             conn.execute("BEGIN IMMEDIATE")
             try:
-                conn.execute(
-                    f"update profiles set {field} = ?, updated_at = ? where id = 1",
-                    (_json_dumps(neutral), _now_iso()),
+                row = conn.execute(
+                    "select revision from profiles where id = 1"
+                ).fetchone()
+                current_revision = row[0] if row else 0
+                new_revision = current_revision + 1
+                updated = conn.execute(
+                    f"update profiles set {field} = ?, revision = ?, "
+                    "updated_at = ? where id = 1",
+                    (_json_dumps(canonical_neutral), new_revision, _now_iso()),
                 )
-                result = {"status": "applied"}
+                if updated.rowcount == 0:
+                    # No profile row yet: create it carrying BOTH canonical
+                    # neutral v1 snapshots, so no column is ever NULL and
+                    # the untouched side is valid from the start.
+                    if field == "emotional_state":
+                        emotional_json = _json_dumps(canonical_neutral)
+                        relationship_json = _json_dumps(
+                            contracts_module.neutral_relationship_snapshot(
+                                _time_now_unix()
+                            )
+                        )
+                    else:
+                        emotional_json = _json_dumps(
+                            contracts_module.neutral_emotional_snapshot(
+                                _time_now_unix()
+                            )
+                        )
+                        relationship_json = _json_dumps(canonical_neutral)
+                    conn.execute(
+                        "insert into profiles (id, emotional_state, "
+                        "relationship_state, revision, updated_at) "
+                        "values (1, ?, ?, ?, ?)",
+                        (emotional_json, relationship_json, new_revision, _now_iso()),
+                    )
+                result = {"status": "applied", "revision": new_revision}
                 conn.execute(
                     "insert into privacy_operations (operation, status, result) "
                     "values (?, 'applied', ?)",
@@ -780,17 +1004,25 @@ class LocalStorage:
     # ── Lifecycle ────────────────────────────────────────────────────────
 
     def close(self) -> None:
+        """Close the store terminally: no later operation may proceed.
+
+        Every thread's connection is closed (connections are per-thread,
+        so each open connection is tracked and closed here), the store is
+        marked closed under the same lock the gate reads, and any later
+        call — on any thread — fails with the stable sanitized
+        ``PersistenceError("storage_closed")`` instead of silently
+        reconnecting.
+        """
         with self._lock:
             if self._closed:
                 return
             self._closed = True
-            conn = getattr(self._local, "conn", None)
-            if conn is not None:
+            for conn in list(self._connections.values()):
                 try:
                     conn.close()
                 except sqlite3.Error:
                     pass
-                self._local.conn = None
+            self._connections.clear()
 
 
 def _json_dumps(value: Any) -> str:

--- a/backend/tests/test_local_storage.py
+++ b/backend/tests/test_local_storage.py
@@ -1273,6 +1273,67 @@ class TestClosedLifecycle:
         assert reopened.load_user_state().revision == 1
         reopened.close()
 
+    def test_cross_thread_connection_really_closed_by_close(self, tmp_path: Path) -> None:
+        """Prove close() deterministically closes other threads' connections.
+
+        A worker thread creates and retains its own connection through
+        the store; the main thread then calls close(). The retained
+        connection object must be genuinely closed — any use raises
+        ProgrammingError, and it must no longer be a functional shortcut
+        past the closed store (no GC reliance, no leaked live handle).
+        """
+        from backend.local_storage import PersistenceError
+
+        store = open_local_storage(tmp_path / "katherine.db")
+        store.commit_turn(**_commit_kwargs(store, "req-close-5", "r5"))
+        barrier = threading.Barrier(2, timeout=10)
+        captured: dict[str, sqlite3.Connection] = {}
+
+        def worker() -> None:
+            captured["conn"] = store._connection_for_tests_only()
+            barrier.wait()  # main thread may close() now
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        barrier.wait()
+        thread.join(timeout=10)
+        worker_conn = captured["conn"]
+        store.close()
+        # The worker's connection was created by another thread, yet
+        # close() shut it down deterministically (not via GC).
+        with pytest.raises(sqlite3.ProgrammingError):
+            worker_conn.execute("select 1")
+        # It is not a functional shortcut: every operation still fails
+        # with the sanitized storage_closed error.
+        with pytest.raises(PersistenceError) as excinfo:
+            store.load_user_state()
+        assert excinfo.value.code == "storage_closed"
+        with pytest.raises(PersistenceError) as excinfo:
+            store.commit_turn(**_commit_kwargs(store, "req-close-6", "r6"))
+        assert excinfo.value.code == "storage_closed"
+
+    def test_backup_after_close_leaves_no_filesystem_artifacts(
+        self, tmp_path: Path
+    ) -> None:
+        """backup_to() on a closed store must not create anything.
+
+        The lifecycle gate runs before any target creation: no backup.db
+        file, no parent directory, no empty side-effect left behind.
+        """
+        from backend.local_storage import PersistenceError
+
+        store = open_local_storage(tmp_path / "katherine.db")
+        store.commit_turn(**_commit_kwargs(store, "req-close-7", "r7"))
+        store.close()
+        backup_dir = tmp_path / "backups"
+        backup_file = backup_dir / "backup.db"
+        with pytest.raises(PersistenceError) as excinfo:
+            store.backup_to(backup_file)
+        assert excinfo.value.code == "storage_closed"
+        assert excinfo.value.message == "storage is closed"
+        assert not backup_file.exists()
+        assert not backup_dir.exists()
+
     def test_close_is_idempotent_and_safe(self, tmp_path: Path) -> None:
         store = open_local_storage(tmp_path / "katherine.db")
         store.close()

--- a/backend/tests/test_local_storage.py
+++ b/backend/tests/test_local_storage.py
@@ -46,13 +46,27 @@ def _emotion_payload(response: str) -> dict:
     }
 
 
+def _neutral_emotional() -> dict:
+    """Real domain neutral v1 emotional snapshot."""
+    from backend.emotional_domain import EmotionalStateV1
+
+    return EmotionalStateV1.neutral(timestamp=1000.0).to_dict()
+
+
+def _neutral_relationship() -> dict:
+    """Real domain neutral v1 relationship snapshot."""
+    from backend.relationship import RelationshipStateV1
+
+    return RelationshipStateV1.neutral(timestamp=1000.0).to_dict()
+
+
 def _commit_kwargs(store: LocalStorage, request_id: str, response: str = "ok") -> dict:
     return {
         "request_id": request_id,
         "user_message": "oi",
         "assistant_message": response,
-        "emotional_state": {"v": 1, "valence": 0.1},
-        "relationship_state": {"v": 1, "trust": 0.5},
+        "emotional_state": _neutral_emotional(),
+        "relationship_state": _neutral_relationship(),
         "public_response": response,
         "replay_payload": _emotion_payload(response),
         "outbox_events": [],
@@ -719,7 +733,7 @@ class TestRealDomainTurnCycle:
             public_response="olá!",
             replay_payload={
                 "response": "olá!",
-                "emotion_state": {"v": 1, "valence": 0.1},
+                "emotion_state": {"valence": 0.1, "arousal": 0.2},
             },
             outbox_events=[],
             expected_revision=revision,
@@ -761,7 +775,7 @@ class TestRealDomainTurnCycle:
             public_response="tudo ótimo",
             replay_payload={
                 "response": "tudo ótimo",
-                "emotion_state": {"v": 1, "valence": -0.05},
+                "emotion_state": {"valence": -0.05, "arousal": 0.1},
             },
             outbox_events=[],
             expected_revision=user_state_2.revision,
@@ -805,3 +819,437 @@ class TestRealDomainTurnCycle:
         assert restored.load_user_state().revision == committed_2.revision
         assert len(restored.load_recent_history(limit=10)) == 4
         restored.close()
+
+
+class TestRequestIdempotencyConflict:
+    """Same request id + divergent determinative payload → deterministic
+    conflict, never a silent replay of the old result, never a write."""
+
+    def test_same_request_same_payload_replays_without_new_writes(
+        self, tmp_path: Path
+    ) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        kw = _commit_kwargs(store, "req-idem", "r1")
+        first = store.commit_turn(**kw)
+        conn = store._connection_for_tests_only()
+        rows_before = conn.execute("select count(*) from chat_logs").fetchone()[0]
+        turns_before = conn.execute("select count(*) from turn_requests").fetchone()[0]
+
+        second = store.commit_turn(**kw)
+
+        assert second.request_id == first.request_id
+        assert second.revision == first.revision
+        assert second.response == first.response
+        assert conn.execute("select count(*) from chat_logs").fetchone()[0] == rows_before
+        assert conn.execute("select count(*) from turn_requests").fetchone()[0] == turns_before
+        store.close()
+
+    def test_same_request_different_user_message_conflicts(
+        self, tmp_path: Path
+    ) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        store.commit_turn(**_commit_kwargs(store, "req-div", "r1"))
+        kw = _commit_kwargs(store, "req-div", "r1")
+        kw["user_message"] = "outra mensagem"
+        with pytest.raises(ConflictError) as excinfo:
+            store.commit_turn(**kw)
+        assert excinfo.value.code == "request_payload_conflict"
+        store.close()
+
+    def test_same_request_different_snapshot_conflicts(self, tmp_path: Path) -> None:
+        from backend.emotional_domain import EmotionalStateV1
+
+        store = open_local_storage(tmp_path / "katherine.db")
+        store.commit_turn(**_commit_kwargs(store, "req-snap", "r1"))
+        kw = _commit_kwargs(store, "req-snap", "r1")
+        snapshot = EmotionalStateV1.neutral(timestamp=2000.0).to_dict()
+        snapshot["pleasure"] = 0.5
+        kw["emotional_state"] = snapshot
+        with pytest.raises(ConflictError) as excinfo:
+            store.commit_turn(**kw)
+        assert excinfo.value.code == "request_payload_conflict"
+        store.close()
+
+    def test_same_request_different_outbox_conflicts(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        kw = _commit_kwargs(store, "req-obx", "r1")
+        store.commit_turn(**kw)
+        kw["outbox_events"] = [
+            (
+                "archival_extraction_requested",
+                {"message_id": "req-obx", "kind": "archival", "version": 1},
+                "archival:req-obx:v1",
+            )
+        ]
+        with pytest.raises(ConflictError) as excinfo:
+            store.commit_turn(**kw)
+        assert excinfo.value.code == "request_payload_conflict"
+        store.close()
+
+    def test_conflict_writes_nothing(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        store.commit_turn(**_commit_kwargs(store, "req-cw", "r1"))
+        revision_before = store.load_user_state().revision
+        history_before = store.load_recent_history(limit=50)
+        conn = store._connection_for_tests_only()
+        turns_before = conn.execute("select count(*) from turn_requests").fetchone()[0]
+        outbox_before = conn.execute("select count(*) from outbox_events").fetchone()[0]
+
+        kw = _commit_kwargs(store, "req-cw", "DIFFERENT")
+        with pytest.raises(ConflictError):
+            store.commit_turn(**kw)
+
+        assert store.load_user_state().revision == revision_before
+        assert store.load_recent_history(limit=50) == history_before
+        assert conn.execute("select count(*) from turn_requests").fetchone()[0] == turns_before
+        assert conn.execute("select count(*) from outbox_events").fetchone()[0] == outbox_before
+        store.close()
+
+    def test_error_never_echoes_payload(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        secret = "conteúdo privado do usuário"
+        store.commit_turn(**_commit_kwargs(store, "req-leak", "r1"))
+        kw = _commit_kwargs(store, "req-leak", "r1")
+        kw["user_message"] = secret
+        with pytest.raises(ConflictError) as excinfo:
+            store.commit_turn(**kw)
+        rendered = str(excinfo.value)
+        assert secret not in rendered
+        assert excinfo.value.message == (
+            "Request id was already completed with a different payload."
+        )
+        store.close()
+
+
+class TestDeleteHistoryPrivacySemantics:
+    """delete_history removes messages, replay ledger and derived outbox,
+    atomically, in one transaction; replay becomes unavailable afterwards."""
+
+    def _committed_store(self, tmp_path: Path):
+        store = open_local_storage(tmp_path / "katherine.db")
+        kw = _commit_kwargs(store, "req-del", "resposta privada")
+        kw["outbox_events"] = [
+            (
+                "archival_extraction_requested",
+                {"message_id": "req-del", "kind": "archival", "version": 1},
+                "archival:req-del:v1",
+            )
+        ]
+        store.commit_turn(**kw)
+        return store
+
+    def test_delete_history_removes_all_history_data(self, tmp_path: Path) -> None:
+        store = self._committed_store(tmp_path)
+        result = store.delete_history()
+        assert result["status"] == "applied"
+        assert result["deleted_messages"] == 2
+        assert result["deleted_turn_requests"] == 1
+        assert result["deleted_outbox_events"] == 1
+
+        conn = store._connection_for_tests_only()
+        assert conn.execute("select count(*) from chat_logs").fetchone()[0] == 0
+        assert conn.execute("select count(*) from turn_requests").fetchone()[0] == 0
+        assert conn.execute("select count(*) from outbox_events").fetchone()[0] == 0
+        # no replay payload content remains anywhere in the file
+        assert store.load_recent_history(limit=10) == []
+        outcome = store.replay("req-del")
+        assert outcome.status == "request_replay_unavailable"
+        assert outcome.committed is None
+
+        # the audit ledger remains, but carries only aggregate counts
+        rows = conn.execute(
+            "select operation, status, result from privacy_operations"
+        ).fetchall()
+        assert rows[0][0] == "delete_history"
+        assert rows[0][1] == "applied"
+        stored_result = json.loads(rows[0][2])
+        assert "resposta privada" not in rows[0][2]
+        assert stored_result["deleted_messages"] == 2
+        store.close()
+
+    def test_delete_history_is_atomic_under_failure(self, tmp_path: Path) -> None:
+        store = self._committed_store(tmp_path)
+        conn = store._connection_for_tests_only()
+        # A trigger that aborts the outbox delete proves the whole
+        # operation rolls back: nothing may be partially deleted.
+        conn.execute(
+            "create trigger block_outbox_delete before delete on outbox_events "
+            "begin select raise(ABORT, 'boom'); end;"
+        )
+        from backend.local_storage import PersistenceError
+
+        with pytest.raises(PersistenceError):
+            store.delete_history()
+        # nothing was deleted: history intact
+        assert conn.execute("select count(*) from chat_logs").fetchone()[0] == 2
+        assert conn.execute("select count(*) from turn_requests").fetchone()[0] == 1
+        assert conn.execute("select count(*) from outbox_events").fetchone()[0] == 1
+        assert store.replay("req-del").status == "completed"
+        store.close()
+
+    def test_delete_history_then_new_turn_still_works(self, tmp_path: Path) -> None:
+        store = self._committed_store(tmp_path)
+        store.delete_history()
+        committed = store.commit_turn(**_commit_kwargs(store, "req-after", "nova resposta"))
+        assert committed.response == "nova resposta"
+        history = store.load_recent_history(limit=10)
+        assert [m["content"] for m in history] == ["oi", "nova resposta"]
+        store.close()
+
+
+class TestNeutralResets:
+    """Resets produce the domain's canonical neutral v1 snapshot, bump the
+    revision coherently, and reject stale commits afterwards."""
+
+    def _non_neutral_state(self):
+        from backend.emotional_domain import AppraisalV1, EmotionalStateV1
+        from backend.emotional_domain.transition import TransitionConfig, transition
+        from backend.relationship import (
+            RelationshipStateV1,
+            RelationshipTransitionConfig,
+            transition_relationship,
+        )
+
+        emotional = transition(
+            EmotionalStateV1.neutral(timestamp=1000.0),
+            AppraisalV1.create(valence_shift=0.5, arousal_shift=0.4, dominance_shift=0.1),
+            1100.0,
+            TransitionConfig.defaults(),
+        ).state
+        relationship = transition_relationship(
+            RelationshipStateV1.neutral(timestamp=1000.0),
+            AppraisalV1.create(valence_shift=0.5, arousal_shift=0.4, dominance_shift=0.1),
+            1200.0,
+            RelationshipTransitionConfig.defaults(),
+        )
+        return emotional, relationship
+
+    def test_reset_emotional_state_persists_canonical_neutral(self, tmp_path: Path) -> None:
+        from backend.emotional_domain import EmotionalStateV1
+
+        store = open_local_storage(tmp_path / "katherine.db")
+        emotional, relationship = self._non_neutral_state()
+        store.commit_turn(
+            request_id="req-neutral-1",
+            user_message="oi",
+            assistant_message="olá",
+            emotional_state=emotional.to_dict(),
+            relationship_state=relationship.to_dict(),
+            public_response="olá",
+            replay_payload=_emotion_payload("olá"),
+            outbox_events=[],
+            expected_revision=0,
+        )
+        revision_before = store.load_user_state().revision
+        assert store.load_user_state().emotional_state != EmotionalStateV1.neutral(
+            timestamp=store.load_user_state().emotional_state["timestamp"]
+        ).to_dict()
+
+        result = store.reset_emotional_state()
+        assert result["status"] == "applied"
+
+        state = store.load_user_state()
+        assert state.revision == revision_before + 1
+        loaded = EmotionalStateV1.from_dict(state.emotional_state)
+        canonical = EmotionalStateV1.neutral(timestamp=loaded.timestamp)
+        assert loaded.to_dict() == canonical.to_dict()
+        # relationship snapshot untouched by the emotional reset
+        assert state.relationship_state == relationship.to_dict()
+        store.close()
+
+    def test_reset_relationship_state_persists_canonical_neutral(
+        self, tmp_path: Path
+    ) -> None:
+        from backend.relationship import RelationshipStateV1
+
+        store = open_local_storage(tmp_path / "katherine.db")
+        emotional, relationship = self._non_neutral_state()
+        store.commit_turn(
+            request_id="req-neutral-2",
+            user_message="oi",
+            assistant_message="olá",
+            emotional_state=emotional.to_dict(),
+            relationship_state=relationship.to_dict(),
+            public_response="olá",
+            replay_payload=_emotion_payload("olá"),
+            outbox_events=[],
+            expected_revision=0,
+        )
+        revision_before = store.load_user_state().revision
+
+        result = store.reset_relationship_state()
+        assert result["status"] == "applied"
+
+        state = store.load_user_state()
+        assert state.revision == revision_before + 1
+        loaded = RelationshipStateV1.from_dict(state.relationship_state)
+        canonical = RelationshipStateV1.neutral(timestamp=loaded.timestamp)
+        assert loaded.to_dict() == canonical.to_dict()
+        assert state.emotional_state == emotional.to_dict()
+        store.close()
+
+    def test_reset_rejects_non_canonical_neutral_argument(self, tmp_path: Path) -> None:
+        from backend.local_storage import ValidationError as LocalValidationError
+
+        store = open_local_storage(tmp_path / "katherine.db")
+        emotional, relationship = self._non_neutral_state()
+        store.commit_turn(
+            request_id="req-neutral-3",
+            user_message="oi",
+            assistant_message="olá",
+            emotional_state=emotional.to_dict(),
+            relationship_state=relationship.to_dict(),
+            public_response="olá",
+            replay_payload=_emotion_payload("olá"),
+            outbox_events=[],
+            expected_revision=0,
+        )
+        forged = emotional.to_dict()  # structurally valid v1, NOT neutral
+        with pytest.raises(LocalValidationError) as excinfo:
+            store.reset_emotional_state(neutral=forged)
+        assert excinfo.value.code == "invalid_reset_payload"
+        with pytest.raises(LocalValidationError):
+            store.reset_emotional_state(neutral={})
+        with pytest.raises(LocalValidationError):
+            store.reset_relationship_state(neutral={"v": 1})
+        store.close()
+
+    def test_stale_commit_after_reset_hits_revision_mismatch(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        emotional, relationship = self._non_neutral_state()
+        committed = store.commit_turn(
+            request_id="req-neutral-4",
+            user_message="oi",
+            assistant_message="olá",
+            emotional_state=emotional.to_dict(),
+            relationship_state=relationship.to_dict(),
+            public_response="olá",
+            replay_payload=_emotion_payload("olá"),
+            outbox_events=[],
+            expected_revision=0,
+        )
+        stale_revision = committed.revision
+
+        store.reset_emotional_state()
+
+        # A commit prepared on the pre-reset revision must not overwrite
+        # the reset: CAS rejects it deterministically.
+        with pytest.raises(ConflictError) as excinfo:
+            store.commit_turn(
+                request_id="req-neutral-5",
+                user_message="de novo",
+                assistant_message="resposta",
+                emotional_state=emotional.to_dict(),
+                relationship_state=relationship.to_dict(),
+                public_response="resposta",
+                replay_payload=_emotion_payload("resposta"),
+                outbox_events=[],
+                expected_revision=stale_revision,
+            )
+        assert excinfo.value.code == "revision_mismatch"
+        state = store.load_user_state()
+        from backend.emotional_domain import EmotionalStateV1
+
+        loaded = EmotionalStateV1.from_dict(state.emotional_state)
+        assert loaded.to_dict() == EmotionalStateV1.neutral(
+            timestamp=loaded.timestamp
+        ).to_dict()
+        store.close()
+
+    def test_reset_on_fresh_database_creates_profile_with_neutral(
+        self, tmp_path: Path
+    ) -> None:
+        from backend.emotional_domain import EmotionalStateV1
+        from backend.relationship import RelationshipStateV1
+
+        store = open_local_storage(tmp_path / "katherine.db")
+        result = store.reset_emotional_state()
+        assert result["status"] == "applied"
+        state = store.load_user_state()
+        assert state.revision == 1
+        loaded = EmotionalStateV1.from_dict(state.emotional_state)
+        assert loaded.to_dict() == EmotionalStateV1.neutral(
+            timestamp=loaded.timestamp
+        ).to_dict()
+        rel = RelationshipStateV1.from_dict(state.relationship_state)
+        assert rel.to_dict() == RelationshipStateV1.neutral(
+            timestamp=rel.timestamp
+        ).to_dict()
+        store.close()
+
+
+class TestClosedLifecycle:
+    """close() is terminal: same thread, other threads, no reconnection."""
+
+    def test_operation_on_same_thread_after_close_fails(self, tmp_path: Path) -> None:
+        from backend.local_storage import PersistenceError
+
+        store = open_local_storage(tmp_path / "katherine.db")
+        store.commit_turn(**_commit_kwargs(store, "req-close-1", "r1"))
+        store.close()
+        with pytest.raises(PersistenceError) as excinfo:
+            store.load_user_state()
+        assert excinfo.value.code == "storage_closed"
+        assert excinfo.value.message == "storage is closed"
+        with pytest.raises(PersistenceError):
+            store.commit_turn(**_commit_kwargs(store, "req-close-2", "r2"))
+        with pytest.raises(PersistenceError):
+            store.replay("req-close-1")
+        with pytest.raises(PersistenceError):
+            store.delete_history()
+        with pytest.raises(PersistenceError):
+            store.storage_metrics()
+        with pytest.raises(PersistenceError):
+            store.backup_to(tmp_path / "backup.db")
+        store.close()  # idempotent
+
+    def test_operation_from_other_thread_after_close_fails(
+        self, tmp_path: Path
+    ) -> None:
+        from backend.local_storage import PersistenceError
+
+        store = open_local_storage(tmp_path / "katherine.db")
+        store.commit_turn(**_commit_kwargs(store, "req-close-3", "r3"))
+        # A second thread opens (and registers) its own connection first.
+        barrier = threading.Barrier(2, timeout=10)
+        errors: list[Exception] = []
+
+        def other_thread_op() -> None:
+            try:
+                store._connection_for_tests_only()
+                barrier.wait()
+                barrier.wait()
+                store.load_user_state()
+                errors.append(AssertionError("operation after close must fail"))
+            except PersistenceError as exc:
+                if exc.code != "storage_closed":
+                    errors.append(exc)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        worker = threading.Thread(target=other_thread_op)
+        worker.start()
+        barrier.wait()  # worker opened its connection
+        store.close()  # closes every registered connection
+        barrier.wait()  # worker proceeds to attempt the operation
+        worker.join(timeout=10)
+        assert errors == []
+
+    def test_no_silent_reconnection_after_close(self, tmp_path: Path) -> None:
+        from backend.local_storage import PersistenceError
+
+        store = open_local_storage(tmp_path / "katherine.db")
+        store.commit_turn(**_commit_kwargs(store, "req-close-4", "r4"))
+        store.close()
+        with pytest.raises(PersistenceError):
+            store._connection_for_tests_only()
+        # The database file still exists and holds the committed data; only
+        # this store instance is closed. A NEW instance may open it normally.
+        reopened = open_local_storage(tmp_path / "katherine.db")
+        assert reopened.load_user_state().revision == 1
+        reopened.close()
+
+    def test_close_is_idempotent_and_safe(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        store.close()
+        store.close()

--- a/backend/tests/test_local_storage.py
+++ b/backend/tests/test_local_storage.py
@@ -96,8 +96,10 @@ class TestMigrations:
         second.close()
 
     def test_partial_migration_failure_never_marks_schema(self, tmp_path: Path) -> None:
-        # Inject a failing migration (DDL that raises) into the migration list
-        # of a fresh store; the version must NOT be recorded.
+        # A migration whose LAST statement fails (trigger aborts the
+        # insert): the earlier DDL inside the same migration must roll
+        # back too — neither the broken table nor the version row may
+        # survive. This is the real mid-migration atomicity case.
         from backend.local_storage import migrations as migrations_module
 
         original = migrations_module.MIGRATIONS
@@ -107,14 +109,11 @@ class TestMigrations:
                 "create table broken_table (id integer primary key);\n"
                 "create trigger boom before insert on broken_table begin "
                 "select raise(ABORT,'boom'); end;\n"
-                "create table this_will_fail (id integer primary key, "
-                "check (1 = 0));\n"
                 "insert into broken_table values (1);",
             )
         ]
-        monkeyver = original
         try:
-            migrations_module.MIGRATIONS = broken
+            migrations_module.MIGRATIONS = tuple(broken)
             path = tmp_path / "partial.db"
             with pytest.raises(Exception):
                 open_local_storage(path)
@@ -122,10 +121,14 @@ class TestMigrations:
             marked = conn.execute(
                 "select count(*) from schema_migrations where version = 99999"
             ).fetchone()[0]
+            table_left = conn.execute(
+                "select count(*) from sqlite_master where name='broken_table'"
+            ).fetchone()[0]
             conn.close()
             assert marked == 0
+            assert table_left == 0, "mid-migration DDL must roll back with the version row"
         finally:
-            migrations_module.MIGRATIONS = monkeyver
+            migrations_module.MIGRATIONS = original
 
 
 class TestRestartAndRecovery:

--- a/backend/tests/test_local_storage.py
+++ b/backend/tests/test_local_storage.py
@@ -26,6 +26,7 @@ from backend.local_storage import (
     ConflictError,
     LocalStorage,
     StorageCorruptError,
+    ValidationError as LocalValidationError,
     default_database_path,
     open_local_storage,
 )
@@ -734,6 +735,7 @@ class TestRealDomainTurnCycle:
             replay_payload={
                 "response": "olá!",
                 "emotion_state": {"valence": 0.1, "arousal": 0.2},
+                "message_id": 2,
             },
             outbox_events=[],
             expected_revision=revision,
@@ -776,6 +778,7 @@ class TestRealDomainTurnCycle:
             replay_payload={
                 "response": "tudo ótimo",
                 "emotion_state": {"valence": -0.05, "arousal": 0.1},
+                "message_id": 4,
             },
             outbox_events=[],
             expected_revision=user_state_2.revision,
@@ -791,7 +794,7 @@ class TestRealDomainTurnCycle:
                 emotional_state=emotional_result.state.to_dict(),
                 relationship_state=roundtrip_relationship.to_dict(),
                 public_response="y",
-                replay_payload={"response": "y", "emotion_state": {}},
+                replay_payload={"response": "y", "emotion_state": {}, "message_id": 5},
                 outbox_events=[],
                 expected_revision=revision,
             )
@@ -854,6 +857,27 @@ class TestRequestIdempotencyConflict:
         with pytest.raises(ConflictError) as excinfo:
             store.commit_turn(**kw)
         assert excinfo.value.code == "request_payload_conflict"
+        store.close()
+
+    def test_replay_payload_foreign_request_id_is_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        # Web parity: a replay payload carrying a request_id must identify
+        # THIS request (web _validate_replay_payload cross-check).
+        store = open_local_storage(tmp_path / "katherine.db")
+        kw = _commit_kwargs(store, "req-foreign", "r1")
+        kw["replay_payload"]["request_id"] = "req-someone-else"
+        with pytest.raises(LocalValidationError) as excinfo:
+            store.commit_turn(**kw)
+        assert excinfo.value.code == "invalid_replay_payload"
+        # Nothing was written by the rejected commit.
+        conn = store._connection_for_tests_only()
+        assert conn.execute("select count(*) from chat_logs").fetchone()[0] == 0
+        assert conn.execute("select count(*) from turn_requests").fetchone()[0] == 0
+        # The matching request_id commits normally.
+        kw["replay_payload"]["request_id"] = "req-foreign"
+        committed = store.commit_turn(**kw)
+        assert committed.request_id == "req-foreign"
         store.close()
 
     def test_same_request_different_snapshot_conflicts(self, tmp_path: Path) -> None:

--- a/backend/tests/test_local_storage.py
+++ b/backend/tests/test_local_storage.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import pytest
 
 from backend.local_storage import (
+    ConflictError,
     LocalStorage,
     StorageCorruptError,
     default_database_path,
@@ -663,3 +664,144 @@ def test_turn_request_row_shape_matches_transactional_contract(tmp_path: Path) -
     assert row[4] != row[5]
     payload = json.loads(row[6])
     assert payload["response"] == "r-shape"
+
+
+class TestRealDomainTurnCycle:
+    """The store supports the operations the real turn flow uses, exercised
+    with the production domain modules (no mocks, no synthetic copies).
+
+    This mirrors the use-case sequence of ``process_turn``:
+    load state + revision → real domain transition → commit_turn with
+    expected_revision → public result parsed back from the persisted
+    payload → replay returns the same persisted result idempotently.
+    """
+
+    def test_full_turn_cycle_with_real_domain_transitions(self, tmp_path: Path) -> None:
+        from backend.emotional_domain import AppraisalV1, EmotionalStateV1
+        from backend.emotional_domain.transition import TransitionConfig, transition
+        from backend.relationship import (
+            RelationshipStateV1,
+            RelationshipTransitionConfig,
+            transition_relationship,
+        )
+
+        store = open_local_storage(tmp_path / "katherine.db")
+
+        # ── turn 1: fresh state, real domain transitions ──────────────────
+        user_state = store.load_user_state()
+        prev_emotional = EmotionalStateV1.from_dict(user_state.emotional_state)
+        prev_relationship = RelationshipStateV1.from_dict(
+            user_state.relationship_state
+        )
+        revision = user_state.revision
+
+        appraisal = AppraisalV1.create(
+            valence_shift=0.3, arousal_shift=0.2, dominance_shift=0.0
+        )
+        t1 = max(prev_emotional.timestamp, prev_relationship.timestamp) + 100.0
+        t2 = t1 + 100.0
+        emotional_result = transition(
+            prev_emotional, appraisal, t1, TransitionConfig.defaults()
+        )
+        new_relationship = transition_relationship(
+            prev_relationship,
+            appraisal,
+            t2,
+            RelationshipTransitionConfig.defaults(),
+        )
+
+        committed = store.commit_turn(
+            request_id="req-cycle-1",
+            user_message="oi Katherine",
+            assistant_message="olá!",
+            emotional_state=emotional_result.state.to_dict(),
+            relationship_state=new_relationship.to_dict(),
+            public_response="olá!",
+            replay_payload={
+                "response": "olá!",
+                "emotion_state": {"v": 1, "valence": 0.1},
+            },
+            outbox_events=[],
+            expected_revision=revision,
+        )
+
+        # Public result is parsed back from the persisted payload — never
+        # from pre-commit variables (process_turn contract).
+        assert committed.response == "olá!"
+        assert committed.revision == revision + 1
+        replayed = store.replay("req-cycle-1")
+        assert replayed.status == "completed"
+        assert replayed.committed.revision == committed.revision
+        assert replayed.committed.response == committed.response
+
+        # ── turn 2: loads turn 1's persisted snapshots, CAS advances ──────
+        user_state_2 = store.load_user_state()
+        assert user_state_2.revision == committed.revision
+        roundtrip_emotional = EmotionalStateV1.from_dict(
+            user_state_2.emotional_state
+        )
+        assert roundtrip_emotional.to_dict() == emotional_result.state.to_dict()
+        roundtrip_relationship = RelationshipStateV1.from_dict(
+            user_state_2.relationship_state
+        )
+        assert roundtrip_relationship.to_dict() == new_relationship.to_dict()
+
+        appraisal_2 = AppraisalV1.create(
+            valence_shift=-0.2, arousal_shift=0.1, dominance_shift=0.0
+        )
+        emotional_result_2 = transition(
+            roundtrip_emotional, appraisal_2, t2, TransitionConfig.defaults()
+        )
+        committed_2 = store.commit_turn(
+            request_id="req-cycle-2",
+            user_message="tudo bem?",
+            assistant_message="tudo ótimo",
+            emotional_state=emotional_result_2.state.to_dict(),
+            relationship_state=roundtrip_relationship.to_dict(),
+            public_response="tudo ótimo",
+            replay_payload={
+                "response": "tudo ótimo",
+                "emotion_state": {"v": 1, "valence": -0.05},
+            },
+            outbox_events=[],
+            expected_revision=user_state_2.revision,
+        )
+        assert committed_2.revision == committed.revision + 1
+
+        # ── stale CAS from turn 1 must be rejected with the real error ──
+        with pytest.raises(ConflictError) as excinfo:
+            store.commit_turn(
+                request_id="req-cycle-stale",
+                user_message="x",
+                assistant_message="y",
+                emotional_state=emotional_result.state.to_dict(),
+                relationship_state=roundtrip_relationship.to_dict(),
+                public_response="y",
+                replay_payload={"response": "y", "emotion_state": {}},
+                outbox_events=[],
+                expected_revision=revision,
+            )
+        assert excinfo.value.code == "revision_mismatch"
+        # actual_revision is the real profile revision at CAS time (both
+        # turns committed), expected is the stale value the caller sent.
+        assert excinfo.value.actual_revision == committed_2.revision
+        assert excinfo.value.expected_revision == revision
+
+        # ── history carries both turns in order ─────────────────────────
+        history = store.load_recent_history(limit=10)
+        assert [m["role"] for m in history] == [
+            "user",
+            "assistant",
+            "user",
+            "assistant",
+        ]
+        assert history[1]["content"] == "olá!"
+
+        # ── backup mid-life is consistent and restorable ────────────────
+        backup_path = tmp_path / "backup.db"
+        store.backup_to(backup_path)
+        store.close()
+        restored = open_local_storage(backup_path)
+        assert restored.load_user_state().revision == committed_2.revision
+        assert len(restored.load_recent_history(limit=10)) == 4
+        restored.close()

--- a/backend/tests/test_local_storage.py
+++ b/backend/tests/test_local_storage.py
@@ -1,0 +1,662 @@
+"""SQLite local persistence foundation — required-behavior suite (#335).
+
+Every test runs against a **real, temporary SQLite file** (``tmp_path``),
+one isolated database per test. No Supabase, no Postgres, no network.
+No mocks are ever used as proof of atomicity: failures are produced by
+real SQLite mechanics (CHECK constraints, triggers, CAS guards) or by
+real I/O error injection on the file.
+
+The suite maps 1:1 to the twelve mandatory tests of issue #335 plus the
+extra invariants the issue text requires (revision CAS, replay
+idempotency, outbox idempotency, backup consistency, XDG override,
+sanitized errors, no-cloud-import).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+from backend.local_storage import (
+    LocalStorage,
+    StorageCorruptError,
+    default_database_path,
+    open_local_storage,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _emotion_payload(response: str) -> dict:
+    """Minimal valid public emotion payload (paridade com replay_payload)."""
+    return {
+        "response": response,
+        "emotion_state": {"valence": 0.1, "arousal": 0.2},
+        "message_id": "4a7f8c21-0000-4000-8000-000000000001",
+        "duration_ms": 12,
+    }
+
+
+def _commit_kwargs(store: LocalStorage, request_id: str, response: str = "ok") -> dict:
+    return {
+        "request_id": request_id,
+        "user_message": "oi",
+        "assistant_message": response,
+        "emotional_state": {"v": 1, "valence": 0.1},
+        "relationship_state": {"v": 1, "trust": 0.5},
+        "public_response": response,
+        "replay_payload": _emotion_payload(response),
+        "outbox_events": [],
+    }
+
+
+class TestMigrations:
+    """Issue #335 tests 1 (zero→migrations), 8 (partial failure)."""
+
+    def test_fresh_database_applies_all_migrations_and_records_version(
+        self, tmp_path: Path
+    ) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        assert store.schema_version() > 0
+        row = store._connection_for_tests_only().execute(
+            "select count(*) from schema_migrations"
+        ).fetchone()
+        assert row[0] == store.schema_version()
+        # every expected table exists
+        conn = store._connection_for_tests_only()
+        for table in (
+            "profiles",
+            "chat_logs",
+            "turn_requests",
+            "outbox_events",
+            "memories",
+            "schema_migrations",
+        ):
+            exists = conn.execute(
+                "select count(*) from sqlite_master where type='table' and name=?",
+                (table,),
+            ).fetchone()[0]
+            assert exists == 1, f"table {table} missing"
+
+    def test_reopen_skips_applied_migrations_idempotently(self, tmp_path: Path) -> None:
+        path = tmp_path / "katherine.db"
+        first = open_local_storage(path)
+        version = first.schema_version()
+        first.close()
+        second = open_local_storage(path)
+        assert second.schema_version() == version
+        second.close()
+
+    def test_partial_migration_failure_never_marks_schema(self, tmp_path: Path) -> None:
+        # Inject a failing migration (DDL that raises) into the migration list
+        # of a fresh store; the version must NOT be recorded.
+        from backend.local_storage import migrations as migrations_module
+
+        original = migrations_module.MIGRATIONS
+        broken = list(original) + [
+            (
+                9_999,
+                "create table broken_table (id integer primary key);\n"
+                "create trigger boom before insert on broken_table begin "
+                "select raise(ABORT,'boom'); end;\n"
+                "create table this_will_fail (id integer primary key, "
+                "check (1 = 0));\n"
+                "insert into broken_table values (1);",
+            )
+        ]
+        monkeyver = original
+        try:
+            migrations_module.MIGRATIONS = broken
+            path = tmp_path / "partial.db"
+            with pytest.raises(Exception):
+                open_local_storage(path)
+            conn = sqlite3.connect(path)
+            marked = conn.execute(
+                "select count(*) from schema_migrations where version = 99999"
+            ).fetchone()[0]
+            conn.close()
+            assert marked == 0
+        finally:
+            migrations_module.MIGRATIONS = monkeyver
+
+
+class TestRestartAndRecovery:
+    """Issue #335 test 2 (restart), 9 (corruption → explicit error)."""
+
+    def test_restart_reopens_state_without_loss(self, tmp_path: Path) -> None:
+        path = tmp_path / "katherine.db"
+        store = open_local_storage(path)
+        committed = store.commit_turn(**_commit_kwargs(store, "req-1", "resposta-1"))
+        store.close()
+
+        reopened = open_local_storage(path)
+        state = reopened.load_user_state()
+        assert state.revision == 1
+        history = reopened.load_recent_history(limit=10)
+        assert [m["content"] for m in history] == ["oi", "resposta-1"]
+        # replay returns the same committed result without a provider
+        outcome = reopened.replay("req-1")
+        assert outcome.status == "completed"
+        assert outcome.committed.response == "resposta-1"
+        reopened.close()
+
+    def test_corrupted_database_raises_explicit_error_never_resets(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "katherine.db"
+        store = open_local_storage(path)
+        store.commit_turn(**_commit_kwargs(store, "req-1"))
+        store.close()
+        # corrupt the file bytes
+        raw = path.read_bytes()
+        path.write_bytes(raw[: max(1, len(raw) // 3)] + b"\x00\x01garbage")
+        with pytest.raises(StorageCorruptError):
+            open_local_storage(path)
+        # the corrupted file is NOT silently recreated: it still fails on reopen
+        with pytest.raises(StorageCorruptError):
+            open_local_storage(path)
+
+    def test_io_error_surfaces_as_persistence_error_not_reset(
+        self, tmp_path: Path
+    ) -> None:
+        import os
+
+        path = tmp_path / "katherine.db"
+        store = open_local_storage(path)
+        store.commit_turn(**_commit_kwargs(store, "req-1"))
+        store.close()
+        os.chmod(path, 0o000)
+        try:
+            with pytest.raises(Exception):
+                open_local_storage(path)
+        finally:
+            os.chmod(path, 0o644)
+
+
+class TestAtomicTurnCommit:
+    """Issue #335 tests 3 (whole-turn failure) and 4 (coherent rollback)."""
+
+    def test_commit_fails_entirely_when_intermediate_write_fails(
+        self, tmp_path: Path
+    ) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        # Real SQLite failure: the assistant row is blocked by a trigger.
+        conn = store._connection_for_tests_only()
+        conn.execute(
+            "create trigger block_assistant_row before insert on chat_logs "
+            "when new.role = 'assistant' begin select raise(ABORT, 'boom'); end;"
+        )
+        before_logs = conn.execute("select count(*) from chat_logs").fetchone()[0]
+        from backend.local_storage import PersistenceError
+
+        with pytest.raises(PersistenceError):
+            store.commit_turn(**_commit_kwargs(store, "req-fail"))
+        after_logs = conn.execute("select count(*) from chat_logs").fetchone()[0]
+        assert before_logs == after_logs  # user row rolled back too
+        # no turn_requests row, no revision bump
+        assert conn.execute("select count(*) from turn_requests").fetchone()[0] == 0
+        assert store.load_user_state().revision == 0
+        store.close()
+
+    def test_rollback_keeps_messages_and_snapshots_coherent(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        store.commit_turn(**_commit_kwargs(store, "req-1", "r1"))
+        rev_before = store.load_user_state().revision
+        conn = store._connection_for_tests_only()
+        conn.execute(
+            "create trigger block_outbox before insert on outbox_events "
+            "begin select raise(ABORT, 'boom'); end;"
+        )
+        kw = _commit_kwargs(store, "req-2", "r2")
+        kw["outbox_events"] = [
+            ("archival_extraction_requested", {"message_id": "req-2", "kind": "archival", "version": 1}, "archival:req-2:v1")
+        ]
+        from backend.local_storage import PersistenceError
+
+        with pytest.raises(PersistenceError):
+            store.commit_turn(**kw)
+        # coherent: nothing from turn 2 landed
+        assert store.load_user_state().revision == rev_before
+        history = store.load_recent_history(limit=10)
+        assert [m["content"] for m in history] == ["oi", "r1"]
+        outcome = store.replay("req-2")
+        assert outcome.status == "request_replay_unavailable"
+        store.close()
+
+    def test_revision_cas_rejects_stale_expected_revision(self, tmp_path: Path) -> None:
+        from backend.local_storage import ConflictError
+
+        store = open_local_storage(tmp_path / "katherine.db")
+        store.commit_turn(**_commit_kwargs(store, "req-1", "r1"))
+        # replay with the stale revision 0 must conflict
+        kw = dict(_commit_kwargs(store, "req-1b", "r1b"), expected_revision=0)
+        with pytest.raises(ConflictError) as excinfo:
+            store.commit_turn(**kw)
+        assert excinfo.value.code == "revision_mismatch"
+        assert excinfo.value.actual_revision == 1
+        store.close()
+
+    def test_duplicate_request_id_replays_committed_turn(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        first = store.commit_turn(**_commit_kwargs(store, "req-dup", "r-dup"))
+        second = store.commit_turn(**_commit_kwargs(store, "req-dup", "r-dup"))
+        assert first.request_id == second.request_id
+        assert first.revision == second.revision
+        # only ONE pair of messages persisted
+        history = store.load_recent_history(limit=10)
+        assert [m["content"] for m in history] == ["oi", "r-dup"]
+        store.close()
+
+    def test_outbox_event_idempotency_key_unique(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        kw = _commit_kwargs(store, "req-ob", "r-ob")
+        kw["outbox_events"] = [
+            ("archival_extraction_requested", {"message_id": "req-ob", "kind": "archival", "version": 1}, "archival:req-ob:v1")
+        ]
+        store.commit_turn(**kw)
+        # same idempotency key again (replay of the same request) must not duplicate
+        second = store.commit_turn(**kw)
+        conn = store._connection_for_tests_only()
+        count = conn.execute(
+            "select count(*) from outbox_events where idempotency_key = 'archival:req-ob:v1'"
+        ).fetchone()[0]
+        assert count == 1
+        assert second.revision == 1
+
+
+class TestForeignKeys:
+    """Issue #335 test 5: foreign keys really enabled."""
+
+    def test_pragma_foreign_keys_enabled_on_every_connection(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        conn = store._connection_for_tests_only()
+        assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+        store.close()
+
+    def test_fk_violation_rejected(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        conn = store._connection_for_tests_only()
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "insert into outbox_events (id, event_type, idempotency_key, "
+                "turn_request_id, payload, created_at) values "
+                "('e1','archival_extraction_requested','k1','nonexistent','{}','2026-01-01T00:00:00Z')"
+            )
+        store.close()
+
+
+class TestPrivacyAndRetention:
+    """Issue #335 tests 6 (real deletion semantics) and 10 (growth bounds)."""
+
+    def test_delete_history_removes_messages_and_respects_semantics(
+        self, tmp_path: Path
+    ) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        store.commit_turn(**_commit_kwargs(store, "req-1", "r1"))
+        store.commit_turn(**_commit_kwargs(store, "req-2", "r2"))
+        result = store.delete_history()
+        assert result["status"] == "applied"
+        assert result["deleted_messages"] == 4
+        assert store.load_recent_history(limit=10) == []
+        # privacy operation is recorded (audit, no content)
+        conn = store._connection_for_tests_only()
+        ops = conn.execute("select operation, status from privacy_operations").fetchall()
+        assert ops == [("delete_history", "applied")]
+        store.close()
+
+    def test_delete_memories_removes_only_memories(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        store.store_memory(
+            content="fato aprovado",
+            metadata={
+                "schema_version": 1,
+                "tags": ["gosto"],
+                "approved": True,
+                "provenance": "archival_extraction",
+                "epistemic_status": "known",
+                "importance": 0.7,
+            },
+        )
+        store.commit_turn(**_commit_kwargs(store, "req-1", "r1"))
+        result = store.delete_memories()
+        assert result["status"] == "applied"
+        assert result["deleted_memories"] == 1
+        history = store.load_recent_history(limit=10)
+        assert len(history) == 2  # chat intact
+        store.close()
+
+    def test_trim_history_enforces_growth_bound(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        for i in range(30):
+            store.commit_turn(
+                **_commit_kwargs(store, f"req-{i}", f"r{i}")
+            )
+        result = store.trim_history(keep_last=10)
+        assert result["status"] == "applied"
+        assert result["remaining"] == 10
+        conn = store._connection_for_tests_only()
+        assert conn.execute("select count(*) from chat_logs").fetchone()[0] == 10
+        store.close()
+
+
+class TestIsolation:
+    """Issue #335 test 7: one temporary database never contaminates another."""
+
+    def test_two_test_databases_are_isolated(self, tmp_path: Path) -> None:
+        a = open_local_storage(tmp_path / "a.db")
+        b = open_local_storage(tmp_path / "b.db")
+        a.commit_turn(**_commit_kwargs(a, "req-a", "resposta-A"))
+        assert [m["content"] for m in b.load_recent_history(limit=10)] == []
+        assert b.load_user_state().revision == 0
+        assert [m["content"] for m in a.load_recent_history(limit=10)] == ["oi", "resposta-A"]
+        a.close()
+        b.close()
+
+
+class TestGrowthAndIndexes:
+    """Issue #335 test 10: growth and basic indexes are evaluated."""
+
+    def test_history_query_uses_index(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        for i in range(50):
+            store.commit_turn(**_commit_kwargs(store, f"req-{i}", f"r{i}"))
+        conn = store._connection_for_tests_only()
+        plan = conn.execute(
+            "explain query plan select id, role, content, created_at from chat_logs "
+            "order by created_at desc, id desc limit 10"
+        ).fetchall()
+        plan_str = " ".join(row[3] for row in plan).lower()
+        store.close()
+        assert "using index" in plan_str, plan_str
+
+    def test_request_replay_lookup_uses_index(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        for i in range(20):
+            store.commit_turn(**_commit_kwargs(store, f"req-{i}", f"r{i}"))
+        conn = store._connection_for_tests_only()
+        plan = conn.execute(
+            "explain query plan select * from turn_requests where request_id = 'req-7'"
+        ).fetchall()
+        plan_str = " ".join(row[3] for row in plan).lower()
+        store.close()
+        assert "using index" in plan_str
+
+    def test_chat_log_count_and_size_metrics(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        for i in range(10):
+            store.commit_turn(**_commit_kwargs(store, f"req-{i}", f"r{i}"))
+        metrics = store.storage_metrics()
+        assert metrics["chat_log_rows"] == 20
+        assert metrics["page_count"] > 0
+        assert metrics["page_size"] > 0
+        store.close()
+
+
+class TestConcurrency:
+    """Issue #335 test 11: explicit serialization policy inside one process."""
+
+    def test_concurrent_commits_serialize_with_clear_policy(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        errors: list[Exception] = []
+        successes: list[int] = []
+
+        def worker(i: int) -> None:
+            try:
+                committed = store.commit_turn(
+                    **_commit_kwargs(store, f"req-{i}", f"r{i}")
+                )
+                successes.append(committed.revision)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+        assert not any(isinstance(e, PersistenceErrorHolder) for e in errors)
+        assert len(errors) == 0, f"unexpected errors: {errors}"
+        # all 8 turns committed, revisions unique and sequential
+        assert sorted(successes) == list(range(1, 9))
+        conn = store._connection_for_tests_only()
+        assert conn.execute("select count(*) from chat_logs").fetchone()[0] == 16
+        store.close()
+
+    def test_reader_thread_sees_committed_state_during_writes(self, tmp_path: Path) -> None:
+        # WAL allows reads to proceed while a write transaction is open.
+        # A separate READER THREAD gets its own connection; the reader must
+        # only ever see committed state (never the in-flight write).
+        store = open_local_storage(tmp_path / "katherine.db")
+        store.commit_turn(**_commit_kwargs(store, "req-1", "r1"))
+        write_conn = store._connection_for_tests_only()
+        write_conn.execute("begin immediate")
+        write_conn.execute(
+            "insert into chat_logs (role, content, created_at) values ('user','x','2026-01-01T00:00:00Z')"
+        )
+        seen: list[int] = []
+
+        def read_committed() -> None:
+            seen.append(
+                store._connection_for_tests_only()
+                .execute("select count(*) from chat_logs")
+                .fetchone()[0]
+            )
+
+        reader = threading.Thread(target=read_committed)
+        reader.start()
+        reader.join(timeout=10)
+        try:
+            assert seen == [2]  # reader sees only committed state
+        finally:
+            write_conn.execute("rollback")
+        store.close()
+
+
+class TestNoCloudImports:
+    """Issue #335 test 12: tests never require Supabase/Postgres/network."""
+
+    def test_package_import_does_not_pull_supabase(self) -> None:
+        import subprocess
+
+        code = "import backend.local_storage, sys; "
+        code += "mods = [m for m in sys.modules if m.split('.')[0] in "
+        code += "('supabase', 'postgrest', 'httpx', 'requests')]; "
+        code += "print('LEAK=' + ','.join(sorted(mods)) if mods else 'CLEAN')"
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=60,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "LEAK=" not in result.stdout, f"cloud imports leaked: {result.stdout}"
+        assert "CLEAN" in result.stdout
+
+
+class TestXdgPaths:
+    """XDG-compliant default path with a safe override for tests."""
+
+    def test_default_path_follows_xdg_data_home(self, tmp_path: Path) -> None:
+        import os
+
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        env = {
+            "HOME": str(fake_home),
+            "XDG_DATA_HOME": str(tmp_path / "data"),
+        }
+        path = default_database_path(env=env)
+        assert str(tmp_path / "data") in str(path)
+        assert "katherine" in path.name
+
+    def test_default_path_creates_directories(self, tmp_path: Path) -> None:
+        env = {"HOME": str(tmp_path), "XDG_DATA_HOME": str(tmp_path / "xdgdata")}
+        path = default_database_path(env=env)
+        assert path.parent.exists()
+
+    def test_fallback_without_xdg_uses_home_local_share(self, tmp_path: Path) -> None:
+        env = {"HOME": str(tmp_path), "XDG_DATA_HOME": ""}
+        path = default_database_path(env=env)
+        assert ".local" in str(path)
+
+
+class TestBackup:
+    """Issue #335: backup/copy must never capture inconsistent state."""
+
+    def test_backup_produces_consistent_copy(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        for i in range(5):
+            store.commit_turn(**_commit_kwargs(store, f"req-{i}", f"r{i}"))
+        backup_path = tmp_path / "backup.db"
+        store.backup_to(backup_path)
+        # the backup is a complete, consistent database
+        check = open_local_storage(backup_path)
+        assert check.load_user_state().revision == 5
+        assert len(check.load_recent_history(limit=10)) == 10
+        check.close()
+        store.close()
+
+    def test_backup_refuses_to_overwrite_existing_file(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        store.commit_turn(**_commit_kwargs(store, "req-1", "r1"))
+        target = tmp_path / "backup.db"
+        target.write_text("existing")
+        with pytest.raises(Exception):
+            store.backup_to(target)
+        assert target.read_text() == "existing"
+        store.close()
+
+
+class TestSanitizedErrors:
+    """Public errors never carry paths, SQL, tracebacks or raw content."""
+
+    def test_persistence_error_is_constant_message(self, tmp_path: Path) -> None:
+        from backend.local_storage import PersistenceError
+
+        store = open_local_storage(tmp_path / "katherine.db")
+        conn = store._connection_for_tests_only()
+        conn.execute(
+            "create trigger boom before insert on chat_logs "
+            "begin select raise(ABORT,'secret-path /home/user/leak'); end;"
+        )
+        with pytest.raises(PersistenceError) as excinfo:
+            store.commit_turn(**_commit_kwargs(store, "req-x"))
+        message = str(excinfo.value)
+        store.close()
+        assert "secret-path" not in message
+        assert "/home" not in message
+        assert "leak" not in message
+
+    def test_validation_error_rejects_oversized_message(self, tmp_path: Path) -> None:
+        from backend.local_storage import ValidationError as LocalValidationError
+
+        store = open_local_storage(tmp_path / "katherine.db")
+        kw = _commit_kwargs(store, "req-big")
+        kw["user_message"] = "x" * 20_001
+        with pytest.raises(LocalValidationError) as excinfo:
+            store.commit_turn(**kw)
+        assert excinfo.value.code == "message_too_long"
+        store.close()
+
+
+class TestReplayContract:
+    """Replay parity with the web contract: same parser, same statuses."""
+
+    def test_replay_unknown_request_is_unavailable(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        outcome = store.replay("does-not-exist")
+        assert outcome.status == "request_replay_unavailable"
+        assert outcome.committed is None
+        store.close()
+
+    def test_pending_request_reports_in_progress_not_recomputed(self, tmp_path: Path) -> None:
+        store = open_local_storage(tmp_path / "katherine.db")
+        conn = store._connection_for_tests_only()
+        conn.execute(
+            "insert into turn_requests (request_id, payload_hash_sha256, status, "
+            "expected_revision, created_at, updated_at) values "
+            "('req-pending', 'deadbeef', 'pending', 0, '2026-01-01T00:00:00Z', "
+            "'2026-01-01T00:00:00Z')"
+        )
+        outcome = store.replay("req-pending")
+        assert outcome.status == "request_in_progress"
+        store.close()
+
+    def test_load_user_state_defaults_neutral(self, tmp_path: Path) -> None:
+        from backend.emotional_domain import EmotionalStateV1
+        from backend.relationship import RelationshipStateV1
+
+        store = open_local_storage(tmp_path / "katherine.db")
+        state = store.load_user_state()
+        assert state.revision == 0
+        assert state.persona_config is None
+        # Neutral v1 snapshots (contract parity with the web flow) — not empty.
+        neutral_emotional = EmotionalStateV1.neutral(timestamp=1.0).to_dict()
+        neutral_relationship = RelationshipStateV1.neutral(timestamp=1.0).to_dict()
+        assert state.emotional_state.keys() == neutral_emotional.keys()
+        assert state.relationship_state.keys() == neutral_relationship.keys()
+        assert state.emotional_state["schema_version"] == 1
+        assert state.relationship_state["schema_version"] == 1
+        store.close()
+
+
+class TestRecoveryOfInterruptedTurns:
+    """Issue #335 test 2 extension: interrupted pending turns fail closed."""
+
+    def test_pending_without_completed_commit_is_marked_interrupted_on_open(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "katherine.db"
+        store = open_local_storage(path)
+        conn = store._connection_for_tests_only()
+        conn.execute(
+            "insert into turn_requests (request_id, payload_hash_sha256, status, "
+            "expected_revision, created_at, updated_at) values "
+            "('req-zombie', 'deadbeef', 'pending', 0, '2026-01-01T00:00:00Z', "
+            "'2026-01-01T00:00:00Z')"
+        )
+        store.close()
+        # simulate crash+restart: reopen marks zombie pending as failed
+        reopened = open_local_storage(path)
+        outcome = reopened.replay("req-zombie")
+        assert outcome.status == "request_replay_unavailable"
+        conn2 = reopened._connection_for_tests_only()
+        status = conn2.execute(
+            "select status from turn_requests where request_id='req-zombie'"
+        ).fetchone()[0]
+        assert status == "failed"
+        reopened.close()
+
+
+class PersistenceErrorHolder(Exception):
+    """Never raised; only used as a sentinel type in concurrency assertions."""
+
+
+def test_turn_request_row_shape_matches_transactional_contract(tmp_path: Path) -> None:
+    """The SQLite turn ledger mirrors the PostgreSQL contract fields."""
+    store = open_local_storage(tmp_path / "katherine.db")
+    store.commit_turn(**_commit_kwargs(store, "req-shape", "r-shape"))
+    conn = store._connection_for_tests_only()
+    row = conn.execute(
+        "select request_id, status, expected_revision, committed_revision, "
+        "user_message_chat_log_id, assistant_message_chat_log_id, replay_payload "
+        "from turn_requests where request_id='req-shape'"
+    ).fetchone()
+    store.close()
+    assert row[0] == "req-shape"
+    assert row[1] == "completed"
+    assert row[2] == 0
+    assert row[3] == 1
+    assert row[4] is not None and row[5] is not None
+    assert row[4] != row[5]
+    payload = json.loads(row[6])
+    assert payload["response"] == "r-shape"

--- a/backend/tests/test_local_storage_contracts.py
+++ b/backend/tests/test_local_storage_contracts.py
@@ -108,6 +108,44 @@ class TestReplayPayloadContract:
             validate_replay_payload(payload)
         assert "exceeds" in excinfo.value.message
 
+    def test_rejects_missing_message_id(self) -> None:
+        # Web parity: _validate_replay_payload requires a message_id
+        # identifying the committed assistant message. Locally the id is a
+        # SQLite rowid (integer) or a bounded identifier string.
+        payload = _valid_replay_payload()
+        del payload["message_id"]
+        with pytest.raises(ValidationError) as excinfo:
+            validate_replay_payload(payload)
+        assert excinfo.value.code == "invalid_replay_payload"
+
+    def test_accepts_rowid_message_id(self) -> None:
+        payload = _valid_replay_payload()
+        payload["message_id"] = 7
+        assert validate_replay_payload(payload) is payload
+
+    def test_rejects_invalid_message_id(self) -> None:
+        payload = _valid_replay_payload()
+        payload["message_id"] = True  # bool is not an int id
+        with pytest.raises(ValidationError) as excinfo:
+            validate_replay_payload(payload)
+        assert excinfo.value.code == "invalid_replay_payload"
+        payload["message_id"] = {"nested": "object"}
+        with pytest.raises(ValidationError):
+            validate_replay_payload(payload)
+
+    def test_rejects_invalid_request_id_reference(self) -> None:
+        # Web parity: request_id, when present, must be a bounded
+        # identifier string; commit_turn additionally cross-checks it
+        # against the enclosing request.
+        payload = _valid_replay_payload()
+        payload["request_id"] = 12345  # not a string
+        with pytest.raises(ValidationError) as excinfo:
+            validate_replay_payload(payload)
+        assert excinfo.value.code == "invalid_replay_payload"
+        payload["request_id"] = "x" * 200  # over the 128-char bound
+        with pytest.raises(ValidationError):
+            validate_replay_payload(payload)
+
 
 class TestOutboxContract:
     def test_accepts_reference_only_payload(self) -> None:

--- a/backend/tests/test_local_storage_contracts.py
+++ b/backend/tests/test_local_storage_contracts.py
@@ -1,0 +1,341 @@
+"""Payload contract tests for the local SQLite store (#335).
+
+Adversarial suite: every rejected input is a real attempt to smuggle
+prompts, raw messages, internal state, identity, non-finite numbers or
+unbounded content into the stored payloads, at any depth.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+from backend.local_storage import ValidationError
+from backend.local_storage.contracts import (
+    canonical_payload_hash,
+    validate_emotional_snapshot,
+    validate_neutral_emotional_snapshot,
+    validate_neutral_relationship_snapshot,
+    validate_outbox_events,
+    validate_relationship_snapshot,
+    validate_replay_payload,
+)
+
+
+def _valid_replay_payload() -> dict:
+    return {
+        "response": "olá!",
+        "emotion_state": {"schema_version": 1, "mood_label": "calma", "pad": {"pleasure": 0.0}},
+        "message_id": "4a7f8c21-0000-4000-8000-000000000001",
+        "duration_ms": 12,
+    }
+
+
+def _valid_emotional_snapshot() -> dict:
+    from backend.emotional_domain import EmotionalStateV1
+
+    return EmotionalStateV1.neutral(timestamp=1000.0).to_dict()
+
+
+def _valid_relationship_snapshot() -> dict:
+    from backend.relationship import RelationshipStateV1
+
+    return RelationshipStateV1.neutral(timestamp=1000.0).to_dict()
+
+
+def _snapshot_code(fn) -> str | None:
+    """Run a validator; return its error code or None on success."""
+    try:
+        fn()
+    except ValidationError as exc:
+        return exc.code
+    return None
+
+
+class TestReplayPayloadContract:
+    def test_accepts_public_payload(self) -> None:
+        payload = _valid_replay_payload()
+        assert validate_replay_payload(payload) is payload
+
+    def test_rejects_non_mapping(self) -> None:
+        with pytest.raises(ValidationError) as excinfo:
+            validate_replay_payload([("response", "x")])
+        assert excinfo.value.code == "invalid_replay_payload"
+
+    def test_rejects_unknown_key(self) -> None:
+        payload = _valid_replay_payload()
+        payload["system_prompt"] = "be nice"
+        with pytest.raises(ValidationError) as excinfo:
+            validate_replay_payload(payload)
+        assert excinfo.value.code == "invalid_replay_payload"
+
+    def test_rejects_nested_content_and_prompt_at_any_depth(self) -> None:
+        for forbidden in ("content", "prompt", "system_prompt", "meta_cognition"):
+            payload = _valid_replay_payload()
+            payload["emotion_state"] = {
+                "schema_version": 1,
+                "nested": {"deeper": {forbidden: "secret instructions"}},
+            }
+            with pytest.raises(ValidationError) as excinfo:
+                validate_replay_payload(payload)
+            assert excinfo.value.code == "invalid_replay_payload"
+
+    def test_rejects_missing_or_non_string_response(self) -> None:
+        payload = _valid_replay_payload()
+        del payload["response"]
+        with pytest.raises(ValidationError):
+            validate_replay_payload(payload)
+        payload = _valid_replay_payload()
+        payload["response"] = 42
+        with pytest.raises(ValidationError):
+            validate_replay_payload(payload)
+
+    def test_rejects_nan_and_infinity(self) -> None:
+        payload = _valid_replay_payload()
+        payload["duration_ms"] = float("nan")
+        with pytest.raises(ValidationError) as excinfo:
+            validate_replay_payload(payload)
+        assert excinfo.value.code == "invalid_replay_payload"
+
+    def test_rejects_oversized_payload(self) -> None:
+        payload = _valid_replay_payload()
+        payload["response"] = "x" * 9000
+        with pytest.raises(ValidationError) as excinfo:
+            validate_replay_payload(payload)
+        assert "exceeds" in excinfo.value.message
+
+
+class TestOutboxContract:
+    def test_accepts_reference_only_payload(self) -> None:
+        events = [
+            (
+                "archival_extraction_requested",
+                {"message_id": "req-1", "kind": "archival", "version": 1},
+                "archival:req-1:v1",
+            )
+        ]
+        assert validate_outbox_events(events) == events
+
+    def test_none_is_empty(self) -> None:
+        assert validate_outbox_events(None) == []
+
+    def test_rejects_wrong_shape(self) -> None:
+        for bad in (
+            "not-a-list",
+            [("only", "two")],
+            [{"event_type": "a", "payload": {}, "idempotency_key": "k"}],
+        ):
+            with pytest.raises(ValidationError) as excinfo:
+                validate_outbox_events(bad)
+            assert excinfo.value.code == "invalid_outbox_events"
+
+    def test_rejects_invalid_event_type(self) -> None:
+        events = [("Event-Type!", {}, "k1")]
+        with pytest.raises(ValidationError) as excinfo:
+            validate_outbox_events(events)
+        assert excinfo.value.code == "invalid_outbox_events"
+
+    def test_rejects_invalid_idempotency_key(self) -> None:
+        events = [("archival_extraction_requested", {}, "key with spaces")]
+        with pytest.raises(ValidationError) as excinfo:
+            validate_outbox_events(events)
+        assert excinfo.value.code == "invalid_outbox_events"
+
+    def test_rejects_disallowed_payload_key(self) -> None:
+        events = [
+            (
+                "archival_extraction_requested",
+                {"message_id": "req-1", "extra": "nope"},
+                "k1",
+            )
+        ]
+        with pytest.raises(ValidationError) as excinfo:
+            validate_outbox_events(events)
+        assert excinfo.value.code == "invalid_outbox_events"
+
+    def test_rejects_nested_forbidden_key(self) -> None:
+        events = [
+            (
+                "archival_extraction_requested",
+                {"ref": {"nested": {"content": "user wrote this"}}},
+                "k1",
+            )
+        ]
+        with pytest.raises(ValidationError) as excinfo:
+            validate_outbox_events(events)
+        assert excinfo.value.code == "invalid_outbox_events"
+
+    def test_rejects_non_reference_value_types(self) -> None:
+        # The payload value contract: reference fields are bounded ASCII
+        # strings; only `version` is an int. A conversational free-text
+        # value cannot be smuggled into any allowed reference field.
+        events = [
+            (
+                "archival_extraction_requested",
+                {"message_id": "mensagem do usuário — conteúdo privado"},
+                "k1",
+            )
+        ]
+        with pytest.raises(ValidationError) as excinfo:
+            validate_outbox_events(events)
+        assert excinfo.value.code == "invalid_outbox_events"
+
+    def test_rejects_bad_version(self) -> None:
+        for bad in (True, "1", 0, 1001, 1.5):
+            events = [
+                (
+                    "archival_extraction_requested",
+                    {"message_id": "req-1", "version": bad},
+                    "k1",
+                )
+            ]
+            with pytest.raises(ValidationError):
+                validate_outbox_events(events)
+
+    def test_rejects_nan(self) -> None:
+        events = [
+            (
+                "archival_extraction_requested",
+                {"message_id": "req-1", "kind": "archival", "version": 1, "x": float("inf")},
+                "k1",
+            )
+        ]
+        with pytest.raises(ValidationError):
+            validate_outbox_events(events)
+
+    def test_rejects_oversized_payload(self) -> None:
+        # Every field value is individually valid (bounded ASCII reference
+        # strings), but together the document crosses the 256 B outbox cap.
+        events = [
+            (
+                "archival_extraction_requested",
+                {
+                    "ref": "r" * 128,
+                    "request_id": "q" * 128,
+                    "turn_id": "t" * 128,
+                },
+                "k1",
+            )
+        ]
+        with pytest.raises(ValidationError) as excinfo:
+            validate_outbox_events(events)
+        assert "exceeds" in excinfo.value.message
+
+    def test_accepts_typical_reference_payload(self) -> None:
+        # A real archival event payload fits comfortably in the bound.
+        events = [
+            (
+                "archival_extraction_requested",
+                {"message_id": "req-1", "kind": "archival", "version": 1},
+                "archival:req-1:v1",
+            )
+        ]
+        validate_outbox_events(events)
+
+    def test_rejects_duplicate_keys_within_turn(self) -> None:
+        events = [
+            ("archival_extraction_requested", {"kind": "archival", "version": 1}, "dup"),
+            ("archival_extraction_requested", {"kind": "archival", "version": 1}, "dup"),
+        ]
+        with pytest.raises(ValidationError) as excinfo:
+            validate_outbox_events(events)
+        assert excinfo.value.code == "invalid_outbox_events"
+
+
+class TestSnapshotContract:
+    def test_accepts_real_domain_snapshots(self) -> None:
+        assert validate_emotional_snapshot(_valid_emotional_snapshot()) is not None
+        assert validate_relationship_snapshot(_valid_relationship_snapshot()) is not None
+
+    def test_rejects_synthetic_snapshot(self) -> None:
+        # `{"v": 1, ...}` documents are not the real contract.
+        with pytest.raises(ValidationError):
+            validate_emotional_snapshot({"v": 1, "valence": 0.1})
+        with pytest.raises(ValidationError):
+            validate_relationship_snapshot({"v": 1, "trust": 0.5})
+
+    def test_rejects_unknown_keys(self) -> None:
+        snapshot = _valid_emotional_snapshot()
+        snapshot["prompt"] = "hidden"
+        with pytest.raises(ValidationError) as excinfo:
+            validate_emotional_snapshot(snapshot)
+        assert excinfo.value.code == "invalid_emotional_state"
+
+    def test_rejects_identity_keys(self) -> None:
+        snapshot = _valid_relationship_snapshot()
+        snapshot["user_id"] = "someone"
+        with pytest.raises(ValidationError) as excinfo:
+            validate_relationship_snapshot(snapshot)
+        assert excinfo.value.code == "invalid_relationship_state"
+
+    def test_rejects_out_of_range_and_nonfinite(self) -> None:
+        snapshot = _valid_emotional_snapshot()
+        snapshot["pleasure"] = 2.0
+        with pytest.raises(ValidationError):
+            validate_emotional_snapshot(snapshot)
+        snapshot = _valid_emotional_snapshot()
+        snapshot["energy"] = float("nan")
+        with pytest.raises(ValidationError):
+            validate_emotional_snapshot(snapshot)
+        snapshot = _valid_relationship_snapshot()
+        snapshot["trust"] = math.inf
+        with pytest.raises(ValidationError):
+            validate_relationship_snapshot(snapshot)
+
+    def test_rejects_oversized_snapshot(self) -> None:
+        # The domain bounds each trigger to 128 chars and the list to 32
+        # entries, but the whole document is still capped. Triggers at the
+        # domain maximum cross the local 4 KB snapshot budget.
+        rel = _valid_relationship_snapshot()
+        rel["triggers"] = [f"t{i:03d}-" + "x" * 122 for i in range(32)]
+        with pytest.raises(ValidationError) as excinfo:
+            validate_relationship_snapshot(rel)
+        assert "exceeds" in excinfo.value.message
+
+
+class TestNeutralSnapshotContract:
+    def test_accepts_domain_neutral(self) -> None:
+        from backend.emotional_domain import EmotionalStateV1
+        from backend.relationship import RelationshipStateV1
+
+        validate_neutral_emotional_snapshot(
+            EmotionalStateV1.neutral(timestamp=123.0).to_dict()
+        )
+        validate_neutral_relationship_snapshot(
+            RelationshipStateV1.neutral(timestamp=123.0).to_dict()
+        )
+
+    def test_rejects_valid_but_non_neutral(self) -> None:
+        snapshot = _valid_emotional_snapshot()
+        snapshot["pleasure"] = 0.9  # structurally valid v1, not neutral
+        with pytest.raises(ValidationError) as excinfo:
+            validate_neutral_emotional_snapshot(snapshot)
+        assert excinfo.value.code == "invalid_reset_payload"
+        rel = _valid_relationship_snapshot()
+        rel["trust"] = 1.0
+        with pytest.raises(ValidationError) as excinfo:
+            validate_neutral_relationship_snapshot(rel)
+        assert excinfo.value.code == "invalid_reset_payload"
+
+    def test_rejects_empty_mapping(self) -> None:
+        with pytest.raises(ValidationError):
+            validate_neutral_emotional_snapshot({})
+        with pytest.raises(ValidationError):
+            validate_neutral_relationship_snapshot({})
+
+
+class TestCanonicalHash:
+    def test_hash_is_deterministic_and_key_order_insensitive(self) -> None:
+        a = {"b": 1, "a": {"y": 2, "x": [3, 4]}}
+        b = {"a": {"x": [3, 4], "y": 2}, "b": 1}
+        assert canonical_payload_hash(a) == canonical_payload_hash(b)
+
+    def test_hash_rejects_nan(self) -> None:
+        with pytest.raises(ValidationError):
+            canonical_payload_hash({"x": float("nan")})
+
+    def test_hash_changes_with_any_input(self) -> None:
+        base = {"x": 1}
+        assert canonical_payload_hash(base) != canonical_payload_hash({"x": 2})

--- a/backend/tests/test_local_storage_contracts.py
+++ b/backend/tests/test_local_storage_contracts.py
@@ -100,6 +100,8 @@ class TestReplayPayloadContract:
         assert excinfo.value.code == "invalid_replay_payload"
 
     def test_rejects_oversized_payload(self) -> None:
+        # Web parity: the SQL CHECK and atomic_turn_commit bound the replay
+        # payload at 8192 bytes; the local contract enforces the same bound.
         payload = _valid_replay_payload()
         payload["response"] = "x" * 9000
         with pytest.raises(ValidationError) as excinfo:
@@ -206,22 +208,13 @@ class TestOutboxContract:
             validate_outbox_events(events)
 
     def test_rejects_oversized_payload(self) -> None:
-        # Every field value is individually valid (bounded ASCII reference
-        # strings), but together the document crosses the 256 B outbox cap.
-        events = [
-            (
-                "archival_extraction_requested",
-                {
-                    "ref": "r" * 128,
-                    "request_id": "q" * 128,
-                    "turn_id": "t" * 128,
-                },
-                "k1",
-            )
-        ]
+        # Web parity (test_atomic_turn_commit.py::test_outbox_payload_byte_limit):
+        # a reference field above the 8192 B bound is rejected with the same
+        # stable code the web contract uses.
+        events = [("turn_completed", {"ref": "x" * 8200}, "key")]
         with pytest.raises(ValidationError) as excinfo:
             validate_outbox_events(events)
-        assert "exceeds" in excinfo.value.message
+        assert excinfo.value.code == "invalid_outbox_events"
 
     def test_accepts_typical_reference_payload(self) -> None:
         # A real archival event payload fits comfortably in the bound.
@@ -286,13 +279,30 @@ class TestSnapshotContract:
 
     def test_rejects_oversized_snapshot(self) -> None:
         # The domain bounds each trigger to 128 chars and the list to 32
-        # entries, but the whole document is still capped. Triggers at the
-        # domain maximum cross the local 4 KB snapshot budget.
+        # entries, but the document is still capped at the 8192 B bound
+        # shared with the web replay/outbox payload limits. Oversized
+        # triggers (invalid for the domain) still cross the byte cap.
         rel = _valid_relationship_snapshot()
-        rel["triggers"] = [f"t{i:03d}-" + "x" * 122 for i in range(32)]
+        rel["triggers"] = ["t" * 300 for _ in range(32)]
         with pytest.raises(ValidationError) as excinfo:
             validate_relationship_snapshot(rel)
         assert "exceeds" in excinfo.value.message
+
+    def test_accepts_domain_maximum_snapshot(self) -> None:
+        # Parity guard: the largest domain-VALID relationship snapshot
+        # (32 distinct triggers x 128 chars, ~4.3 KB canonical) must be
+        # accepted locally. The web contract has no snapshot byte bound;
+        # the local bound (8192) matches its replay/outbox bounds and
+        # never rejects a snapshot the domain itself considers valid.
+        from backend.relationship import RelationshipStateV1
+
+        triggers = [f"{i:03d}-" + "t" * 123 for i in range(32)]
+        state = RelationshipStateV1.create(
+            trust=0.5, affection=0.5, tension=0.5,
+            triggers=triggers, timestamp=1790000000.123456,
+        )
+        validated = validate_relationship_snapshot(state.to_dict())
+        assert validated == state.to_dict()
 
 
 class TestNeutralSnapshotContract:

--- a/docs/architecture/local-sqlite-persistence.md
+++ b/docs/architecture/local-sqlite-persistence.md
@@ -50,6 +50,23 @@ primeira escrita.**
   "coordenação" é garantido pela posse única da conexão escrevente, e
   não por lock distribuído.
 
+### Lifecycle da store (pertence à aplicação)
+
+`close()` é **terminal**. Ele fecha todas as conexões registradas (uma
+por thread que usou a store), marca a store fechada sob o mesmo lock que
+o gate de conexão lê, e a partir daí:
+
+- nenhuma nova conexão é criada pela store, em nenhuma thread;
+- nenhuma leitura/escrita continua silenciosamente;
+- toda chamada posterior falha com o erro sanitizado estável
+  `PersistenceError("storage_closed")` — mesma thread ou outra thread;
+- `close()` é idempotente; o arquivo do banco permanece intacto e uma
+  **nova** instância pode abri-lo normalmente (o dado não é destruído,
+  apenas esta store é encerrada).
+
+Sem daemon, sem pool pesado, sem framework: um dict de conexões por
+thread ID e um gate sob o lock existente.
+
 ### Recovery
 
 Na abertura, todo ``turn_requests`` com ``status='pending'`` é marcado
@@ -72,30 +89,85 @@ presente no disco é recuperado pelo próprio SQLite.
 
 Uma única transação ``BEGIN IMMEDIATE`` … ``COMMIT`` executa, nesta ordem:
 
-1. **Idempotência**: request_id já ``completed`` → retorna o turn
-   commitado original sem escrever nada (replay idempotente);
-2. **CAS**: lê ``profiles.revision``; se ``expected_revision`` difere →
+1. **Validação de payload** (antes de qualquer escrita): replay payload,
+   snapshots e outbox são validados contra os contratos de payload
+   locais (``backend/local_storage/contracts.py``); ``public_response``
+   deve ser igual a ``replay_payload["response"]`` (fonte única
+   autoritativa do resultado público);
+2. **Idempotência**: request_id já ``completed`` **com o mesmo payload
+   canônico** → retorna o turn commitado original sem escrever nada;
+   o hash canônico cobre **todos** os inputs determinantes do turno
+   (request_id, expected_revision, mensagens, snapshots,
+   public_response, replay_payload, outbox_events). O mesmo request_id
+   com qualquer input divergente → ``ConflictError`` código estável
+   ``request_payload_conflict``, determinístico, **sem nenhuma
+   escrita** (mensagens, snapshots, revision, ledger, outbox) e sem
+   expor payload/hash no erro. A checagem roda fora da transação
+   (fast path) e é refeita dentro de ``BEGIN IMMEDIATE`` (a leitura
+   inicial não é parte da transação de escrita);
+3. **CAS**: lê ``profiles.revision``; se ``expected_revision`` difere →
    ``ConflictError("revision_mismatch")`` com rollback integral;
-3. INSERT mensagem do usuário (``chat_logs``);
-4. INSERT mensagem da assistente (``chat_logs``);
-5. UPSERT do perfil com ``revision = expected + 1`` e os snapshots
+4. INSERT mensagem do usuário (``chat_logs``);
+5. INSERT mensagem da assistente (``chat_logs``);
+6. UPSERT do perfil com ``revision = expected + 1`` e os snapshots
    emocional/relacional do turno;
-6. INSERT do ledger ``turn_requests`` (``status='completed'``,
-   ``replay_payload`` canônico);
-7. INSERT dos ``outbox_events`` (``ON CONFLICT (idempotency_key) DO
-   NOTHING``).
+7. INSERT do ledger ``turn_requests`` (``status='completed'``,
+   ``replay_payload`` canônico, hash canônico do payload completo);
+8. INSERT dos ``outbox_events`` (``ON CONFLICT (idempotency_key,
+   event_type) DO NOTHING``).
 
-Qualquer falha entre 2 e 7 → rollback do turno inteiro: mensagens e
+Qualquer falha entre 2 e 8 → rollback do turno inteiro: mensagens e
 snapshots jamais divergem (testes 3 e 4 da issue). O CAS substitui o
 lock transacional per-user do PostgreSQL: o invariante "uma escrita
 obsoleta nunca sobrescreve estado novo" é preservado pelo mesmo mecanismo
 lógico (version token), agora guardado por transação serializada.
 
+## Contratos de payload (validados em código, testados adversarialmente)
+
+Os contratos que a arquitetura web garante no PostgreSQL são aplicados
+localmente pela store, sem copiar complexidade cloud (sem campos de
+identidade remota):
+
+- **Serialização canônica**: JSON determinístico (keys ordenadas,
+  separadores compactos, UTF-8, ``allow_nan=False``) — a mesma
+  serialização usada para hash e para armazenar payloads.
+- **Replay payload**: deve ser ``Mapping``; apenas campos públicos
+  aprovados; nenhuma chave proibida (``prompt``, ``system_prompt``,
+  ``meta_cognition``, ``internal_instructions``, ``message``,
+  ``content``, …) em **qualquer profundidade**; ``response`` obrigatório
+  como string; JSON finito; limite explícito de 8 KB.
+- **Outbox**: shape do evento, ``event_type`` (``^[a-z0-9_]{1,64}$``),
+  ``idempotency_key`` (``^[A-Za-z0-9_.:-]{1,128}$``), allowlist de
+  keys do payload, chaves proibidas recursivas, **tipos dos valores**
+  (campos de referência são strings ASCII limitadas; ``version`` é
+  inteiro em [1, 1000]), JSON finito, limite de 256 B por payload e
+  no máximo 32 eventos por turno. Mensagens, prompts e conteúdo
+  conversacional não podem ser duplicados no outbox — o código
+  garante o que a documentação afirma.
+- **Snapshots**: não são documentos arbitrários. São validados pelos
+  **modelos reais do domínio** (``EmotionalStateV1`` /
+  ``RelationshipStateV1``), que já rejeitam keys desconhecidas, campos
+  faltantes, identidade/conteúdo interno, valores fora de range,
+  não finitos e bool como numérico; limite de 4 KB por snapshot.
+- **Resets**: o único payload aceito é o **snapshot neutro canônico
+  v1 produzido pelos construtores do domínio** (``EmotionalStateV1.neutral``
+  / ``RelationshipStateV1.neutral``), verificado por reconstrução.
+  Não existem duas definições de "neutro".
+- **Unicidade de outbox**: ``(idempotency_key, event_type)`` único — o
+  mesmo contrato em schema (``UNIQUE``), código (``ON CONFLICT``) e
+  testes. A mesma key pode rotular tipos distintos de evento de um
+  turno; reentregar o mesmo evento é rejeitado.
+
 ## Migrations
 
 - Em código: lista frozen ``(version, sql)`` em
-  ``backend/local_storage/migrations.py`` — ordenadas, append-only,
-  reprodutíveis, sem dependência nova e sem arquivos soltos.
+  ``backend/local_storage/migrations.py`` — ordenadas, reprodutíveis,
+  sem dependência nova e sem arquivos soltos. **Append-only após o
+  merge**: a migration inicial 0001 ainda não está na `main`, então é
+  ela própria que carrega as FKs `ON DELETE CASCADE` e a unicidade
+  composta do outbox exigidas pela semântica de privacidade do
+  `delete_history`; após o merge, mudanças de schema entram como novas
+  migrations, e migrations aplicadas nunca são editadas.
 - ``schema_migrations(version PK, applied_at)`` registra as aplicadas;
   reabrir pula as existentes (idempotente).
 - **Atomicidade por migration**: cada migration roda em sua própria
@@ -109,8 +181,8 @@ lógico (version token), agora guardado por transação serializada.
 |---|---|---|
 | `profiles` (persona, user_profile, emocional, relacional, revision) | `profiles` (1 linha, `id=1`) | Snapshots como JSON canônico; `revision` mantém o CAS |
 | `chat_logs` | `chat_logs` | Sem `user_id` (single-user); índice `(created_at, id)` para recência |
-| `turn_requests` | `turn_requests` | Ledger de idempotência/replay; FKs para `chat_logs` `ON DELETE SET NULL` (privacidade nunca é bloqueada pelo ledger, paridade com o trigger do PostgreSQL) |
-| `outbox_events` | `outbox_events` | Idempotency key única; payload estrito de referências (sem conteúdo) |
+| `turn_requests` | `turn_requests` | Ledger de idempotência/replay com hash canônico do payload completo; FKs para `chat_logs` `ON DELETE CASCADE` (o ledger morre com as mensagens — nada de replay sobrevive ao delete_history) |
+| `outbox_events` | `outbox_events` | Unicidade `(idempotency_key, event_type)`; payload estrito de referências (sem conteúdo), validado em código; FK para `turn_requests` `ON DELETE CASCADE` (eventos derivados são removidos com o turno) |
 | `memories` | `memories` | Metadados JSON com o mesmo contrato de versão/aprovação |
 | `privacy_operations` | `privacy_operations` | Auditoria local (operação, status, result) sem conteúdo privado |
 | `account_deletion_jobs` / worker | **removido nesta fundação** | Destruição de conta é o equivalente local a apagar o arquivo do banco; a operação é documentada, o worker distribuído não se aplica |
@@ -123,12 +195,15 @@ lógico (version token), agora guardado por transação serializada.
 | Commit do turno como unidade atômica | **Preservado** | `BEGIN IMMEDIATE` + rollback integral |
 | Mensagens e snapshots não divergem após crash | **Preservado** | Transação única + WAL + `synchronous=FULL` |
 | Schema versionado, migrations reproduzíveis | **Preservado** | Lista em código + `schema_migrations` |
-| Integridade referencial | **Preservado** | `PRAGMA foreign_keys=ON` + FKs com ON DELETE coerentes |
-| Revision para detectar estado obsoleto | **Preservado** | CAS em `profiles.revision` |
-| Idempotência/replay | **Preservado** | `turn_requests` PK + replay do commitado |
+| Integridade referencial | **Preservado** | `PRAGMA foreign_keys=ON` + FKs `ON DELETE CASCADE` coerentes com a semântica de privacidade |
+| Revision para detectar estado obsoleto | **Preservado** | CAS em `profiles.revision` (commits e resets) |
+| Idempotência/replay com rejeição de payload divergente | **Preservado** | `turn_requests` PK + hash canônico cobrindo todos os inputs determinantes; divergência → `request_payload_conflict` sem escrita |
+| Contratos de payload (allowlists, chaves proibidas, limites, JSON finito) | **Preservado** | `backend/local_storage/contracts.py` + testes adversariais |
 | Recuperação previsível pós-interrupção | **Preservado** | WAL auto-recovery + pending→failed fail-closed |
-| Retenção e exclusão reais | **Preservado** | `delete_history`/`delete_memories`/`trim_history` + auditoria |
-| Limites de tamanho/crescimento | **Preservado** | `MAX_MESSAGE_LENGTH`, trim por contagem, métricas |
+| Retenção e exclusão reais | **Preservado** | `delete_history` remove `chat_logs` + `turn_requests` (replay incluso) + outbox derivado numa única transação; `delete_memories`/`trim_history` + auditoria sem conteúdo privado |
+| Reset neutro canônico v1 | **Preservado** | Snapshot neutro produzido por `EmotionalStateV1.neutral` / `RelationshipStateV1.neutral`; revision incrementada coerentemente |
+| Lifecycle da store | **Preservado** | `close()` terminal: nenhuma nova conexão, nenhuma operação silenciosa, erro estável `storage_closed` em qualquer thread |
+| Limites de tamanho/crescimento | **Preservado** | `MAX_MESSAGE_LENGTH`, limites de bytes por payload (replay 8 KB, outbox 256 B, snapshot 4 KB), trim por contagem, métricas |
 | Erros sanitizados | **Preservado** | code+message constantes; sem SQL/path/conteúdo |
 | Nada importante só em RAM | **Preservado** | Toda escrita de turno é transação commitada |
 | RLS multiusuário | **Removido** | Single-user local; o arquivo é a fronteira de confiança |
@@ -161,12 +236,25 @@ folha futura:
 
 ## Testes
 
-``backend/tests/test_local_storage.py`` — 35 testes, todos contra
-arquivos SQLite **reais temporários** (um banco isolado por teste,
-``tmp_path``). Falhas são produzidas por mecânica SQLite real (triggers
-de abort, CHECK, CAS), nunca por mocks. Mapeamento direto dos 12
-testes obrigatórios da issue + extras (CAS, replay, outbox, backup,
-XDG, sanitized, no-cloud-imports, recovery de pending).
+Duas suítes, todas contra arquivos SQLite **reais temporários** (um
+banco isolado por teste, ``tmp_path``). Falhas são produzidas por
+mecânica SQLite real (triggers de abort, CHECK, CAS, FK), nunca por
+mocks.
+
+- ``backend/tests/test_local_storage.py`` — mapeamento direto dos 12
+  testes obrigatórios da issue + extras: CAS, replay, idempotência com
+  rejeição de payload divergente (``request_payload_conflict`` sem
+  escrita), outbox, delete_history completo (mensagens + ledger +
+  outbox, replay indisponível, atomicidade sob falha), resets neutros
+  canônicos com revision e commit obsoleto rejeitado, lifecycle fechado
+  (mesma thread, outra thread, nenhuma reconexão silenciosa), backup,
+  XDG, sanitized, no-cloud-imports, recovery de pending, ciclo de turno
+  completo com os módulos reais do domínio.
+- ``backend/tests/test_local_storage_contracts.py`` — testes
+  adversariais dos contratos de payload: chaves ``content``/``prompt``
+  aninhadas a qualquer profundidade, payload acima do limite, NaN/
+  Infinity, snapshot inválido/sintético, identidade dentro do snapshot,
+  public_response divergente, tipos de valor de outbox.
 
 Nenhum teste exige Supabase/Postgres/rede; o teste de import
 verifica por subprocess que o pacote não puxa `supabase`/`postgrest`/

--- a/docs/architecture/local-sqlite-persistence.md
+++ b/docs/architecture/local-sqlite-persistence.md
@@ -135,7 +135,12 @@ identidade remota):
   aprovados; nenhuma chave proibida (``prompt``, ``system_prompt``,
   ``meta_cognition``, ``internal_instructions``, ``message``,
   ``content``, …) em **qualquer profundidade**; ``response`` obrigatório
-  como string; JSON finito; limite explícito de 8 KB.
+  como string; ``message_id`` obrigatório (paridade web; local aceita
+  rowid inteiro ou identificador limitado — a web exige UUID porque seus
+  PKs são uuid, o schema local não); ``request_id``, quando presente,
+  deve ser identificador limitado e igual ao request do turno
+  (cross-check em ``commit_turn``, paridade web); JSON finito; limite
+  explícito de 8 KB.
 - **Outbox**: shape do evento, ``event_type`` (``^[a-z0-9_]{1,64}$``),
   ``idempotency_key`` (``^[A-Za-z0-9_.:-]{1,128}$``), allowlist de
   keys do payload, chaves proibidas recursivas, **tipos dos valores**

--- a/docs/architecture/local-sqlite-persistence.md
+++ b/docs/architecture/local-sqlite-persistence.md
@@ -60,9 +60,24 @@ o gate de conexão lê, e a partir daí:
 - nenhuma leitura/escrita continua silenciosamente;
 - toda chamada posterior falha com o erro sanitizado estável
   `PersistenceError("storage_closed")` — mesma thread ou outra thread;
+- `backup_to()` numa store fechada falha com `storage_closed` **antes
+  de qualquer efeito no filesystem**: nenhum diretório e nenhum
+  `backup.db` vazio é criado após `close()`;
 - `close()` é idempotente; o arquivo do banco permanece intacto e uma
   **nova** instância pode abri-lo normalmente (o dado não é destruído,
   apenas esta store é encerrada).
+
+**Política de threads das conexões.** As conexões continuam
+estritamente por thread (uma chave de thread → uma conexão, nunca
+compartilhada entre operações/threads), mas são abertas com
+`check_same_thread=False` para que o `close()` — que roda na thread
+que chamou — possa fechar deterministicamente, sem depender de GC, as
+conexões criadas por outras threads. Sem isso, o sqlite3 padrão
+levantaria `ProgrammingError` no fechamento cross-thread e as
+conexões permaneceriam abertas. O teste
+`test_cross_thread_connection_really_closed_by_close` retém a conexão
+da worker thread e prova que ela está de fato fechada/inutilizável
+após `store.close()`.
 
 Sem daemon, sem pool pesado, sem framework: um dict de conexões por
 thread ID e um gate sob o lock existente.
@@ -254,7 +269,9 @@ mocks.
   escrita), outbox, delete_history completo (mensagens + ledger +
   outbox, replay indisponível, atomicidade sob falha), resets neutros
   canônicos com revision e commit obsoleto rejeitado, lifecycle fechado
-  (mesma thread, outra thread, nenhuma reconexão silenciosa), backup,
+  (mesma thread, outra thread, nenhuma reconexão silenciosa, conexão da
+  worker thread de fato fechada por `close()`, `backup_to()` após
+  `close()` sem nenhum artefato no filesystem), backup,
   XDG, sanitized, no-cloud-imports, recovery de pending, ciclo de turno
   completo com os módulos reais do domínio.
 - ``backend/tests/test_local_storage_contracts.py`` — testes

--- a/docs/architecture/local-sqlite-persistence.md
+++ b/docs/architecture/local-sqlite-persistence.md
@@ -140,15 +140,17 @@ identidade remota):
   ``idempotency_key`` (``^[A-Za-z0-9_.:-]{1,128}$``), allowlist de
   keys do payload, chaves proibidas recursivas, **tipos dos valores**
   (campos de referência são strings ASCII limitadas; ``version`` é
-  inteiro em [1, 1000]), JSON finito, limite de 256 B por payload e
-  no máximo 32 eventos por turno. Mensagens, prompts e conteúdo
+  inteiro em [1, 1000]), JSON finito, limite de 8 KB por payload
+  (paridade com o contrato web) e no máximo 32 eventos por turno. Mensagens, prompts e conteúdo
   conversacional não podem ser duplicados no outbox — o código
   garante o que a documentação afirma.
 - **Snapshots**: não são documentos arbitrários. São validados pelos
   **modelos reais do domínio** (``EmotionalStateV1`` /
   ``RelationshipStateV1``), que já rejeitam keys desconhecidas, campos
   faltantes, identidade/conteúdo interno, valores fora de range,
-  não finitos e bool como numérico; limite de 4 KB por snapshot.
+  não finitos e bool como numérico; limite de 8 KB por snapshot
+  (paridade com os limites web de replay/outbox; admite o maior
+  snapshot válido do domínio, ~4,3 KB com 32 triggers de 128 chars).
 - **Resets**: o único payload aceito é o **snapshot neutro canônico
   v1 produzido pelos construtores do domínio** (``EmotionalStateV1.neutral``
   / ``RelationshipStateV1.neutral``), verificado por reconstrução.
@@ -203,7 +205,7 @@ identidade remota):
 | Retenção e exclusão reais | **Preservado** | `delete_history` remove `chat_logs` + `turn_requests` (replay incluso) + outbox derivado numa única transação; `delete_memories`/`trim_history` + auditoria sem conteúdo privado |
 | Reset neutro canônico v1 | **Preservado** | Snapshot neutro produzido por `EmotionalStateV1.neutral` / `RelationshipStateV1.neutral`; revision incrementada coerentemente |
 | Lifecycle da store | **Preservado** | `close()` terminal: nenhuma nova conexão, nenhuma operação silenciosa, erro estável `storage_closed` em qualquer thread |
-| Limites de tamanho/crescimento | **Preservado** | `MAX_MESSAGE_LENGTH`, limites de bytes por payload (replay 8 KB, outbox 256 B, snapshot 4 KB), trim por contagem, métricas |
+| Limites de tamanho/crescimento | **Preservado** | `MAX_MESSAGE_LENGTH`, limites de bytes por payload (replay/outbox/snapshot 8 KB, paridade web), trim por contagem, métricas |
 | Erros sanitizados | **Preservado** | code+message constantes; sem SQL/path/conteúdo |
 | Nada importante só em RAM | **Preservado** | Toda escrita de turno é transação commitada |
 | RLS multiusuário | **Removido** | Single-user local; o arquivo é a fronteira de confiança |

--- a/docs/architecture/local-sqlite-persistence.md
+++ b/docs/architecture/local-sqlite-persistence.md
@@ -259,9 +259,12 @@ mocks.
   completo com os módulos reais do domínio.
 - ``backend/tests/test_local_storage_contracts.py`` — testes
   adversariais dos contratos de payload: chaves ``content``/``prompt``
-  aninhadas a qualquer profundidade, payload acima do limite, NaN/
-  Infinity, snapshot inválido/sintético, identidade dentro do snapshot,
-  public_response divergente, tipos de valor de outbox.
+  aninhadas a qualquer profundidade, payload acima do limite (paridade
+  web de 8192 bytes), NaN/Infinity, snapshot inválido/sintético,
+  identidade dentro do snapshot, public_response divergente, tipos de
+  valor de outbox, ``message_id`` ausente/inválido, ``request_id``
+  estranho ao turno, snapshot no máximo do domínio (32 triggers x 128
+  chars) aceito.
 
 Nenhum teste exige Supabase/Postgres/rede; o teste de import
 verifica por subprocess que o pacote não puxa `supabase`/`postgrest`/

--- a/docs/architecture/local-sqlite-persistence.md
+++ b/docs/architecture/local-sqlite-persistence.md
@@ -1,0 +1,182 @@
+# Local SQLite Persistence (Katherine desktop) — #335
+
+Estado: **implementado (fundação)**. Esta é a camada de persistência
+local da Katherine desktop, extraída dos invariantes da arquitetura
+PostgreSQL/Supabase sem transportar a complexidade multiusuário/cloud.
+O modo web com Supabase permanece intocado; a fundação é o destino do
+fluxo desktop (a integração do runtime desktop com esta camada é a
+próxima folha, fora do escopo aqui).
+
+## Localização
+
+```text
+~/.local/share/katherine/katherine.db
+```
+
+Caminho resolvido por ``default_database_path()`` seguindo
+``XDG_DATA_HOME`` (com fallback ``~/.local/share``). O environment é
+injetável (``env`` mapping) para testes; os diretórios são criados com
+``0o700``. Override: qualquer caminho passado a
+``open_local_storage(path)`` — os testes usam ``tmp_path`` com um banco
+isolado por teste.
+
+## Decisões explícitas
+
+### Journaling e durability
+
+| PRAGMA | Valor | Motivo |
+|---|---|---|
+| `journal_mode` | `WAL` | Leitores nunca bloqueiam escritor (snapshot consistente por leitura), recuperação pós-crash automática pelo próprio SQLite, backup online consistente via `Connection.backup()`. |
+| `synchronous` | `FULL` | Sem réplica/replay: o arquivo local é a única cópia. `FULL` garante que um `COMMIT` retornado sobreviva a queda de energia no dispositivo. O custo é aceitável no padrão de escrita da Katherine (1 commit por turno). |
+| `foreign_keys` | `ON` | Integridade referencial real em toda conexão, não advisory. |
+| `busy_timeout` | 5s | Contenção transitória leitor/escritor dentro do processo. |
+
+### Concorrência (política explícita)
+
+**Serialização por lock de processo + `BEGIN IMMEDIATE` prévio à
+primeira escrita.**
+
+- A store possui um ``threading.RLock``; todo caminho de escrita o toma.
+- A transação abre com ``BEGIN IMMEDIATE`` — o lock de escrita é
+  adquirido **antes** de qualquer statement, eliminando a janela em que
+  um upgrade deferred pode falhar com ``SQLITE_BUSY`` no meio de um
+  turno (atomicidade ameaçada).
+- Cada thread tem sua própria conexão (``threading.local``); conexões
+  SQLite não são compartilháveis entre threads. Com WAL, leitores sempre
+  veem o último **snapshot commitado** — nunca um turno em andamento.
+- **Outro processo não faz parte do contrato**: o banco pertence ao
+  processo da aplicação desktop (single-user, sem daemon). Isso é a
+  substituição local dos advisory locks distribuídos: o invariante
+  "coordenação" é garantido pela posse única da conexão escrevente, e
+  não por lock distribuído.
+
+### Recovery
+
+Na abertura, todo ``turn_requests`` com ``status='pending'`` é marcado
+``failed`` com ``error_code='interrupted'`` numa única transação. Um
+turno pendente sem escritor vivo só pode existir após crash; a política
+é **fail-closed** (paridade com o contrato web
+``request_replay_unavailable``: nunca reexecuta automaticamente). O WAL
+presente no disco é recuperado pelo próprio SQLite.
+
+### Corrupção e I/O
+
+- Corrupção (``sqlite3.DatabaseError`` na abertura) →
+  ``StorageCorruptError``. O arquivo **não é nunca recriado
+  silenciosamente** — reset destruiria dados do usuário sem consentimento.
+- Erros de I/O/permissão → ``PersistenceError`` com mensagem constante
+  sanitizada. Nenhum SQL, path, conteúdo de mensagem, traceback ou
+  detalhe do driver atravessa a fronteira pública.
+
+## Commit atômico do turno
+
+Uma única transação ``BEGIN IMMEDIATE`` … ``COMMIT`` executa, nesta ordem:
+
+1. **Idempotência**: request_id já ``completed`` → retorna o turn
+   commitado original sem escrever nada (replay idempotente);
+2. **CAS**: lê ``profiles.revision``; se ``expected_revision`` difere →
+   ``ConflictError("revision_mismatch")`` com rollback integral;
+3. INSERT mensagem do usuário (``chat_logs``);
+4. INSERT mensagem da assistente (``chat_logs``);
+5. UPSERT do perfil com ``revision = expected + 1`` e os snapshots
+   emocional/relacional do turno;
+6. INSERT do ledger ``turn_requests`` (``status='completed'``,
+   ``replay_payload`` canônico);
+7. INSERT dos ``outbox_events`` (``ON CONFLICT (idempotency_key) DO
+   NOTHING``).
+
+Qualquer falha entre 2 e 7 → rollback do turno inteiro: mensagens e
+snapshots jamais divergem (testes 3 e 4 da issue). O CAS substitui o
+lock transacional per-user do PostgreSQL: o invariante "uma escrita
+obsoleta nunca sobrescreve estado novo" é preservado pelo mesmo mecanismo
+lógico (version token), agora guardado por transação serializada.
+
+## Migrations
+
+- Em código: lista frozen ``(version, sql)`` em
+  ``backend/local_storage/migrations.py`` — ordenadas, append-only,
+  reprodutíveis, sem dependência nova e sem arquivos soltos.
+- ``schema_migrations(version PK, applied_at)`` registra as aplicadas;
+  reabrir pula as existentes (idempotente).
+- **Atomicidade por migration**: cada migration roda em sua própria
+  transação junto com a inserção da sua linha de versão — uma migration
+  que falha no meio não fica nem aplicada nem marcada (teste 8). A
+  próxima abertura a retria do início.
+
+## Mapeamento de dados (PostgreSQL → SQLite)
+
+| Dado (origem) | Destino local | Notas |
+|---|---|---|
+| `profiles` (persona, user_profile, emocional, relacional, revision) | `profiles` (1 linha, `id=1`) | Snapshots como JSON canônico; `revision` mantém o CAS |
+| `chat_logs` | `chat_logs` | Sem `user_id` (single-user); índice `(created_at, id)` para recência |
+| `turn_requests` | `turn_requests` | Ledger de idempotência/replay; FKs para `chat_logs` `ON DELETE SET NULL` (privacidade nunca é bloqueada pelo ledger, paridade com o trigger do PostgreSQL) |
+| `outbox_events` | `outbox_events` | Idempotency key única; payload estrito de referências (sem conteúdo) |
+| `memories` | `memories` | Metadados JSON com o mesmo contrato de versão/aprovação |
+| `privacy_operations` | `privacy_operations` | Auditoria local (operação, status, result) sem conteúdo privado |
+| `account_deletion_jobs` / worker | **removido nesta fundação** | Destruição de conta é o equivalente local a apagar o arquivo do banco; a operação é documentada, o worker distribuído não se aplica |
+| `admission_reservations` / HMAC de identidade | **removido nesta fundação** | Admissão/rate-limit e correlação HMAC eram proteções do serviço multiusuário remoto; o runtime desktop decide o uso deles na próxima folha |
+
+## Invariantes: preservados x removidos
+
+| Invariante | Status | Como |
+|---|---|---|
+| Commit do turno como unidade atômica | **Preservado** | `BEGIN IMMEDIATE` + rollback integral |
+| Mensagens e snapshots não divergem após crash | **Preservado** | Transação única + WAL + `synchronous=FULL` |
+| Schema versionado, migrations reproduzíveis | **Preservado** | Lista em código + `schema_migrations` |
+| Integridade referencial | **Preservado** | `PRAGMA foreign_keys=ON` + FKs com ON DELETE coerentes |
+| Revision para detectar estado obsoleto | **Preservado** | CAS em `profiles.revision` |
+| Idempotência/replay | **Preservado** | `turn_requests` PK + replay do commitado |
+| Recuperação previsível pós-interrupção | **Preservado** | WAL auto-recovery + pending→failed fail-closed |
+| Retenção e exclusão reais | **Preservado** | `delete_history`/`delete_memories`/`trim_history` + auditoria |
+| Limites de tamanho/crescimento | **Preservado** | `MAX_MESSAGE_LENGTH`, trim por contagem, métricas |
+| Erros sanitizados | **Preservado** | code+message constantes; sem SQL/path/conteúdo |
+| Nada importante só em RAM | **Preservado** | Toda escrita de turno é transação commitada |
+| RLS multiusuário | **Removido** | Single-user local; o arquivo é a fronteira de confiança |
+| service-role ACLs / grants | **Removido** | Idem; sem papéis no SQLite |
+| Advisory locks distribuídos / réplicas | **Removido** | Um processo, um escrevente, lock de processo |
+| HMAC de identidade (`user_id` remoto) | **Removido** | Sem identidade multiusuário para esconder |
+| Lease/claim entre workers | **Removido** | Substituído pelo lock de processo + pending→failed |
+| PostgREST/RPC | **Removido** | Chamadas diretas à store local |
+
+## Importação futura (Supabase → SQLite) — estratégia definida
+
+A importação de uma instalação existente **não é implementada nesta
+entrega**; o formato e a política são definidos aqui e a execução é
+folha futura:
+
+1. **Explícita**: comando dedicado (CLI), nunca automática no primeiro
+   boot.
+2. **Validação de origem**: verifica schema version da origem e o
+   conjunto esperado de tabelas antes de ler; origem incompatível
+   aborta sem escrever.
+3. **Idempotente**: chave de importação por tabela (contagens +
+   hash canônico por row na tabela de auditoria local); reexecutar
+   detecta "já importado" e é no-op.
+4. **Origem preservada**: a origem nunca é apagada nem modificada antes
+   de verificação pós-importação integral (contagens por tabela
+   conferidas).
+5. **Evidência sem conteúdo privado**: o relatório importa apenas
+   contagens por tabela, duração e versões; nenhum conteúdo de
+   mensagem/memória entra em log.
+
+## Testes
+
+``backend/tests/test_local_storage.py`` — 35 testes, todos contra
+arquivos SQLite **reais temporários** (um banco isolado por teste,
+``tmp_path``). Falhas são produzidas por mecânica SQLite real (triggers
+de abort, CHECK, CAS), nunca por mocks. Mapeamento direto dos 12
+testes obrigatórios da issue + extras (CAS, replay, outbox, backup,
+XDG, sanitized, no-cloud-imports, recovery de pending).
+
+Nenhum teste exige Supabase/Postgres/rede; o teste de import
+verifica por subprocess que o pacote não puxa `supabase`/`postgrest`/
+`httpx`/`requests` ao ser importado.
+
+## Fora do escopo desta fundação
+
+- Integração do runtime desktop com esta store (próxima folha);
+- Remoção do Supabase/Auth do backend (#336);
+- Importação de produção;
+- Vector search local (a coluna/metadata existe; o retrieval local é
+  redesign de memória, folha futura);
+- Packaging Linux.


### PR DESCRIPTION
Closes #335.

## What

Local-first SQLite persistence package (`backend/local_storage/`) extracting the reliability invariants of the PostgreSQL/Supabase architecture into a single-user desktop store — **without** removing Supabase from the runtime (that is #336, out of scope here) and without transporting cloud/multi-user complexity.

### Public surface (duck-typed, no runtime imports from the app)

- `LocalStorage` facade: `load_user_state`, `load_recent_history`, `commit_turn`, `replay`, `delete_history`, `delete_memories`, `trim_history`, `reset_emotional_state`, `reset_relationship_state`, `backup_to`, `storage_metrics`, `close`
- `ConflictError` / `ValidationError` / `PersistenceError` / `StorageCorruptError` — constant `code` + `message`, no SQL, no paths, no data, no tracebacks
- Migrations in code (frozen list, version 0001), applied one-by-one inside the same transaction that records the version — `executescript` is never used (it issues an implicit COMMIT)

### Preserved invariants (from the PostgreSQL architecture)

| Invariant | Local realization |
|---|---|
| Atomic turn commit (messages + profile snapshot + ledger + outbox) | single `BEGIN IMMEDIATE`…`COMMIT` with CAS on profile revision; failure anywhere rolls back everything |
| Revision CAS / optimistic concurrency | `expected_revision` compare-and-swap; mismatch raises `ConflictError` with expected/actual; resets bump the revision too, so a commit prepared before a reset can never silently overwrite it |
| Idempotency (turn replay) with payload conflict | `turn_requests.request_id` unique; a completed request replays the committed payload without writing **only when the canonical hash matches**; any divergent determinative input raises `ConflictError("request_payload_conflict")` before any write |
| Outbox event idempotency | unique `(idempotency_key, event_type)`; conflict inserts are skipped |
| Payload contracts | replay payload, outbox events and snapshots validated at the store boundary (allowlists, recursive forbidden keys, value types, finite JSON, byte bounds); snapshots must be real domain v1 documents |
| Privacy / deletion | `delete_history` removes `chat_logs` + `turn_requests` (replay ledger included) + derived `outbox_events` in one transaction; `delete_memories` wipes memories in one transaction |
| Neutral resets | the persisted result is the canonical neutral v1 snapshot produced by `EmotionalStateV1.neutral` / `RelationshipStateV1.neutral`; an explicit argument must BE that snapshot |
| Retention | `trim_history(keep_last)` removes old messages transactionally |
| Recovery (fail-closed) | unexpected `pending`/`failed` turn rows load as **failed**, never silently treated as committed |
| Lifecycle | `close()` is terminal: no new connections, no silent operations on any thread; later calls fail with `PersistenceError("storage_closed")`; connections stay per-thread but open with `check_same_thread=False` so close deterministically closes (no GC reliance) connections other threads created; `backup_to()` after close fails before creating any file/directory |
| Sanitized errors | constant code+message on every raise; no SQL/path/content leakage |
| Durability | WAL journal + `synchronous=FULL` |
| No new dependencies | stdlib `sqlite3` + `json` only |

### Deliberately removed (single-user desktop)

`user_id` columns, RLS/ACL policies, per-user scoping, identity HMAC, distributed advisory locks/leases — the local file is the trust boundary; the store lock + pending→failed recovery replace distributed coordination.

## How the review blockers are fixed

### Divergent request payload is rejected

`commit_turn` computes a canonical hash over **every** determinative input: `request_id`, `expected_revision`, `user_message`, `assistant_message`, `emotional_state`, `relationship_state`, `public_response`, `replay_payload`, `outbox_events` (no cloud identity fields — they do not exist locally). The canonical serialization is deterministic (sorted keys, compact separators, UTF-8, `allow_nan=False`).

- Same `request_id` + same canonical payload → replay of the original committed result, zero writes.
- Same `request_id` + any divergent input → `ConflictError` with stable code `request_payload_conflict`, raised **before** any write (checked on a pre-transaction fast path and re-checked inside `BEGIN IMMEDIATE`, since the initial read is not part of the write transaction). Messages, snapshots, revision, ledger and outbox are untouched; the error never echoes the payload or hash.
- `public_response` is no longer a dead argument: it must equal `replay_payload["response"]` (single authoritative source), mirroring the web contract.

Tests: same payload replays with no new rows; divergent `user_message`, divergent snapshot, divergent outbox each conflict; a conflict leaves counts/revision unchanged; the error message never contains the divergent content.

### `delete_history` makes replay unavailable

`delete_history()` now removes, atomically in **one** transaction, everything the local turn flow persists for those turns: `chat_logs`, `turn_requests` (including `replay_payload`) and the `outbox_events` derived from them. Migration 0001 (pre-merge, so amendable) carries `ON DELETE CASCADE` on the turn→chat-log FKs and on the outbox→turn FK, making the cascade explicit and simple. After `delete_history`:

- `load_recent_history()` returns empty;
- `replay(request_id)` returns `request_replay_unavailable`;
- no outbox row associated with the deleted turns remains;
- the `privacy_operations` ledger row stays for audit, carrying aggregate counts only (no message content).

Tests prove each property against a real SQLite file, including a trigger-abort test showing the operation is atomic (nothing is partially deleted), and that a new turn still works after a delete.

### Outbox / replay / snapshots are limited and validated

New module `backend/local_storage/contracts.py` enforces, in code, the contracts the documentation promises (adapted from the web schema without cloud identity):

- **Replay payload**: must be a `Mapping`; only allowlisted public keys; no `prompt`/`system_prompt`/`meta_cognition`/`internal_instructions`/`message`/`content` key at **any depth**; `response` required as a string; `message_id` required (web parity: integer rowid or bounded identifier — web requires UUID because its PKs are uuid, the local schema is not); `request_id` when present must equal the enclosing request (cross-check in `commit_turn`, same as the web); finite JSON; 8 KB bound.
- **Outbox**: event shape, `event_type` charset, `idempotency_key` charset, payload allowlist, recursive forbidden keys, **value types** (reference fields are bounded ASCII strings, `version` an int in 1–1000), finite JSON, 8 KB bound (same as the web contract's `_MAX_OUTBOX_PAYLOAD_BYTES`), ≤32 events per turn, unique keys within a turn. Conversation content cannot be duplicated into the outbox.
- **Snapshots**: not arbitrary documents — validated through the **real domain models** (`EmotionalStateV1` / `RelationshipStateV1`), which reject unknown/missing keys, identity/internal content, out-of-range and non-finite values; 8 KB bound per snapshot (the web contract has no snapshot byte bound; the local bound matches its replay/outbox 8 KB bounds and provably admits the largest domain-valid snapshot, ~4.3 KB = 32 triggers × 128 chars).
- **Uniqueness coherence**: the doc previously claimed `(idempotency_key, event_type)` while the schema had only `idempotency_key`. The chosen contract is `(idempotency_key, event_type)` unique — schema (`UNIQUE`), code (`ON CONFLICT` target) and tests all agree.

Adversarial tests (`backend/tests/test_local_storage_contracts.py`, 37 tests): nested `content`/`prompt` keys, oversized payloads (8192-byte web parity), NaN/Infinity, synthetic/invalid snapshots, identity inside snapshots, divergent `public_response`, outbox value-type smuggling, missing/invalid `message_id`, foreign `request_id` rejected with zero writes, domain-maximum snapshot (32 triggers x 128 chars) accepted.

### Neutral resets preserve revision

`reset_emotional_state()` / `reset_relationship_state()` persist the **canonical neutral v1 snapshot produced by the domain constructors** (`EmotionalStateV1.neutral` / `RelationshipStateV1.neutral`) — one definition of "neutral", no `{}` fallback. An explicit `neutral` argument must BE that canonical snapshot (verified by reconstructing it through the domain constructor with the payload's own timestamp). Because a reset changes persistent state, it increments `profiles.revision` coherently: a commit prepared on the previous revision fails with `revision_mismatch` instead of silently overwriting the reset. On a fresh database a reset creates the profile row with both neutral snapshots.

Tests: persist non-neutral state → record revision → reset → load state and compare against the real domain neutral → revision incremented → stale commit rejected with `revision_mismatch`; also forged non-neutral arguments and empty mappings rejected.

### `close()` prevents reuse

`close()` is terminal. Connections are per-thread and tracked in one registry, so close closes **every** open connection (not only the caller thread's). Connections open with `check_same_thread=False` — they remain strictly per-thread (one thread id -> one connection, never shared), but sqlite3's default thread affinity would make cross-thread `conn.close()` raise `ProgrammingError` and silently leak the connection; the store now closes every registered connection deterministically, with no GC reliance. A test retains a worker thread's connection and proves it is closed/unusable after `store.close()` (this test fails on the previous code). The lifecycle gate inside `_connection()` — under the same lock `close()` takes — refuses to create or reuse connections once closed, on any thread. `backup_to()` gates on the closed store **before** any filesystem effect: after `close()` no target directory and no empty `backup.db` is created (tested). No daemon, no pool, no framework: a dict keyed by thread id and a gate. Later calls fail with the stable sanitized `PersistenceError("storage_closed")`; `close()` is idempotent; the database file is untouched (a new instance can open it).

Tests: operation on the same thread after close; operation from another thread after close (that thread opened its own connection before close); no silent reconnection; close idempotent.

## Tests — TDD, real SQLite files, no mocks as proof

`backend/tests/test_local_storage.py` (57 tests) and `backend/tests/test_local_storage_contracts.py` (37 tests), every one against a real on-disk SQLite database in `tmp_path`. Failures are produced by real CHECK constraints, triggers, FK cascades and CAS mismatches, never by mocking. Store tests use **real domain v1 snapshots** (produced by the domain constructors/transitions), not synthetic `{"v": 1, ...}` documents.

Notable red-phase findings the tests caught (original foundation commits):

1. `sqlite3.Connection.executescript()` issues an implicit COMMIT before running — it silently broke per-migration atomicity. Fixed: statements are split (`BEGIN…END` trigger bodies handled) and executed one-by-one inside the migration transaction.
2. Ordering by rowid PK was reported as SCAN; explicit `(created_at, id)` index now drives both ordering and the query plan.
3. Mid-migration failure test injects a trigger that `raise(ABORT)`s on the migration's **last** statement — proving earlier DDL inside the same migration rolls back with the version row.

## Evidence

- `python -m compileall -q backend` — clean
- Local storage suites: **94/94 passed** (`test_local_storage.py` 57 + `test_local_storage_contracts.py` 37)
- Atomic turn / process turn suites: **320/320 passed** (incl. the two local storage suites)
- CI-equivalent suite (exact `backend` job command, 17 `--ignore`s verbatim): **2729 passed, 0 failed**
- Full local suite real-DB failures (Postgres/Supabase-dependent integration tests) are pre-existing on `main` and covered by the CI `database` job with a local Supabase instance; the `backend` job runs the same 17 ignores as this validation

## Out of scope (tracked separately)

#336 (Supabase removal), production data import, local vector search, desktop runtime integration with this store, packaging.


