### PR TITLE
fix(frontend): harden companion layout scaling

### DIFF
--- a/frontend/src/features/chat/components/CompanionLayout.css
+++ b/frontend/src/features/chat/components/CompanionLayout.css
@@ -37,6 +37,8 @@
 
 .companion-layout .katherine-face--companion {
     width: clamp(12rem, 27vw, 24rem);
+    max-width: 100%;
+    max-height: 100%;
 }
 
 .companion-layout__conversation {
@@ -142,19 +144,21 @@
 @media (max-width: 68rem) {
     .companion-layout__body {
         /* Keep the conversation rail below half the viewport until stacking. */
-        grid-template-columns: minmax(0, 1.25fr) minmax(18rem, 22rem);
+        grid-template-columns: minmax(0, 1.25fr) minmax(min(18rem, 38%), min(22rem, 44%));
     }
 
     .companion-layout__body--with-auxiliary {
-        grid-template-columns: minmax(0, 1fr) minmax(19rem, 26rem) minmax(15rem, 18rem);
+        grid-template-columns: minmax(0, 1fr) minmax(min(19rem, 38%), min(26rem, 44%)) minmax(15rem, 18rem);
     }
 
     .companion-layout__presence {
-        padding: 2rem;
+        padding: clamp(1.25rem, 3vw, 2rem);
     }
 
     .companion-layout .katherine-face--companion {
         width: clamp(11rem, 24vw, 18rem);
+        max-width: 100%;
+        max-height: 100%;
     }
 }
 

--- a/frontend/tests/projectLocalSkills.test.js
+++ b/frontend/tests/projectLocalSkills.test.js
@@ -86,28 +86,3 @@ test('companion layout disables incidental disclosure motion for reduced-motion 
     assert.match(css, /@media\s*\(prefers-reduced-motion:\s*reduce\)/);
     assert.match(css, /transition-duration:\s*0ms/);
 });
-
-test('narrow desktop keeps the Katherine presence track wider than the conversation rail', () => {
-    const css = readFileSync(
-        join(FRONTEND_ROOT, 'src', 'features', 'chat', 'components', 'CompanionLayout.css'),
-        'utf8',
-    );
-    const narrowDesktop = css.match(
-        /@media\s*\(max-width:\s*68rem\)([\s\S]*?)@media\s*\(max-width:\s*48rem\)/,
-    )?.[1];
-
-    assert.ok(narrowDesktop, 'narrow desktop media query is missing');
-    const columns = narrowDesktop.match(
-        /grid-template-columns:\s*minmax\(0,\s*([\d.]+)fr\)\s+minmax\(18rem,\s*([\d.]+)rem\)/,
-    );
-
-    assert.ok(columns, 'narrow desktop columns must reserve a bounded conversation rail');
-    const conversationMaxPx = Number(columns[2]) * 16;
-
-    for (const viewportWidth of [769, 800]) {
-        assert.ok(
-            viewportWidth - conversationMaxPx > conversationMaxPx,
-            `presence must remain wider than the conversation rail at ${viewportWidth}px`,
-        );
-    }
-});

--- a/scripts/presence_review.py
+++ b/scripts/presence_review.py
@@ -18,6 +18,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--output', required=True, type=Path)
 parser.add_argument('--scripted', action='store_true')
 parser.add_argument('--verify-v2', action='store_true')
+parser.add_argument('--verify-scaling', action='store_true')
 parser.add_argument('--reduced-motion', action='store_true')
 args = parser.parse_args()
 args.output.mkdir(parents=True, exist_ok=True)
@@ -144,6 +145,95 @@ def optical_probes(window):
     results['settledFaceMutationsOverOneSecond'] = mutations
 
 
+def verify_scaling_matrix(window):
+    from gi.repository import GLib
+    from webview.platforms.gtk import BrowserView
+    bv = BrowserView.instances.get(window.uid)
+    scenarios = [
+        ('scale-1440x900-100', 1440, 900, 1.0),
+        ('scale-1024x768-100', 1024, 768, 1.0),
+        ('scale-800x600-100', 800, 600, 1.0),
+        ('scale-800x600-125', 800, 600, 1.25),
+        ('scale-800x600-150', 800, 600, 1.50),
+    ]
+    results['scalingMatrix'] = []
+    for name, w, h, zoom in scenarios:
+        window.resize(w, h)
+        wait_for(window, f'innerWidth === {w}')
+        time.sleep(0.4)
+        if bv:
+            def apply():
+                settings = bv.webview.get_settings()
+                settings.props.zoom_text_only = True
+                bv.webview.set_zoom_level(zoom)
+                return False
+            GLib.idle_add(apply)
+            time.sleep(0.8)
+
+        capture(window, f'{name}-closed')
+
+        geo = window.evaluate_js("""(() => {
+            const face = document.querySelector('[data-testid="katherine-face"]');
+            const fRect = face ? face.getBoundingClientRect() : null;
+            const presence = document.querySelector('[data-testid="companion-presence"]');
+            const pRect = presence ? presence.getBoundingClientRect() : null;
+            const conv = document.querySelector('.companion-layout__conversation');
+            const cRect = conv ? conv.getBoundingClientRect() : null;
+            const input = document.querySelector('textarea');
+            return {
+                presenceWidth: pRect ? pRect.width : 0,
+                convWidth: cRect ? cRect.width : 0,
+                presenceWider: pRect && cRect ? (pRect.width > cRect.width) : false,
+                faceClippedRight: (fRect && pRect) ? (fRect.right > pRect.right) : false,
+                faceClippedLeft: (fRect && pRect) ? (fRect.left < pRect.left) : false,
+                faceWidth: fRect ? fRect.width : 0,
+                inputVisible: input ? (input.getBoundingClientRect().bottom <= innerHeight) : false,
+                horizontalOverflow: document.documentElement.scrollWidth > innerWidth,
+            };
+        })()""")
+        assert geo['presenceWider'], f'{name}: presence track must be wider than conversation rail'
+        assert not geo['faceClippedRight'], f'{name}: face clipped on right'
+        assert not geo['faceClippedLeft'], f'{name}: face clipped on left'
+        assert geo['inputVisible'], f'{name}: composer not visible'
+        assert not geo['horizontalOverflow'], f'{name}: horizontal overflow'
+
+        window.evaluate_js("""(() => {
+            const d1 = document.querySelector('[data-testid=companion-emotion-details]');
+            if (d1) d1.open = true;
+            const d2 = document.querySelector('[data-testid=companion-privacy-details]');
+            if (d2) d2.open = true;
+        })()""")
+        time.sleep(0.6)
+        capture(window, f'{name}-open')
+        open_geo = window.evaluate_js("""(() => {
+            const input = document.querySelector('textarea');
+            const utils = document.querySelector('[data-testid="companion-utilities"]');
+            return {
+                inputVisible: input ? (input.getBoundingClientRect().bottom <= innerHeight) : false,
+                horizontalOverflow: document.documentElement.scrollWidth > innerWidth,
+                utilsCanScroll: utils ? (utils.scrollHeight >= utils.clientHeight) : false,
+            };
+        })()""")
+        assert open_geo['inputVisible'], f'{name} open: composer not visible'
+        assert not open_geo['horizontalOverflow'], f'{name} open: horizontal overflow'
+
+        window.evaluate_js("""(() => {
+            const d1 = document.querySelector('[data-testid=companion-emotion-details]');
+            if (d1) d1.open = false;
+            const d2 = document.querySelector('[data-testid=companion-privacy-details]');
+            if (d2) d2.open = false;
+        })()""")
+        time.sleep(0.4)
+        results['scalingMatrix'].append({'scenario': name, 'closed': geo, 'open': open_geo})
+
+    if bv:
+        def restore():
+            bv.webview.set_zoom_level(1.0)
+            return False
+        GLib.idle_add(restore)
+        time.sleep(0.3)
+
+
 def inspect():
     window = None
     try:
@@ -185,6 +275,8 @@ def inspect():
             wait_for(window, 'document.body.innerText.includes("A presença pode permanecer tranquila")')
             time.sleep(1)
             capture(window, 'response-800')
+            if args.verify_scaling:
+                verify_scaling_matrix(window)
         else:
             wait_for(window, 'document.body.innerText.includes("O provedor remoto não está configurado")')
             wait_for(window, '!document.querySelector("textarea").disabled')


### PR DESCRIPTION
## Origem
Issue #362 — P2 follow-up: validar scaling do companion layout e remover teste frágil

## Base
* **Base SHA (main pós-#363):** `c2021c2d50a9b57ffa823a656c467d9de8907d6a`
* **HEAD SHA:** `cfd6d06c6891f8532c891cc249ee258699275385`

## Diagnóstico
* **Falsa Prova Identificada:** O teste `narrow desktop keeps the Katherine presence track wider than the conversation rail` em `frontend/tests/projectLocalSkills.test.js` (antigas linhas 90–113) parseava `CompanionLayout.css` via regex textual e efetuava cálculo aritmético rígido assumindo `1rem = 16px`. Ele não renderizava o DOM, ignorava paddings, scrollbars e desconsiderava acessibilidade sob zoom/font scaling elevado.
* **Veredito em Runtime:** **BUG CONFIRMADO**.
* **Causa Raiz:** Em `@media (max-width: 68rem)`, a definição `grid-template-columns: minmax(0, 1.25fr) minmax(18rem, 22rem)` permitia que o conversation rail expandisse até `22rem`. Sob escala de 150% (`1rem = 24px`), `22rem = 528px`, ocupando 66% de uma janela de 800px e reduzindo a presença para 272px (34%). Somado ao `padding: 2rem` (96px total), a área útil da presença caía para 176px, forçando `KatherineFace` (`clamp(11rem, 24vw, 18rem)` = 264px) a vazar os limites com `overflow: hidden`, ceifando 40px do rosto e 61px do arco de atividade à direita.

## Teamwork (AGY CLI Teamwork Preview)
* **Agent A — Runtime & Scaling Validator:** Investigou a stack pywebview/WebKitGTK/GTK e reproduziu os testes com scaling verdadeiro (`zoom_text_only = True` + `set_zoom_level` no WebKit nativo, mantendo a viewport física e escalando `rem`). Detectou o corte de 40px no rosto em 800×600 @ 150% e a inversão para 55% do rail em 125%.
* **Agent B — Test Contract Auditor:** Identificou a fragilidade das asserções de regex textual em `projectLocalSkills.test.js`, comprovou a ausência de motor de layout no Vitest/Node e recomendou a remoção limpa do teste, deixando a garantia geométrica a cargo de medições reais no WebKitGTK (`scripts/presence_review.py`). Realizou também o review final read-only aprovando o diff em todos os 10 critérios.
* **Agent C — Layout & Architecture Reviewer:** Mapeou as fronteiras arquiteturais (`ChatWindow`/`useChat`, `renderLayout` seam desktop, `AppDesktop`/`AppWeb`, `KatherineFace`, painéis auxiliares) e desenhou a menor correção CSS admissível limitando o rail e garantindo que o rosto não transborde.
* **Lead / Integrator:** Consolidou os relatórios no Join Gate, implementou a menor correção cirúrgica em `CompanionLayout.css`, removeu o teste frágil, estendeu `scripts/presence_review.py` com a matriz `--verify-scaling` e revalidou 100% da suíte determinística.

## Matriz de Evidência Runtime

| Resolução | Scaling | Método Real | PASS/FAIL | Overflow Horiz. | Composer Visível | Face Cortada? | Disclosures Abertos | Proporção (Presença vs Rail) |
| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| 1440×900 | 100% (16px) | WebKitGTK zoom 1.0x | **PASS** | Não | Sim (closed & open) | Não (0px) | OK, scroll interno | 944px (65.6%) vs 496px (34.4%) |
| 1024×768 | 100% (16px) | WebKitGTK zoom 1.0x | **PASS** | Não | Sim (closed & open) | Não (0px) | OK, scroll interno | 672px (65.6%) vs 352px (34.4%) |
| 800×600 | 100% (16px) | WebKitGTK zoom 1.0x | **PASS** | Não | Sim (closed & open) | Não (0px) | OK, scroll interno | 448px (56.0%) vs 352px (44.0%) |
| 800×600 | 125% (20px) | WebKitGTK zoom 1.25x | **PASS** | Não | Sim (closed & open) | Não (0px) | OK, scroll interno | 448px (56.0%) vs 352px (44.0%) |
| 800×600 | 150% (24px) | WebKitGTK zoom 1.50x | **PASS** | Não | Sim (closed & open) | Não (0px) | OK, scroll interno | 448px (56.0%) vs 352px (44.0%) |

## Mudanças
1. `frontend/tests/projectLocalSkills.test.js`:
   - Remoção do teste frágil `narrow desktop keeps the Katherine presence track wider than the conversation rail` (linhas 90–113).
2. `frontend/src/features/chat/components/CompanionLayout.css`:
   - Nas media queries `<= 68rem`, o grid foi ajustado para `minmax(0, 1.25fr) minmax(min(18rem, 38%), min(22rem, 44%))` (e variante auxiliar correspondente), assegurando que o conversation rail nunca ultrapasse 44% da viewport até o empilhamento.
   - O padding da presença em `<= 68rem` agora usa `clamp(1.25rem, 3vw, 2rem)`.
   - Adicionada defesa `max-width: 100%; max-height: 100%` a `.katherine-face--companion`.
3. `scripts/presence_review.py`:
   - Adicionado argumento `--verify-scaling` e rotina `verify_scaling_matrix(window)` que executa programmaticamente a matriz de 5 cenários com medições DOM via `getBoundingClientRect()`, captura de screenshots isolados e validação de disclosures abertos.

## Testes Executados
```bash
# Frontend unit tests (16 arquivos, 114 testes)
cd frontend && npm test
# Output: 16 passed, 114 passed (100% green)

# Linting
npm run lint
# Output: 0 errors

# Produção build
npm run build
# Output: built in 3.43s (dist/desktop.html e dist/index.html gerados com sucesso)

# Auditoria de segurança
npm audit --audit-level=high
# Output: found 0 vulnerabilities

# Verificação do isolamento do grafo desktop
node tests/desktopGraph.test.js
# Output: 5 passed

# Verificação de skills locais sem a falsa prova
node --test tests/projectLocalSkills.test.js
# Output: 5 passed

# Verificação de diff e formatação
git diff --check
# Output: 0 issues (limpo)

# Testes de integração desktop Python
uv run --project backend python -m pytest backend/tests/test_desktop_*.py
# Output: 96 passed in 5.70s

# Smoke nativo do shell desktop
xvfb-run -a -s "-screen 0 1280x800x24" uv run --project backend python -c "
import sys, runpy
sys.path.append('/usr/lib/python3/dist-packages')
runpy.run_path('scripts/desktop_smoke.py', run_name='__main__')
"
# Output: SMOKE_OK

# Validação da suite de scaling no entry de produção
xvfb-run -a -s "-screen 0 1920x1080x24" uv run --project backend python -c "
import sys, runpy
sys.path.append('/usr/lib/python3/dist-packages')
sys.argv = ['presence_review.py', '--scripted', '--verify-v2', '--verify-scaling', '--output', '/tmp/review_scaling_output']
runpy.run_path('scripts/presence_review.py', run_name='__main__')
"
# Output: Todos os cenários da matriz aprovados (0 falhas)
```

## Dependências
Nenhuma nova dependência foi adicionada. Grafo `uv.lock` e `package-lock.json` rigorosamente inalterados.

## Riscos, Migração e Rollback
* **Riscos:** Risco nulo para produção web, pois as alterações em `CompanionLayout.css` residem sob a classe `.companion-layout` e afetam exclusivamente a janela desktop.
* **Migração:** Não aplicável (sem alterações de dados persistidos, schema ou API).
* **Rollback:** Reversão limpa do commit via `git revert`.

## Fora de Escopo Preservado
* Nenhuma alteração no backend, schemas, migrations, transportes ou providers.
* Nenhuma alteração na geometria do rosto Katherine ou vendor `bfce`.
* Comportamento do arco de presença (#363) 100% preservado.
