### PR TITLE
feat(desktop): add transparent Katherine presence mode

### DIFF
--- a/backend/desktop/api.py
+++ b/backend/desktop/api.py
@@ -43,15 +43,20 @@ DESKTOP_API_METHODS: tuple[str, ...] = (
     "delete_memories",
     "reset_emotional_state",
     "reset_relationship_state",
+    "set_presence_mode",
+    "set_always_on_top",
+    "window_state",
+    "close_window",
 )
 
 #: Version of the desktop bridge contract. The frontend can feature-check
 #: against this single integer instead of sniffing for methods.
-DESKTOP_API_VERSION = 2
+DESKTOP_API_VERSION = 3
 
 #: Public error codes. Structured, stable, safe to show in the UI.
 _ERROR_INVALID_INPUT = "invalid_input"
 _ERROR_INTERNAL = "internal_error"
+_ERROR_WINDOW_UNAVAILABLE = "window_unavailable"
 
 #: Messages are deliberately generic and free of internal detail (and
 #: never contain the offending input).
@@ -59,6 +64,7 @@ _MSG_UNKNOWN_METHOD = "Unknown method."
 _MSG_INTERNAL = "The desktop bridge failed to complete the request."
 _MSG_UNEXPECTED_RESPONSE = "Unexpected bridge response."
 _MSG_NO_RUNTIME = "The desktop runtime is not available."
+_MSG_NO_WINDOW = "The window controller is not available."
 
 #: History window bounds (validated here before reaching the runtime).
 _HISTORY_LIMIT_MIN = 1
@@ -98,6 +104,10 @@ class DesktopApiError(Exception):
 # ---------------------------------------------------------------------------
 # Input validation (pure, total, never raises)
 # ---------------------------------------------------------------------------
+
+
+def _is_bool(value: Any) -> bool:
+    return isinstance(value, bool)
 
 
 def _is_int(value: Any) -> bool:
@@ -151,10 +161,16 @@ class DesktopApi:
     never imports the runtime module (import purity) and never touches
     anything beyond these methods. ``None`` fails every companion call
     closed with a sanitized ``internal_error`` payload.
+
+    ``window_controller`` coordinates native GTK window lifecycle and
+    mode transitions (#342). Injected as an object implementing the window
+    lifecycle methods. ``None`` fails window operations closed with a
+    sanitized ``window_unavailable`` payload.
     """
 
-    def __init__(self, runtime: Any = None) -> None:
+    def __init__(self, runtime: Any = None, window_controller: Any = None) -> None:
         self._runtime = runtime
+        self._window_controller = window_controller
 
     # -- #334: round-trip probe -------------------------------------------
 
@@ -258,6 +274,58 @@ class DesktopApi:
         """Reset the relationship state to neutral (transactional)."""
         return self._privacy_op("reset_relationship_state", args)
 
+    # -- #342: window lifecycle operations ---------------------------------
+
+    def set_presence_mode(self, *args: Any) -> dict[str, Any]:
+        """Transition between companion and floating presence modes."""
+        if len(args) != 1 or not _is_bool(args[0]):
+            raise DesktopApiError(
+                _ERROR_INVALID_INPUT,
+                "set_presence_mode() takes exactly one boolean argument.",
+            )
+        controller = self._require_window_controller()
+        result = controller.set_presence_mode(args[0])
+        if not isinstance(result, dict):
+            raise DesktopApiError(_ERROR_INTERNAL, _MSG_UNEXPECTED_RESPONSE)
+        return dict(result)
+
+    def set_always_on_top(self, *args: Any) -> dict[str, Any]:
+        """Toggle always-on-top window layering."""
+        if len(args) != 1 or not _is_bool(args[0]):
+            raise DesktopApiError(
+                _ERROR_INVALID_INPUT,
+                "set_always_on_top() takes exactly one boolean argument.",
+            )
+        controller = self._require_window_controller()
+        result = controller.set_always_on_top(args[0])
+        if not isinstance(result, dict):
+            raise DesktopApiError(_ERROR_INTERNAL, _MSG_UNEXPECTED_RESPONSE)
+        return dict(result)
+
+    def window_state(self, *args: Any) -> dict[str, Any]:
+        """Query current window state (mode, on_top, geometry)."""
+        if args:
+            raise DesktopApiError(
+                _ERROR_INVALID_INPUT, "window_state() takes no arguments."
+            )
+        controller = self._require_window_controller()
+        result = controller.window_state()
+        if not isinstance(result, dict):
+            raise DesktopApiError(_ERROR_INTERNAL, _MSG_UNEXPECTED_RESPONSE)
+        return dict(result)
+
+    def close_window(self, *args: Any) -> dict[str, Any]:
+        """Request clean window closure and application shutdown."""
+        if args:
+            raise DesktopApiError(
+                _ERROR_INVALID_INPUT, "close_window() takes no arguments."
+            )
+        controller = self._require_window_controller()
+        result = controller.close_window()
+        if not isinstance(result, dict):
+            raise DesktopApiError(_ERROR_INTERNAL, _MSG_UNEXPECTED_RESPONSE)
+        return dict(result)
+
     # -- internals ----------------------------------------------------------
 
     def _privacy_op(self, name: str, args: tuple[Any, ...]) -> dict[str, Any]:
@@ -283,6 +351,12 @@ class DesktopApi:
             raise DesktopApiError(_ERROR_INTERNAL, _MSG_NO_RUNTIME)
         return runtime
 
+    def _require_window_controller(self) -> Any:
+        controller = self._window_controller
+        if controller is None:
+            raise DesktopApiError(_ERROR_WINDOW_UNAVAILABLE, _MSG_NO_WINDOW)
+        return controller
+
 
 # ---------------------------------------------------------------------------
 # The facade actually handed to pywebview
@@ -290,7 +364,7 @@ class DesktopApi:
 
 
 class DesktopBridge:
-    """The object actually delivered to pywebview's ``js_api`` (#334, #336).
+    """The object actually delivered to pywebview's ``js_api`` (#334, #336, #342).
 
     Hard boundary guarantees:
 
@@ -305,13 +379,19 @@ class DesktopBridge:
       input returns data, never an exception.
     """
 
-    def __init__(self, api: DesktopApi | None = None, *, runtime: Any = None) -> None:
-        # ``runtime`` is a convenience injection used by make_js_api; the
-        # canonical construction path is DesktopApi(runtime=...).
+    def __init__(
+        self,
+        api: DesktopApi | None = None,
+        *,
+        runtime: Any = None,
+        window_controller: Any = None,
+    ) -> None:
+        # ``runtime`` and ``window_controller`` are convenience injections
+        # used by make_js_api; canonical path is DesktopApi(runtime=..., window_controller=...).
         if api is None:
-            api = DesktopApi(runtime=runtime)
-        elif runtime is not None:
-            raise ValueError("pass api or runtime, not both")
+            api = DesktopApi(runtime=runtime, window_controller=window_controller)
+        elif runtime is not None or window_controller is not None:
+            raise ValueError("pass api or runtime/window_controller, not both")
         self._api = api
         self._handlers: dict[str, Any] = {
             "health": self._api.health,
@@ -322,6 +402,10 @@ class DesktopBridge:
             "delete_memories": self._api.delete_memories,
             "reset_emotional_state": self._api.reset_emotional_state,
             "reset_relationship_state": self._api.reset_relationship_state,
+            "set_presence_mode": self._api.set_presence_mode,
+            "set_always_on_top": self._api.set_always_on_top,
+            "window_state": self._api.window_state,
+            "close_window": self._api.close_window,
         }
         # Sanity: the allowlist and the bound surface must match exactly,
         # at construction time (fail fast in dev/test, never in JS).
@@ -362,6 +446,22 @@ class DesktopBridge:
         """Sanitized wrapper; never raises."""
         return self._invoke("reset_relationship_state", args)
 
+    def set_presence_mode(self, *args: Any) -> dict[str, Any]:
+        """Sanitized wrapper; never raises."""
+        return self._invoke("set_presence_mode", args)
+
+    def set_always_on_top(self, *args: Any) -> dict[str, Any]:
+        """Sanitized wrapper; never raises."""
+        return self._invoke("set_always_on_top", args)
+
+    def window_state(self, *args: Any) -> dict[str, Any]:
+        """Sanitized wrapper; never raises."""
+        return self._invoke("window_state", args)
+
+    def close_window(self, *args: Any) -> dict[str, Any]:
+        """Sanitized wrapper; never raises."""
+        return self._invoke("close_window", args)
+
     # -- boundary internals (never exposed: underscore-prefixed) ---------
 
     def _invoke(self, method: str, args: tuple[Any, ...]) -> dict[str, Any]:
@@ -379,13 +479,13 @@ class DesktopBridge:
         return result
 
 
-def make_js_api(runtime: Any = None) -> DesktopBridge:
-    """Build the sanitized bridge object to pass as ``js_api=`` (#334, #336).
+def make_js_api(runtime: Any = None, window_controller: Any = None) -> DesktopBridge:
+    """Build the sanitized bridge object to pass as ``js_api=`` (#334, #336, #342).
 
-    ``runtime`` is the local companion runtime. This is the single
-    construction path used by the shell entrypoint; tests assert that
-    ``run_desktop_shell`` hands exactly this kind of object to pywebview,
-    so the sanitized facade is the *real* boundary (not an auxiliary
-    helper disconnected from the exposed path).
+    ``runtime`` is the local companion runtime.
+    ``window_controller`` coordinates native window mutations.
+    This is the single construction path used by the shell entrypoint;
+    tests assert that ``run_desktop_shell`` hands exactly this kind of
+    object to pywebview, so the sanitized facade is the *real* boundary.
     """
-    return DesktopBridge(DesktopApi(runtime=runtime))
+    return DesktopBridge(DesktopApi(runtime=runtime, window_controller=window_controller))

--- a/backend/desktop/api.py
+++ b/backend/desktop/api.py
@@ -47,6 +47,7 @@ DESKTOP_API_METHODS: tuple[str, ...] = (
     "set_always_on_top",
     "window_state",
     "close_window",
+    "minimize_window",
 )
 
 #: Version of the desktop bridge contract. The frontend can feature-check
@@ -326,6 +327,18 @@ class DesktopApi:
             raise DesktopApiError(_ERROR_INTERNAL, _MSG_UNEXPECTED_RESPONSE)
         return dict(result)
 
+    def minimize_window(self, *args: Any) -> dict[str, Any]:
+        """Minimize the desktop window to the taskbar/dock (#342)."""
+        if args:
+            raise DesktopApiError(
+                _ERROR_INVALID_INPUT, "minimize_window() takes no arguments."
+            )
+        controller = self._require_window_controller()
+        result = controller.minimize_window()
+        if not isinstance(result, dict):
+            raise DesktopApiError(_ERROR_INTERNAL, _MSG_UNEXPECTED_RESPONSE)
+        return dict(result)
+
     # -- internals ----------------------------------------------------------
 
     def _privacy_op(self, name: str, args: tuple[Any, ...]) -> dict[str, Any]:
@@ -406,6 +419,7 @@ class DesktopBridge:
             "set_always_on_top": self._api.set_always_on_top,
             "window_state": self._api.window_state,
             "close_window": self._api.close_window,
+            "minimize_window": self._api.minimize_window,
         }
         # Sanity: the allowlist and the bound surface must match exactly,
         # at construction time (fail fast in dev/test, never in JS).
@@ -461,6 +475,10 @@ class DesktopBridge:
     def close_window(self, *args: Any) -> dict[str, Any]:
         """Sanitized wrapper; never raises."""
         return self._invoke("close_window", args)
+
+    def minimize_window(self, *args: Any) -> dict[str, Any]:
+        """Sanitized wrapper for DesktopApi.minimize_window; never raises."""
+        return self._invoke("minimize_window", args)
 
     # -- boundary internals (never exposed: underscore-prefixed) ---------
 

--- a/backend/desktop/app.py
+++ b/backend/desktop/app.py
@@ -268,6 +268,202 @@ class BuildTrust:
         return current_url == committed and is_local_build_url(current_url, self._build)
 
 
+def _dispatch_main_loop(action: Callable[[], Any]) -> None:
+    """Schedule an action on the GUI main loop via GLib.idle_add if available."""
+    try:
+        from gi.repository import GLib  # type: ignore[import-not-found]
+
+        def _callback() -> bool:
+            try:
+                action()
+            except Exception:  # noqa: BLE001
+                pass
+            return False
+
+        GLib.idle_add(_callback)
+    except (ImportError, AttributeError):
+        try:
+            action()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+class WindowController:
+    """Thread-safe controller for desktop window lifecycle and mode transitions (#342).
+
+    Dispatches native GTK operations (set_decorated, resize, move, on_top, destroy)
+    safely onto the GUI main loop via GLib.idle_add while maintaining atomic state
+    tracking for mode, geometry, and always-on-top status across worker threads.
+    """
+
+    def __init__(self, window: Any = None) -> None:
+        import threading
+
+        self._lock = threading.Lock()
+        self._window = window
+        self._mode = "companion"
+        self._on_top = False
+        self._width = _WINDOW_SIZE[0]
+        self._height = _WINDOW_SIZE[1]
+        self._saved_geometry: tuple[int | None, int | None, int, int] = (
+            None,
+            None,
+            _WINDOW_SIZE[0],
+            _WINDOW_SIZE[1],
+        )
+
+    def set_window(self, window: Any) -> None:
+        """Bind the pywebview window instance after creation."""
+        with self._lock:
+            self._window = window
+
+    def set_presence_mode(self, enabled: bool) -> dict[str, Any]:
+        """Transition between companion and floating presence modes."""
+        with self._lock:
+            if self._window is None:
+                return {
+                    "ok": False,
+                    "code": "window_unavailable",
+                    "message": "The window is not available.",
+                }
+            window = self._window
+
+            if enabled:
+                curr_x: int | None = None
+                curr_y: int | None = None
+                curr_w: int | None = None
+                curr_h: int | None = None
+
+                native = getattr(window, "native", None)
+                if native is not None:
+                    try:
+                        if hasattr(native, "get_position"):
+                            curr_x, curr_y = native.get_position()
+                        if hasattr(native, "get_size"):
+                            curr_w, curr_h = native.get_size()
+                    except Exception:  # noqa: BLE001
+                        pass
+
+                if curr_x is None:
+                    curr_x = getattr(window, "x", None)
+                if curr_y is None:
+                    curr_y = getattr(window, "y", None)
+                if curr_w is None and hasattr(window, "width") and isinstance(window.width, int):
+                    curr_w = window.width
+                if curr_h is None and hasattr(window, "height") and isinstance(window.height, int):
+                    curr_h = window.height
+
+                if self._mode == "companion":
+                    self._saved_geometry = (
+                        curr_x,
+                        curr_y,
+                        curr_w or self._width or _WINDOW_SIZE[0],
+                        curr_h or self._height or _WINDOW_SIZE[1],
+                    )
+
+                def _apply_presence() -> None:
+                    nat = getattr(window, "native", None)
+                    if nat is not None and hasattr(nat, "set_decorated"):
+                        nat.set_decorated(False)
+                    if hasattr(window, "resize"):
+                        window.resize(200, 200)
+                    if hasattr(window, "on_top"):
+                        window.on_top = True
+
+                _dispatch_main_loop(_apply_presence)
+
+                self._mode = "presence"
+                self._on_top = True
+                self._width = 200
+                self._height = 200
+
+                return {
+                    "ok": True,
+                    "mode": "presence",
+                    "on_top": True,
+                    "width": 200,
+                    "height": 200,
+                }
+            else:
+                saved_x, saved_y, saved_w, saved_h = self._saved_geometry
+                target_w = saved_w or _WINDOW_SIZE[0]
+                target_h = saved_h or _WINDOW_SIZE[1]
+
+                def _apply_companion() -> None:
+                    nat = getattr(window, "native", None)
+                    if nat is not None and hasattr(nat, "set_decorated"):
+                        nat.set_decorated(True)
+                    if hasattr(window, "resize"):
+                        window.resize(target_w, target_h)
+                    if saved_x is not None and saved_y is not None and hasattr(window, "move"):
+                        window.move(saved_x, saved_y)
+                    if hasattr(window, "on_top"):
+                        window.on_top = False
+
+                _dispatch_main_loop(_apply_companion)
+
+                self._mode = "companion"
+                self._on_top = False
+                self._width = target_w
+                self._height = target_h
+
+                return {
+                    "ok": True,
+                    "mode": "companion",
+                    "on_top": False,
+                    "width": target_w,
+                    "height": target_h,
+                }
+
+    def set_always_on_top(self, enabled: bool) -> dict[str, Any]:
+        """Toggle always-on-top layering for the window."""
+        with self._lock:
+            if self._window is None:
+                return {
+                    "ok": False,
+                    "code": "window_unavailable",
+                    "message": "The window is not available.",
+                }
+            window = self._window
+
+            def _apply_on_top() -> None:
+                if hasattr(window, "on_top"):
+                    window.on_top = enabled
+
+            _dispatch_main_loop(_apply_on_top)
+            self._on_top = enabled
+            return {"ok": True, "on_top": enabled}
+
+    def window_state(self) -> dict[str, Any]:
+        """Return current window state snapshot."""
+        with self._lock:
+            return {
+                "ok": True,
+                "mode": self._mode,
+                "on_top": self._on_top,
+                "width": self._width,
+                "height": self._height,
+            }
+
+    def close_window(self) -> dict[str, Any]:
+        """Request window destruction and clean shell shutdown."""
+        with self._lock:
+            if self._window is None:
+                return {
+                    "ok": False,
+                    "code": "window_unavailable",
+                    "message": "The window is not available.",
+                }
+            window = self._window
+
+            def _apply_close() -> None:
+                if hasattr(window, "destroy"):
+                    window.destroy()
+
+            _dispatch_main_loop(_apply_close)
+            return {"ok": True}
+
+
 class LocalBuildBridge:
     """``js_api`` facade that fails closed outside the local build (#334).
 
@@ -353,6 +549,22 @@ class LocalBuildBridge:
     def reset_relationship_state(self, *args: Any) -> dict[str, Any]:
         """Privacy: reset relationship state, local-build-only; never raises."""
         return self._serve("reset_relationship_state", args)
+
+    def set_presence_mode(self, *args: Any) -> dict[str, Any]:
+        """Window presence mode, local-build-only; never raises."""
+        return self._serve("set_presence_mode", args)
+
+    def set_always_on_top(self, *args: Any) -> dict[str, Any]:
+        """Window always on top, local-build-only; never raises."""
+        return self._serve("set_always_on_top", args)
+
+    def window_state(self, *args: Any) -> dict[str, Any]:
+        """Window state query, local-build-only; never raises."""
+        return self._serve("window_state", args)
+
+    def close_window(self, *args: Any) -> dict[str, Any]:
+        """Window close, local-build-only; never raises."""
+        return self._serve("close_window", args)
 
 
 class NavigationPolicy:
@@ -491,7 +703,9 @@ def run_desktop_shell(
             return None
         return _get_url_safely(window_holder[0].get_current_url)
 
-    js_api = LocalBuildBridge(make_js_api(runtime=runtime), build, _current_url, trust)
+    window_controller = WindowController()
+    bridge_facade = make_js_api(runtime=runtime, window_controller=window_controller)
+    js_api = LocalBuildBridge(bridge_facade, build, _current_url, trust)
 
     window = webview.create_window(
         title=_WINDOW_TITLE,
@@ -499,8 +713,11 @@ def run_desktop_shell(
         js_api=js_api,
         width=_WINDOW_SIZE[0],
         height=_WINDOW_SIZE[1],
+        transparent=True,
+        min_size=(120, 120),
     )
     window_holder.append(window)
+    window_controller.set_window(window)
 
     # Policy layer 1: on every completed load, commit local pages as
     # trusted and revert non-local navigation back to the build. A

--- a/backend/desktop/app.py
+++ b/backend/desktop/app.py
@@ -383,32 +383,33 @@ def _query_workareas_and_primary() -> tuple[list[WorkArea], int]:
         from gi.repository import Gdk  # type: ignore[import-not-found]
 
         display = Gdk.Display.get_default()
-        if display is not None:
-            n = display.get_n_monitors()
-            if n > 0:
-                primary_mon = (
-                    display.get_primary_monitor()
-                    if hasattr(display, "get_primary_monitor")
-                    else None
-                )
-                workareas: list[WorkArea] = []
-                primary_idx = 0
-                for i in range(n):
-                    mon = display.get_monitor(i)
-                    if mon is primary_mon:
-                        primary_idx = i
-                    if mon is not None and hasattr(mon, "get_workarea"):
-                        rect = mon.get_workarea()
-                        workareas.append(
-                            WorkArea(rect.x, rect.y, rect.width, rect.height)
-                        )
-                    elif mon is not None and hasattr(mon, "get_geometry"):
-                        rect = mon.get_geometry()
-                        workareas.append(
-                            WorkArea(rect.x, rect.y, rect.width, rect.height)
-                        )
-                if workareas:
-                    return workareas, primary_idx
+        if display is None:
+            return [], 0
+        n = display.get_n_monitors()
+        if n > 0:
+            primary_mon = (
+                display.get_primary_monitor()
+                if hasattr(display, "get_primary_monitor")
+                else None
+            )
+            workareas: list[WorkArea] = []
+            primary_idx = 0
+            for i in range(n):
+                mon = display.get_monitor(i)
+                if mon is primary_mon:
+                    primary_idx = i
+                if mon is not None and hasattr(mon, "get_workarea"):
+                    rect = mon.get_workarea()
+                    workareas.append(
+                        WorkArea(rect.x, rect.y, rect.width, rect.height)
+                    )
+                elif mon is not None and hasattr(mon, "get_geometry"):
+                    rect = mon.get_geometry()
+                    workareas.append(
+                        WorkArea(rect.x, rect.y, rect.width, rect.height)
+                    )
+            if workareas:
+                return workareas, primary_idx
     except Exception:  # noqa: BLE001
         pass
 
@@ -502,7 +503,7 @@ class WindowController:
     ) -> None:
         import threading
 
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._window = window
         self._workareas = workareas
         self._dispatch_timeout = dispatch_timeout
@@ -510,17 +511,210 @@ class WindowController:
         self._on_top = False
         self._width = _WINDOW_SIZE[0]
         self._height = _WINDOW_SIZE[1]
+        self._x: int | None = None
+        self._y: int | None = None
+        self._is_reconciling = False
+        self._screen_signals_connected = False
         self._saved_geometry: tuple[int | None, int | None, int, int] = (
             None,
             None,
             _WINDOW_SIZE[0],
             _WINDOW_SIZE[1],
         )
+        if window is not None:
+            self._bind_window_events(window)
+
+    def _bind_window_events(self, window: Any) -> None:
+        """Bind moved and lifecycle event handlers on the pywebview window."""
+        if hasattr(window, "events") and hasattr(window.events, "moved"):
+            try:
+                window.events.moved -= self._on_window_moved
+            except (ValueError, KeyError, AttributeError):
+                pass
+            window.events.moved += self._on_window_moved
+        if hasattr(window, "events") and hasattr(window.events, "shown"):
+            try:
+                window.events.shown -= self._connect_screen_signals
+            except (ValueError, KeyError, AttributeError):
+                pass
+            window.events.shown += self._connect_screen_signals
 
     def set_window(self, window: Any) -> None:
         """Bind the pywebview window instance after creation."""
         with self._lock:
             self._window = window
+            if window is not None:
+                self._bind_window_events(window)
+
+    def _connect_screen_signals(self, *args: Any) -> None:
+        """Connect to Gdk.Screen signals for monitor/resolution changes (#342, #366)."""
+        with self._lock:
+            if self._screen_signals_connected:
+                return
+        try:
+            import gi
+
+            try:
+                gi.require_version("Gdk", "3.0")
+            except (ValueError, AttributeError):
+                pass
+            from gi.repository import Gdk  # type: ignore[import-not-found]
+
+            display = Gdk.Display.get_default()
+            if display is None:
+                return
+
+            screen = Gdk.Screen.get_default()
+            if screen is not None and hasattr(screen, "connect"):
+                screen.connect("monitors-changed", self._on_screen_changed)
+                screen.connect("size-changed", self._on_screen_changed)
+                with self._lock:
+                    self._screen_signals_connected = True
+        except Exception:
+            pass
+
+    def _on_screen_changed(self, *args: Any) -> None:
+        """Reconcile geometry upon display monitor addition, removal, or resolution changes."""
+        self.reconcile_geometry()
+
+    def _on_window_moved(self, *args: Any, **kwargs: Any) -> None:
+        """Handle window move event (e.g. from drag region or configure-event) with loop protection."""
+        if self._is_reconciling:
+            return
+        int_args = [a for a in args if isinstance(a, int) and not isinstance(a, bool)]
+        x = int_args[0] if len(int_args) >= 1 else None
+        y = int_args[1] if len(int_args) >= 2 else None
+        self.reconcile_geometry(x=x, y=y)
+
+    def reconcile_geometry(
+        self, x: int | None = None, y: int | None = None
+    ) -> dict[str, Any]:
+        """Reconcile window geometry against usable workareas while in presence mode (#342, #366).
+
+        Ensures dragged or shifted presence window stays 100% within usable bounds
+        and recovers windows upon resolution or monitor changes.
+        Protected against re-entrant event loops.
+        """
+        with self._lock:
+            if self._is_reconciling:
+                return {"ok": True, "clamped": False, "in_progress": True}
+            if self._window is None:
+                return {"ok": False, "code": "window_unavailable"}
+            if self._mode != "presence":
+                return {"ok": True, "clamped": False, "mode": self._mode}
+
+            window = self._window
+            curr_x = x
+            curr_y = y
+            curr_w = None
+            curr_h = None
+
+            native = getattr(window, "native", None)
+            if native is not None:
+                try:
+                    if (curr_x is None or curr_y is None) and hasattr(native, "get_position"):
+                        pos = native.get_position()
+                        if pos and len(pos) == 2:
+                            curr_x, curr_y = pos[0], pos[1]
+                    if hasattr(native, "get_size"):
+                        sz = native.get_size()
+                        if sz and len(sz) == 2:
+                            curr_w, curr_h = sz[0], sz[1]
+                except Exception:
+                    pass
+
+            if curr_x is None:
+                curr_x = getattr(window, "x", None)
+            if curr_y is None:
+                curr_y = getattr(window, "y", None)
+            if curr_w is None:
+                w_attr = getattr(window, "width", None)
+                curr_w = (
+                    w_attr
+                    if isinstance(w_attr, int) and not isinstance(w_attr, bool)
+                    else self._width
+                )
+            if curr_h is None:
+                h_attr = getattr(window, "height", None)
+                curr_h = (
+                    h_attr
+                    if isinstance(h_attr, int) and not isinstance(h_attr, bool)
+                    else self._height
+                )
+
+            w = curr_w if isinstance(curr_w, int) and curr_w > 0 else 200
+            h = curr_h if isinstance(curr_h, int) and curr_h > 0 else 200
+
+            workareas = self._workareas
+            primary_idx = 0
+            if workareas is None:
+                queried, pri = _query_workareas_and_primary()
+                if queried:
+                    workareas = queried
+                    primary_idx = pri
+
+            clamped = clamp_window_geometry(
+                (curr_x, curr_y, w, h),
+                workareas or [],
+                primary_index=primary_idx,
+                min_size=(120, 120),
+            )
+
+            needs_move = (
+                curr_x is not None
+                and curr_y is not None
+                and (clamped.x != curr_x or clamped.y != curr_y)
+            )
+            needs_resize = clamped.width != w or clamped.height != h
+
+            if not needs_move and not needs_resize:
+                if curr_x is not None:
+                    self._x = curr_x
+                if curr_y is not None:
+                    self._y = curr_y
+                self._width = clamped.width
+                self._height = clamped.height
+                return {
+                    "ok": True,
+                    "clamped": False,
+                    "x": clamped.x,
+                    "y": clamped.y,
+                    "width": clamped.width,
+                    "height": clamped.height,
+                }
+
+            self._is_reconciling = True
+
+        try:
+            def _apply_reconcile() -> None:
+                if needs_resize and hasattr(window, "resize"):
+                    window.resize(clamped.width, clamped.height)
+                if needs_move and hasattr(window, "move"):
+                    window.move(clamped.x, clamped.y)
+
+            ok, err = _dispatch_sync(_apply_reconcile, timeout=self._dispatch_timeout)
+            if not ok:
+                return {
+                    "ok": False,
+                    "code": "reconciliation_failed",
+                    "error": str(err),
+                }
+        finally:
+            with self._lock:
+                self._is_reconciling = False
+                self._x = clamped.x
+                self._y = clamped.y
+                self._width = clamped.width
+                self._height = clamped.height
+
+        return {
+            "ok": True,
+            "clamped": True,
+            "x": clamped.x,
+            "y": clamped.y,
+            "width": clamped.width,
+            "height": clamped.height,
+        }
 
     def set_presence_mode(self, enabled: bool) -> dict[str, Any]:
         """Transition between companion and floating presence modes."""
@@ -632,11 +826,15 @@ class WindowController:
                         "message": "The window operation could not be completed.",
                     }
 
+                self._connect_screen_signals()
+
                 # Commit transactional state only after confirmed success
                 self._saved_geometry = candidate_saved_geometry
                 self._mode = "presence"
                 self._width = presence_w
                 self._height = presence_h
+                self._x = presence_x
+                self._y = presence_y
 
                 return {
                     "ok": True,
@@ -721,6 +919,8 @@ class WindowController:
                 self._mode = "companion"
                 self._width = companion_w
                 self._height = companion_h
+                self._x = companion_x
+                self._y = companion_y
 
                 return {
                     "ok": True,
@@ -794,13 +994,18 @@ class WindowController:
     def window_state(self) -> dict[str, Any]:
         """Return current window state snapshot."""
         with self._lock:
-            return {
+            state: dict[str, Any] = {
                 "ok": True,
                 "mode": self._mode,
                 "on_top": self._on_top,
                 "width": self._width,
                 "height": self._height,
             }
+            if self._x is not None:
+                state["x"] = self._x
+            if self._y is not None:
+                state["y"] = self._y
+            return state
 
     def close_window(self) -> dict[str, Any]:
         """Request window destruction and clean shell shutdown."""
@@ -1103,6 +1308,7 @@ def run_desktop_shell(
         trust=trust,
     )
     window.events.loaded += policy.on_loaded
+    window.events.loaded += window_controller._connect_screen_signals
 
     try:
         webview.start()

--- a/backend/desktop/app.py
+++ b/backend/desktop/app.py
@@ -683,14 +683,41 @@ class WindowController:
                     "height": clamped.height,
                 }
 
+            orig_w = w
+            orig_h = h
+            orig_x = curr_x
+            orig_y = curr_y
+
             self._is_reconciling = True
 
         try:
             def _apply_reconcile() -> None:
-                if needs_resize and hasattr(window, "resize"):
-                    window.resize(clamped.width, clamped.height)
-                if needs_move and hasattr(window, "move"):
-                    window.move(clamped.x, clamped.y)
+                resized = False
+                moved = False
+                try:
+                    if needs_resize and hasattr(window, "resize"):
+                        window.resize(clamped.width, clamped.height)
+                        resized = True
+                    if needs_move and hasattr(window, "move"):
+                        window.move(clamped.x, clamped.y)
+                        moved = True
+                except Exception:
+                    if resized and hasattr(window, "resize"):
+                        try:
+                            window.resize(orig_w, orig_h)
+                        except Exception:  # noqa: BLE001
+                            pass
+                    if (
+                        moved
+                        and orig_x is not None
+                        and orig_y is not None
+                        and hasattr(window, "move")
+                    ):
+                        try:
+                            window.move(orig_x, orig_y)
+                        except Exception:  # noqa: BLE001
+                            pass
+                    raise
 
             ok, err = _dispatch_sync(_apply_reconcile, timeout=self._dispatch_timeout)
             if not ok:

--- a/backend/desktop/app.py
+++ b/backend/desktop/app.py
@@ -58,8 +58,9 @@ committing again.
 from __future__ import annotations
 
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 from urllib.parse import urlsplit
 
 import webview
@@ -268,39 +269,243 @@ class BuildTrust:
         return current_url == committed and is_local_build_url(current_url, self._build)
 
 
-def _dispatch_main_loop(action: Callable[[], Any]) -> None:
-    """Schedule an action on the GUI main loop via GLib.idle_add if available."""
+@dataclass(frozen=True)
+class WorkArea:
+    x: int
+    y: int
+    width: int
+    height: int
+
+    @property
+    def right(self) -> int:
+        return self.x + self.width
+
+    @property
+    def bottom(self) -> int:
+        return self.y + self.height
+
+
+@dataclass(frozen=True)
+class ClampedGeometry:
+    x: int
+    y: int
+    width: int
+    height: int
+
+
+def clamp_window_geometry(
+    target_rect: tuple[int | None, int | None, int, int],
+    workareas: Sequence[WorkArea],
+    primary_index: int = 0,
+    min_size: tuple[int, int] = (120, 120),
+) -> ClampedGeometry:
+    """Pure, deterministic clamp ensuring window is reachable and within usable screen bounds.
+
+    - Handles negative coordinates for multi-monitor setups.
+    - Uses usable workareas (excluding OS panels/docks).
+    - Recovers windows when monitors vanish or resolution shrinks.
+    """
+    if not workareas:
+        workareas = [WorkArea(0, 0, _WINDOW_SIZE[0], _WINDOW_SIZE[1])]
+
+    pri_idx = primary_index if 0 <= primary_index < len(workareas) else 0
+    primary_wa = workareas[pri_idx]
+
+    prop_x, prop_y, prop_w, prop_h = target_rect
+    w = max(min_size[0], prop_w)
+    h = max(min_size[1], prop_h)
+
+    # 1. Unspecified position: center on primary workarea
+    if prop_x is None or prop_y is None:
+        target_w = min(w, primary_wa.width)
+        target_h = min(h, primary_wa.height)
+        target_x = primary_wa.x + max(0, (primary_wa.width - target_w) // 2)
+        target_y = primary_wa.y + max(0, (primary_wa.height - target_h) // 2)
+        return ClampedGeometry(target_x, target_y, target_w, target_h)
+
+    # 2. Select best workarea based on maximum overlap area
+    best_wa: WorkArea | None = None
+    max_overlap = -1
+    for wa in workareas:
+        ix1 = max(prop_x, wa.x)
+        iy1 = max(prop_y, wa.y)
+        ix2 = min(prop_x + w, wa.right)
+        iy2 = min(prop_y + h, wa.bottom)
+        overlap = max(0, ix2 - ix1) * max(0, iy2 - iy1)
+        if overlap > max_overlap:
+            max_overlap = overlap
+            best_wa = wa
+
+    # 3. If zero overlap (e.g. monitor unplugged), pick closest workarea by center distance
+    if max_overlap <= 0 or best_wa is None:
+        center_x = prop_x + w / 2
+        center_y = prop_y + h / 2
+        min_dist_sq = float("inf")
+        best_wa = primary_wa
+        for wa in workareas:
+            wa_cx = wa.x + wa.width / 2
+            wa_cy = wa.y + wa.height / 2
+            dist_sq = (center_x - wa_cx) ** 2 + (center_y - wa_cy) ** 2
+            if dist_sq < min_dist_sq:
+                min_dist_sq = dist_sq
+                best_wa = wa
+
+    # 4. Clamp dimensions to selected workarea
+    clamped_w = min(w, best_wa.width)
+    clamped_h = min(h, best_wa.height)
+
+    # 5. Clamp coordinates to keep window 100% inside workarea bounds
+    max_x = best_wa.x + best_wa.width - clamped_w
+    max_y = best_wa.y + best_wa.height - clamped_h
+
+    clamped_x = max(best_wa.x, min(prop_x, max_x))
+    clamped_y = max(best_wa.y, min(prop_y, max_y))
+
+    return ClampedGeometry(clamped_x, clamped_y, clamped_w, clamped_h)
+
+
+def _query_workareas_and_primary() -> tuple[list[WorkArea], int]:
+    """Query available monitor workareas from Gdk Display, excluding OS panels/docks."""
+    try:
+        import sys
+
+        wgtk = sys.modules.get("webview.platforms.gtk")
+        has_active_app = wgtk is not None and getattr(wgtk, "_app", None) is not None
+        if not has_active_app:
+            return [], 0
+
+        import gi
+
+        try:
+            gi.require_version("Gdk", "3.0")
+        except (ValueError, AttributeError):
+            pass
+        from gi.repository import Gdk  # type: ignore[import-not-found]
+
+        display = Gdk.Display.get_default()
+        if display is not None:
+            n = display.get_n_monitors()
+            if n > 0:
+                primary_mon = (
+                    display.get_primary_monitor()
+                    if hasattr(display, "get_primary_monitor")
+                    else None
+                )
+                workareas: list[WorkArea] = []
+                primary_idx = 0
+                for i in range(n):
+                    mon = display.get_monitor(i)
+                    if mon is primary_mon:
+                        primary_idx = i
+                    if mon is not None and hasattr(mon, "get_workarea"):
+                        rect = mon.get_workarea()
+                        workareas.append(
+                            WorkArea(rect.x, rect.y, rect.width, rect.height)
+                        )
+                    elif mon is not None and hasattr(mon, "get_geometry"):
+                        rect = mon.get_geometry()
+                        workareas.append(
+                            WorkArea(rect.x, rect.y, rect.width, rect.height)
+                        )
+                if workareas:
+                    return workareas, primary_idx
+    except Exception:  # noqa: BLE001
+        pass
+
+    return [], 0
+
+
+def _dispatch_sync(
+    action: Callable[[], Any], timeout: float = 2.0
+) -> tuple[bool, Any]:
+    """Execute action synchronously on the GUI main loop thread with bounded timeout.
+
+    If already on the GUI thread or if no GTK main loop is active, runs immediately.
+    Returns (True, result) on success, (False, exception) on failure or timeout.
+    """
     try:
         from gi.repository import GLib  # type: ignore[import-not-found]
+        import sys
+
+        wgtk = sys.modules.get("webview.platforms.gtk")
+        has_active_app = wgtk is not None and getattr(wgtk, "_app", None) is not None
+
+        is_owner = False
+        try:
+            main_ctx = GLib.MainContext.default()
+            if main_ctx is not None and hasattr(main_ctx, "is_owner"):
+                is_owner = main_ctx.is_owner()
+        except Exception:  # noqa: BLE001
+            is_owner = False
+
+        if is_owner or not has_active_app:
+            try:
+                return True, action()
+            except Exception as exc:  # noqa: BLE001
+                return False, exc
+
+        import threading
+
+        cancelled = threading.Event()
+        event = threading.Event()
+        result_box: list[Any] = []
+        error_box: list[Exception] = []
 
         def _callback() -> bool:
+            if cancelled.is_set():
+                return False
             try:
-                action()
-            except Exception:  # noqa: BLE001
-                pass
+                result_box.append(action())
+            except Exception as exc:  # noqa: BLE001
+                error_box.append(exc)
+            finally:
+                event.set()
             return False
 
-        GLib.idle_add(_callback)
+        source_id = GLib.idle_add(_callback)
+        if not event.wait(timeout=timeout):
+            cancelled.set()
+            try:
+                if hasattr(GLib, "source_remove"):
+                    GLib.source_remove(source_id)
+            except Exception:  # noqa: BLE001
+                pass
+            return False, TimeoutError("Window operation timed out.")
+        if error_box:
+            return False, error_box[0]
+        return True, result_box[0] if result_box else None
     except (ImportError, AttributeError):
         try:
-            action()
-        except Exception:  # noqa: BLE001
-            pass
+            return True, action()
+        except Exception as exc:  # noqa: BLE001
+            return False, exc
+
+
+def _dispatch_main_loop(action: Callable[[], Any]) -> None:
+    """Legacy helper; delegates to _dispatch_sync."""
+    _dispatch_sync(action)
 
 
 class WindowController:
     """Thread-safe controller for desktop window lifecycle and mode transitions (#342).
 
     Dispatches native GTK operations (set_decorated, resize, move, on_top, destroy)
-    safely onto the GUI main loop via GLib.idle_add while maintaining atomic state
-    tracking for mode, geometry, and always-on-top status across worker threads.
+    safely onto the GUI main loop via bounded synchronous dispatch while maintaining
+    transactional state tracking for mode, geometry, and always-on-top status.
     """
 
-    def __init__(self, window: Any = None) -> None:
+    def __init__(
+        self,
+        window: Any = None,
+        workareas: Sequence[WorkArea] | None = None,
+        dispatch_timeout: float = 2.0,
+    ) -> None:
         import threading
 
         self._lock = threading.Lock()
         self._window = window
+        self._workareas = workareas
+        self._dispatch_timeout = dispatch_timeout
         self._mode = "companion"
         self._on_top = False
         self._width = _WINDOW_SIZE[0]
@@ -353,66 +558,176 @@ class WindowController:
                 if curr_h is None and hasattr(window, "height") and isinstance(window.height, int):
                     curr_h = window.height
 
+                # Precompute candidate saved geometry only when transitioning from companion
+                candidate_saved_geometry = self._saved_geometry
                 if self._mode == "companion":
-                    self._saved_geometry = (
+                    candidate_saved_geometry = (
                         curr_x,
                         curr_y,
                         curr_w or self._width or _WINDOW_SIZE[0],
                         curr_h or self._height or _WINDOW_SIZE[1],
                     )
 
+                # Query or use injected workareas
+                workareas = self._workareas
+                primary_idx = 0
+                if workareas is None:
+                    queried, pri = _query_workareas_and_primary()
+                    if queried:
+                        workareas = queried
+                        primary_idx = pri
+
+                if workareas:
+                    clamped = clamp_window_geometry(
+                        (curr_x, curr_y, 200, 200),
+                        workareas,
+                        primary_index=primary_idx,
+                    )
+                    presence_w = clamped.width
+                    presence_h = clamped.height
+                    presence_x = clamped.x
+                    presence_y = clamped.y
+                else:
+                    presence_w = 200
+                    presence_h = 200
+                    presence_x = curr_x
+                    presence_y = curr_y
+
+                orig_w = curr_w or self._width or _WINDOW_SIZE[0]
+                orig_h = curr_h or self._height or _WINDOW_SIZE[1]
+
                 def _apply_presence() -> None:
                     nat = getattr(window, "native", None)
+                    decorated_modified = False
+                    resized = False
                     if nat is not None and hasattr(nat, "set_decorated"):
                         nat.set_decorated(False)
-                    if hasattr(window, "resize"):
-                        window.resize(200, 200)
-                    if hasattr(window, "on_top"):
-                        window.on_top = True
+                        decorated_modified = True
+                    try:
+                        if hasattr(window, "resize"):
+                            window.resize(presence_w, presence_h)
+                            resized = True
+                        if hasattr(window, "move") and presence_x is not None and presence_y is not None:
+                            if presence_x != curr_x or presence_y != curr_y:
+                                window.move(presence_x, presence_y)
+                    except Exception:
+                        if resized and hasattr(window, "resize"):
+                            try:
+                                window.resize(orig_w, orig_h)
+                            except Exception:  # noqa: BLE001
+                                pass
+                        if decorated_modified and hasattr(nat, "set_decorated"):
+                            try:
+                                nat.set_decorated(True)
+                            except Exception:  # noqa: BLE001
+                                pass
+                        raise
 
-                _dispatch_main_loop(_apply_presence)
+                ok, err = _dispatch_sync(_apply_presence, timeout=self._dispatch_timeout)
+                if not ok:
+                    code = "timeout" if isinstance(err, TimeoutError) else "window_mutation_failed"
+                    return {
+                        "ok": False,
+                        "code": code,
+                        "message": "The window operation could not be completed.",
+                    }
 
+                # Commit transactional state only after confirmed success
+                self._saved_geometry = candidate_saved_geometry
                 self._mode = "presence"
-                self._on_top = True
-                self._width = 200
-                self._height = 200
+                self._width = presence_w
+                self._height = presence_h
 
                 return {
                     "ok": True,
                     "mode": "presence",
-                    "on_top": True,
-                    "width": 200,
-                    "height": 200,
+                    "on_top": self._on_top,
+                    "width": self._width,
+                    "height": self._height,
                 }
             else:
                 saved_x, saved_y, saved_w, saved_h = self._saved_geometry
                 target_w = saved_w or _WINDOW_SIZE[0]
                 target_h = saved_h or _WINDOW_SIZE[1]
 
+                # Query or use injected workareas
+                workareas = self._workareas
+                primary_idx = 0
+                if workareas is None:
+                    queried, pri = _query_workareas_and_primary()
+                    if queried:
+                        workareas = queried
+                        primary_idx = pri
+
+                if workareas:
+                    clamped = clamp_window_geometry(
+                        (saved_x, saved_y, target_w, target_h),
+                        workareas,
+                        primary_index=primary_idx,
+                    )
+                    companion_w = clamped.width
+                    companion_h = clamped.height
+                    companion_x = clamped.x
+                    companion_y = clamped.y
+                else:
+                    companion_w = target_w
+                    companion_h = target_h
+                    companion_x = saved_x
+                    companion_y = saved_y
+
+                presence_w = getattr(window, "width", None)
+                if not isinstance(presence_w, int):
+                    presence_w = self._width if isinstance(self._width, int) else 200
+                presence_h = getattr(window, "height", None)
+                if not isinstance(presence_h, int):
+                    presence_h = self._height if isinstance(self._height, int) else 200
+
                 def _apply_companion() -> None:
                     nat = getattr(window, "native", None)
+                    decorated_modified = False
+                    resized = False
                     if nat is not None and hasattr(nat, "set_decorated"):
                         nat.set_decorated(True)
-                    if hasattr(window, "resize"):
-                        window.resize(target_w, target_h)
-                    if saved_x is not None and saved_y is not None and hasattr(window, "move"):
-                        window.move(saved_x, saved_y)
-                    if hasattr(window, "on_top"):
-                        window.on_top = False
+                        decorated_modified = True
+                    try:
+                        if hasattr(window, "resize"):
+                            window.resize(companion_w, companion_h)
+                            resized = True
+                        if hasattr(window, "move") and companion_x is not None and companion_y is not None:
+                            window.move(companion_x, companion_y)
+                    except Exception:
+                        if resized and hasattr(window, "resize"):
+                            try:
+                                window.resize(presence_w, presence_h)
+                            except Exception:  # noqa: BLE001
+                                pass
+                        if decorated_modified and hasattr(nat, "set_decorated"):
+                            try:
+                                nat.set_decorated(False)
+                            except Exception:  # noqa: BLE001
+                                pass
+                        raise
 
-                _dispatch_main_loop(_apply_companion)
+                ok, err = _dispatch_sync(_apply_companion, timeout=self._dispatch_timeout)
+                if not ok:
+                    code = "timeout" if isinstance(err, TimeoutError) else "window_mutation_failed"
+                    return {
+                        "ok": False,
+                        "code": code,
+                        "message": "The window operation could not be completed.",
+                    }
 
+                # Commit transactional state only after confirmed success
                 self._mode = "companion"
-                self._on_top = False
-                self._width = target_w
-                self._height = target_h
+                self._width = companion_w
+                self._height = companion_h
 
                 return {
                     "ok": True,
                     "mode": "companion",
-                    "on_top": False,
-                    "width": target_w,
-                    "height": target_h,
+                    "on_top": self._on_top,
+                    "width": self._width,
+                    "height": self._height,
                 }
 
     def set_always_on_top(self, enabled: bool) -> dict[str, Any]:
@@ -429,10 +744,52 @@ class WindowController:
             def _apply_on_top() -> None:
                 if hasattr(window, "on_top"):
                     window.on_top = enabled
+                else:
+                    raise RuntimeError("Native window capability not supported")
 
-            _dispatch_main_loop(_apply_on_top)
+            ok, err = _dispatch_sync(_apply_on_top, timeout=self._dispatch_timeout)
+            if not ok:
+                code = "timeout" if isinstance(err, TimeoutError) else "window_mutation_failed"
+                return {
+                    "ok": False,
+                    "code": code,
+                    "message": "The window operation could not be completed.",
+                }
+
             self._on_top = enabled
             return {"ok": True, "on_top": enabled}
+
+    def minimize_window(self) -> dict[str, Any]:
+        """Minimize the window to the desktop taskbar/dock (#342)."""
+        with self._lock:
+            if self._window is None:
+                return {
+                    "ok": False,
+                    "code": "window_unavailable",
+                    "message": "The window is not available.",
+                }
+            window = self._window
+
+            def _apply_minimize() -> None:
+                if hasattr(window, "minimize"):
+                    window.minimize()
+                else:
+                    native = getattr(window, "native", None)
+                    if native is not None and hasattr(native, "iconify"):
+                        native.iconify()
+                    else:
+                        raise RuntimeError("Native window capability not supported")
+
+            ok, err = _dispatch_sync(_apply_minimize, timeout=self._dispatch_timeout)
+            if not ok:
+                code = "timeout" if isinstance(err, TimeoutError) else "window_mutation_failed"
+                return {
+                    "ok": False,
+                    "code": code,
+                    "message": "The window operation could not be completed.",
+                }
+
+            return {"ok": True}
 
     def window_state(self) -> dict[str, Any]:
         """Return current window state snapshot."""
@@ -459,8 +816,18 @@ class WindowController:
             def _apply_close() -> None:
                 if hasattr(window, "destroy"):
                     window.destroy()
+                else:
+                    raise RuntimeError("Native window capability not supported")
 
-            _dispatch_main_loop(_apply_close)
+            ok, err = _dispatch_sync(_apply_close, timeout=self._dispatch_timeout)
+            if not ok:
+                code = "timeout" if isinstance(err, TimeoutError) else "window_mutation_failed"
+                return {
+                    "ok": False,
+                    "code": code,
+                    "message": "The window operation could not be completed.",
+                }
+
             return {"ok": True}
 
 
@@ -565,6 +932,10 @@ class LocalBuildBridge:
     def close_window(self, *args: Any) -> dict[str, Any]:
         """Window close, local-build-only; never raises."""
         return self._serve("close_window", args)
+
+    def minimize_window(self, *args: Any) -> dict[str, Any]:
+        """Window minimize, local-build-only; never raises."""
+        return self._serve("minimize_window", args)
 
 
 class NavigationPolicy:

--- a/backend/desktop/app.py
+++ b/backend/desktop/app.py
@@ -694,18 +694,24 @@ class WindowController:
 
             ok, err = _dispatch_sync(_apply_reconcile, timeout=self._dispatch_timeout)
             if not ok:
+                code = (
+                    "timeout"
+                    if isinstance(err, TimeoutError)
+                    else "window_mutation_failed"
+                )
                 return {
                     "ok": False,
-                    "code": "reconciliation_failed",
-                    "error": str(err),
+                    "code": code,
+                    "message": "The window operation could not be completed.",
                 }
-        finally:
             with self._lock:
-                self._is_reconciling = False
                 self._x = clamped.x
                 self._y = clamped.y
                 self._width = clamped.width
                 self._height = clamped.height
+        finally:
+            with self._lock:
+                self._is_reconciling = False
 
         return {
             "ok": True,

--- a/backend/tests/test_desktop_adversarial.py
+++ b/backend/tests/test_desktop_adversarial.py
@@ -471,6 +471,82 @@ class TestWindowControllerFaultTolerance:
         assert res["message"] == "The window operation could not be completed."
         assert wc._is_reconciling is False
 
+    def test_reconcile_geometry_composite_mutation_rollback_on_move_failure(self) -> None:
+        """When needs_resize and needs_move are both True, resize succeeds, and move fails:
+
+        the native resize is rolled back to original geometry, logical state does not advance,
+        reentrancy guard is released, and sanitized error is returned.
+        """
+        win = _FaultyWindow()
+        win.native.position = (100, 150)
+        win.native.size = (200, 200)
+        wc = WindowController(window=win, workareas=[WorkArea(0, 0, 1920, 1080)])
+
+        r = wc.set_presence_mode(True)
+        assert r["ok"] is True
+        st_initial = wc.window_state()
+        assert st_initial["x"] == 100
+        assert st_initial["y"] == 150
+        assert st_initial["width"] == 200
+        assert st_initial["height"] == 200
+
+        # Set up conditions where BOTH resize and move are required:
+        # Native size 80x80 is under min_size 120 -> clamped to 120x120 (needs_resize == True)
+        # Position (-400, -400) is out of bounds -> clamped to (0, 0) (needs_move == True)
+        win.native.size = (80, 80)
+        win.width = 80
+        win.height = 80
+        win.native.position = (100, 150)
+        win.x = 100
+        win.y = 150
+
+        # Resize succeeds, but move fails
+        win.fail_resize = False
+        win.fail_move = True
+
+        res = wc.reconcile_geometry(x=-400, y=-400)
+        assert res["ok"] is False
+        assert res["code"] == "window_mutation_failed"
+        assert res["message"] == "The window operation could not be completed."
+
+        # Native size was rolled back to original (80, 80)
+        assert win.native.size == (80, 80)
+        assert win.width == 80
+        assert win.height == 80
+
+        # Native position remained original (100, 150)
+        assert win.native.position == (100, 150)
+        assert win.x == 100
+        assert win.y == 150
+
+        # Logical window_state did NOT advance to clamped values (0, 0, 120, 120)
+        st_after = wc.window_state()
+        assert st_after["x"] == 100
+        assert st_after["y"] == 150
+        assert st_after["width"] == 200
+        assert st_after["height"] == 200
+
+        # Guard is released
+        assert wc._is_reconciling is False
+
+        # Recover from failure and verify composite mutation succeeds completely
+        win.fail_move = False
+        res2 = wc.reconcile_geometry(x=-400, y=-400)
+        assert res2["ok"] is True
+        assert res2["clamped"] is True
+        assert res2["x"] == 0
+        assert res2["y"] == 0
+        assert res2["width"] == 120
+        assert res2["height"] == 120
+
+        assert win.native.position == (0, 0)
+        assert win.native.size == (120, 120)
+        st_final = wc.window_state()
+        assert st_final["x"] == 0
+        assert st_final["y"] == 0
+        assert st_final["width"] == 120
+        assert st_final["height"] == 120
+
     def test_dispatch_sync_timeout_returns_timeout_code(self, monkeypatch) -> None:
         """When an operation exceeds timeout, code 'timeout' is returned."""
         class FakeMainContext:

--- a/backend/tests/test_desktop_adversarial.py
+++ b/backend/tests/test_desktop_adversarial.py
@@ -1,0 +1,366 @@
+"""Adversarial stress tests for Issue #342 (Floating presence mode).
+
+Tests concurrency, rapid mode switching, boundary inputs, type attacks,
+native GTK exception handling, and fail-closed navigation security.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import random
+import threading
+from typing import Any
+import pytest
+
+from backend.desktop.api import (
+    DESKTOP_API_METHODS,
+    DesktopApi,
+    DesktopBridge,
+    make_js_api,
+)
+from backend.desktop.app import (
+    LocalBuildBridge,
+    NavigationPolicy,
+    WindowController,
+)
+from backend.desktop.build_resolver import ResolvedBuild
+
+
+class _FaultyNative:
+    """Mock GTK native widget that can inject faults on demand."""
+
+    def __init__(
+        self,
+        x: int = 100,
+        y: int = 150,
+        w: int = 1280,
+        h: int = 800,
+        fail_get_pos: bool = False,
+        fail_get_size: bool = False,
+        fail_set_decorated: bool = False,
+    ) -> None:
+        self.decorated = True
+        self.position = (x, y)
+        self.size = (w, h)
+        self.fail_get_pos = fail_get_pos
+        self.fail_get_size = fail_get_size
+        self.fail_set_decorated = fail_set_decorated
+
+    def set_decorated(self, val: bool) -> None:
+        if self.fail_set_decorated:
+            raise RuntimeError("GTK X11 error: set_decorated failed")
+        self.decorated = val
+
+    def get_position(self) -> tuple[int, int]:
+        if self.fail_get_pos:
+            raise RuntimeError("GTK X11 error: BadWindow on get_position")
+        return self.position
+
+    def get_size(self) -> tuple[int, int]:
+        if self.fail_get_size:
+            raise RuntimeError("GTK X11 error: BadWindow on get_size")
+        return self.size
+
+
+class _FaultyWindow:
+    """Mock pywebview window with configurable fault injection."""
+
+    def __init__(
+        self,
+        native: Any = None,
+        fail_resize: bool = False,
+        fail_move: bool = False,
+        fail_destroy: bool = False,
+    ) -> None:
+        self.native = native if native is not None else _FaultyNative()
+        self.on_top = False
+        self.width = 1280
+        self.height = 800
+        self.x = 100
+        self.y = 150
+        self.fail_resize = fail_resize
+        self.fail_move = fail_move
+        self.fail_destroy = fail_destroy
+        self.destroyed = False
+
+    def resize(self, w: int, h: int) -> None:
+        if self.fail_resize:
+            raise RuntimeError("Window resize fault")
+        self.width = w
+        self.height = h
+        if self.native:
+            self.native.size = (w, h)
+
+    def move(self, x: int, y: int) -> None:
+        if self.fail_move:
+            raise RuntimeError("Window move fault")
+        self.x = x
+        self.y = y
+        if self.native:
+            self.native.position = (x, y)
+
+    def destroy(self) -> None:
+        if self.fail_destroy:
+            raise RuntimeError("Window destroy fault")
+        self.destroyed = True
+
+
+class TestWindowControllerAdversarialConcurrency:
+    """Adversarial concurrent stress testing on WindowController."""
+
+    def test_rapid_concurrent_mode_switching(self) -> None:
+        """50 concurrent worker threads rapidly invoking mode changes and queries."""
+        win = _FaultyWindow()
+        wc = WindowController(window=win)
+
+        errors: list[Exception] = []
+        states_seen: list[dict[str, Any]] = []
+
+        def worker(thread_id: int) -> None:
+            try:
+                for i in range(50):
+                    action = i % 5
+                    if action == 0:
+                        res = wc.set_presence_mode(True)
+                        assert res["ok"] is True
+                        assert res["mode"] == "presence"
+                        assert res["width"] == 200
+                        assert res["height"] == 200
+                    elif action == 1:
+                        res = wc.set_presence_mode(False)
+                        assert res["ok"] is True
+                        assert res["mode"] == "companion"
+                        assert res["width"] > 0
+                        assert res["height"] > 0
+                    elif action == 2:
+                        res = wc.set_always_on_top(bool(i % 2))
+                        assert res["ok"] is True
+                    elif action == 3:
+                        s = wc.window_state()
+                        assert s["ok"] is True
+                        assert s["mode"] in ("presence", "companion")
+                        assert isinstance(s["on_top"], bool)
+                        states_seen.append(s)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(t,)) for t in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10.0)
+
+        assert not errors, f"Concurrent execution produced errors: {errors}"
+        final_state = wc.window_state()
+        assert final_state["ok"] is True
+        assert final_state["mode"] in ("presence", "companion")
+
+    def test_geometry_preservation_under_repeated_presence_calls(self) -> None:
+        """Calling set_presence_mode(True) repeatedly must NOT overwrite saved companion geometry."""
+        win = _FaultyWindow()
+        win.native.position = (250, 350)
+        win.native.size = (1400, 900)
+        wc = WindowController(window=win)
+
+        # First enter presence: should record (250, 350, 1400, 900)
+        r1 = wc.set_presence_mode(True)
+        assert r1["ok"] is True
+        assert r1["mode"] == "presence"
+
+        # Repeated calls to enter presence while ALREADY in presence
+        for _ in range(10):
+            r = wc.set_presence_mode(True)
+            assert r["ok"] is True
+            assert r["mode"] == "presence"
+
+        # Now exit presence: should restore (250, 350, 1400, 900), NOT (200, 200)!
+        exit_res = wc.set_presence_mode(False)
+        assert exit_res["ok"] is True
+        assert exit_res["mode"] == "companion"
+        assert exit_res["width"] == 1400
+        assert exit_res["height"] == 900
+        assert win.native.position == (250, 350)
+        assert win.native.size == (1400, 900)
+
+    def test_geometry_preservation_when_companion_moves_between_sessions(self) -> None:
+        """When companion moves while in companion mode, next presence captures updated position."""
+        win = _FaultyWindow()
+        wc = WindowController(window=win)
+
+        # 1. First presence roundtrip
+        wc.set_presence_mode(True)
+        wc.set_presence_mode(False)
+
+        # User moves companion window to new location
+        win.native.position = (500, 600)
+        win.native.size = (1100, 750)
+
+        # 2. Enter presence again
+        wc.set_presence_mode(True)
+        # 3. Exit presence
+        wc.set_presence_mode(False)
+
+        # Verify it restored the NEW location, not the original (100, 150)
+        assert win.native.position == (500, 600)
+        assert win.native.size == (1100, 750)
+
+
+class TestWindowControllerFaultTolerance:
+    """Stress tests on native GTK failures and fault injection."""
+
+    def test_native_position_and_size_exceptions_handled_gracefully(self) -> None:
+        """When GTK throws BadWindow on get_position/get_size, fallbacks are used."""
+        faulty_native = _FaultyNative(fail_get_pos=True, fail_get_size=True)
+        win = _FaultyWindow(native=faulty_native)
+        win.x = 80
+        win.y = 90
+        win.width = 1200
+        win.height = 700
+        wc = WindowController(window=win)
+
+        # Should not raise despite native exceptions
+        r = wc.set_presence_mode(True)
+        assert r["ok"] is True
+        assert r["mode"] == "presence"
+
+        exit_r = wc.set_presence_mode(False)
+        assert exit_r["ok"] is True
+        assert exit_r["width"] == 1200
+        assert exit_r["height"] == 700
+
+    def test_native_mutation_exceptions_do_not_crash_controller(self) -> None:
+        """When native window methods raise during dispatch, controller state remains consistent."""
+        faulty_native = _FaultyNative(fail_set_decorated=True)
+        win = _FaultyWindow(native=faulty_native, fail_resize=True, fail_move=True)
+        wc = WindowController(window=win)
+
+        # Dispatched action fails silently in _dispatch_main_loop
+        r = wc.set_presence_mode(True)
+        assert r["ok"] is True
+        assert wc.window_state()["mode"] == "presence"
+
+        exit_r = wc.set_presence_mode(False)
+        assert exit_r["ok"] is True
+        assert wc.window_state()["mode"] == "companion"
+
+
+class TestBridgeFuzzingAndValidation:
+    """Boundary, typing, and fuzzing attacks on the 4 new window bridge methods."""
+
+    @pytest.fixture
+    def bridge(self) -> DesktopBridge:
+        win = _FaultyWindow()
+        wc = WindowController(window=win)
+        return make_js_api(window_controller=wc)
+
+    @pytest.mark.parametrize(
+        "bad_input",
+        [
+            1,  # int 1 must NOT be accepted as bool
+            0,  # int 0 must NOT be accepted as bool
+            -1,
+            100,
+            1.0,
+            0.0,
+            float("nan"),
+            float("inf"),
+            "true",
+            "True",
+            "false",
+            "False",
+            "",
+            None,
+            [],
+            [True],
+            {},
+            {"ok": True},
+            set(),
+            object(),
+            b"true",
+        ],
+    )
+    def test_set_presence_mode_rejects_non_booleans(
+        self, bridge: DesktopBridge, bad_input: Any
+    ) -> None:
+        res = bridge.set_presence_mode(bad_input)
+        assert res["ok"] is False
+        assert res["code"] == "invalid_input"
+        payload_str = json.dumps(res)
+        assert "Traceback" not in payload_str
+        assert f"'{type(bad_input).__name__}'" not in payload_str or bad_input in (1, 0)
+
+    @pytest.mark.parametrize(
+        "bad_input",
+        [
+            1,
+            0,
+            "true",
+            "false",
+            None,
+            [],
+            {},
+            1.5,
+        ],
+    )
+    def test_set_always_on_top_rejects_non_booleans(
+        self, bridge: DesktopBridge, bad_input: Any
+    ) -> None:
+        res = bridge.set_always_on_top(bad_input)
+        assert res["ok"] is False
+        assert res["code"] == "invalid_input"
+
+    def test_arity_attacks_on_all_window_methods(
+        self, bridge: DesktopBridge
+    ) -> None:
+        # set_presence_mode takes exactly 1 arg
+        assert bridge.set_presence_mode()["ok"] is False
+        assert bridge.set_presence_mode(True, True)["ok"] is False
+        assert bridge.set_presence_mode(True, "extra", 123)["ok"] is False
+
+        # set_always_on_top takes exactly 1 arg
+        assert bridge.set_always_on_top()["ok"] is False
+        assert bridge.set_always_on_top(True, False)["ok"] is False
+
+        # window_state takes 0 args
+        assert bridge.window_state(True)["ok"] is False
+        assert bridge.window_state(1)["ok"] is False
+        assert bridge.window_state(None)["ok"] is False
+
+        # close_window takes 0 args
+        assert bridge.close_window(True)["ok"] is False
+        assert bridge.close_window("now")["ok"] is False
+
+
+class TestNavigationFailClosedSecurityForWindowOps:
+    """Verify that NavigationPolicy and LocalBuildBridge lock down all 4 window ops."""
+
+    def test_all_window_ops_fail_closed_on_untrusted_navigation(
+        self, tmp_path
+    ) -> None:
+        dist = tmp_path / "dist"
+        dist.mkdir()
+        entry = dist / "index-desktop.html"
+        entry.write_text("<!doctype html><title>Katherine</title>")
+        build = ResolvedBuild(dist_dir=dist, index_html=entry, desktop_html=entry)
+
+        win = _FaultyWindow()
+        wc = WindowController(window=win)
+        bridge = make_js_api(window_controller=wc)
+
+        current_url = ["https://malicious-site.com/evil.html"]
+        local_bridge = LocalBuildBridge(
+            bridge=bridge,
+            build=build,
+            get_url=lambda: current_url[0],
+        )
+
+        for op in ("set_presence_mode", "set_always_on_top"):
+            res = getattr(local_bridge, op)(True)
+            assert res["ok"] is False
+            assert res["code"] == "bridge_unavailable"
+
+        for op in ("window_state", "close_window"):
+            res = getattr(local_bridge, op)()
+            assert res["ok"] is False
+            assert res["code"] == "bridge_unavailable"

--- a/backend/tests/test_desktop_adversarial.py
+++ b/backend/tests/test_desktop_adversarial.py
@@ -396,6 +396,81 @@ class TestWindowControllerFaultTolerance:
         assert res["ok"] is False
         assert res["code"] == "window_mutation_failed"
 
+    def test_reconcile_geometry_move_failure_preserves_state_and_clears_guard(self) -> None:
+        """When native move fails during reconciliation in presence mode,
+
+        state does NOT advance to unapplied coordinates, native geometry is untouched,
+        sanitized error is returned, and reentrancy guard is released.
+        """
+        win = _FaultyWindow()
+        win.native.position = (100, 150)
+        win.native.size = (200, 200)
+        wc = WindowController(window=win, workareas=[WorkArea(0, 0, 1920, 1080)])
+
+        # Enter presence mode: initial state committed
+        r = wc.set_presence_mode(True)
+        assert r["ok"] is True
+        st_before = wc.window_state()
+        assert st_before["x"] == 100
+        assert st_before["y"] == 150
+        assert st_before["width"] == 200
+        assert st_before["height"] == 200
+
+        # Inject failure on move
+        win.fail_move = True
+
+        # Attempt to reconcile out-of-bounds coords (e.g. -400, -400)
+        res = wc.reconcile_geometry(x=-400, y=-400)
+        assert res["ok"] is False
+        assert res["code"] == "window_mutation_failed"
+        assert res["message"] == "The window operation could not be completed."
+
+        # Native geometry must remain untouched
+        assert win.native.position == (100, 150)
+        assert win.x == 100
+        assert win.y == 150
+
+        # Logical window_state must NOT advance to clamped (0, 0)
+        st_after = wc.window_state()
+        assert st_after["x"] == 100
+        assert st_after["y"] == 150
+        assert st_after["width"] == 200
+        assert st_after["height"] == 200
+
+        # Reentrancy guard must be cleared
+        assert wc._is_reconciling is False
+
+        # Clear fault and verify subsequent reconciliation succeeds
+        win.fail_move = False
+        res_recovered = wc.reconcile_geometry(x=-400, y=-400)
+        assert res_recovered["ok"] is True
+        assert res_recovered["clamped"] is True
+        assert res_recovered["x"] == 0
+        assert res_recovered["y"] == 0
+        assert win.native.position == (0, 0)
+        st_final = wc.window_state()
+        assert st_final["x"] == 0
+        assert st_final["y"] == 0
+
+    def test_reconcile_geometry_resize_failure_preserves_state_and_clears_guard(self) -> None:
+        """When native resize fails during reconciliation, state does not advance and guard is cleared."""
+        win = _FaultyWindow()
+        win.native.position = (100, 150)
+        win.native.size = (200, 200)
+        wc = WindowController(window=win, workareas=[WorkArea(0, 0, 1920, 1080)])
+
+        r = wc.set_presence_mode(True)
+        assert r["ok"] is True
+
+        win.fail_resize = True
+        win.native.size = (80, 80)  # less than min_size 120, requiring resize to 120
+        win.width = 80
+        res = wc.reconcile_geometry(x=100, y=150)
+        assert res["ok"] is False
+        assert res["code"] == "window_mutation_failed"
+        assert res["message"] == "The window operation could not be completed."
+        assert wc._is_reconciling is False
+
     def test_dispatch_sync_timeout_returns_timeout_code(self, monkeypatch) -> None:
         """When an operation exceeds timeout, code 'timeout' is returned."""
         class FakeMainContext:

--- a/backend/tests/test_desktop_adversarial.py
+++ b/backend/tests/test_desktop_adversarial.py
@@ -20,9 +20,12 @@ from backend.desktop.api import (
     make_js_api,
 )
 from backend.desktop.app import (
+    ClampedGeometry,
     LocalBuildBridge,
     NavigationPolicy,
     WindowController,
+    WorkArea,
+    clamp_window_geometry,
 )
 from backend.desktop.build_resolver import ResolvedBuild
 
@@ -72,9 +75,11 @@ class _FaultyWindow:
         fail_resize: bool = False,
         fail_move: bool = False,
         fail_destroy: bool = False,
+        fail_on_top: bool = False,
+        fail_minimize: bool = False,
     ) -> None:
         self.native = native if native is not None else _FaultyNative()
-        self.on_top = False
+        self._on_top = False
         self.width = 1280
         self.height = 800
         self.x = 100
@@ -82,7 +87,20 @@ class _FaultyWindow:
         self.fail_resize = fail_resize
         self.fail_move = fail_move
         self.fail_destroy = fail_destroy
+        self.fail_on_top = fail_on_top
+        self.fail_minimize = fail_minimize
         self.destroyed = False
+        self.minimized = False
+
+    @property
+    def on_top(self) -> bool:
+        return self._on_top
+
+    @on_top.setter
+    def on_top(self, val: bool) -> None:
+        if self.fail_on_top:
+            raise RuntimeError("Always on top fault")
+        self._on_top = val
 
     def resize(self, w: int, h: int) -> None:
         if self.fail_resize:
@@ -99,6 +117,11 @@ class _FaultyWindow:
         self.y = y
         if self.native:
             self.native.position = (x, y)
+
+    def minimize(self) -> None:
+        if self.fail_minimize:
+            raise RuntimeError("Window minimize fault")
+        self.minimized = True
 
     def destroy(self) -> None:
         if self.fail_destroy:
@@ -229,20 +252,364 @@ class TestWindowControllerFaultTolerance:
         assert exit_r["width"] == 1200
         assert exit_r["height"] == 700
 
-    def test_native_mutation_exceptions_do_not_crash_controller(self) -> None:
-        """When native window methods raise during dispatch, controller state remains consistent."""
+    def test_set_decorated_failure_returns_error_and_preserves_companion_state(self) -> None:
+        """When set_decorated fails, mode transition fails and state remains companion."""
         faulty_native = _FaultyNative(fail_set_decorated=True)
-        win = _FaultyWindow(native=faulty_native, fail_resize=True, fail_move=True)
+        win = _FaultyWindow(native=faulty_native)
         wc = WindowController(window=win)
 
-        # Dispatched action fails silently in _dispatch_main_loop
-        r = wc.set_presence_mode(True)
-        assert r["ok"] is True
+        res = wc.set_presence_mode(True)
+        assert res["ok"] is False
+        assert res["code"] == "window_mutation_failed"
+        assert res["message"] == "The window operation could not be completed."
+        assert wc.window_state()["mode"] == "companion"
+
+    def test_resize_failure_on_presence_rolls_back_decoration_and_preserves_mode(self) -> None:
+        """When resize fails entering presence, decoration is rolled back and mode remains companion."""
+        faulty_native = _FaultyNative()
+        win = _FaultyWindow(native=faulty_native, fail_resize=True)
+        wc = WindowController(window=win)
+
+        res = wc.set_presence_mode(True)
+        assert res["ok"] is False
+        assert res["code"] == "window_mutation_failed"
+        assert res["message"] == "The window operation could not be completed."
+        assert wc.window_state()["mode"] == "companion"
+        assert win.native.decorated is True
+
+    def test_resize_failure_on_companion_preserves_presence_mode(self) -> None:
+        """When resize fails returning to companion, state remains presence and decoration is rolled back."""
+        win = _FaultyWindow()
+        wc = WindowController(window=win)
+
+        enter_res = wc.set_presence_mode(True)
+        assert enter_res["ok"] is True
+        assert wc.window_state()["mode"] == "presence"
+        assert win.native.decorated is False
+
+        win.fail_resize = True
+        exit_res = wc.set_presence_mode(False)
+        assert exit_res["ok"] is False
+        assert exit_res["code"] == "window_mutation_failed"
+        assert wc.window_state()["mode"] == "presence"
+        assert win.native.decorated is False
+
+    def test_move_failure_on_companion_preserves_presence_mode(self) -> None:
+        """When move fails returning to companion, state remains presence and decoration/size are rolled back."""
+        win = _FaultyWindow()
+        wc = WindowController(window=win)
+
+        enter_res = wc.set_presence_mode(True)
+        assert enter_res["ok"] is True
+        assert wc.window_state()["mode"] == "presence"
+        assert win.native.decorated is False
+
+        win.fail_move = True
+        exit_res = wc.set_presence_mode(False)
+        assert exit_res["ok"] is False
+        assert exit_res["code"] == "window_mutation_failed"
+        assert wc.window_state()["mode"] == "presence"
+        assert win.native.decorated is False
+        assert (win.width, win.height) == (200, 200)
+
+    def test_companion_mutation_failure_rolls_back_decoration(self) -> None:
+        """BUG-M1-01 regression: resize or move failure when returning to companion rolls back decoration to False."""
+        for failure_attr in ("fail_resize", "fail_move"):
+            win = _FaultyWindow()
+            wc = WindowController(window=win)
+
+            enter_res = wc.set_presence_mode(True)
+            assert enter_res["ok"] is True
+            assert wc.window_state()["mode"] == "presence"
+            assert win.native.decorated is False
+
+            setattr(win, failure_attr, True)
+            exit_res = wc.set_presence_mode(False)
+            assert exit_res["ok"] is False
+            assert exit_res["code"] == "window_mutation_failed"
+            assert exit_res["message"] == "The window operation could not be completed."
+            assert wc.window_state()["mode"] == "presence"
+            assert win.native.decorated is False, (
+                f"Decoration was left as True after {failure_attr} failure returning to companion"
+            )
+
+    def test_presence_move_failure_rolls_back_resize_and_decoration(self) -> None:
+        """Compound rollback: When move fails entering presence, resize and decoration are rolled back."""
+        win = _FaultyWindow(fail_move=True)
+        win.width, win.height = 1280, 800
+        win.x, win.y = 5000, 5000
+        win.native.position = (5000, 5000)
+        wc = WindowController(window=win, workareas=[WorkArea(0, 0, 1920, 1080)])
+
+        res = wc.set_presence_mode(True)
+        assert res["ok"] is False
+        assert res["code"] == "window_mutation_failed"
+        assert (win.width, win.height) == (1280, 800)
+        assert win.native.decorated is True
+        assert wc.window_state()["mode"] == "companion"
+
+    def test_companion_move_failure_rolls_back_resize_and_decoration(self) -> None:
+        """Compound rollback: When move fails returning to companion, resize and decoration are rolled back."""
+        win = _FaultyWindow()
+        win.x, win.y = 5000, 5000
+        win.native.position = (5000, 5000)
+        wc = WindowController(window=win, workareas=[WorkArea(0, 0, 1920, 1080)])
+
+        enter_res = wc.set_presence_mode(True)
+        assert enter_res["ok"] is True
+        assert (win.width, win.height) == (200, 200)
+        assert win.native.decorated is False
+
+        win.fail_move = True
+        exit_res = wc.set_presence_mode(False)
+        assert exit_res["ok"] is False
+        assert exit_res["code"] == "window_mutation_failed"
+        assert (win.width, win.height) == (200, 200)
+        assert win.native.decorated is False
         assert wc.window_state()["mode"] == "presence"
 
-        exit_r = wc.set_presence_mode(False)
-        assert exit_r["ok"] is True
+    def test_set_always_on_top_failure_preserves_state(self) -> None:
+        """When setting always_on_top raises natively, state is not committed."""
+        win = _FaultyWindow(fail_on_top=True)
+        wc = WindowController(window=win)
+
+        res = wc.set_always_on_top(True)
+        assert res["ok"] is False
+        assert res["code"] == "window_mutation_failed"
+        assert wc.window_state()["on_top"] is False
+
+    def test_close_window_failure_returns_error(self) -> None:
+        """When window destroy raises natively, sanitized error is returned."""
+        win = _FaultyWindow(fail_destroy=True)
+        wc = WindowController(window=win)
+
+        res = wc.close_window()
+        assert res["ok"] is False
+        assert res["code"] == "window_mutation_failed"
+
+    def test_minimize_window_failure_returns_error(self) -> None:
+        """When window minimize raises natively, sanitized error is returned."""
+        win = _FaultyWindow(fail_minimize=True)
+        wc = WindowController(window=win)
+
+        res = wc.minimize_window()
+        assert res["ok"] is False
+        assert res["code"] == "window_mutation_failed"
+
+    def test_dispatch_sync_timeout_returns_timeout_code(self, monkeypatch) -> None:
+        """When an operation exceeds timeout, code 'timeout' is returned."""
+        class FakeMainContext:
+            def is_owner(self) -> bool:
+                return False
+
+        class FakeGLib:
+            class MainContext:
+                @staticmethod
+                def default():
+                    return FakeMainContext()
+
+            @staticmethod
+            def idle_add(cb: Any) -> Any:
+                return False
+
+        import types
+        import sys
+
+        fake_gi_repo = types.ModuleType("gi.repository")
+        fake_gi_repo.GLib = FakeGLib  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "gi.repository", fake_gi_repo)
+
+        fake_wgtk = types.ModuleType("webview.platforms.gtk")
+        fake_wgtk._app = object()  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "webview.platforms.gtk", fake_wgtk)
+
+        win = _FaultyWindow()
+        wc = WindowController(window=win, dispatch_timeout=0.05)
+        res = wc.set_presence_mode(True)
+        assert res["ok"] is False
+        assert res["code"] == "timeout"
+        assert res["message"] == "The window operation could not be completed."
+
+    def test_delayed_glib_callback_after_timeout_does_not_mutate_native_window(
+        self, monkeypatch
+    ) -> None:
+        """BUG-M1-02 regression: Delayed GLib callback after timeout must not execute native mutations.
+
+        When _dispatch_sync times out on a worker thread, the queued GLib callback
+        must be cancelled. When the main loop later drains idle sources, the callback
+        must return False immediately without mutating native window state (decorations,
+        geometry, or size).
+        """
+        idle_queue: list[Any] = []
+
+        class FakeMainContext:
+            def is_owner(self) -> bool:
+                return False
+
+        class FakeGLib:
+            class MainContext:
+                @staticmethod
+                def default() -> FakeMainContext:
+                    return FakeMainContext()
+
+            @staticmethod
+            def idle_add(cb: Any) -> int:
+                idle_queue.append(cb)
+                return len(idle_queue)
+
+            @staticmethod
+            def source_remove(source_id: int) -> bool:
+                return True
+
+        import sys
+        import types
+
+        fake_gi_repo = types.ModuleType("gi.repository")
+        fake_gi_repo.GLib = FakeGLib  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "gi.repository", fake_gi_repo)
+
+        fake_wgtk = types.ModuleType("webview.platforms.gtk")
+        fake_wgtk._app = object()  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "webview.platforms.gtk", fake_wgtk)
+
+        win = _FaultyWindow()
+        wc = WindowController(window=win, dispatch_timeout=0.05)
+
+        res = wc.set_presence_mode(True)
+        assert res["ok"] is False
+        assert res["code"] == "timeout"
+        assert res["message"] == "The window operation could not be completed."
         assert wc.window_state()["mode"] == "companion"
+        assert len(idle_queue) == 1
+
+        # Simulate GTK main loop resuming and draining delayed callbacks
+        for cb in idle_queue:
+            ret = cb()
+            assert ret is False, "Cancelled callback must return False to unregister from GLib"
+
+        # CRITICAL: Native window must not have been modified by the delayed callback
+        assert win.native.decorated is True, (
+            "BUG-M1-02 regression: Delayed callback undecorated native window after timeout"
+        )
+        assert (win.width, win.height) == (1280, 800), (
+            f"BUG-M1-02 regression: Delayed callback resized native window to ({win.width}, {win.height})"
+        )
+        assert (win.x, win.y) == (100, 150)
+        assert wc.window_state()["mode"] == "companion"
+
+    @pytest.mark.parametrize(
+        ("op_name", "action_fn", "mutation_check"),
+        [
+            (
+                "on_top",
+                lambda wc: wc.set_always_on_top(True),
+                lambda win: win.on_top is False,
+            ),
+            (
+                "minimize",
+                lambda wc: wc.minimize_window(),
+                lambda win: win.minimized is False,
+            ),
+            (
+                "close",
+                lambda wc: wc.close_window(),
+                lambda win: win.destroyed is False,
+            ),
+        ],
+    )
+    def test_delayed_glib_callbacks_all_mutations_cancelled_after_timeout(
+        self, monkeypatch, op_name: str, action_fn: Any, mutation_check: Any
+    ) -> None:
+        """BUG-M1-02 regression: All native mutators must cancel delayed callbacks on timeout."""
+        idle_queue: list[Any] = []
+
+        class FakeMainContext:
+            def is_owner(self) -> bool:
+                return False
+
+        class FakeGLib:
+            class MainContext:
+                @staticmethod
+                def default() -> FakeMainContext:
+                    return FakeMainContext()
+
+            @staticmethod
+            def idle_add(cb: Any) -> int:
+                idle_queue.append(cb)
+                return len(idle_queue)
+
+            @staticmethod
+            def source_remove(source_id: int) -> bool:
+                return True
+
+        import sys
+        import types
+
+        fake_gi_repo = types.ModuleType("gi.repository")
+        fake_gi_repo.GLib = FakeGLib  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "gi.repository", fake_gi_repo)
+
+        fake_wgtk = types.ModuleType("webview.platforms.gtk")
+        fake_wgtk._app = object()  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "webview.platforms.gtk", fake_wgtk)
+
+        win = _FaultyWindow()
+        wc = WindowController(window=win, dispatch_timeout=0.05)
+
+        res = action_fn(wc)
+        assert res["ok"] is False
+        assert res["code"] == "timeout"
+        assert len(idle_queue) == 1
+
+        for cb in idle_queue:
+            ret = cb()
+            assert ret is False
+
+        assert mutation_check(win), f"Delayed mutation occurred for operation '{op_name}' after timeout!"
+
+    def test_window_controller_fails_closed_when_native_capability_missing(self) -> None:
+        """Verify set_always_on_top, minimize_window, close_window fail closed if native capability missing."""
+        class BareWindow:
+            pass
+
+        win = BareWindow()
+        wc = WindowController(window=win)
+
+        res_on_top = wc.set_always_on_top(True)
+        assert res_on_top["ok"] is False
+        assert res_on_top["code"] == "window_mutation_failed"
+        assert wc.window_state()["on_top"] is False
+
+        res_min = wc.minimize_window()
+        assert res_min["ok"] is False
+        assert res_min["code"] == "window_mutation_failed"
+
+        res_close = wc.close_window()
+        assert res_close["ok"] is False
+        assert res_close["code"] == "window_mutation_failed"
+
+    def test_bridge_exception_containment(self) -> None:
+        """Verify no unhandled exceptions cross the DesktopBridge boundary to JS."""
+        faulty_win = _FaultyWindow(
+            fail_resize=True,
+            fail_move=True,
+            fail_destroy=True,
+            fail_on_top=True,
+            fail_minimize=True,
+        )
+        wc = WindowController(window=faulty_win)
+        bridge = make_js_api(window_controller=wc)
+
+        for call, kwargs in [
+            (bridge.set_presence_mode, {"args": (True,)}),
+            (bridge.set_always_on_top, {"args": (True,)}),
+            (bridge.minimize_window, {"args": ()}),
+            (bridge.close_window, {"args": ()}),
+        ]:
+            res = call(*kwargs["args"])
+            assert isinstance(res, dict)
+            assert res["ok"] is False
+            assert res["code"] == "window_mutation_failed"
 
 
 class TestBridgeFuzzingAndValidation:
@@ -331,9 +698,13 @@ class TestBridgeFuzzingAndValidation:
         assert bridge.close_window(True)["ok"] is False
         assert bridge.close_window("now")["ok"] is False
 
+        # minimize_window takes 0 args
+        assert bridge.minimize_window(True)["ok"] is False
+        assert bridge.minimize_window("now")["ok"] is False
+
 
 class TestNavigationFailClosedSecurityForWindowOps:
-    """Verify that NavigationPolicy and LocalBuildBridge lock down all 4 window ops."""
+    """Verify that NavigationPolicy and LocalBuildBridge lock down all window ops."""
 
     def test_all_window_ops_fail_closed_on_untrusted_navigation(
         self, tmp_path
@@ -360,7 +731,111 @@ class TestNavigationFailClosedSecurityForWindowOps:
             assert res["ok"] is False
             assert res["code"] == "bridge_unavailable"
 
-        for op in ("window_state", "close_window"):
+        for op in ("window_state", "close_window", "minimize_window"):
             res = getattr(local_bridge, op)()
             assert res["ok"] is False
             assert res["code"] == "bridge_unavailable"
+
+
+class TestGeometryClamping:
+    """Pure unit tests for clamp_window_geometry covering all 11 multi-monitor scenarios."""
+
+    def test_scenario_1_fully_inside(self) -> None:
+        """Window fully inside workarea remains unchanged."""
+        wa = [WorkArea(0, 0, 1920, 1080)]
+        target = (100, 100, 1280, 800)
+        clamped = clamp_window_geometry(target, wa)
+        assert clamped == ClampedGeometry(100, 100, 1280, 800)
+
+    def test_scenario_2_partially_left(self) -> None:
+        """Window overflowing to the left is clamped to workarea left bound."""
+        wa = [WorkArea(0, 0, 1920, 1080)]
+        target = (-100, 100, 1280, 800)
+        clamped = clamp_window_geometry(target, wa)
+        assert clamped == ClampedGeometry(0, 100, 1280, 800)
+
+    def test_scenario_3_partially_right(self) -> None:
+        """Window overflowing to the right is clamped to workarea right bound."""
+        wa = [WorkArea(0, 0, 1920, 1080)]
+        target = (1000, 100, 1280, 800)
+        clamped = clamp_window_geometry(target, wa)
+        assert clamped == ClampedGeometry(640, 100, 1280, 800)
+
+    def test_scenario_4_partially_top_with_panel(self) -> None:
+        """Window obscured by top OS panel is clamped below panel."""
+        wa = [WorkArea(0, 32, 1920, 1048)]
+        target = (100, 10, 1280, 800)
+        clamped = clamp_window_geometry(target, wa)
+        assert clamped == ClampedGeometry(100, 32, 1280, 800)
+
+    def test_scenario_5_partially_bottom_with_dock(self) -> None:
+        """Window obscured by bottom OS dock is clamped above dock."""
+        wa = [WorkArea(0, 0, 1920, 1000)]
+        target = (100, 400, 1280, 800)
+        clamped = clamp_window_geometry(target, wa)
+        assert clamped == ClampedGeometry(100, 200, 1280, 800)
+
+    def test_scenario_6_valid_negative_x_left_monitor(self) -> None:
+        """Negative X coordinates in multi-monitor left setup are preserved."""
+        was = [WorkArea(0, 0, 1920, 1080), WorkArea(-1920, 0, 1920, 1080)]
+        target = (-1500, 200, 1280, 800)
+        clamped = clamp_window_geometry(target, was, primary_index=0)
+        assert clamped == ClampedGeometry(-1500, 200, 1280, 800)
+
+    def test_scenario_7_valid_negative_y_top_monitor(self) -> None:
+        """Negative Y coordinates in multi-monitor top setup are preserved."""
+        was = [WorkArea(0, 0, 1920, 1080), WorkArea(0, -1080, 1920, 1080)]
+        target = (100, -800, 1280, 800)
+        clamped = clamp_window_geometry(target, was, primary_index=0)
+        assert clamped == ClampedGeometry(100, -800, 1280, 800)
+
+    def test_scenario_8_vanished_monitor_recovery(self) -> None:
+        """Window previously on disconnected monitor is recovered onto remaining primary."""
+        wa = [WorkArea(0, 0, 1920, 1080)]
+        target = (-1500, 200, 1280, 800)
+        clamped = clamp_window_geometry(target, wa)
+        assert clamped == ClampedGeometry(0, 200, 1280, 800)
+
+    def test_scenario_9_reduced_resolution(self) -> None:
+        """Window larger than shrunken display resolution is dimension-clamped."""
+        wa = [WorkArea(0, 0, 1024, 768)]
+        target = (0, 0, 1280, 800)
+        clamped = clamp_window_geometry(target, wa)
+        assert clamped == ClampedGeometry(0, 0, 1024, 768)
+
+    def test_scenario_10_presence_recovery(self) -> None:
+        """Presence window placed at screen boundary is fully visible with reachable controls."""
+        wa = [WorkArea(0, 0, 1920, 1080)]
+        target = (1900, 1000, 200, 200)
+        clamped = clamp_window_geometry(target, wa)
+        assert clamped == ClampedGeometry(1720, 880, 200, 200)
+
+    def test_scenario_11_unpositioned_companion_restore_centers_on_primary(self) -> None:
+        """Unpositioned window restores centered on primary workarea."""
+        wa = [WorkArea(0, 0, 1920, 1080)]
+        target = (None, None, 1280, 800)
+        clamped = clamp_window_geometry(target, wa)
+        assert clamped == ClampedGeometry(320, 140, 1280, 800)
+
+    def test_window_controller_integrates_geometry_clamping(self) -> None:
+        """WindowController clamps presence and companion mode when workareas exist."""
+        win = _FaultyWindow()
+        win.native.position = (1200, 1000)
+        win.native.size = (1400, 900)
+        wc = WindowController(
+            window=win, workareas=[WorkArea(0, 0, 1280, 800)]
+        )
+
+        # Enter presence: position (1200, 1000, 200, 200) clamped to (1080, 600, 200, 200)
+        r_pres = wc.set_presence_mode(True)
+        assert r_pres["ok"] is True
+        assert win.x == 1080
+        assert win.y == 600
+
+        # Return companion: saved (1200, 1000, 1400, 900) clamped to (0, 0, 1280, 800)
+        r_comp = wc.set_presence_mode(False)
+        assert r_comp["ok"] is True
+        assert win.x == 0
+        assert win.y == 0
+        assert win.width == 1280
+        assert win.height == 800

--- a/backend/tests/test_desktop_api.py
+++ b/backend/tests/test_desktop_api.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import sys
 from pathlib import Path
 
 import backend.desktop.api as desktop_api_module
@@ -35,7 +36,7 @@ from backend.desktop.api import (
     DesktopApiError,
     make_js_api,
 )
-from backend.desktop.app import LocalBuildBridge, is_local_build_url
+from backend.desktop.app import LocalBuildBridge, WindowController, is_local_build_url
 from backend.desktop.build_resolver import ResolvedBuild
 
 
@@ -146,6 +147,10 @@ class TestRealBoundarySanitization:
             "delete_memories",
             "reset_emotional_state",
             "reset_relationship_state",
+            "set_presence_mode",
+            "set_always_on_top",
+            "window_state",
+            "close_window",
         )
 
     def test_api_exposes_no_generic_objects(self) -> None:
@@ -228,6 +233,10 @@ class TestCompanionAllowlist:
             "delete_memories",
             "reset_emotional_state",
             "reset_relationship_state",
+            "set_presence_mode",
+            "set_always_on_top",
+            "window_state",
+            "close_window",
         )
 
     def test_facade_exposes_exactly_the_allowlist(self) -> None:
@@ -403,3 +412,254 @@ class TestCompanionSanitization:
         serialized = json.dumps(bridge.load_history(object()))
         assert "object" not in serialized.lower() or "object_at" not in serialized
         assert "Traceback" not in serialized
+
+
+# =========================================================================
+# #342 extension: window lifecycle & floating presence mode surface
+# =========================================================================
+
+
+class _MockNative:
+    def __init__(self, x: int = 100, y: int = 150, w: int = 1280, h: int = 800) -> None:
+        self.decorated = True
+        self.position = (x, y)
+        self.size = (w, h)
+
+    def set_decorated(self, val: bool) -> None:
+        self.decorated = val
+
+    def get_position(self) -> tuple[int, int]:
+        return self.position
+
+    def get_size(self) -> tuple[int, int]:
+        return self.size
+
+
+class _MockWindow:
+    def __init__(self) -> None:
+        self.native = _MockNative()
+        self.on_top = False
+        self.resized: tuple[int, int] | None = None
+        self.moved: tuple[int, int] | None = None
+        self.destroyed = False
+
+    def resize(self, w: int, h: int) -> None:
+        self.resized = (w, h)
+        self.native.size = (w, h)
+
+    def move(self, x: int, y: int) -> None:
+        self.moved = (x, y)
+        self.native.position = (x, y)
+
+    def destroy(self) -> None:
+        self.destroyed = True
+
+
+class _StubWindowController:
+    """Deterministic window controller double for bridge testing."""
+
+    def __init__(self) -> None:
+        self.calls: list[Any] = []
+        self.mode = "companion"
+        self.on_top = False
+
+    def set_presence_mode(self, enabled: bool) -> dict:
+        self.calls.append(("set_presence_mode", enabled))
+        self.mode = "presence" if enabled else "companion"
+        self.on_top = enabled
+        return {
+            "ok": True,
+            "mode": self.mode,
+            "on_top": self.on_top,
+            "width": 200 if enabled else 1280,
+            "height": 200 if enabled else 800,
+        }
+
+    def set_always_on_top(self, enabled: bool) -> dict:
+        self.calls.append(("set_always_on_top", enabled))
+        self.on_top = enabled
+        return {"ok": True, "on_top": enabled}
+
+    def window_state(self) -> dict:
+        self.calls.append("window_state")
+        return {
+            "ok": True,
+            "mode": self.mode,
+            "on_top": self.on_top,
+            "width": 200 if self.mode == "presence" else 1280,
+            "height": 200 if self.mode == "presence" else 800,
+        }
+
+    def close_window(self) -> dict:
+        self.calls.append("close_window")
+        return {"ok": True}
+
+
+class TestWindowControllerDirect:
+    """Direct tests for WindowController native mutations and thread-safe state."""
+
+    def test_window_controller_initial_state(self) -> None:
+        win = _MockWindow()
+        wc = WindowController(window=win)
+        state = wc.window_state()
+        assert state == {
+            "ok": True,
+            "mode": "companion",
+            "on_top": False,
+            "width": 1280,
+            "height": 800,
+        }
+
+    def test_presence_mode_roundtrip(self) -> None:
+        win = _MockWindow()
+        wc = WindowController(window=win)
+
+        # 1. Switch to presence
+        enter_res = wc.set_presence_mode(True)
+        assert enter_res == {
+            "ok": True,
+            "mode": "presence",
+            "on_top": True,
+            "width": 200,
+            "height": 200,
+        }
+        assert win.native.decorated is False
+        assert win.resized == (200, 200)
+        assert win.on_top is True
+        assert wc.window_state()["mode"] == "presence"
+
+        # 2. Switch back to companion (restores saved geometry)
+        exit_res = wc.set_presence_mode(False)
+        assert exit_res == {
+            "ok": True,
+            "mode": "companion",
+            "on_top": False,
+            "width": 1280,
+            "height": 800,
+        }
+        assert win.native.decorated is True
+        assert win.resized == (1280, 800)
+        assert win.moved == (100, 150)
+        assert win.on_top is False
+        assert wc.window_state()["mode"] == "companion"
+
+    def test_set_always_on_top(self) -> None:
+        win = _MockWindow()
+        wc = WindowController(window=win)
+        res = wc.set_always_on_top(True)
+        assert res == {"ok": True, "on_top": True}
+        assert win.on_top is True
+        assert wc.window_state()["on_top"] is True
+
+        res_off = wc.set_always_on_top(False)
+        assert res_off == {"ok": True, "on_top": False}
+        assert win.on_top is False
+
+    def test_close_window(self) -> None:
+        win = _MockWindow()
+        wc = WindowController(window=win)
+        assert wc.close_window() == {"ok": True}
+        assert win.destroyed is True
+
+    def test_controller_without_window_fails_closed(self) -> None:
+        wc = WindowController(window=None)
+        assert wc.set_presence_mode(True)["ok"] is False
+        assert wc.set_presence_mode(True)["code"] == "window_unavailable"
+        assert wc.set_always_on_top(True)["code"] == "window_unavailable"
+        assert wc.close_window()["code"] == "window_unavailable"
+        # window_state returns local snapshot safely
+        assert wc.window_state()["ok"] is True
+
+    def test_glib_idle_add_dispatch_when_available(self, monkeypatch) -> None:
+        idle_calls: list[Any] = []
+
+        class FakeGLib:
+            @staticmethod
+            def idle_add(cb: Any) -> Any:
+                idle_calls.append(cb)
+                return cb()
+
+        import types
+
+        fake_gi_repo = types.ModuleType("gi.repository")
+        fake_gi_repo.GLib = FakeGLib  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "gi.repository", fake_gi_repo)
+
+        win = _MockWindow()
+        wc = WindowController(window=win)
+        wc.set_presence_mode(True)
+        assert len(idle_calls) == 1
+        assert win.native.decorated is False
+
+
+class TestWindowBridgeContract:
+    """Bridge facade behavior and argument validation for window operations."""
+
+    def test_window_operations_through_bridge(self) -> None:
+        wc = _StubWindowController()
+        bridge = make_js_api(window_controller=wc)
+
+        enter = bridge.set_presence_mode(True)
+        assert enter["ok"] is True
+        assert enter["mode"] == "presence"
+        assert ("set_presence_mode", True) in wc.calls
+
+        pin = bridge.set_always_on_top(True)
+        assert pin["ok"] is True
+        assert pin["on_top"] is True
+        assert ("set_always_on_top", True) in wc.calls
+
+        state = bridge.window_state()
+        assert state["ok"] is True
+        assert state["mode"] == "presence"
+
+        close = bridge.close_window()
+        assert close["ok"] is True
+        assert "close_window" in wc.calls
+
+    def test_set_presence_mode_validates_argument(self) -> None:
+        wc = _StubWindowController()
+        bridge = make_js_api(window_controller=wc)
+
+        # Non-boolean inputs must be rejected
+        for bad in ("true", 1, 0, None, [True], {"enabled": True}):
+            res = bridge.set_presence_mode(bad)
+            assert res["ok"] is False
+            assert res["code"] == "invalid_input"
+
+        # Wrong arity
+        assert bridge.set_presence_mode()["ok"] is False
+        assert bridge.set_presence_mode(True, False)["ok"] is False
+
+    def test_set_always_on_top_validates_argument(self) -> None:
+        wc = _StubWindowController()
+        bridge = make_js_api(window_controller=wc)
+
+        for bad in ("true", 1, 0, None):
+            res = bridge.set_always_on_top(bad)
+            assert res["ok"] is False
+            assert res["code"] == "invalid_input"
+
+        assert bridge.set_always_on_top()["ok"] is False
+        assert bridge.set_always_on_top(True, False)["ok"] is False
+
+    def test_nullary_window_methods_reject_arguments(self) -> None:
+        wc = _StubWindowController()
+        bridge = make_js_api(window_controller=wc)
+
+        assert bridge.window_state("unexpected")["ok"] is False
+        assert bridge.window_state("unexpected")["code"] == "invalid_input"
+        assert bridge.close_window("unexpected")["ok"] is False
+        assert bridge.close_window("unexpected")["code"] == "invalid_input"
+
+    def test_missing_window_controller_fails_closed(self) -> None:
+        bridge = make_js_api(window_controller=None)
+        for name in ("set_presence_mode", "set_always_on_top"):
+            res = getattr(bridge, name)(True)
+            assert res["ok"] is False
+            assert res["code"] == "window_unavailable"
+
+        for name in ("window_state", "close_window"):
+            res = getattr(bridge, name)()
+            assert res["ok"] is False
+            assert res["code"] == "window_unavailable"

--- a/backend/tests/test_desktop_api.py
+++ b/backend/tests/test_desktop_api.py
@@ -151,6 +151,7 @@ class TestRealBoundarySanitization:
             "set_always_on_top",
             "window_state",
             "close_window",
+            "minimize_window",
         )
 
     def test_api_exposes_no_generic_objects(self) -> None:
@@ -237,6 +238,7 @@ class TestCompanionAllowlist:
             "set_always_on_top",
             "window_state",
             "close_window",
+            "minimize_window",
         )
 
     def test_facade_exposes_exactly_the_allowlist(self) -> None:
@@ -442,6 +444,7 @@ class _MockWindow:
         self.resized: tuple[int, int] | None = None
         self.moved: tuple[int, int] | None = None
         self.destroyed = False
+        self.minimized = False
 
     def resize(self, w: int, h: int) -> None:
         self.resized = (w, h)
@@ -453,6 +456,9 @@ class _MockWindow:
 
     def destroy(self) -> None:
         self.destroyed = True
+
+    def minimize(self) -> None:
+        self.minimized = True
 
 
 class _StubWindowController:
@@ -466,7 +472,6 @@ class _StubWindowController:
     def set_presence_mode(self, enabled: bool) -> dict:
         self.calls.append(("set_presence_mode", enabled))
         self.mode = "presence" if enabled else "companion"
-        self.on_top = enabled
         return {
             "ok": True,
             "mode": self.mode,
@@ -479,6 +484,10 @@ class _StubWindowController:
         self.calls.append(("set_always_on_top", enabled))
         self.on_top = enabled
         return {"ok": True, "on_top": enabled}
+
+    def minimize_window(self) -> dict:
+        self.calls.append("minimize_window")
+        return {"ok": True}
 
     def window_state(self) -> dict:
         self.calls.append("window_state")
@@ -519,13 +528,13 @@ class TestWindowControllerDirect:
         assert enter_res == {
             "ok": True,
             "mode": "presence",
-            "on_top": True,
+            "on_top": False,
             "width": 200,
             "height": 200,
         }
         assert win.native.decorated is False
         assert win.resized == (200, 200)
-        assert win.on_top is True
+        assert win.on_top is False
         assert wc.window_state()["mode"] == "presence"
 
         # 2. Switch back to companion (restores saved geometry)
@@ -543,6 +552,51 @@ class TestWindowControllerDirect:
         assert win.on_top is False
         assert wc.window_state()["mode"] == "companion"
 
+    def test_always_on_top_lifecycle_persistence(self) -> None:
+        """Always-on-top persists independently across mode transitions (#342)."""
+        win = _MockWindow()
+        wc = WindowController(window=win)
+
+        # 1. Startup: on_top is False
+        assert wc.window_state()["on_top"] is False
+        assert win.on_top is False
+
+        # 2. Enter presence: on_top remains False
+        r_presence = wc.set_presence_mode(True)
+        assert r_presence["ok"] is True
+        assert r_presence["on_top"] is False
+        assert win.on_top is False
+
+        # 3. User pins: on_top becomes True
+        r_pin = wc.set_always_on_top(True)
+        assert r_pin["ok"] is True
+        assert r_pin["on_top"] is True
+        assert win.on_top is True
+
+        # 4. Return companion: on_top remains True
+        r_comp = wc.set_presence_mode(False)
+        assert r_comp["ok"] is True
+        assert r_comp["on_top"] is True
+        assert win.on_top is True
+
+        # 5. Enter presence again: on_top remains True
+        r_pres2 = wc.set_presence_mode(True)
+        assert r_pres2["ok"] is True
+        assert r_pres2["on_top"] is True
+        assert win.on_top is True
+
+        # 6. User unpins: on_top becomes False
+        r_unpin = wc.set_always_on_top(False)
+        assert r_unpin["ok"] is True
+        assert r_unpin["on_top"] is False
+        assert win.on_top is False
+
+        # 7. Return companion again: on_top remains False
+        r_comp2 = wc.set_presence_mode(False)
+        assert r_comp2["ok"] is True
+        assert r_comp2["on_top"] is False
+        assert win.on_top is False
+
     def test_set_always_on_top(self) -> None:
         win = _MockWindow()
         wc = WindowController(window=win)
@@ -555,6 +609,13 @@ class TestWindowControllerDirect:
         assert res_off == {"ok": True, "on_top": False}
         assert win.on_top is False
 
+    def test_minimize_window(self) -> None:
+        win = _MockWindow()
+        wc = WindowController(window=win)
+        res = wc.minimize_window()
+        assert res == {"ok": True}
+        assert win.minimized is True
+
     def test_close_window(self) -> None:
         win = _MockWindow()
         wc = WindowController(window=win)
@@ -566,6 +627,7 @@ class TestWindowControllerDirect:
         assert wc.set_presence_mode(True)["ok"] is False
         assert wc.set_presence_mode(True)["code"] == "window_unavailable"
         assert wc.set_always_on_top(True)["code"] == "window_unavailable"
+        assert wc.minimize_window()["code"] == "window_unavailable"
         assert wc.close_window()["code"] == "window_unavailable"
         # window_state returns local snapshot safely
         assert wc.window_state()["ok"] is True
@@ -573,7 +635,16 @@ class TestWindowControllerDirect:
     def test_glib_idle_add_dispatch_when_available(self, monkeypatch) -> None:
         idle_calls: list[Any] = []
 
+        class FakeMainContext:
+            def is_owner(self) -> bool:
+                return False
+
         class FakeGLib:
+            class MainContext:
+                @staticmethod
+                def default():
+                    return FakeMainContext()
+
             @staticmethod
             def idle_add(cb: Any) -> Any:
                 idle_calls.append(cb)
@@ -584,6 +655,10 @@ class TestWindowControllerDirect:
         fake_gi_repo = types.ModuleType("gi.repository")
         fake_gi_repo.GLib = FakeGLib  # type: ignore[attr-defined]
         monkeypatch.setitem(sys.modules, "gi.repository", fake_gi_repo)
+
+        fake_wgtk = types.ModuleType("webview.platforms.gtk")
+        fake_wgtk._app = object()  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "webview.platforms.gtk", fake_wgtk)
 
         win = _MockWindow()
         wc = WindowController(window=win)
@@ -612,6 +687,10 @@ class TestWindowBridgeContract:
         state = bridge.window_state()
         assert state["ok"] is True
         assert state["mode"] == "presence"
+
+        min_res = bridge.minimize_window()
+        assert min_res["ok"] is True
+        assert "minimize_window" in wc.calls
 
         close = bridge.close_window()
         assert close["ok"] is True
@@ -649,6 +728,8 @@ class TestWindowBridgeContract:
 
         assert bridge.window_state("unexpected")["ok"] is False
         assert bridge.window_state("unexpected")["code"] == "invalid_input"
+        assert bridge.minimize_window("unexpected")["ok"] is False
+        assert bridge.minimize_window("unexpected")["code"] == "invalid_input"
         assert bridge.close_window("unexpected")["ok"] is False
         assert bridge.close_window("unexpected")["code"] == "invalid_input"
 
@@ -659,7 +740,7 @@ class TestWindowBridgeContract:
             assert res["ok"] is False
             assert res["code"] == "window_unavailable"
 
-        for name in ("window_state", "close_window"):
+        for name in ("window_state", "close_window", "minimize_window"):
             res = getattr(bridge, name)()
             assert res["ok"] is False
             assert res["code"] == "window_unavailable"

--- a/backend/tests/test_desktop_api.py
+++ b/backend/tests/test_desktop_api.py
@@ -36,7 +36,12 @@ from backend.desktop.api import (
     DesktopApiError,
     make_js_api,
 )
-from backend.desktop.app import LocalBuildBridge, WindowController, is_local_build_url
+from backend.desktop.app import (
+    LocalBuildBridge,
+    WindowController,
+    WorkArea,
+    is_local_build_url,
+)
 from backend.desktop.build_resolver import ResolvedBuild
 
 
@@ -437,9 +442,35 @@ class _MockNative:
         return self.size
 
 
+class _MockEvent:
+    def __init__(self) -> None:
+        self._handlers: list[Any] = []
+
+    def __iadd__(self, handler: Any) -> "_MockEvent":
+        self._handlers.append(handler)
+        return self
+
+    def __isub__(self, handler: Any) -> "_MockEvent":
+        if handler in self._handlers:
+            self._handlers.remove(handler)
+        return self
+
+    def emit(self, *args: Any, **kwargs: Any) -> None:
+        for h in list(self._handlers):
+            h(*args, **kwargs)
+
+
+class _MockWindowEvents:
+    def __init__(self) -> None:
+        self.moved = _MockEvent()
+        self.shown = _MockEvent()
+        self.loaded = _MockEvent()
+
+
 class _MockWindow:
     def __init__(self) -> None:
         self.native = _MockNative()
+        self.events = _MockWindowEvents()
         self.on_top = False
         self.resized: tuple[int, int] | None = None
         self.moved: tuple[int, int] | None = None
@@ -665,6 +696,81 @@ class TestWindowControllerDirect:
         wc.set_presence_mode(True)
         assert len(idle_calls) == 1
         assert win.native.decorated is False
+
+    def test_reconcile_geometry_out_of_bounds_in_presence(self) -> None:
+        """Moving or dragging presence window out of bounds reconciles it back inside usable workarea."""
+        win = _MockWindow()
+        wa = [WorkArea(0, 0, 1920, 1080)]
+        wc = WindowController(window=win, workareas=wa)
+        wc.set_presence_mode(True)
+        assert wc.window_state()["mode"] == "presence"
+
+        # 1. Drag to negative out of bounds
+        win.events.moved.emit(-300, -200)
+        assert win.moved == (0, 0)
+        st = wc.window_state()
+        assert st["x"] == 0 and st["y"] == 0
+        assert st["mode"] == "presence"
+
+        # 2. Drag beyond bottom-right
+        win.events.moved.emit(2500, 1500)
+        assert win.moved == (1720, 880)
+        st2 = wc.window_state()
+        assert st2["x"] == 1720 and st2["y"] == 880
+        assert st2["mode"] == "presence"
+
+    def test_reconcile_geometry_noop_in_companion_mode(self) -> None:
+        """Moving window in companion mode does not clamp to presence 200x200 bounds."""
+        win = _MockWindow()
+        wa = [WorkArea(0, 0, 1920, 1080)]
+        wc = WindowController(window=win, workareas=wa)
+        assert wc.window_state()["mode"] == "companion"
+
+        win.events.moved.emit(-300, -200)
+        # Position was not mutated/clamped by presence reconciliation
+        assert win.moved is None
+
+    def test_reconcile_geometry_event_loop_protection(self) -> None:
+        """Re-entrant reconciliation calls return in_progress: True without looping."""
+        win = _MockWindow()
+        wc = WindowController(window=win)
+        wc.set_presence_mode(True)
+
+        wc._is_reconciling = True
+        res = wc.reconcile_geometry(-100, -100)
+        assert res["ok"] is True
+        assert res["clamped"] is False
+        assert res["in_progress"] is True
+        wc._is_reconciling = False
+
+    def test_reconcile_geometry_screen_changed(self) -> None:
+        """Screen/monitors change reconciles presence window position to new bounds."""
+        win = _MockWindow()
+        wa_large = [WorkArea(0, 0, 1920, 1080)]
+        wc = WindowController(window=win, workareas=wa_large)
+        wc.set_presence_mode(True)
+        # Simulate window moved to (1720, 880) within large screen
+        win.native.position = (1720, 880)
+        win.events.moved.emit(1720, 880)
+        st_before = wc.window_state()
+        assert st_before["x"] == 1720 and st_before["y"] == 880
+
+        # Resolution shrinks / secondary monitor unplugged:
+        wa_small = [WorkArea(0, 0, 1024, 768)]
+        wc._workareas = wa_small
+        wc._on_screen_changed()
+
+        # Window must be clamped into the 1024x768 boundary (1024 - 200, 768 - 200)
+        assert win.moved == (824, 568)
+        st = wc.window_state()
+        assert st["x"] == 824 and st["y"] == 568
+        assert st["mode"] == "presence"
+
+    def test_reconcile_geometry_without_window_fails_closed(self) -> None:
+        wc = WindowController(window=None)
+        wc._mode = "presence"
+        res = wc.reconcile_geometry(100, 100)
+        assert res == {"ok": False, "code": "window_unavailable"}
 
 
 class TestWindowBridgeContract:

--- a/backend/tests/test_desktop_app_runtime.py
+++ b/backend/tests/test_desktop_app_runtime.py
@@ -192,6 +192,35 @@ class TestRuntimeLifecycleWiring:
         bridge = kwargs["js_api"]
         assert bridge._bridge._api._runtime is runtime
 
+    def test_create_window_sets_transparent_and_min_size(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        # #342: create_window must set transparent=True for native GTK RGBA visual
+        # and min_size=(120, 120) to permit shrinking down to floating presence dimensions.
+        _make_dist(tmp_path)
+        recorded = _stub_webview(monkeypatch)
+
+        class FakeRuntime:
+            def close(self) -> None:
+                pass
+
+        monkeypatch.setattr(
+            desktop_app_module, "_build_runtime", lambda: FakeRuntime()
+        )
+
+        exit_code = desktop_app_module.run_desktop_shell(frontend_root=tmp_path)
+        assert exit_code == 0
+        kwargs = recorded["create_window_calls"][0]
+        assert kwargs["transparent"] is True
+        assert kwargs["min_size"] == (120, 120)
+        assert kwargs["width"] == 1280
+        assert kwargs["height"] == 800
+        assert kwargs["title"] == "Katherine"
+        bridge = kwargs["js_api"]
+        wc = bridge._bridge._api._window_controller
+        assert wc is not None
+        assert wc._window is not None
+
     def test_startup_storage_failure_is_sanitized_no_window(
         self, monkeypatch, tmp_path: Path, capsys
     ) -> None:

--- a/backend/tests/test_desktop_navigation.py
+++ b/backend/tests/test_desktop_navigation.py
@@ -123,7 +123,7 @@ class TestBridgeFailsClosedOutsideLocalBuild:
         url = build.index_html.as_uri()
         # The loaded handler committed this local page as trusted.
         wrapper = self._bridge_for(build, url, trusted=True)
-        assert wrapper.health() == {"ok": True, "api_version": 2}
+        assert wrapper.health() == {"ok": True, "api_version": 3}
 
     def test_local_url_before_commit_is_refused(self, tmp_path: Path) -> None:
         # Trust is only granted after the loaded handler commits the
@@ -321,7 +321,7 @@ class TestLoadedHandlerRevertsNavigation:
         local_uri = (dist / "desktop.html").as_uri()
         _, recorded = self._run_with_stubbed_webview(monkeypatch, tmp_path, local_uri)
         js_api = recorded["create_window_kwargs"]["js_api"]
-        assert js_api.health() == {"ok": True, "api_version": 2}
+        assert js_api.health() == {"ok": True, "api_version": 3}
 
     def test_js_api_health_remote_via_wrapper(self, monkeypatch, tmp_path: Path) -> None:
         self._run_with_stubbed_webview(monkeypatch, tmp_path, "https://example.com/")
@@ -425,7 +425,7 @@ class TestRevertToSameEntryUrl:
         # Only after the new local load completes (loaded event → new
         # commit) may the bridge serve again — same URL, new state.
         machine.on_loaded()
-        assert bridge.health() == {"ok": True, "api_version": 2}
+        assert bridge.health() == {"ok": True, "api_version": 3}
 
     def test_bridge_reopens_only_after_new_local_load_completes(
         self, tmp_path: Path
@@ -457,7 +457,7 @@ class TestRevertToSameEntryUrl:
         # 3) New local load completes: the loaded event re-commits and
         #    the bridge serves again.
         machine.on_loaded()
-        assert bridge.health() == {"ok": True, "api_version": 2}
+        assert bridge.health() == {"ok": True, "api_version": 3}
 
     def test_revert_navigates_to_the_entry_url(self, tmp_path: Path) -> None:
         # The revert load goes back to the same entry_html the shell
@@ -669,11 +669,20 @@ class TestCompanionOpsFailClosed:
         ("delete_memories", ()),
         ("reset_emotional_state", ()),
         ("reset_relationship_state", ()),
+        ("set_presence_mode", (True,)),
+        ("set_always_on_top", (True,)),
+        ("window_state", ()),
+        ("close_window", ()),
     ]
 
     def _wrapper_for(self, build: ResolvedBuild, url: str | None):
         trust = BuildTrust(build)
-        return LocalBuildBridge(make_js_api(runtime=_NoopRuntime()), build, lambda: url, trust)
+        return LocalBuildBridge(
+            make_js_api(runtime=_NoopRuntime(), window_controller=_NoopWindowController()),
+            build,
+            lambda: url,
+            trust,
+        )
 
     def test_every_op_refuses_remote_url(self, tmp_path: Path) -> None:
         import json
@@ -698,7 +707,10 @@ class TestCompanionOpsFailClosed:
         trust.commit_if_local(local)
         trust.revoke()  # the non-local load report dropped the trust
         wrapper = LocalBuildBridge(
-            make_js_api(runtime=_NoopRuntime()), build, lambda: local, trust
+            make_js_api(runtime=_NoopRuntime(), window_controller=_NoopWindowController()),
+            build,
+            lambda: local,
+            trust,
         )
         for op, args in self._OPS:
             assert getattr(wrapper, op)(*args)["code"] == ERROR_BRIDGE_UNAVAILABLE, op
@@ -710,7 +722,10 @@ class TestCompanionOpsFailClosed:
         local = build.index_html.as_uri()
         trust.commit_if_local(local)
         wrapper = LocalBuildBridge(
-            make_js_api(runtime=_NoopRuntime()), build, lambda: local, trust
+            make_js_api(runtime=_NoopRuntime(), window_controller=_NoopWindowController()),
+            build,
+            lambda: local,
+            trust,
         )
         for op, args in self._OPS:
             result = getattr(wrapper, op)(*args)
@@ -729,7 +744,9 @@ class TestCompanionOpsFailClosed:
             raise RuntimeError("boom")
 
         wrapper = LocalBuildBridge(
-            make_js_api(runtime=_NoopRuntime()), build, _raising
+            make_js_api(runtime=_NoopRuntime(), window_controller=_NoopWindowController()),
+            build,
+            _raising,
         )
         for op, args in self._OPS:
             assert getattr(wrapper, op)(*args)["code"] == ERROR_BRIDGE_UNAVAILABLE, op
@@ -756,5 +773,27 @@ class _NoopRuntime:
     def reset_emotional_state(self) -> dict:
         return {"success": True, "result": {"status": "applied"}}
 
-    def reset_relationship_state(self) -> dict:
+    def reset_relationship_state(self, *args: Any) -> dict:
         return {"success": True, "result": {"status": "applied"}}
+
+
+class _NoopWindowController:
+    """Window controller double whose every method returns an ok payload."""
+
+    def set_presence_mode(self, enabled: bool) -> dict:
+        return {
+            "ok": True,
+            "mode": "presence" if enabled else "companion",
+            "on_top": enabled,
+            "width": 200 if enabled else 1280,
+            "height": 200 if enabled else 800,
+        }
+
+    def set_always_on_top(self, enabled: bool) -> dict:
+        return {"ok": True, "on_top": enabled}
+
+    def window_state(self) -> dict:
+        return {"ok": True, "mode": "companion", "on_top": False, "width": 1280, "height": 800}
+
+    def close_window(self) -> dict:
+        return {"ok": True}

--- a/backend/tests/test_desktop_security.py
+++ b/backend/tests/test_desktop_security.py
@@ -70,10 +70,15 @@ class TestNoBridgeForRemoteContent:
             "delete_memories",
             "reset_emotional_state",
             "reset_relationship_state",
+            "set_presence_mode",
+            "set_always_on_top",
+            "window_state",
+            "close_window",
         )
         bridge = make_js_api()
         public = sorted(name for name in dir(bridge) if not name.startswith("_"))
         assert public == [
+            "close_window",
             "delete_history",
             "delete_memories",
             "health",
@@ -82,6 +87,9 @@ class TestNoBridgeForRemoteContent:
             "reset_relationship_state",
             "runtime_state",
             "send_message",
+            "set_always_on_top",
+            "set_presence_mode",
+            "window_state",
         ]
 
     def test_bridge_has_no_generic_dispatch_or_passthrough(self) -> None:

--- a/backend/tests/test_desktop_security.py
+++ b/backend/tests/test_desktop_security.py
@@ -74,6 +74,7 @@ class TestNoBridgeForRemoteContent:
             "set_always_on_top",
             "window_state",
             "close_window",
+            "minimize_window",
         )
         bridge = make_js_api()
         public = sorted(name for name in dir(bridge) if not name.startswith("_"))
@@ -83,6 +84,7 @@ class TestNoBridgeForRemoteContent:
             "delete_memories",
             "health",
             "load_history",
+            "minimize_window",
             "reset_emotional_state",
             "reset_relationship_state",
             "runtime_state",

--- a/frontend/src/AppDesktop.jsx
+++ b/frontend/src/AppDesktop.jsx
@@ -102,7 +102,11 @@ export default function AppDesktop() {
     }, [isAlwaysOnTop]);
 
     const handleMinimize = useCallback(async () => {
-        await minimizeDesktopWindow();
+        const res = await minimizeDesktopWindow();
+        if (typeof window !== 'undefined') {
+            window.__lastMinimizeResult = res;
+        }
+        return res;
     }, []);
 
     const handleClose = useCallback(async () => {

--- a/frontend/src/AppDesktop.jsx
+++ b/frontend/src/AppDesktop.jsx
@@ -1,5 +1,5 @@
 /**
- * Desktop companion root (#336, review blocker 1).
+ * Desktop companion root (#336, #342).
  *
  * This module is the desktop app's ONLY root. It contains ONLY
  * desktop concerns and imports nothing from the web stack: no
@@ -10,18 +10,125 @@
  * no cloud): ChatWindow renders directly and all data flows through
  * the local bridge transport (useChat / chatTransport /
  * desktopBridge).
+ *
+ * Mode switching (#342):
+ * - 'companion': full companion layout (ChatHeader, face, message history,
+ *   composer, emotion and privacy utilities) on solid dark background.
+ * - 'presence': minimal floating presence surface (KatherinePresence) with
+ *   true alpha transparency on the window surface.
+ * - In presence mode, CompanionLayout and all conversation DOM elements are
+ *   completely unmounted.
  */
+import React, { useState, useCallback, useEffect } from 'react';
 import ChatWindow from './features/chat/components/ChatWindow';
 import CompanionLayout from './features/chat/components/CompanionLayout.jsx';
-
-const renderCompanionLayout = (chatModel) => (
-    <CompanionLayout {...chatModel} />
-);
+import KatherinePresence from './features/katherine-face/KatherinePresence.jsx';
+import {
+    setPresenceMode,
+    setAlwaysOnTop,
+    getWindowState,
+    closeDesktopWindow,
+} from './lib/desktopBridge';
 
 export default function AppDesktop() {
+    const [mode, setMode] = useState('companion');
+    const [isAlwaysOnTop, setIsAlwaysOnTop] = useState(false);
+
+    // Bounded one-shot sync on shell startup (#342) - no continuous polling.
+    useEffect(() => {
+        let active = true;
+        getWindowState().then((state) => {
+            if (active && state?.ok) {
+                if (state.mode === 'presence' || state.mode === 'companion') {
+                    setMode(state.mode);
+                }
+                if (typeof state.on_top === 'boolean') {
+                    setIsAlwaysOnTop(state.on_top);
+                }
+            }
+        });
+        return () => {
+            active = false;
+        };
+    }, []);
+
+    const handleEnterPresence = useCallback(async () => {
+        const res = await setPresenceMode(true);
+        if (res?.ok) {
+            setMode('presence');
+            if (typeof res.on_top === 'boolean') {
+                setIsAlwaysOnTop(res.on_top);
+            }
+        }
+    }, []);
+
+    const handleReturnToCompanion = useCallback(async () => {
+        const res = await setPresenceMode(false);
+        if (res?.ok) {
+            setMode('companion');
+            if (typeof res.on_top === 'boolean') {
+                setIsAlwaysOnTop(res.on_top);
+            }
+        }
+    }, []);
+
+    const handleToggleAlwaysOnTop = useCallback(async () => {
+        const nextState = !isAlwaysOnTop;
+        const res = await setAlwaysOnTop(nextState);
+        if (res?.ok && typeof res.on_top === 'boolean') {
+            setIsAlwaysOnTop(res.on_top);
+        }
+    }, [isAlwaysOnTop]);
+
+    const handleClose = useCallback(async () => {
+        await closeDesktopWindow();
+    }, []);
+
+    const renderLayout = useCallback(
+        (chatModel) => {
+            if (mode === 'presence') {
+                return (
+                    <KatherinePresence
+                        emotionState={chatModel.emotionState}
+                        isLoading={chatModel.isLoading}
+                        onReturnToCompanion={handleReturnToCompanion}
+                        onClose={handleClose}
+                        onToggleAlwaysOnTop={handleToggleAlwaysOnTop}
+                        isAlwaysOnTop={isAlwaysOnTop}
+                    />
+                );
+            }
+            return (
+                <CompanionLayout
+                    {...chatModel}
+                    onEnterPresence={handleEnterPresence}
+                />
+            );
+        },
+        [
+            mode,
+            isAlwaysOnTop,
+            handleEnterPresence,
+            handleReturnToCompanion,
+            handleToggleAlwaysOnTop,
+            handleClose,
+        ],
+    );
+
+    const isPresence = mode === 'presence';
+
     return (
-        <div className="min-h-screen bg-gray-900 text-gray-100 font-sans antialiased">
-            <ChatWindow renderLayout={renderCompanionLayout} />
+        <div
+            className={`app-desktop ${
+                isPresence
+                    ? 'app-desktop--presence font-sans antialiased'
+                    : 'app-desktop--companion min-h-screen bg-gray-900 text-gray-100 font-sans antialiased'
+            }`}
+            style={isPresence ? { background: 'transparent' } : undefined}
+            data-testid="app-desktop-root"
+            data-desktop-mode={mode}
+        >
+            <ChatWindow renderLayout={renderLayout} />
         </div>
     );
 }

--- a/frontend/src/AppDesktop.jsx
+++ b/frontend/src/AppDesktop.jsx
@@ -19,7 +19,7 @@
  * - In presence mode, CompanionLayout and all conversation DOM elements are
  *   completely unmounted.
  */
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import ChatWindow from './features/chat/components/ChatWindow';
 import CompanionLayout from './features/chat/components/CompanionLayout.jsx';
 import KatherinePresence from './features/katherine-face/KatherinePresence.jsx';
@@ -28,11 +28,14 @@ import {
     setAlwaysOnTop,
     getWindowState,
     closeDesktopWindow,
+    minimizeDesktopWindow,
 } from './lib/desktopBridge';
 
 export default function AppDesktop() {
     const [mode, setMode] = useState('companion');
     const [isAlwaysOnTop, setIsAlwaysOnTop] = useState(false);
+    const isTransitioningRef = useRef(false);
+    const isPinningRef = useRef(false);
 
     // Bounded one-shot sync on shell startup (#342) - no continuous polling.
     useEffect(() => {
@@ -53,32 +56,54 @@ export default function AppDesktop() {
     }, []);
 
     const handleEnterPresence = useCallback(async () => {
-        const res = await setPresenceMode(true);
-        if (res?.ok) {
-            setMode('presence');
-            if (typeof res.on_top === 'boolean') {
-                setIsAlwaysOnTop(res.on_top);
+        if (isTransitioningRef.current) return;
+        isTransitioningRef.current = true;
+        try {
+            const res = await setPresenceMode(true);
+            if (res?.ok) {
+                setMode('presence');
+                if (typeof res.on_top === 'boolean') {
+                    setIsAlwaysOnTop(res.on_top);
+                }
             }
+        } finally {
+            isTransitioningRef.current = false;
         }
     }, []);
 
     const handleReturnToCompanion = useCallback(async () => {
-        const res = await setPresenceMode(false);
-        if (res?.ok) {
-            setMode('companion');
-            if (typeof res.on_top === 'boolean') {
-                setIsAlwaysOnTop(res.on_top);
+        if (isTransitioningRef.current) return;
+        isTransitioningRef.current = true;
+        try {
+            const res = await setPresenceMode(false);
+            if (res?.ok) {
+                setMode('companion');
+                if (typeof res.on_top === 'boolean') {
+                    setIsAlwaysOnTop(res.on_top);
+                }
             }
+        } finally {
+            isTransitioningRef.current = false;
         }
     }, []);
 
     const handleToggleAlwaysOnTop = useCallback(async () => {
-        const nextState = !isAlwaysOnTop;
-        const res = await setAlwaysOnTop(nextState);
-        if (res?.ok && typeof res.on_top === 'boolean') {
-            setIsAlwaysOnTop(res.on_top);
+        if (isPinningRef.current) return;
+        isPinningRef.current = true;
+        try {
+            const nextState = !isAlwaysOnTop;
+            const res = await setAlwaysOnTop(nextState);
+            if (res?.ok && typeof res.on_top === 'boolean') {
+                setIsAlwaysOnTop(res.on_top);
+            }
+        } finally {
+            isPinningRef.current = false;
         }
     }, [isAlwaysOnTop]);
+
+    const handleMinimize = useCallback(async () => {
+        await minimizeDesktopWindow();
+    }, []);
 
     const handleClose = useCallback(async () => {
         await closeDesktopWindow();
@@ -94,6 +119,7 @@ export default function AppDesktop() {
                         onReturnToCompanion={handleReturnToCompanion}
                         onClose={handleClose}
                         onToggleAlwaysOnTop={handleToggleAlwaysOnTop}
+                        onMinimize={handleMinimize}
                         isAlwaysOnTop={isAlwaysOnTop}
                     />
                 );
@@ -111,6 +137,7 @@ export default function AppDesktop() {
             handleEnterPresence,
             handleReturnToCompanion,
             handleToggleAlwaysOnTop,
+            handleMinimize,
             handleClose,
         ],
     );

--- a/frontend/src/features/chat/components/CompanionLayout.css
+++ b/frontend/src/features/chat/components/CompanionLayout.css
@@ -193,8 +193,68 @@
     }
 }
 
+.companion-layout__header {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    background: #111827;
+    border-bottom: 1px solid #1f2937;
+}
+
+.companion-layout__header > header {
+    flex: 1 1 auto;
+    min-width: 0;
+    border-bottom: none;
+    padding-right: 0.5rem;
+}
+
+.companion-layout__header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding-right: 1rem;
+}
+
+@media (min-width: 768px) {
+    .companion-layout__header-actions {
+        padding-right: 2rem;
+    }
+}
+
+.companion-layout__presence-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.5rem;
+    border: none;
+    border-radius: 0.375rem;
+    background: transparent;
+    color: #9ca3af;
+    cursor: pointer;
+    transition: color 150ms ease, background-color 150ms ease, transform 150ms ease-out;
+}
+
+.companion-layout__presence-toggle:hover {
+    color: #e5e7eb;
+    background-color: #1f2937;
+}
+
+.companion-layout__presence-toggle:active {
+    transform: scale(0.95);
+}
+
+.companion-layout__presence-toggle:focus-visible {
+    outline: 2px solid #93c5fd;
+    outline-offset: 2px;
+}
+
 @media (prefers-reduced-motion: reduce) {
     .companion-layout__utilities summary::after {
         transition-duration: 0ms;
+    }
+
+    .companion-layout__presence-toggle {
+        transition-duration: 0ms !important;
+        transform: none !important;
     }
 }

--- a/frontend/src/features/chat/components/CompanionLayout.jsx
+++ b/frontend/src/features/chat/components/CompanionLayout.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Minimize2 } from 'lucide-react';
 import ChatHeader from './ChatHeader';
 import ChatInput from './ChatInput';
 import EmotionPanel from './EmotionPanel';
@@ -27,13 +28,33 @@ export default function CompanionLayout({
     clearScreen,
     transport,
     auxiliarySlot = null,
+    onEnterPresence = null,
 }) {
     const hasAuxiliarySlot = Boolean(auxiliarySlot);
     const hasDesktopPrivacy = isDesktopTransport(transport);
 
     return (
         <div className="companion-layout" data-testid="companion-layout">
-            <ChatHeader clearScreen={clearScreen} />
+            {onEnterPresence ? (
+                <div className="companion-layout__header" data-testid="companion-header-bar">
+                    <ChatHeader clearScreen={clearScreen} />
+                    <div className="companion-layout__header-actions">
+                        <button
+                            type="button"
+                            onClick={onEnterPresence}
+                            className="companion-layout__presence-toggle"
+                            data-testid="companion-enter-presence-btn"
+                            title="Modo presença flutuante (Minimizar)"
+                            aria-label="Modo presença flutuante"
+                        >
+                            <Minimize2 size={20} aria-hidden="true" />
+                        </button>
+                    </div>
+                </div>
+            ) : (
+                <ChatHeader clearScreen={clearScreen} />
+            )}
+
 
             <main
                 className={`companion-layout__body${hasAuxiliarySlot ? ' companion-layout__body--with-auxiliary' : ''}`}

--- a/frontend/src/features/chat/components/CompanionLayout.jsx
+++ b/frontend/src/features/chat/components/CompanionLayout.jsx
@@ -44,7 +44,7 @@ export default function CompanionLayout({
                             onClick={onEnterPresence}
                             className="companion-layout__presence-toggle"
                             data-testid="companion-enter-presence-btn"
-                            title="Modo presença flutuante (Minimizar)"
+                            title="Modo presença flutuante"
                             aria-label="Modo presença flutuante"
                         >
                             <Minimize2 size={20} aria-hidden="true" />

--- a/frontend/src/features/katherine-face/KatherinePresence.css
+++ b/frontend/src/features/katherine-face/KatherinePresence.css
@@ -1,0 +1,118 @@
+.katherine-presence {
+    position: relative;
+    display: grid;
+    place-items: center;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    background: transparent !important;
+    user-select: none;
+}
+
+.katherine-presence__drag-handle {
+    display: grid;
+    place-items: center;
+    width: 100%;
+    height: 100%;
+    cursor: grab;
+    -webkit-app-region: drag;
+}
+
+.katherine-presence__drag-handle:active {
+    cursor: grabbing;
+}
+
+.katherine-face--presence {
+    width: clamp(7.5rem, 80vw, 9.5rem);
+    height: clamp(7.5rem, 80vw, 9.5rem);
+    pointer-events: none;
+}
+
+/* Ephemeral Controls Overlay */
+.katherine-presence__controls {
+    position: absolute;
+    top: 0.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.4rem;
+    background: rgba(17, 24, 39, 0.82);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 9999px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+    opacity: 0;
+    pointer-events: none;
+    transform: scale(0.95) translateY(-4px);
+    transition: opacity 160ms cubic-bezier(0.23, 1, 0.32, 1),
+                transform 160ms cubic-bezier(0.23, 1, 0.32, 1);
+    -webkit-app-region: no-drag;
+    z-index: 50;
+}
+
+/* Hover & Focus Disclosure */
+@media (hover: hover) and (pointer: fine) {
+    .katherine-presence:hover .katherine-presence__controls {
+        opacity: 1;
+        pointer-events: auto;
+        transform: scale(1) translateY(0);
+    }
+}
+
+.katherine-presence:focus-within .katherine-presence__controls {
+    opacity: 1;
+    pointer-events: auto;
+    transform: scale(1) translateY(0);
+}
+
+/* Ephemeral Control Buttons */
+.katherine-presence__btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.85rem;
+    height: 1.85rem;
+    padding: 0;
+    border: none;
+    border-radius: 9999px;
+    background: transparent;
+    color: #d1d5db;
+    cursor: pointer;
+    transition: background-color 120ms ease, color 120ms ease, transform 120ms ease-out;
+    -webkit-app-region: no-drag;
+}
+
+.katherine-presence__btn:hover {
+    background: rgba(255, 255, 255, 0.12);
+    color: #ffffff;
+}
+
+.katherine-presence__btn:active {
+    transform: scale(0.94);
+}
+
+.katherine-presence__btn:focus-visible {
+    outline: 2px solid #93c5fd;
+    outline-offset: 2px;
+}
+
+.katherine-presence__btn--active {
+    background: rgba(59, 130, 246, 0.25);
+    color: #60a5fa;
+}
+
+.katherine-presence__btn--danger:hover {
+    background: rgba(239, 68, 68, 0.25);
+    color: #f87171;
+}
+
+/* Accessibility: Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .katherine-presence__controls,
+    .katherine-presence__btn {
+        animation: none !important;
+        transition-duration: 0ms !important;
+        transform: none !important;
+    }
+}

--- a/frontend/src/features/katherine-face/KatherinePresence.jsx
+++ b/frontend/src/features/katherine-face/KatherinePresence.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { ArrowUpRight, Pin, PinOff, X } from 'lucide-react';
+import KatherineFace from './KatherineFace.jsx';
+import './KatherinePresence.css';
+
+/**
+ * Floating presence surface for Katherine desktop (#342).
+ *
+ * Minimal presence surface: face + ephemeral controls.
+ * - Entire region is transparent.
+ * - KatherineFace has pointer-events: none and is wrapped in .pywebview-drag-region,
+ *   allowing grabbing the face to directly move the window.
+ * - Ephemeral controls overlay discloses on hover or focus-within.
+ * - Ephemeral control buttons stop mousedown propagation and specify
+ *   -webkit-app-region: no-drag so clicks never trigger window moves.
+ * - Zero chat history, zero composer, zero sidebar, zero memory rendered.
+ */
+export default function KatherinePresence({
+    emotionState,
+    isLoading,
+    onReturnToCompanion,
+    onClose,
+    onToggleAlwaysOnTop,
+    isAlwaysOnTop = false,
+}) {
+    const handleControlMouseDown = (e) => {
+        e.stopPropagation();
+        if (typeof e.nativeEvent?.stopImmediatePropagation === 'function') {
+            e.nativeEvent.stopImmediatePropagation();
+        }
+    };
+
+    return (
+        <div
+            className="katherine-presence"
+            data-testid="katherine-presence-surface"
+            role="region"
+            aria-label="Presença flutuante da Katherine"
+        >
+            {/* Dedicated drag surface under and surrounding the face */}
+            <div
+                className="katherine-presence__drag-handle pywebview-drag-region"
+                data-testid="katherine-presence-drag-handle"
+                title="Arraste para mover Katherine"
+            >
+                <KatherineFace
+                    emotionState={emotionState}
+                    isLoading={isLoading}
+                    className="katherine-face--presence"
+                />
+            </div>
+
+            {/* Ephemeral Controls: revealed on hover or focus-within */}
+            <div
+                className="katherine-presence__controls"
+                data-testid="katherine-presence-controls"
+                role="toolbar"
+                aria-label="Controles da presença"
+            >
+                <button
+                    type="button"
+                    className="katherine-presence__btn"
+                    onClick={onReturnToCompanion}
+                    onMouseDown={handleControlMouseDown}
+                    title="Voltar ao companion (Expandir)"
+                    aria-label="Voltar ao companion"
+                    data-testid="presence-return-btn"
+                >
+                    <ArrowUpRight size={16} aria-hidden="true" />
+                </button>
+
+                <button
+                    type="button"
+                    className={`katherine-presence__btn ${isAlwaysOnTop ? 'katherine-presence__btn--active' : ''}`}
+                    onClick={onToggleAlwaysOnTop}
+                    onMouseDown={handleControlMouseDown}
+                    title={isAlwaysOnTop ? 'Desafixar do topo' : 'Manter no topo'}
+                    aria-label={isAlwaysOnTop ? 'Desafixar do topo' : 'Manter no topo'}
+                    aria-pressed={isAlwaysOnTop}
+                    data-testid="presence-pin-btn"
+                >
+                    {isAlwaysOnTop ? (
+                        <PinOff size={16} aria-hidden="true" />
+                    ) : (
+                        <Pin size={16} aria-hidden="true" />
+                    )}
+                </button>
+
+                <button
+                    type="button"
+                    className="katherine-presence__btn katherine-presence__btn--danger"
+                    onClick={onClose}
+                    onMouseDown={handleControlMouseDown}
+                    title="Fechar"
+                    aria-label="Fechar"
+                    data-testid="presence-close-btn"
+                >
+                    <X size={16} aria-hidden="true" />
+                </button>
+            </div>
+
+            {/* Accessible screen-reader announcement for loading without continuous polling */}
+            {isLoading && (
+                <div role="status" className="sr-only">
+                    Preparando resposta…
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/features/katherine-face/KatherinePresence.jsx
+++ b/frontend/src/features/katherine-face/KatherinePresence.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ArrowUpRight, Pin, PinOff, X } from 'lucide-react';
+import { ArrowUpRight, Minus, Pin, PinOff, X } from 'lucide-react';
 import KatherineFace from './KatherineFace.jsx';
 import './KatherinePresence.css';
 
@@ -21,6 +21,7 @@ export default function KatherinePresence({
     onReturnToCompanion,
     onClose,
     onToggleAlwaysOnTop,
+    onMinimize,
     isAlwaysOnTop = false,
 }) {
     const handleControlMouseDown = (e) => {
@@ -84,6 +85,18 @@ export default function KatherinePresence({
                     ) : (
                         <Pin size={16} aria-hidden="true" />
                     )}
+                </button>
+
+                <button
+                    type="button"
+                    className="katherine-presence__btn"
+                    onClick={onMinimize}
+                    onMouseDown={handleControlMouseDown}
+                    title="Minimizar"
+                    aria-label="Minimizar"
+                    data-testid="presence-minimize-btn"
+                >
+                    <Minus size={16} aria-hidden="true" />
                 </button>
 
                 <button

--- a/frontend/src/lib/desktopBridge.js
+++ b/frontend/src/lib/desktopBridge.js
@@ -341,12 +341,18 @@ export async function runPrivacyOpViaBridge(op, targetWindow) {
 // #342: presence mode & window control callers
 // =========================================================================
 
+const BRIDGE_UNAVAILABLE = Object.freeze({
+    ok: false,
+    code: 'bridge_unavailable',
+    message: 'Desktop window control is unavailable.',
+});
+
 /**
  * Toggle between desktop companion mode and floating presence mode (#342).
  *
  * @param {boolean} enabled - true to enter presence mode, false to return to companion
  * @param {object} [targetWindow] - optional window override for testing
- * @returns {Promise<{ok: boolean, mode: 'presence' | 'companion', on_top?: boolean, width?: number, height?: number, fallback?: boolean} | {ok: false, code: string, message: string}>}
+ * @returns {Promise<{ok: true, mode: 'presence' | 'companion', on_top: boolean, width?: number, height?: number} | {ok: false, code: string, message: string}>}
  */
 export async function setPresenceMode(enabled, targetWindow) {
     if (typeof enabled !== 'boolean') {
@@ -354,12 +360,7 @@ export async function setPresenceMode(enabled, targetWindow) {
     }
     const api = await resolveBridge(targetWindow);
     if (!api || typeof api.set_presence_mode !== 'function') {
-        return {
-            ok: true,
-            mode: enabled ? 'presence' : 'companion',
-            on_top: false,
-            fallback: true,
-        };
+        return { ...BRIDGE_UNAVAILABLE };
     }
     try {
         const payload = await api.set_presence_mode(enabled);
@@ -380,7 +381,7 @@ export async function setPresenceMode(enabled, targetWindow) {
  *
  * @param {boolean} enabled - true to keep window on top, false otherwise
  * @param {object} [targetWindow] - optional window override for testing
- * @returns {Promise<{ok: boolean, on_top: boolean, fallback?: boolean} | {ok: false, code: string, message: string}>}
+ * @returns {Promise<{ok: true, on_top: boolean} | {ok: false, code: string, message: string}>}
  */
 export async function setAlwaysOnTop(enabled, targetWindow) {
     if (typeof enabled !== 'boolean') {
@@ -388,7 +389,7 @@ export async function setAlwaysOnTop(enabled, targetWindow) {
     }
     const api = await resolveBridge(targetWindow);
     if (!api || typeof api.set_always_on_top !== 'function') {
-        return { ok: true, on_top: enabled, fallback: true };
+        return { ...BRIDGE_UNAVAILABLE };
     }
     try {
         const payload = await api.set_always_on_top(enabled);
@@ -408,12 +409,12 @@ export async function setAlwaysOnTop(enabled, targetWindow) {
  * Read current window state (mode, on_top, geometry) from the desktop bridge (#342).
  *
  * @param {object} [targetWindow] - optional window override for testing
- * @returns {Promise<{ok: boolean, mode: 'presence' | 'companion', on_top: boolean, width?: number, height?: number, fallback?: boolean} | {ok: false, code: string, message: string}>}
+ * @returns {Promise<{ok: true, mode: 'presence' | 'companion', on_top: boolean, width?: number, height?: number} | {ok: false, code: string, message: string}>}
  */
 export async function getWindowState(targetWindow) {
     const api = await resolveBridge(targetWindow);
     if (!api || typeof api.window_state !== 'function') {
-        return { ok: true, mode: 'companion', on_top: false, fallback: true };
+        return { ...BRIDGE_UNAVAILABLE };
     }
     try {
         const payload = await api.window_state();
@@ -433,24 +434,19 @@ export async function getWindowState(targetWindow) {
  * Request clean closure of the desktop window (#342).
  *
  * @param {object} [targetWindow] - optional window override for testing
- * @returns {Promise<{ok: boolean, fallback?: boolean} | {ok: false, code: string, message: string}>}
+ * @returns {Promise<{ok: true} | {ok: false, code: string, message: string}>}
  */
 export async function closeDesktopWindow(targetWindow) {
     const api = await resolveBridge(targetWindow);
     if (!api || typeof api.close_window !== 'function') {
-        const scope = targetWindow ?? (typeof window !== 'undefined' ? window : undefined);
-        if (scope && typeof scope.close === 'function') {
-            try {
-                scope.close();
-            } catch {
-                // Ignore if blocked by browser security
-            }
-        }
-        return { ok: true, fallback: true };
+        return { ...BRIDGE_UNAVAILABLE };
     }
     try {
         const payload = await api.close_window();
         if (isPlainObject(payload) && payload.ok === true) {
+            return payload;
+        }
+        if (isPlainObject(payload) && payload.ok === false) {
             return payload;
         }
         return { ok: false, code: 'unknown', message: 'Invalid payload from desktop bridge' };
@@ -458,3 +454,30 @@ export async function closeDesktopWindow(targetWindow) {
         return { ok: false, code: 'bridge_error', message: 'Failed to communicate with desktop bridge' };
     }
 }
+
+/**
+ * Request minimization of the desktop window (#342).
+ *
+ * @param {object} [targetWindow] - optional window override for testing
+ * @returns {Promise<{ok: true} | {ok: false, code: string, message: string}>}
+ */
+export async function minimizeDesktopWindow(targetWindow) {
+    const api = await resolveBridge(targetWindow);
+    if (!api || typeof api.minimize_window !== 'function') {
+        return { ...BRIDGE_UNAVAILABLE };
+    }
+    try {
+        const payload = await api.minimize_window();
+        if (isPlainObject(payload) && payload.ok === true) {
+            return payload;
+        }
+        if (isPlainObject(payload) && payload.ok === false) {
+            return payload;
+        }
+        return { ok: false, code: 'unknown', message: 'Invalid payload from desktop bridge' };
+    } catch {
+        return { ok: false, code: 'bridge_error', message: 'Failed to communicate with desktop bridge' };
+    }
+}
+
+export const minimizeWindow = minimizeDesktopWindow;

--- a/frontend/src/lib/desktopBridge.js
+++ b/frontend/src/lib/desktopBridge.js
@@ -336,3 +336,125 @@ export async function runPrivacyOpViaBridge(op, targetWindow) {
     }
     throw new ChatError('unknown', CHAT_ERROR_MESSAGES.unknown);
 }
+
+// =========================================================================
+// #342: presence mode & window control callers
+// =========================================================================
+
+/**
+ * Toggle between desktop companion mode and floating presence mode (#342).
+ *
+ * @param {boolean} enabled - true to enter presence mode, false to return to companion
+ * @param {object} [targetWindow] - optional window override for testing
+ * @returns {Promise<{ok: boolean, mode: 'presence' | 'companion', on_top?: boolean, width?: number, height?: number, fallback?: boolean} | {ok: false, code: string, message: string}>}
+ */
+export async function setPresenceMode(enabled, targetWindow) {
+    if (typeof enabled !== 'boolean') {
+        return { ok: false, code: 'invalid_input', message: 'enabled must be a boolean' };
+    }
+    const api = await resolveBridge(targetWindow);
+    if (!api || typeof api.set_presence_mode !== 'function') {
+        return {
+            ok: true,
+            mode: enabled ? 'presence' : 'companion',
+            on_top: false,
+            fallback: true,
+        };
+    }
+    try {
+        const payload = await api.set_presence_mode(enabled);
+        if (isPlainObject(payload) && payload.ok === true) {
+            return payload;
+        }
+        if (isPlainObject(payload) && payload.ok === false) {
+            return payload;
+        }
+        return { ok: false, code: 'unknown', message: 'Invalid payload from desktop bridge' };
+    } catch {
+        return { ok: false, code: 'bridge_error', message: 'Failed to communicate with desktop bridge' };
+    }
+}
+
+/**
+ * Toggle always-on-top state for the desktop window (#342).
+ *
+ * @param {boolean} enabled - true to keep window on top, false otherwise
+ * @param {object} [targetWindow] - optional window override for testing
+ * @returns {Promise<{ok: boolean, on_top: boolean, fallback?: boolean} | {ok: false, code: string, message: string}>}
+ */
+export async function setAlwaysOnTop(enabled, targetWindow) {
+    if (typeof enabled !== 'boolean') {
+        return { ok: false, code: 'invalid_input', message: 'enabled must be a boolean' };
+    }
+    const api = await resolveBridge(targetWindow);
+    if (!api || typeof api.set_always_on_top !== 'function') {
+        return { ok: true, on_top: enabled, fallback: true };
+    }
+    try {
+        const payload = await api.set_always_on_top(enabled);
+        if (isPlainObject(payload) && payload.ok === true) {
+            return payload;
+        }
+        if (isPlainObject(payload) && payload.ok === false) {
+            return payload;
+        }
+        return { ok: false, code: 'unknown', message: 'Invalid payload from desktop bridge' };
+    } catch {
+        return { ok: false, code: 'bridge_error', message: 'Failed to communicate with desktop bridge' };
+    }
+}
+
+/**
+ * Read current window state (mode, on_top, geometry) from the desktop bridge (#342).
+ *
+ * @param {object} [targetWindow] - optional window override for testing
+ * @returns {Promise<{ok: boolean, mode: 'presence' | 'companion', on_top: boolean, width?: number, height?: number, fallback?: boolean} | {ok: false, code: string, message: string}>}
+ */
+export async function getWindowState(targetWindow) {
+    const api = await resolveBridge(targetWindow);
+    if (!api || typeof api.window_state !== 'function') {
+        return { ok: true, mode: 'companion', on_top: false, fallback: true };
+    }
+    try {
+        const payload = await api.window_state();
+        if (isPlainObject(payload) && payload.ok === true) {
+            return payload;
+        }
+        if (isPlainObject(payload) && payload.ok === false) {
+            return payload;
+        }
+        return { ok: false, code: 'unknown', message: 'Invalid payload from desktop bridge' };
+    } catch {
+        return { ok: false, code: 'bridge_error', message: 'Failed to communicate with desktop bridge' };
+    }
+}
+
+/**
+ * Request clean closure of the desktop window (#342).
+ *
+ * @param {object} [targetWindow] - optional window override for testing
+ * @returns {Promise<{ok: boolean, fallback?: boolean} | {ok: false, code: string, message: string}>}
+ */
+export async function closeDesktopWindow(targetWindow) {
+    const api = await resolveBridge(targetWindow);
+    if (!api || typeof api.close_window !== 'function') {
+        const scope = targetWindow ?? (typeof window !== 'undefined' ? window : undefined);
+        if (scope && typeof scope.close === 'function') {
+            try {
+                scope.close();
+            } catch {
+                // Ignore if blocked by browser security
+            }
+        }
+        return { ok: true, fallback: true };
+    }
+    try {
+        const payload = await api.close_window();
+        if (isPlainObject(payload) && payload.ok === true) {
+            return payload;
+        }
+        return { ok: false, code: 'unknown', message: 'Invalid payload from desktop bridge' };
+    } catch {
+        return { ok: false, code: 'bridge_error', message: 'Failed to communicate with desktop bridge' };
+    }
+}

--- a/frontend/tests/AppDesktopAdversarial.test.jsx
+++ b/frontend/tests/AppDesktopAdversarial.test.jsx
@@ -1,0 +1,336 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+const chatHarness = vi.hoisted(() => ({
+    calls: 0,
+    model: {
+        messages: [
+            { role: 'user', content: 'SECRET_USER_TOKEN_12345' },
+            { role: 'assistant', content: 'Confidential assistant reply' },
+        ],
+        input: 'SECRET_UNSENT_INPUT_DRAFT',
+        setInput: vi.fn(),
+        isLoading: false,
+        emotionState: {
+            schema_version: 1,
+            mood_label: 'ALEGRE',
+            pad: { pleasure: 0.8, arousal: 0.5, dominance: 0.3 },
+            dominant_emotions: [{ name: 'joy', intensity: 0.95 }],
+            timestamp: 1700000000,
+        },
+        messagesEndRef: { current: null },
+        inputRef: { current: null },
+        handleSend: vi.fn(),
+        clearScreen: vi.fn(),
+        transport: {
+            mode: 'desktop',
+            runPrivacyOp: vi.fn(async () => ({ status: 'applied' })),
+        },
+    },
+}));
+
+vi.mock('../src/features/chat/hooks/useChat', () => ({
+    useChat: () => {
+        chatHarness.calls += 1;
+        return chatHarness.model;
+    },
+}));
+
+import AppDesktop from '../src/AppDesktop.jsx';
+import KatherinePresence from '../src/features/katherine-face/KatherinePresence.jsx';
+import {
+    setPresenceMode,
+    setAlwaysOnTop,
+    getWindowState,
+    closeDesktopWindow,
+} from '../src/lib/desktopBridge.js';
+
+let pywebviewApi;
+
+function setupBridge() {
+    pywebviewApi = {
+        set_presence_mode: vi.fn(async (enabled) => ({
+            ok: true,
+            mode: enabled ? 'presence' : 'companion',
+            on_top: false,
+            width: enabled ? 200 : 1280,
+            height: enabled ? 200 : 800,
+        })),
+        set_always_on_top: vi.fn(async (enabled) => ({
+            ok: true,
+            on_top: enabled,
+        })),
+        window_state: vi.fn(async () => ({
+            ok: true,
+            mode: 'companion',
+            on_top: false,
+            width: 1280,
+            height: 800,
+        })),
+        close_window: vi.fn(async () => ({
+            ok: true,
+        })),
+        health: vi.fn(async () => ({
+            ok: true,
+            api_version: 3,
+        })),
+    };
+
+    window.pywebview = { api: pywebviewApi };
+}
+
+describe('Adversarial Stress Suite — Frontend Floating Presence', () => {
+    beforeEach(() => {
+        chatHarness.calls = 0;
+        setupBridge();
+        document.body.innerHTML = '';
+    });
+
+    describe('1. Rapid Mode Switching Stress Tests', () => {
+        it('survives rapid successive mode transitions without crashing or desyncing DOM state', async () => {
+            render(<AppDesktop />);
+
+            const root = screen.getByTestId('app-desktop-root');
+            expect(root).toHaveAttribute('data-desktop-mode', 'companion');
+
+            // Rapidly enter presence
+            const enterBtn = screen.getByTestId('companion-enter-presence-btn');
+            await act(async () => {
+                fireEvent.click(enterBtn);
+            });
+            expect(root).toHaveAttribute('data-desktop-mode', 'presence');
+
+            // Rapid alternation: 10 cycles back and forth
+            for (let i = 0; i < 10; i++) {
+                const returnBtn = screen.getByTestId('presence-return-btn');
+                await act(async () => {
+                    fireEvent.click(returnBtn);
+                });
+                expect(root).toHaveAttribute('data-desktop-mode', 'companion');
+
+                const presenceBtn = screen.getByTestId('companion-enter-presence-btn');
+                await act(async () => {
+                    fireEvent.click(presenceBtn);
+                });
+                expect(root).toHaveAttribute('data-desktop-mode', 'presence');
+            }
+
+            expect(screen.getByTestId('katherine-presence-surface')).toBeInTheDocument();
+            expect(screen.queryByTestId('companion-layout')).toBeNull();
+        });
+
+        it('handles rapid repeated pin button clicks safely', async () => {
+            render(<AppDesktop />);
+
+            // Enter presence
+            await act(async () => {
+                fireEvent.click(screen.getByTestId('companion-enter-presence-btn'));
+            });
+
+            const pinBtn = screen.getByTestId('presence-pin-btn');
+
+            // Rapid fire 10 clicks on pin button
+            for (let i = 0; i < 10; i++) {
+                await act(async () => {
+                    fireEvent.click(pinBtn);
+                });
+            }
+
+            expect(pywebviewApi.set_always_on_top).toHaveBeenCalledTimes(10);
+            expect(pinBtn).toBeInTheDocument();
+        });
+    });
+
+    describe('2. Strict Privacy Isolation Under Adversarial Inspection', () => {
+        it('guarantees zero confidential data, messages, or composer input exists anywhere in DOM during presence', async () => {
+            render(<AppDesktop />);
+
+            // Pre-condition: secrets exist in companion mode
+            expect(screen.getByText('SECRET_USER_TOKEN_12345')).toBeInTheDocument();
+            expect(screen.getByText('Confidential assistant reply')).toBeInTheDocument();
+            expect(screen.getByDisplayValue('SECRET_UNSENT_INPUT_DRAFT')).toBeInTheDocument();
+
+            // Transition to presence mode
+            await act(async () => {
+                fireEvent.click(screen.getByTestId('companion-enter-presence-btn'));
+            });
+
+            // Adversarial audit of document body HTML
+            const fullHtml = document.body.innerHTML;
+            expect(fullHtml).not.toContain('SECRET_USER_TOKEN_12345');
+            expect(fullHtml).not.toContain('Confidential assistant reply');
+            expect(fullHtml).not.toContain('SECRET_UNSENT_INPUT_DRAFT');
+            expect(fullHtml).not.toContain('textarea');
+            expect(fullHtml).not.toContain('input');
+            expect(fullHtml).not.toContain('valence');
+            expect(fullHtml).not.toContain('arousal');
+            expect(fullHtml).not.toContain('dominance');
+
+            // DOM structure check
+            expect(screen.queryByRole('textbox')).toBeNull();
+            expect(screen.queryByTestId('companion-history')).toBeNull();
+            expect(screen.queryByTestId('companion-layout')).toBeNull();
+            expect(screen.queryByTestId('emotion-panel')).toBeNull();
+            expect(screen.queryByTestId('privacy-panel')).toBeNull();
+        });
+    });
+
+    describe('3. Drag Handle vs Button Hit-Testing & Event Isolation', () => {
+        it('verifies control buttons stop propagation and do not bubble to drag handle', () => {
+            const onReturn = vi.fn();
+            const onClose = vi.fn();
+            const onToggle = vi.fn();
+
+            render(
+                <KatherinePresence
+                    emotionState={null}
+                    isLoading={false}
+                    onReturnToCompanion={onReturn}
+                    onClose={onClose}
+                    onToggleAlwaysOnTop={onToggle}
+                    isAlwaysOnTop={false}
+                />,
+            );
+
+            const dragHandle = screen.getByTestId('katherine-presence-drag-handle');
+            let dragHandleReceivedMouseDown = false;
+            dragHandle.addEventListener('mousedown', () => {
+                dragHandleReceivedMouseDown = true;
+            });
+
+            // Test return button
+            const returnBtn = screen.getByTestId('presence-return-btn');
+            const evt1 = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+            returnBtn.dispatchEvent(evt1);
+            expect(dragHandleReceivedMouseDown).toBe(false);
+
+            // Test pin button
+            const pinBtn = screen.getByTestId('presence-pin-btn');
+            const evt2 = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+            pinBtn.dispatchEvent(evt2);
+            expect(dragHandleReceivedMouseDown).toBe(false);
+
+            // Test close button
+            const closeBtn = screen.getByTestId('presence-close-btn');
+            const evt3 = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+            closeBtn.dispatchEvent(evt3);
+            expect(dragHandleReceivedMouseDown).toBe(false);
+        });
+
+        it('verifies KatherineFace has pointer-events: none class so drag events pass to handle', () => {
+            render(
+                <KatherinePresence
+                    emotionState={null}
+                    isLoading={false}
+                    onReturnToCompanion={vi.fn()}
+                    onClose={vi.fn()}
+                    onToggleAlwaysOnTop={vi.fn()}
+                    isAlwaysOnTop={false}
+                />,
+            );
+
+            const dragHandle = screen.getByTestId('katherine-presence-drag-handle');
+            expect(dragHandle).toHaveClass('pywebview-drag-region');
+            expect(dragHandle).toHaveClass('katherine-presence__drag-handle');
+
+            const faceContainer = dragHandle.firstElementChild;
+            expect(faceContainer).toHaveClass('katherine-face--presence');
+        });
+    });
+
+    describe('4. Boundary, Typing, and Error Resilience in Bridge Client', () => {
+        it('rejects all non-boolean types in setPresenceMode', async () => {
+            const invalidValues = [
+                1, 0, -1, 100, 'true', 'false', '', null, undefined, {}, [], () => {}, Symbol('test'),
+            ];
+
+            for (const val of invalidValues) {
+                const res = await setPresenceMode(val);
+                expect(res.ok).toBe(false);
+                expect(res.code).toBe('invalid_input');
+                expect(res.message).toBe('enabled must be a boolean');
+            }
+        });
+
+        it('rejects all non-boolean types in setAlwaysOnTop', async () => {
+            const invalidValues = [
+                1, 0, 'true', 'false', null, undefined, {}, [], () => {},
+            ];
+
+            for (const val of invalidValues) {
+                const res = await setAlwaysOnTop(val);
+                expect(res.ok).toBe(false);
+                expect(res.code).toBe('invalid_input');
+                expect(res.message).toBe('enabled must be a boolean');
+            }
+        });
+
+        it('handles bridge exceptions gracefully without crashing or throwing to caller', async () => {
+            const failingWindow = {
+                pywebview: {
+                    api: {
+                        set_presence_mode: vi.fn(async () => {
+                            throw new Error('GTK IPC pipe broken');
+                        }),
+                        set_always_on_top: vi.fn(async () => {
+                            throw new Error('WebKit IPC disconnected');
+                        }),
+                        window_state: vi.fn(async () => {
+                            throw new Error('X11 server died');
+                        }),
+                        close_window: vi.fn(async () => {
+                            throw new Error('Process killed');
+                        }),
+                    },
+                },
+            };
+
+            const r1 = await setPresenceMode(true, failingWindow);
+            expect(r1.ok).toBe(false);
+            expect(r1.code).toBe('bridge_error');
+
+            const r2 = await setAlwaysOnTop(true, failingWindow);
+            expect(r2.ok).toBe(false);
+            expect(r2.code).toBe('bridge_error');
+
+            const r3 = await getWindowState(failingWindow);
+            expect(r3.ok).toBe(false);
+            expect(r3.code).toBe('bridge_error');
+
+            const r4 = await closeDesktopWindow(failingWindow);
+            expect(r4.ok).toBe(false);
+            expect(r4.code).toBe('bridge_error');
+        });
+
+        it('handles malformed payloads from backend gracefully', async () => {
+            const malformedWindow = {
+                pywebview: {
+                    api: {
+                        set_presence_mode: vi.fn(async () => 'not a json object'),
+                        set_always_on_top: vi.fn(async () => 42),
+                        window_state: vi.fn(async () => null),
+                        close_window: vi.fn(async () => undefined),
+                    },
+                },
+            };
+
+            const r1 = await setPresenceMode(true, malformedWindow);
+            expect(r1.ok).toBe(false);
+            expect(r1.code).toBe('unknown');
+
+            const r2 = await setAlwaysOnTop(true, malformedWindow);
+            expect(r2.ok).toBe(false);
+            expect(r2.code).toBe('unknown');
+
+            const r3 = await getWindowState(malformedWindow);
+            expect(r3.ok).toBe(false);
+            expect(r3.code).toBe('unknown');
+
+            const r4 = await closeDesktopWindow(malformedWindow);
+            expect(r4.ok).toBe(false);
+            expect(r4.code).toBe('unknown');
+        });
+    });
+});

--- a/frontend/tests/AppDesktopAdversarial.test.jsx
+++ b/frontend/tests/AppDesktopAdversarial.test.jsx
@@ -45,6 +45,7 @@ import {
     setAlwaysOnTop,
     getWindowState,
     closeDesktopWindow,
+    minimizeDesktopWindow,
 } from '../src/lib/desktopBridge.js';
 
 let pywebviewApi;
@@ -70,6 +71,9 @@ function setupBridge() {
             height: 800,
         })),
         close_window: vi.fn(async () => ({
+            ok: true,
+        })),
+        minimize_window: vi.fn(async () => ({
             ok: true,
         })),
         health: vi.fn(async () => ({
@@ -141,6 +145,49 @@ describe('Adversarial Stress Suite — Frontend Floating Presence', () => {
             expect(pywebviewApi.set_always_on_top).toHaveBeenCalledTimes(10);
             expect(pinBtn).toBeInTheDocument();
         });
+
+        it('handles intermittent bridge mutation failures during rapid switching without ghost state', async () => {
+            let attempt = 0;
+            pywebviewApi.set_presence_mode = vi.fn(async (enabled) => {
+                attempt += 1;
+                // Fail odd attempts
+                if (attempt % 2 === 1) {
+                    return {
+                        ok: false,
+                        code: 'window_mutation_failed',
+                        message: 'Synthetic GTK timeout',
+                    };
+                }
+                return {
+                    ok: true,
+                    mode: enabled ? 'presence' : 'companion',
+                    on_top: false,
+                    width: enabled ? 200 : 1280,
+                    height: enabled ? 200 : 800,
+                };
+            });
+
+            render(<AppDesktop />);
+            const root = screen.getByTestId('app-desktop-root');
+            expect(root).toHaveAttribute('data-desktop-mode', 'companion');
+
+            const enterBtn = screen.getByTestId('companion-enter-presence-btn');
+            // Attempt 1: bridge fails -> UI must remain companion
+            await act(async () => {
+                fireEvent.click(enterBtn);
+            });
+            expect(root).toHaveAttribute('data-desktop-mode', 'companion');
+            expect(screen.getByTestId('companion-layout')).toBeInTheDocument();
+            expect(screen.queryByTestId('katherine-presence-surface')).toBeNull();
+
+            // Attempt 2: bridge succeeds -> UI transitions to presence
+            await act(async () => {
+                fireEvent.click(enterBtn);
+            });
+            expect(root).toHaveAttribute('data-desktop-mode', 'presence');
+            expect(screen.getByTestId('katherine-presence-surface')).toBeInTheDocument();
+            expect(screen.queryByTestId('companion-layout')).toBeNull();
+        });
     });
 
     describe('2. Strict Privacy Isolation Under Adversarial Inspection', () => {
@@ -181,6 +228,7 @@ describe('Adversarial Stress Suite — Frontend Floating Presence', () => {
         it('verifies control buttons stop propagation and do not bubble to drag handle', () => {
             const onReturn = vi.fn();
             const onClose = vi.fn();
+            const onMinimize = vi.fn();
             const onToggle = vi.fn();
 
             render(
@@ -189,6 +237,7 @@ describe('Adversarial Stress Suite — Frontend Floating Presence', () => {
                     isLoading={false}
                     onReturnToCompanion={onReturn}
                     onClose={onClose}
+                    onMinimize={onMinimize}
                     onToggleAlwaysOnTop={onToggle}
                     isAlwaysOnTop={false}
                 />,
@@ -206,16 +255,22 @@ describe('Adversarial Stress Suite — Frontend Floating Presence', () => {
             returnBtn.dispatchEvent(evt1);
             expect(dragHandleReceivedMouseDown).toBe(false);
 
+            // Test minimize button
+            const minBtn = screen.getByTestId('presence-minimize-btn');
+            const evt2 = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+            minBtn.dispatchEvent(evt2);
+            expect(dragHandleReceivedMouseDown).toBe(false);
+
             // Test pin button
             const pinBtn = screen.getByTestId('presence-pin-btn');
-            const evt2 = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
-            pinBtn.dispatchEvent(evt2);
+            const evt3 = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+            pinBtn.dispatchEvent(evt3);
             expect(dragHandleReceivedMouseDown).toBe(false);
 
             // Test close button
             const closeBtn = screen.getByTestId('presence-close-btn');
-            const evt3 = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
-            closeBtn.dispatchEvent(evt3);
+            const evt4 = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+            closeBtn.dispatchEvent(evt4);
             expect(dragHandleReceivedMouseDown).toBe(false);
         });
 
@@ -226,6 +281,7 @@ describe('Adversarial Stress Suite — Frontend Floating Presence', () => {
                     isLoading={false}
                     onReturnToCompanion={vi.fn()}
                     onClose={vi.fn()}
+                    onMinimize={vi.fn()}
                     onToggleAlwaysOnTop={vi.fn()}
                     isAlwaysOnTop={false}
                 />,
@@ -283,6 +339,9 @@ describe('Adversarial Stress Suite — Frontend Floating Presence', () => {
                         close_window: vi.fn(async () => {
                             throw new Error('Process killed');
                         }),
+                        minimize_window: vi.fn(async () => {
+                            throw new Error('GTK minimize failed');
+                        }),
                     },
                 },
             };
@@ -302,6 +361,10 @@ describe('Adversarial Stress Suite — Frontend Floating Presence', () => {
             const r4 = await closeDesktopWindow(failingWindow);
             expect(r4.ok).toBe(false);
             expect(r4.code).toBe('bridge_error');
+
+            const r5 = await minimizeDesktopWindow(failingWindow);
+            expect(r5.ok).toBe(false);
+            expect(r5.code).toBe('bridge_error');
         });
 
         it('handles malformed payloads from backend gracefully', async () => {
@@ -312,6 +375,7 @@ describe('Adversarial Stress Suite — Frontend Floating Presence', () => {
                         set_always_on_top: vi.fn(async () => 42),
                         window_state: vi.fn(async () => null),
                         close_window: vi.fn(async () => undefined),
+                        minimize_window: vi.fn(async () => 123),
                     },
                 },
             };
@@ -331,6 +395,28 @@ describe('Adversarial Stress Suite — Frontend Floating Presence', () => {
             const r4 = await closeDesktopWindow(malformedWindow);
             expect(r4.ok).toBe(false);
             expect(r4.code).toBe('unknown');
+
+            const r5 = await minimizeDesktopWindow(malformedWindow);
+            expect(r5.ok).toBe(false);
+            expect(r5.code).toBe('unknown');
+        });
+
+        it('returns honest bridge_unavailable across all window control methods when bridge is missing (Blocker 3)', async () => {
+            const emptyWindow = {};
+            const methods = [
+                () => setPresenceMode(true, emptyWindow),
+                () => setAlwaysOnTop(true, emptyWindow),
+                () => getWindowState(emptyWindow),
+                () => closeDesktopWindow(emptyWindow),
+                () => minimizeDesktopWindow(emptyWindow),
+            ];
+
+            for (const fn of methods) {
+                const res = await fn();
+                expect(res.ok).toBe(false);
+                expect(res.code).toBe('bridge_unavailable');
+                expect(res.message).toBe('Desktop window control is unavailable.');
+            }
         });
     });
 });

--- a/frontend/tests/AppDesktopPresence.test.jsx
+++ b/frontend/tests/AppDesktopPresence.test.jsx
@@ -1,0 +1,323 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+const chatHarness = vi.hoisted(() => ({
+    calls: 0,
+    model: {
+        messages: [{ role: 'user', content: 'Minha mensagem confidencial' }],
+        input: 'Texto no composer',
+        setInput: vi.fn(),
+        isLoading: false,
+        emotionState: {
+            schema_version: 1,
+            mood_label: 'ALEGRE',
+            pad: { pleasure: 0.6, arousal: 0.4, dominance: 0.2 },
+            dominant_emotions: [{ name: 'joy', intensity: 0.9 }],
+            timestamp: 1700000000,
+        },
+        messagesEndRef: { current: null },
+        inputRef: { current: null },
+        handleSend: vi.fn(),
+        clearScreen: vi.fn(),
+        transport: {
+            mode: 'desktop',
+            runPrivacyOp: vi.fn(async () => ({ status: 'applied' })),
+        },
+    },
+}));
+
+vi.mock('../src/features/chat/hooks/useChat', () => ({
+    useChat: () => {
+        chatHarness.calls += 1;
+        return chatHarness.model;
+    },
+}));
+
+import AppDesktop from '../src/AppDesktop.jsx';
+import {
+    setPresenceMode,
+    setAlwaysOnTop,
+    getWindowState,
+    closeDesktopWindow,
+} from '../src/lib/desktopBridge.js';
+
+if (typeof HTMLElement.prototype.scrollIntoView !== 'function') {
+    HTMLElement.prototype.scrollIntoView = () => {};
+}
+
+let pywebviewApi;
+
+function setupBridge() {
+    pywebviewApi = {
+        set_presence_mode: vi.fn(async (enabled) => ({
+            ok: true,
+            mode: enabled ? 'presence' : 'companion',
+            on_top: false,
+            width: enabled ? 200 : 1280,
+            height: enabled ? 200 : 800,
+        })),
+        set_always_on_top: vi.fn(async (enabled) => ({
+            ok: true,
+            on_top: enabled,
+        })),
+        window_state: vi.fn(async () => ({
+            ok: true,
+            mode: 'companion',
+            on_top: false,
+            width: 1280,
+            height: 800,
+        })),
+        close_window: vi.fn(async () => ({
+            ok: true,
+        })),
+        health: vi.fn(async () => ({
+            ok: true,
+            api_version: 3,
+        })),
+    };
+
+    window.pywebview = { api: pywebviewApi };
+}
+
+function resetState() {
+    chatHarness.calls = 0;
+    setupBridge();
+    document.body.innerHTML = '';
+}
+
+describe('AppDesktop Presence Mode Integration', () => {
+    beforeEach(resetState);
+
+    it('initializes in companion mode with solid dark background and single chat model authority', async () => {
+        render(<AppDesktop />);
+
+        expect(chatHarness.calls).toBe(1);
+        const root = screen.getByTestId('app-desktop-root');
+        expect(root).toHaveClass('app-desktop--companion');
+        expect(root).toHaveClass('bg-gray-900');
+        expect(root).toHaveAttribute('data-desktop-mode', 'companion');
+        expect(root.style.background).not.toBe('transparent');
+
+        expect(screen.getByTestId('companion-layout')).toBeInTheDocument();
+        expect(screen.getByTestId('companion-enter-presence-btn')).toBeInTheDocument();
+        expect(screen.queryByTestId('katherine-presence-surface')).toBeNull();
+    });
+
+    it('transitions smoothly to presence mode, unmounting all conversation data and applying transparent background', async () => {
+        render(<AppDesktop />);
+
+        const enterBtn = screen.getByTestId('companion-enter-presence-btn');
+        await act(async () => {
+            fireEvent.click(enterBtn);
+        });
+
+        expect(pywebviewApi.set_presence_mode).toHaveBeenCalledWith(true);
+
+        const root = screen.getByTestId('app-desktop-root');
+        expect(root).toHaveClass('app-desktop--presence');
+        expect(root).not.toHaveClass('bg-gray-900');
+        expect(root).toHaveAttribute('data-desktop-mode', 'presence');
+        expect(root.style.background).toBe('transparent');
+
+        // Verify KatherinePresence is mounted
+        expect(screen.getByTestId('katherine-presence-surface')).toBeInTheDocument();
+
+        // Strict privacy assertion: CompanionLayout and all conversation DOM are completely unmounted
+        expect(screen.queryByTestId('companion-layout')).toBeNull();
+        expect(screen.queryByTestId('companion-history')).toBeNull();
+        expect(screen.queryByRole('textbox')).toBeNull();
+        expect(screen.queryByText('Minha mensagem confidencial')).toBeNull();
+        expect(screen.queryByText('Texto no composer')).toBeNull();
+
+        // ChatWindow remains mounted; re-rendered with new layout
+        expect(chatHarness.calls).toBeGreaterThanOrEqual(1);
+    });
+
+    it('toggles always-on-top in presence mode through the bridge', async () => {
+        render(<AppDesktop />);
+
+        // Enter presence
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('companion-enter-presence-btn'));
+        });
+
+        const pinBtn = screen.getByTestId('presence-pin-btn');
+        expect(pinBtn).toHaveAttribute('aria-pressed', 'false');
+
+        // Toggle on
+        await act(async () => {
+            fireEvent.click(pinBtn);
+        });
+        expect(pywebviewApi.set_always_on_top).toHaveBeenCalledWith(true);
+        expect(pinBtn).toHaveAttribute('aria-pressed', 'true');
+
+        // Toggle off
+        await act(async () => {
+            fireEvent.click(pinBtn);
+        });
+        expect(pywebviewApi.set_always_on_top).toHaveBeenCalledWith(false);
+        expect(pinBtn).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('returns from presence mode back to companion mode cleanly', async () => {
+        render(<AppDesktop />);
+
+        // Enter presence
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('companion-enter-presence-btn'));
+        });
+
+        expect(screen.getByTestId('katherine-presence-surface')).toBeInTheDocument();
+
+        // Click return button
+        const returnBtn = screen.getByTestId('presence-return-btn');
+        await act(async () => {
+            fireEvent.click(returnBtn);
+        });
+
+        expect(pywebviewApi.set_presence_mode).toHaveBeenCalledWith(false);
+
+        // Root restored to companion
+        const root = screen.getByTestId('app-desktop-root');
+        expect(root).toHaveClass('app-desktop--companion');
+        expect(root).toHaveClass('bg-gray-900');
+        expect(root).toHaveAttribute('data-desktop-mode', 'companion');
+        expect(root.style.background).not.toBe('transparent');
+
+        // CompanionLayout restored, KatherinePresence unmounted
+        expect(screen.getByTestId('companion-layout')).toBeInTheDocument();
+        expect(screen.queryByTestId('katherine-presence-surface')).toBeNull();
+
+        // History is back
+        expect(screen.getByText('Minha mensagem confidencial')).toBeInTheDocument();
+    });
+
+    it('calls closeDesktopWindow when close button is clicked in presence mode', async () => {
+        render(<AppDesktop />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('companion-enter-presence-btn'));
+        });
+
+        const closeBtn = screen.getByTestId('presence-close-btn');
+        await act(async () => {
+            fireEvent.click(closeBtn);
+        });
+
+        expect(pywebviewApi.close_window).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('desktopBridge window control client functions (unmocked)', () => {
+    function makeBridgeWindow(api = {}) {
+        return {
+            addEventListener: () => {},
+            pywebview: { api },
+        };
+    }
+
+    it('setPresenceMode calls api.set_presence_mode with boolean parameter', async () => {
+        let calledWith = null;
+        const fakeWindow = makeBridgeWindow({
+            set_presence_mode: async (val) => {
+                calledWith = val;
+                return { ok: true, mode: 'presence', on_top: false, width: 200, height: 200 };
+            },
+        });
+
+        const res = await setPresenceMode(true, fakeWindow);
+        expect(calledWith).toBe(true);
+        expect(res).toEqual({ ok: true, mode: 'presence', on_top: false, width: 200, height: 200 });
+    });
+
+    it('setPresenceMode validates parameter and rejects non-boolean', async () => {
+        const res = await setPresenceMode('invalid');
+        expect(res).toEqual({
+            ok: false,
+            code: 'invalid_input',
+            message: 'enabled must be a boolean',
+        });
+    });
+
+    it('setPresenceMode provides graceful fallback when pywebview is absent', async () => {
+        const res = await setPresenceMode(true, {});
+        expect(res).toEqual({
+            ok: true,
+            mode: 'presence',
+            on_top: false,
+            fallback: true,
+        });
+    });
+
+    it('setAlwaysOnTop calls api.set_always_on_top and provides graceful fallback', async () => {
+        let calledWith = null;
+        const fakeWindow = makeBridgeWindow({
+            set_always_on_top: async (val) => {
+                calledWith = val;
+                return { ok: true, on_top: val };
+            },
+        });
+
+        const res = await setAlwaysOnTop(true, fakeWindow);
+        expect(calledWith).toBe(true);
+        expect(res).toEqual({ ok: true, on_top: true });
+
+        // Fallback when api missing
+        const fallbackRes = await setAlwaysOnTop(true, {});
+        expect(fallbackRes).toEqual({ ok: true, on_top: true, fallback: true });
+    });
+
+    it('getWindowState calls api.window_state and provides fallback', async () => {
+        const fakeWindow = makeBridgeWindow({
+            window_state: async () => ({
+                ok: true,
+                mode: 'presence',
+                on_top: true,
+                width: 200,
+                height: 200,
+            }),
+        });
+
+        const res = await getWindowState(fakeWindow);
+        expect(res).toEqual({
+            ok: true,
+            mode: 'presence',
+            on_top: true,
+            width: 200,
+            height: 200,
+        });
+
+        // Fallback
+        const fallbackRes = await getWindowState({});
+        expect(fallbackRes).toEqual({
+            ok: true,
+            mode: 'companion',
+            on_top: false,
+            fallback: true,
+        });
+    });
+
+    it('closeDesktopWindow calls api.close_window and handles fallback', async () => {
+        let closeCalled = false;
+        const fakeWindow = makeBridgeWindow({
+            close_window: async () => {
+                closeCalled = true;
+                return { ok: true };
+            },
+        });
+
+        const res = await closeDesktopWindow(fakeWindow);
+        expect(closeCalled).toBe(true);
+        expect(res).toEqual({ ok: true });
+
+        // Fallback
+        let windowClosed = false;
+        const fallbackRes = await closeDesktopWindow({
+            close: () => { windowClosed = true; },
+        });
+        expect(windowClosed).toBe(true);
+        expect(fallbackRes).toEqual({ ok: true, fallback: true });
+    });
+});

--- a/frontend/tests/AppDesktopPresence.test.jsx
+++ b/frontend/tests/AppDesktopPresence.test.jsx
@@ -41,6 +41,7 @@ import {
     setAlwaysOnTop,
     getWindowState,
     closeDesktopWindow,
+    minimizeDesktopWindow,
 } from '../src/lib/desktopBridge.js';
 
 if (typeof HTMLElement.prototype.scrollIntoView !== 'function') {
@@ -70,6 +71,9 @@ function setupBridge() {
             height: 800,
         })),
         close_window: vi.fn(async () => ({
+            ok: true,
+        })),
+        minimize_window: vi.fn(async () => ({
             ok: true,
         })),
         health: vi.fn(async () => ({
@@ -161,6 +165,51 @@ describe('AppDesktop Presence Mode Integration', () => {
         expect(pinBtn).toHaveAttribute('aria-pressed', 'false');
     });
 
+    it('preserves always-on-top pin state across mode transitions without resetting (Blocker 1)', async () => {
+        let currentOnTop = false;
+        pywebviewApi.set_always_on_top = vi.fn(async (enabled) => {
+            currentOnTop = enabled;
+            return { ok: true, on_top: enabled };
+        });
+        pywebviewApi.set_presence_mode = vi.fn(async (enabled) => ({
+            ok: true,
+            mode: enabled ? 'presence' : 'companion',
+            on_top: currentOnTop,
+            width: enabled ? 200 : 1280,
+            height: enabled ? 200 : 800,
+        }));
+
+        render(<AppDesktop />);
+
+        // 1. Enter presence mode
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('companion-enter-presence-btn'));
+        });
+
+        const pinBtn = screen.getByTestId('presence-pin-btn');
+        expect(pinBtn).toHaveAttribute('aria-pressed', 'false');
+
+        // 2. User pins window
+        await act(async () => {
+            fireEvent.click(pinBtn);
+        });
+        expect(pinBtn).toHaveAttribute('aria-pressed', 'true');
+        expect(currentOnTop).toBe(true);
+
+        // 3. Return to companion
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('presence-return-btn'));
+        });
+        expect(screen.getByTestId('companion-layout')).toBeInTheDocument();
+
+        // 4. Re-enter presence - pin state must survive
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('companion-enter-presence-btn'));
+        });
+        const pinBtnAfterReturn = screen.getByTestId('presence-pin-btn');
+        expect(pinBtnAfterReturn).toHaveAttribute('aria-pressed', 'true');
+    });
+
     it('returns from presence mode back to companion mode cleanly', async () => {
         render(<AppDesktop />);
 
@@ -208,6 +257,114 @@ describe('AppDesktop Presence Mode Integration', () => {
 
         expect(pywebviewApi.close_window).toHaveBeenCalledTimes(1);
     });
+
+    it('calls minimizeDesktopWindow when minimize button is clicked in presence mode (Major 5)', async () => {
+        render(<AppDesktop />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('companion-enter-presence-btn'));
+        });
+
+        const minimizeBtn = screen.getByTestId('presence-minimize-btn');
+        expect(minimizeBtn).toBeInTheDocument();
+        expect(minimizeBtn).toHaveAttribute('aria-label', 'Minimizar');
+
+        await act(async () => {
+            fireEvent.click(minimizeBtn);
+        });
+
+        expect(pywebviewApi.minimize_window).toHaveBeenCalledTimes(1);
+    });
+
+    it('remains in companion mode when bridge set_presence_mode returns failure (Blocker 3 UI invariant)', async () => {
+        pywebviewApi.set_presence_mode.mockResolvedValueOnce({
+            ok: false,
+            code: 'window_mutation_failed',
+            message: 'Failed to enter presence mode',
+        });
+
+        render(<AppDesktop />);
+
+        const enterBtn = screen.getByTestId('companion-enter-presence-btn');
+        await act(async () => {
+            fireEvent.click(enterBtn);
+        });
+
+        expect(pywebviewApi.set_presence_mode).toHaveBeenCalledWith(true);
+
+        const root = screen.getByTestId('app-desktop-root');
+        expect(root).toHaveClass('app-desktop--companion');
+        expect(root).toHaveAttribute('data-desktop-mode', 'companion');
+        expect(screen.getByTestId('companion-layout')).toBeInTheDocument();
+        expect(screen.queryByTestId('katherine-presence-surface')).toBeNull();
+    });
+
+    it('remains in companion mode when bridge is unavailable in browser/dev environment (Blocker 3)', async () => {
+        delete window.pywebview;
+
+        render(<AppDesktop />);
+
+        const enterBtn = screen.getByTestId('companion-enter-presence-btn');
+        await act(async () => {
+            fireEvent.click(enterBtn);
+        });
+
+        const root = screen.getByTestId('app-desktop-root');
+        expect(root).toHaveClass('app-desktop--companion');
+        expect(root).toHaveAttribute('data-desktop-mode', 'companion');
+        expect(screen.getByTestId('companion-layout')).toBeInTheDocument();
+        expect(screen.queryByTestId('katherine-presence-surface')).toBeNull();
+    });
+
+    it('does not toggle always-on-top state when bridge set_always_on_top returns failure (Blocker 3)', async () => {
+        render(<AppDesktop />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('companion-enter-presence-btn'));
+        });
+
+        const pinBtn = screen.getByTestId('presence-pin-btn');
+        expect(pinBtn).toHaveAttribute('aria-pressed', 'false');
+
+        pywebviewApi.set_always_on_top.mockResolvedValueOnce({
+            ok: false,
+            code: 'window_mutation_failed',
+            message: 'Failed to pin window',
+        });
+
+        await act(async () => {
+            fireEvent.click(pinBtn);
+        });
+
+        expect(pywebviewApi.set_always_on_top).toHaveBeenCalledWith(true);
+        expect(pinBtn).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('remains in presence mode when set_presence_mode(false) fails returning to companion', async () => {
+        render(<AppDesktop />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('companion-enter-presence-btn'));
+        });
+
+        expect(screen.getByTestId('katherine-presence-surface')).toBeInTheDocument();
+
+        pywebviewApi.set_presence_mode.mockResolvedValueOnce({
+            ok: false,
+            code: 'window_mutation_failed',
+            message: 'Failed to restore companion',
+        });
+
+        const returnBtn = screen.getByTestId('presence-return-btn');
+        await act(async () => {
+            fireEvent.click(returnBtn);
+        });
+
+        const root = screen.getByTestId('app-desktop-root');
+        expect(root).toHaveAttribute('data-desktop-mode', 'presence');
+        expect(screen.getByTestId('katherine-presence-surface')).toBeInTheDocument();
+        expect(screen.queryByTestId('companion-layout')).toBeNull();
+    });
 });
 
 describe('desktopBridge window control client functions (unmocked)', () => {
@@ -241,17 +398,23 @@ describe('desktopBridge window control client functions (unmocked)', () => {
         });
     });
 
-    it('setPresenceMode provides graceful fallback when pywebview is absent', async () => {
-        const res = await setPresenceMode(true, {});
-        expect(res).toEqual({
-            ok: true,
-            mode: 'presence',
-            on_top: false,
-            fallback: true,
+    it('setPresenceMode returns honest bridge_unavailable error when pywebview is absent or missing method', async () => {
+        const res1 = await setPresenceMode(true, {});
+        expect(res1).toEqual({
+            ok: false,
+            code: 'bridge_unavailable',
+            message: 'Desktop window control is unavailable.',
+        });
+
+        const res2 = await setPresenceMode(true, makeBridgeWindow({}));
+        expect(res2).toEqual({
+            ok: false,
+            code: 'bridge_unavailable',
+            message: 'Desktop window control is unavailable.',
         });
     });
 
-    it('setAlwaysOnTop calls api.set_always_on_top and provides graceful fallback', async () => {
+    it('setAlwaysOnTop calls api.set_always_on_top and returns honest error when bridge missing', async () => {
         let calledWith = null;
         const fakeWindow = makeBridgeWindow({
             set_always_on_top: async (val) => {
@@ -264,12 +427,23 @@ describe('desktopBridge window control client functions (unmocked)', () => {
         expect(calledWith).toBe(true);
         expect(res).toEqual({ ok: true, on_top: true });
 
-        // Fallback when api missing
-        const fallbackRes = await setAlwaysOnTop(true, {});
-        expect(fallbackRes).toEqual({ ok: true, on_top: true, fallback: true });
+        // Honest error when api missing
+        const missingRes1 = await setAlwaysOnTop(true, {});
+        expect(missingRes1).toEqual({
+            ok: false,
+            code: 'bridge_unavailable',
+            message: 'Desktop window control is unavailable.',
+        });
+
+        const missingRes2 = await setAlwaysOnTop(true, makeBridgeWindow({}));
+        expect(missingRes2).toEqual({
+            ok: false,
+            code: 'bridge_unavailable',
+            message: 'Desktop window control is unavailable.',
+        });
     });
 
-    it('getWindowState calls api.window_state and provides fallback', async () => {
+    it('getWindowState calls api.window_state and returns honest error when bridge missing', async () => {
         const fakeWindow = makeBridgeWindow({
             window_state: async () => ({
                 ok: true,
@@ -289,17 +463,23 @@ describe('desktopBridge window control client functions (unmocked)', () => {
             height: 200,
         });
 
-        // Fallback
-        const fallbackRes = await getWindowState({});
-        expect(fallbackRes).toEqual({
-            ok: true,
-            mode: 'companion',
-            on_top: false,
-            fallback: true,
+        // Honest error when api missing
+        const missingRes1 = await getWindowState({});
+        expect(missingRes1).toEqual({
+            ok: false,
+            code: 'bridge_unavailable',
+            message: 'Desktop window control is unavailable.',
+        });
+
+        const missingRes2 = await getWindowState(makeBridgeWindow({}));
+        expect(missingRes2).toEqual({
+            ok: false,
+            code: 'bridge_unavailable',
+            message: 'Desktop window control is unavailable.',
         });
     });
 
-    it('closeDesktopWindow calls api.close_window and handles fallback', async () => {
+    it('closeDesktopWindow calls api.close_window and returns honest error without simulating closure', async () => {
         let closeCalled = false;
         const fakeWindow = makeBridgeWindow({
             close_window: async () => {
@@ -312,12 +492,51 @@ describe('desktopBridge window control client functions (unmocked)', () => {
         expect(closeCalled).toBe(true);
         expect(res).toEqual({ ok: true });
 
-        // Fallback
+        // Honest error: must NOT call window.close() or simulate closure
         let windowClosed = false;
-        const fallbackRes = await closeDesktopWindow({
+        const missingRes1 = await closeDesktopWindow({
             close: () => { windowClosed = true; },
         });
-        expect(windowClosed).toBe(true);
-        expect(fallbackRes).toEqual({ ok: true, fallback: true });
+        expect(windowClosed).toBe(false);
+        expect(missingRes1).toEqual({
+            ok: false,
+            code: 'bridge_unavailable',
+            message: 'Desktop window control is unavailable.',
+        });
+
+        const missingRes2 = await closeDesktopWindow(makeBridgeWindow({}));
+        expect(missingRes2).toEqual({
+            ok: false,
+            code: 'bridge_unavailable',
+            message: 'Desktop window control is unavailable.',
+        });
+    });
+
+    it('minimizeDesktopWindow calls api.minimize_window and returns honest error when missing (Major 5)', async () => {
+        let minimizeCalled = false;
+        const fakeWindow = makeBridgeWindow({
+            minimize_window: async () => {
+                minimizeCalled = true;
+                return { ok: true };
+            },
+        });
+
+        const res = await minimizeDesktopWindow(fakeWindow);
+        expect(minimizeCalled).toBe(true);
+        expect(res).toEqual({ ok: true });
+
+        const missingRes1 = await minimizeDesktopWindow({});
+        expect(missingRes1).toEqual({
+            ok: false,
+            code: 'bridge_unavailable',
+            message: 'Desktop window control is unavailable.',
+        });
+
+        const missingRes2 = await minimizeDesktopWindow(makeBridgeWindow({}));
+        expect(missingRes2).toEqual({
+            ok: false,
+            code: 'bridge_unavailable',
+            message: 'Desktop window control is unavailable.',
+        });
     });
 });

--- a/frontend/tests/KatherinePresence.test.jsx
+++ b/frontend/tests/KatherinePresence.test.jsx
@@ -1,53 +1,246 @@
 import React from 'react';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
-import { render, screen } from '@testing-library/react';
-import KatherineFace from '../src/features/katherine-face/KatherineFace.jsx';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
-// Exercise the real SVG renderer, not a replacement face component.
-describe('Katherine presence activity', () => {
-    it('projects confirmed loading into one decorative activity signal without replacing the face', () => {
-        const { rerender } = render(<KatherineFace isLoading={false} />);
-        const presence = screen.getByTestId('katherine-face');
-        const head = presence.querySelector('.bwf-head');
-        const eyes = [...presence.querySelectorAll('.bwf-eye')];
-        const arc = screen.getByTestId('katherine-activity-arc');
+const faceProps = vi.hoisted(() => ({ current: null }));
 
-        expect(head).not.toBeNull();
-        expect(eyes).toHaveLength(2);
-        expect(presence).toHaveAttribute('data-activity', 'idle');
-        expect(arc).toHaveAttribute('aria-hidden', 'true');
-        expect(arc).toHaveAttribute('focusable', 'false');
-        expect(arc.querySelectorAll('path')).toHaveLength(1);
-        expect(arc.querySelector('animate, animateTransform')).toBeNull();
-        expect(screen.queryByRole('progressbar')).toBeNull();
+vi.mock('../src/features/katherine-face/KatherineFace.jsx', () => ({
+    default: (props) => {
+        faceProps.current = props;
+        return (
+            <div
+                data-testid="katherine-face"
+                aria-hidden="true"
+                className={props.className}
+            />
+        );
+    },
+}));
 
-        rerender(<KatherineFace isLoading />);
-        expect(presence).toHaveAttribute('data-activity', 'busy');
-        expect(presence.querySelector('.bwf-head')).toBe(head);
-        expect([...presence.querySelectorAll('.bwf-eye')]).toEqual(eyes);
-        expect(screen.getAllByTestId('katherine-activity-arc')).toHaveLength(1);
+import KatherinePresence from '../src/features/katherine-face/KatherinePresence.jsx';
 
-        rerender(<KatherineFace isLoading={false} />);
-        expect(presence).toHaveAttribute('data-activity', 'idle');
-        expect(presence.querySelector('.bwf-head')).toBe(head);
+const makeEmotionState = () => ({
+    schema_version: 1,
+    mood_label: 'NEUTRA',
+    pad: { pleasure: 0.1, arousal: 0, dominance: 0.1 },
+    dominant_emotions: [{ name: 'gratitude', intensity: 0.7 }],
+    timestamp: 1700000000,
+});
+
+describe('KatherinePresence Component', () => {
+    beforeEach(() => {
+        faceProps.current = null;
+        document.body.innerHTML = '';
     });
 
-    it.each([undefined, null, 0, 1, 'true', {}, []])('does not infer activity from unconfirmed loading: %s', (isLoading) => {
-        render(<KatherineFace isLoading={isLoading} />);
-        expect(screen.getByTestId('katherine-face')).toHaveAttribute('data-activity', 'idle');
+    it('renders the minimal presence surface with face inside the pywebview drag handle', () => {
+        const emotionState = makeEmotionState();
+        render(
+            <KatherinePresence
+                emotionState={emotionState}
+                isLoading={false}
+                onReturnToCompanion={vi.fn()}
+                onClose={vi.fn()}
+                onToggleAlwaysOnTop={vi.fn()}
+                isAlwaysOnTop={false}
+            />,
+        );
+
+        const surface = screen.getByTestId('katherine-presence-surface');
+        expect(surface).toHaveAttribute('role', 'region');
+        expect(surface).toHaveAttribute('aria-label', 'Presença flutuante da Katherine');
+
+        const dragHandle = screen.getByTestId('katherine-presence-drag-handle');
+        expect(dragHandle).toHaveClass('katherine-presence__drag-handle');
+        expect(dragHandle).toHaveClass('pywebview-drag-region');
+
+        const face = screen.getByTestId('katherine-face');
+        expect(dragHandle).toContainElement(face);
+        expect(faceProps.current).toEqual(
+            expect.objectContaining({
+                emotionState,
+                isLoading: false,
+                className: 'katherine-face--presence',
+            }),
+        );
     });
 
-    it('isolates simultaneous face instances and removes their signals on unmount', () => {
-        const first = render(<KatherineFace isLoading />);
-        const second = render(<KatherineFace isLoading={false} />);
-        const faces = screen.getAllByTestId('katherine-face');
-        expect(faces[0]).toHaveAttribute('data-activity', 'busy');
-        expect(faces[1]).toHaveAttribute('data-activity', 'idle');
-        first.unmount();
-        expect(screen.getAllByTestId('katherine-activity-arc')).toHaveLength(1);
-        expect(screen.getByTestId('katherine-face')).toHaveAttribute('data-activity', 'idle');
-        second.unmount();
-        expect(screen.queryByTestId('katherine-activity-arc')).toBeNull();
+    it('renders ephemeral control buttons with proper accessible roles and labels', () => {
+        render(
+            <KatherinePresence
+                emotionState={null}
+                isLoading={false}
+                onReturnToCompanion={vi.fn()}
+                onClose={vi.fn()}
+                onToggleAlwaysOnTop={vi.fn()}
+                isAlwaysOnTop={false}
+            />,
+        );
+
+        const controls = screen.getByTestId('katherine-presence-controls');
+        expect(controls).toHaveAttribute('role', 'toolbar');
+        expect(controls).toHaveAttribute('aria-label', 'Controles da presença');
+
+        const returnBtn = screen.getByTestId('presence-return-btn');
+        expect(returnBtn).toHaveAttribute('aria-label', 'Voltar ao companion');
+
+        const pinBtn = screen.getByTestId('presence-pin-btn');
+        expect(pinBtn).toHaveAttribute('aria-label', 'Manter no topo');
+        expect(pinBtn).toHaveAttribute('aria-pressed', 'false');
+
+        const closeBtn = screen.getByTestId('presence-close-btn');
+        expect(closeBtn).toHaveAttribute('aria-label', 'Fechar');
+    });
+
+    it('reflects always-on-top state via aria-pressed and accessible title/label', () => {
+        const { rerender } = render(
+            <KatherinePresence
+                emotionState={null}
+                isLoading={false}
+                onReturnToCompanion={vi.fn()}
+                onClose={vi.fn()}
+                onToggleAlwaysOnTop={vi.fn()}
+                isAlwaysOnTop={false}
+            />,
+        );
+
+        const pinBtn = screen.getByTestId('presence-pin-btn');
+        expect(pinBtn).toHaveAttribute('aria-pressed', 'false');
+        expect(pinBtn).toHaveAttribute('aria-label', 'Manter no topo');
+        expect(pinBtn).not.toHaveClass('katherine-presence__btn--active');
+
+        rerender(
+            <KatherinePresence
+                emotionState={null}
+                isLoading={false}
+                onReturnToCompanion={vi.fn()}
+                onClose={vi.fn()}
+                onToggleAlwaysOnTop={vi.fn()}
+                isAlwaysOnTop={true}
+            />,
+        );
+
+        expect(pinBtn).toHaveAttribute('aria-pressed', 'true');
+        expect(pinBtn).toHaveAttribute('aria-label', 'Desafixar do topo');
+        expect(pinBtn).toHaveClass('katherine-presence__btn--active');
+    });
+
+    it('triggers the corresponding action callbacks on control click', () => {
+        const onReturn = vi.fn();
+        const onTogglePin = vi.fn();
+        const onClose = vi.fn();
+
+        render(
+            <KatherinePresence
+                emotionState={null}
+                isLoading={false}
+                onReturnToCompanion={onReturn}
+                onClose={onClose}
+                onToggleAlwaysOnTop={onTogglePin}
+                isAlwaysOnTop={false}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('presence-return-btn'));
+        expect(onReturn).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByTestId('presence-pin-btn'));
+        expect(onTogglePin).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByTestId('presence-close-btn'));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops mousedown propagation on buttons to isolate clicks from pywebview dragging', () => {
+        render(
+            <KatherinePresence
+                emotionState={null}
+                isLoading={false}
+                onReturnToCompanion={vi.fn()}
+                onClose={vi.fn()}
+                onToggleAlwaysOnTop={vi.fn()}
+                isAlwaysOnTop={false}
+            />,
+        );
+
+        for (const testId of ['presence-return-btn', 'presence-pin-btn', 'presence-close-btn']) {
+            const btn = screen.getByTestId(testId);
+            const mousedownEvent = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+            const stopPropagationSpy = vi.spyOn(mousedownEvent, 'stopPropagation');
+            const stopImmediatePropagationSpy = vi.spyOn(mousedownEvent, 'stopImmediatePropagation');
+
+            btn.dispatchEvent(mousedownEvent);
+
+            expect(stopPropagationSpy).toHaveBeenCalled();
+            expect(stopImmediatePropagationSpy).toHaveBeenCalled();
+        }
+    });
+
+    it('strictly isolates privacy: zero chat history, zero composer, zero memory in the DOM', () => {
+        render(
+            <KatherinePresence
+                emotionState={makeEmotionState()}
+                isLoading={false}
+                onReturnToCompanion={vi.fn()}
+                onClose={vi.fn()}
+                onToggleAlwaysOnTop={vi.fn()}
+                isAlwaysOnTop={false}
+            />,
+        );
+
+        expect(screen.queryByRole('textbox')).toBeNull();
+        expect(screen.queryByTestId('companion-history')).toBeNull();
+        expect(screen.queryByTestId('companion-utilities')).toBeNull();
+        expect(screen.queryByTestId('companion-emotion-details')).toBeNull();
+        expect(screen.queryByTestId('companion-privacy-details')).toBeNull();
+        expect(screen.queryByText(/privacidade|memória|histórico|sua mensagem/i)).toBeNull();
+    });
+
+    it('announces loading preparation to assistive tech without continuous polling', () => {
+        const { rerender } = render(
+            <KatherinePresence
+                emotionState={null}
+                isLoading={false}
+                onReturnToCompanion={vi.fn()}
+                onClose={vi.fn()}
+                onToggleAlwaysOnTop={vi.fn()}
+                isAlwaysOnTop={false}
+            />,
+        );
+
+        expect(screen.queryByRole('status')).toBeNull();
+
+        rerender(
+            <KatherinePresence
+                emotionState={null}
+                isLoading={true}
+                onReturnToCompanion={vi.fn()}
+                onClose={vi.fn()}
+                onToggleAlwaysOnTop={vi.fn()}
+                isAlwaysOnTop={false}
+            />,
+        );
+
+        const status = screen.getByRole('status');
+        expect(status).toHaveTextContent('Preparando resposta…');
+    });
+
+    it('declares reduced-motion rules, 160ms ease-out transitions, and transparent background in CSS', () => {
+        const cssPath = join(
+            __dirname,
+            '../src/features/katherine-face/KatherinePresence.css',
+        );
+        const css = readFileSync(cssPath, 'utf8');
+
+        expect(css).toMatch(/background:\s*transparent/);
+        expect(css).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)/);
+        expect(css).toMatch(/transition-duration:\s*0ms\s*!important/);
+        expect(css).toMatch(/transform:\s*none\s*!important/);
+        expect(css).toMatch(/cubic-bezier\(0\.23,\s*1,\s*0\.32,\s*1\)/);
+        expect(css).toMatch(/-webkit-app-region:\s*drag/);
+        expect(css).toMatch(/-webkit-app-region:\s*no-drag/);
     });
 });

--- a/frontend/tests/KatherinePresence.test.jsx
+++ b/frontend/tests/KatherinePresence.test.jsx
@@ -44,6 +44,7 @@ describe('KatherinePresence Component', () => {
                 isLoading={false}
                 onReturnToCompanion={vi.fn()}
                 onClose={vi.fn()}
+                onMinimize={vi.fn()}
                 onToggleAlwaysOnTop={vi.fn()}
                 isAlwaysOnTop={false}
             />,
@@ -75,6 +76,7 @@ describe('KatherinePresence Component', () => {
                 isLoading={false}
                 onReturnToCompanion={vi.fn()}
                 onClose={vi.fn()}
+                onMinimize={vi.fn()}
                 onToggleAlwaysOnTop={vi.fn()}
                 isAlwaysOnTop={false}
             />,
@@ -86,6 +88,10 @@ describe('KatherinePresence Component', () => {
 
         const returnBtn = screen.getByTestId('presence-return-btn');
         expect(returnBtn).toHaveAttribute('aria-label', 'Voltar ao companion');
+
+        const minimizeBtn = screen.getByTestId('presence-minimize-btn');
+        expect(minimizeBtn).toHaveAttribute('aria-label', 'Minimizar');
+        expect(minimizeBtn).toHaveAttribute('title', 'Minimizar');
 
         const pinBtn = screen.getByTestId('presence-pin-btn');
         expect(pinBtn).toHaveAttribute('aria-label', 'Manter no topo');
@@ -102,6 +108,7 @@ describe('KatherinePresence Component', () => {
                 isLoading={false}
                 onReturnToCompanion={vi.fn()}
                 onClose={vi.fn()}
+                onMinimize={vi.fn()}
                 onToggleAlwaysOnTop={vi.fn()}
                 isAlwaysOnTop={false}
             />,
@@ -118,6 +125,7 @@ describe('KatherinePresence Component', () => {
                 isLoading={false}
                 onReturnToCompanion={vi.fn()}
                 onClose={vi.fn()}
+                onMinimize={vi.fn()}
                 onToggleAlwaysOnTop={vi.fn()}
                 isAlwaysOnTop={true}
             />,
@@ -130,6 +138,7 @@ describe('KatherinePresence Component', () => {
 
     it('triggers the corresponding action callbacks on control click', () => {
         const onReturn = vi.fn();
+        const onMinimize = vi.fn();
         const onTogglePin = vi.fn();
         const onClose = vi.fn();
 
@@ -139,6 +148,7 @@ describe('KatherinePresence Component', () => {
                 isLoading={false}
                 onReturnToCompanion={onReturn}
                 onClose={onClose}
+                onMinimize={onMinimize}
                 onToggleAlwaysOnTop={onTogglePin}
                 isAlwaysOnTop={false}
             />,
@@ -146,6 +156,9 @@ describe('KatherinePresence Component', () => {
 
         fireEvent.click(screen.getByTestId('presence-return-btn'));
         expect(onReturn).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByTestId('presence-minimize-btn'));
+        expect(onMinimize).toHaveBeenCalledTimes(1);
 
         fireEvent.click(screen.getByTestId('presence-pin-btn'));
         expect(onTogglePin).toHaveBeenCalledTimes(1);
@@ -161,12 +174,18 @@ describe('KatherinePresence Component', () => {
                 isLoading={false}
                 onReturnToCompanion={vi.fn()}
                 onClose={vi.fn()}
+                onMinimize={vi.fn()}
                 onToggleAlwaysOnTop={vi.fn()}
                 isAlwaysOnTop={false}
             />,
         );
 
-        for (const testId of ['presence-return-btn', 'presence-pin-btn', 'presence-close-btn']) {
+        for (const testId of [
+            'presence-return-btn',
+            'presence-minimize-btn',
+            'presence-pin-btn',
+            'presence-close-btn',
+        ]) {
             const btn = screen.getByTestId(testId);
             const mousedownEvent = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
             const stopPropagationSpy = vi.spyOn(mousedownEvent, 'stopPropagation');
@@ -186,6 +205,7 @@ describe('KatherinePresence Component', () => {
                 isLoading={false}
                 onReturnToCompanion={vi.fn()}
                 onClose={vi.fn()}
+                onMinimize={vi.fn()}
                 onToggleAlwaysOnTop={vi.fn()}
                 isAlwaysOnTop={false}
             />,
@@ -206,6 +226,7 @@ describe('KatherinePresence Component', () => {
                 isLoading={false}
                 onReturnToCompanion={vi.fn()}
                 onClose={vi.fn()}
+                onMinimize={vi.fn()}
                 onToggleAlwaysOnTop={vi.fn()}
                 isAlwaysOnTop={false}
             />,
@@ -219,6 +240,7 @@ describe('KatherinePresence Component', () => {
                 isLoading={true}
                 onReturnToCompanion={vi.fn()}
                 onClose={vi.fn()}
+                onMinimize={vi.fn()}
                 onToggleAlwaysOnTop={vi.fn()}
                 isAlwaysOnTop={false}
             />,

--- a/frontend/tests/desktopBridge.test.js
+++ b/frontend/tests/desktopBridge.test.js
@@ -1,8 +1,9 @@
 /**
- * Tests for the desktop bridge client (#334).
+ * Tests for the desktop bridge client (#334, #342).
  *
  * Node-native tests (no DOM): validate the contract rules —
- * null outside the shell, payload validation inside it, bounded wait.
+ * null outside the shell for companion ops, payload validation inside it,
+ * honest bridge_unavailable failure for native window capabilities.
  * The window object is injected explicitly (no global mutation).
  */
 
@@ -228,8 +229,6 @@ test('sendMessageViaBridge rejects a non-dict success payload', async () => {
 // =========================================================================
 
 test('sendMessageViaBridge settles as timeout when the signal aborts (bridge never resolves)', async () => {
-    // Deterministic hung bridge: the underlying promise NEVER settles.
-    // The aborted signal must race it and reject with ChatError timeout.
     const window = apiWindow({
         send_message: () => new Promise(() => {}), // hangs forever
     });
@@ -318,4 +317,62 @@ test('runPrivacyOpViaBridge maps a failed op to a ChatError', async () => {
         () => runPrivacyOpViaBridge('delete_history', window),
         (err) => err.name === 'ChatError' && err.type === 'service_unavailable',
     );
+});
+
+// =========================================================================
+// #342: presence mode & window control client functions (honest bridge)
+// =========================================================================
+
+import {
+    setPresenceMode,
+    setAlwaysOnTop,
+    getWindowState,
+    closeDesktopWindow,
+    minimizeDesktopWindow,
+} from '../src/lib/desktopBridge.js';
+
+test('window control functions return bridge_unavailable when bridge is missing', async () => {
+    const emptyWindow = {};
+    const expectedError = {
+        ok: false,
+        code: 'bridge_unavailable',
+        message: 'Desktop window control is unavailable.',
+    };
+
+    assert.deepEqual(await setPresenceMode(true, emptyWindow), expectedError);
+    assert.deepEqual(await setAlwaysOnTop(true, emptyWindow), expectedError);
+    assert.deepEqual(await getWindowState(emptyWindow), expectedError);
+    assert.deepEqual(await closeDesktopWindow(emptyWindow), expectedError);
+    assert.deepEqual(await minimizeDesktopWindow(emptyWindow), expectedError);
+});
+
+test('window control functions return bridge_unavailable when methods are missing on api', async () => {
+    const window = apiWindow({});
+    const expectedError = {
+        ok: false,
+        code: 'bridge_unavailable',
+        message: 'Desktop window control is unavailable.',
+    };
+
+    assert.deepEqual(await setPresenceMode(true, window), expectedError);
+    assert.deepEqual(await setAlwaysOnTop(true, window), expectedError);
+    assert.deepEqual(await getWindowState(window), expectedError);
+    assert.deepEqual(await closeDesktopWindow(window), expectedError);
+    assert.deepEqual(await minimizeDesktopWindow(window), expectedError);
+});
+
+test('window control functions pass through valid responses from api', async () => {
+    const window = apiWindow({
+        set_presence_mode: async (val) => ({ ok: true, mode: val ? 'presence' : 'companion', on_top: false }),
+        set_always_on_top: async (val) => ({ ok: true, on_top: val }),
+        window_state: async () => ({ ok: true, mode: 'presence', on_top: true }),
+        close_window: async () => ({ ok: true }),
+        minimize_window: async () => ({ ok: true }),
+    });
+
+    assert.deepEqual(await setPresenceMode(true, window), { ok: true, mode: 'presence', on_top: false });
+    assert.deepEqual(await setAlwaysOnTop(true, window), { ok: true, on_top: true });
+    assert.deepEqual(await getWindowState(window), { ok: true, mode: 'presence', on_top: true });
+    assert.deepEqual(await closeDesktopWindow(window), { ok: true });
+    assert.deepEqual(await minimizeDesktopWindow(window), { ok: true });
 });

--- a/frontend/tests/presenceChallenger2.test.jsx
+++ b/frontend/tests/presenceChallenger2.test.jsx
@@ -1,0 +1,538 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const chatHarness = vi.hoisted(() => ({
+    calls: 0,
+    model: {
+        messages: [{ role: 'user', content: 'Secret test token' }],
+        input: 'Draft composer input',
+        setInput: vi.fn(),
+        isLoading: false,
+        emotionState: {
+            schema_version: 1,
+            mood_label: 'ALEGRE',
+            pad: { pleasure: 0.5, arousal: 0.5, dominance: 0.5 },
+            dominant_emotions: [{ name: 'joy', intensity: 0.8 }],
+            timestamp: 1700000000,
+        },
+        messagesEndRef: { current: null },
+        inputRef: { current: null },
+        handleSend: vi.fn(),
+        clearScreen: vi.fn(),
+        transport: {
+            mode: 'desktop',
+            runPrivacyOp: vi.fn(async () => ({ status: 'applied' })),
+        },
+    },
+}));
+
+vi.mock('../src/features/chat/hooks/useChat', () => ({
+    useChat: () => {
+        chatHarness.calls += 1;
+        return chatHarness.model;
+    },
+}));
+
+import AppDesktop from '../src/AppDesktop.jsx';
+import KatherinePresence from '../src/features/katherine-face/KatherinePresence.jsx';
+
+if (typeof HTMLElement.prototype.scrollIntoView !== 'function') {
+    HTMLElement.prototype.scrollIntoView = () => {};
+}
+
+let pywebviewApi;
+
+function setupBridge(customOverrides = {}) {
+    pywebviewApi = {
+        set_presence_mode: vi.fn(async (enabled) => ({
+            ok: true,
+            mode: enabled ? 'presence' : 'companion',
+            on_top: false,
+            width: enabled ? 200 : 1280,
+            height: enabled ? 200 : 800,
+        })),
+        set_always_on_top: vi.fn(async (enabled) => ({
+            ok: true,
+            on_top: enabled,
+        })),
+        window_state: vi.fn(async () => ({
+            ok: true,
+            mode: 'companion',
+            on_top: false,
+            width: 1280,
+            height: 800,
+        })),
+        close_window: vi.fn(async () => ({
+            ok: true,
+        })),
+        minimize_window: vi.fn(async () => ({
+            ok: true,
+        })),
+        health: vi.fn(async () => ({
+            ok: true,
+            api_version: 3,
+        })),
+        ...customOverrides,
+    };
+
+    window.pywebview = { api: pywebviewApi };
+}
+
+describe('Challenger 2 Empirical Verification: Native Minimization & Event Isolation', () => {
+    beforeEach(() => {
+        chatHarness.calls = 0;
+        setupBridge();
+        document.body.innerHTML = '';
+    });
+
+    describe('1. Native Minimization in KatherinePresence.jsx', () => {
+        it('renders presence-minimize-btn with full accessibility attributes and toolbar role', () => {
+            const onMinimize = vi.fn();
+            render(
+                <KatherinePresence
+                    emotionState={null}
+                    isLoading={false}
+                    onReturnToCompanion={vi.fn()}
+                    onClose={vi.fn()}
+                    onMinimize={onMinimize}
+                    onToggleAlwaysOnTop={vi.fn()}
+                    isAlwaysOnTop={false}
+                />,
+            );
+
+            const toolbar = screen.getByTestId('katherine-presence-controls');
+            expect(toolbar).toHaveAttribute('role', 'toolbar');
+            expect(toolbar).toHaveAttribute('aria-label', 'Controles da presença');
+
+            const minimizeBtn = screen.getByTestId('presence-minimize-btn');
+            expect(minimizeBtn).toBeInTheDocument();
+            expect(toolbar).toContainElement(minimizeBtn);
+            expect(minimizeBtn.tagName.toLowerCase()).toBe('button');
+            expect(minimizeBtn).toHaveAttribute('type', 'button');
+            expect(minimizeBtn).toHaveAttribute('aria-label', 'Minimizar');
+            expect(minimizeBtn).toHaveAttribute('title', 'Minimizar');
+
+            // Icon SVG must be aria-hidden so screen readers do not read decorative SVG
+            const svgIcon = minimizeBtn.querySelector('svg');
+            expect(svgIcon).not.toBeNull();
+            expect(svgIcon).toHaveAttribute('aria-hidden', 'true');
+
+            // Click triggers onMinimize
+            fireEvent.click(minimizeBtn);
+            expect(onMinimize).toHaveBeenCalledTimes(1);
+        });
+
+        it('supports keyboard navigation and activation on presence-minimize-btn', () => {
+            const onMinimize = vi.fn();
+            render(
+                <KatherinePresence
+                    emotionState={null}
+                    isLoading={false}
+                    onReturnToCompanion={vi.fn()}
+                    onClose={vi.fn()}
+                    onMinimize={onMinimize}
+                    onToggleAlwaysOnTop={vi.fn()}
+                    isAlwaysOnTop={false}
+                />,
+            );
+
+            const minimizeBtn = screen.getByTestId('presence-minimize-btn');
+            minimizeBtn.focus();
+            expect(document.activeElement).toBe(minimizeBtn);
+
+            // Native button responds to click generated by Space/Enter
+            fireEvent.click(minimizeBtn);
+            expect(onMinimize).toHaveBeenCalledTimes(1);
+        });
+
+        it('safely handles omitted onMinimize without errors', () => {
+            render(
+                <KatherinePresence
+                    emotionState={null}
+                    isLoading={false}
+                    onReturnToCompanion={vi.fn()}
+                    onClose={vi.fn()}
+                    onToggleAlwaysOnTop={vi.fn()}
+                    isAlwaysOnTop={false}
+                />,
+            );
+
+            const minimizeBtn = screen.getByTestId('presence-minimize-btn');
+            expect(() => fireEvent.click(minimizeBtn)).not.toThrow();
+        });
+    });
+
+    describe('2. Drag Event Isolation & onMouseDown stopPropagation', () => {
+        it('stops React synthetic mousedown propagation to parent React containers', () => {
+            let parentReceivedMouseDown = false;
+            const ParentWrapper = () => (
+                <div onMouseDown={() => { parentReceivedMouseDown = true; }}>
+                    <KatherinePresence
+                        emotionState={null}
+                        isLoading={false}
+                        onReturnToCompanion={vi.fn()}
+                        onClose={vi.fn()}
+                        onMinimize={vi.fn()}
+                        onToggleAlwaysOnTop={vi.fn()}
+                        isAlwaysOnTop={false}
+                    />
+                </div>
+            );
+
+            render(<ParentWrapper />);
+            const minimizeBtn = screen.getByTestId('presence-minimize-btn');
+
+            fireEvent.mouseDown(minimizeBtn);
+
+            // Because handleControlMouseDown calls e.stopPropagation(), parent React container never receives it
+            expect(parentReceivedMouseDown).toBe(false);
+        });
+
+        it('stops native event propagation via stopPropagation and stopImmediatePropagation', () => {
+            render(
+                <KatherinePresence
+                    emotionState={null}
+                    isLoading={false}
+                    onReturnToCompanion={vi.fn()}
+                    onClose={vi.fn()}
+                    onMinimize={vi.fn()}
+                    onToggleAlwaysOnTop={vi.fn()}
+                    isAlwaysOnTop={false}
+                />,
+            );
+
+            const minimizeBtn = screen.getByTestId('presence-minimize-btn');
+            const mousedownEvent = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+            const stopPropagationSpy = vi.spyOn(mousedownEvent, 'stopPropagation');
+            const stopImmediatePropagationSpy = vi.spyOn(mousedownEvent, 'stopImmediatePropagation');
+
+            minimizeBtn.dispatchEvent(mousedownEvent);
+
+            expect(stopPropagationSpy).toHaveBeenCalled();
+            expect(stopImmediatePropagationSpy).toHaveBeenCalled();
+        });
+
+        it('strictly isolates all ephemeral toolbar buttons from the pywebview drag handle', () => {
+            render(
+                <KatherinePresence
+                    emotionState={null}
+                    isLoading={false}
+                    onReturnToCompanion={vi.fn()}
+                    onClose={vi.fn()}
+                    onMinimize={vi.fn()}
+                    onToggleAlwaysOnTop={vi.fn()}
+                    isAlwaysOnTop={false}
+                />,
+            );
+
+            const dragHandle = screen.getByTestId('katherine-presence-drag-handle');
+            let dragHandleReceived = false;
+            dragHandle.addEventListener('mousedown', () => { dragHandleReceived = true; });
+
+            const buttonIds = [
+                'presence-return-btn',
+                'presence-pin-btn',
+                'presence-minimize-btn',
+                'presence-close-btn',
+            ];
+
+            for (const testId of buttonIds) {
+                const btn = screen.getByTestId(testId);
+                const evt = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+                btn.dispatchEvent(evt);
+                expect(dragHandleReceived).toBe(false);
+            }
+        });
+
+        it('verifies CSS layout invariants for pywebview drag regions', () => {
+            const cssPath = join(
+                __dirname,
+                '../src/features/katherine-face/KatherinePresence.css',
+            );
+            const css = readFileSync(cssPath, 'utf8');
+
+            // Drag handle must have -webkit-app-region: drag
+            expect(css).toMatch(/\.katherine-presence__drag-handle[\s\S]*?-webkit-app-region:\s*drag;/);
+
+            // Ephemeral controls overlay must have -webkit-app-region: no-drag
+            expect(css).toMatch(/\.katherine-presence__controls[\s\S]*?-webkit-app-region:\s*no-drag;/);
+
+            // Buttons must have -webkit-app-region: no-drag
+            expect(css).toMatch(/\.katherine-presence__btn[\s\S]*?-webkit-app-region:\s*no-drag;/);
+
+            // Face must have pointer-events: none so dragging the face triggers the drag handle behind it
+            expect(css).toMatch(/\.katherine-face--presence[\s\S]*?pointer-events:\s*none;/);
+        });
+    });
+
+    describe('3. Stress Testing Rapid Clicking & Re-Entrancy Guards', () => {
+        it('drops concurrent spam clicks on enter-presence button while transition is in flight', async () => {
+            let resolveTransition;
+            pywebviewApi.set_presence_mode = vi.fn(
+                () => new Promise((resolve) => {
+                    resolveTransition = resolve;
+                }),
+            );
+
+            render(<AppDesktop />);
+            const enterBtn = screen.getByTestId('companion-enter-presence-btn');
+
+            // Fire 1st click: launches in-flight transition
+            fireEvent.click(enterBtn);
+
+            // Fire 20 rapid concurrent clicks while bridge call is pending
+            for (let i = 0; i < 20; i++) {
+                fireEvent.click(enterBtn);
+            }
+
+            // Flush microtasks so the initial bridge call runs
+            await Promise.resolve();
+            await Promise.resolve();
+
+            // In-flight guard MUST have dropped all 20 re-entrant attempts! Exactly 1 call reached the bridge!
+            expect(pywebviewApi.set_presence_mode).toHaveBeenCalledTimes(1);
+
+            // Fire another 10 clicks while still waiting for backend resolution
+            for (let i = 0; i < 10; i++) {
+                fireEvent.click(enterBtn);
+            }
+            await Promise.resolve();
+            expect(pywebviewApi.set_presence_mode).toHaveBeenCalledTimes(1);
+
+            // Resolve the in-flight bridge operation
+            await act(async () => {
+                resolveTransition({
+                    ok: true,
+                    mode: 'presence',
+                    on_top: false,
+                    width: 200,
+                    height: 200,
+                });
+            });
+
+            // UI successfully enters presence
+            expect(screen.getByTestId('app-desktop-root')).toHaveAttribute('data-desktop-mode', 'presence');
+            expect(screen.getByTestId('katherine-presence-surface')).toBeInTheDocument();
+        });
+
+        it('drops concurrent spam clicks on return-to-companion button while transition is in flight', async () => {
+            render(<AppDesktop />);
+            await act(async () => {
+                fireEvent.click(screen.getByTestId('companion-enter-presence-btn'));
+            });
+
+            expect(screen.getByTestId('katherine-presence-surface')).toBeInTheDocument();
+
+            // Set up delayed bridge response for return
+            let resolveReturn;
+            pywebviewApi.set_presence_mode = vi.fn(
+                () => new Promise((resolve) => {
+                    resolveReturn = resolve;
+                }),
+            );
+
+            const returnBtn = screen.getByTestId('presence-return-btn');
+
+            // Fire 1st click
+            fireEvent.click(returnBtn);
+
+            // Spam 20 concurrent clicks
+            for (let i = 0; i < 20; i++) {
+                fireEvent.click(returnBtn);
+            }
+
+            await Promise.resolve();
+            await Promise.resolve();
+
+            // Re-entrancy guard MUST drop all 20 clicks: exactly 1 call reached bridge!
+            expect(pywebviewApi.set_presence_mode).toHaveBeenCalledTimes(1);
+
+            // Spam 10 more clicks
+            for (let i = 0; i < 10; i++) {
+                fireEvent.click(returnBtn);
+            }
+            await Promise.resolve();
+            expect(pywebviewApi.set_presence_mode).toHaveBeenCalledTimes(1);
+
+            // Complete transition
+            await act(async () => {
+                resolveReturn({
+                    ok: true,
+                    mode: 'companion',
+                    on_top: false,
+                    width: 1280,
+                    height: 800,
+                });
+            });
+
+            // Restored companion
+            expect(screen.getByTestId('app-desktop-root')).toHaveAttribute('data-desktop-mode', 'companion');
+            expect(screen.getByTestId('companion-layout')).toBeInTheDocument();
+        });
+
+        it('drops concurrent spam clicks on pin button while pin operation is in flight', async () => {
+            render(<AppDesktop />);
+            await act(async () => {
+                fireEvent.click(screen.getByTestId('companion-enter-presence-btn'));
+            });
+
+            let resolvePin;
+            pywebviewApi.set_always_on_top = vi.fn(
+                () => new Promise((resolve) => {
+                    resolvePin = resolve;
+                }),
+            );
+
+            const pinBtn = screen.getByTestId('presence-pin-btn');
+            expect(pinBtn).toHaveAttribute('aria-pressed', 'false');
+
+            // Fire 1st click
+            fireEvent.click(pinBtn);
+
+            // Spam 20 concurrent clicks
+            for (let i = 0; i < 20; i++) {
+                fireEvent.click(pinBtn);
+            }
+
+            await Promise.resolve();
+            await Promise.resolve();
+
+            // Re-entrancy guard MUST drop all 20 clicks: exactly 1 bridge call!
+            expect(pywebviewApi.set_always_on_top).toHaveBeenCalledTimes(1);
+            expect(pywebviewApi.set_always_on_top).toHaveBeenCalledWith(true);
+
+            // Spam 10 more clicks while awaiting backend
+            for (let i = 0; i < 10; i++) {
+                fireEvent.click(pinBtn);
+            }
+            await Promise.resolve();
+            expect(pywebviewApi.set_always_on_top).toHaveBeenCalledTimes(1);
+
+            // Resolve pin operation
+            await act(async () => {
+                resolvePin({ ok: true, on_top: true });
+            });
+
+            expect(pinBtn).toHaveAttribute('aria-pressed', 'true');
+        });
+
+        it('releases in-flight guards when bridge operations fail so the user can retry', async () => {
+            let attempt = 0;
+            pywebviewApi.set_presence_mode = vi.fn(async () => {
+                attempt += 1;
+                if (attempt === 1) {
+                    return { ok: false, code: 'window_mutation_failed', message: 'GTK failed' };
+                }
+                return { ok: true, mode: 'presence', on_top: false, width: 200, height: 200 };
+            });
+
+            render(<AppDesktop />);
+            const enterBtn = screen.getByTestId('companion-enter-presence-btn');
+
+            // 1st attempt fails
+            await act(async () => {
+                fireEvent.click(enterBtn);
+            });
+            expect(attempt).toBe(1);
+            expect(screen.getByTestId('app-desktop-root')).toHaveAttribute('data-desktop-mode', 'companion');
+
+            // In-flight guard MUST be released in finally block; retry must be accepted
+            await act(async () => {
+                fireEvent.click(enterBtn);
+            });
+            expect(attempt).toBe(2);
+            expect(screen.getByTestId('app-desktop-root')).toHaveAttribute('data-desktop-mode', 'presence');
+        });
+
+        it('releases pin in-flight guard when setAlwaysOnTop fails so user can retry', async () => {
+            render(<AppDesktop />);
+            await act(async () => {
+                fireEvent.click(screen.getByTestId('companion-enter-presence-btn'));
+            });
+
+            let attempt = 0;
+            pywebviewApi.set_always_on_top = vi.fn(async (enabled) => {
+                attempt += 1;
+                if (attempt === 1) {
+                    return { ok: false, code: 'window_mutation_failed', message: 'Pin failed' };
+                }
+                return { ok: true, on_top: enabled };
+            });
+
+            const pinBtn = screen.getByTestId('presence-pin-btn');
+
+            // 1st attempt fails
+            await act(async () => {
+                fireEvent.click(pinBtn);
+            });
+            expect(attempt).toBe(1);
+            expect(pinBtn).toHaveAttribute('aria-pressed', 'false');
+
+            // 2nd attempt succeeds
+            await act(async () => {
+                fireEvent.click(pinBtn);
+            });
+            expect(attempt).toBe(2);
+            expect(pinBtn).toHaveAttribute('aria-pressed', 'true');
+        });
+
+        it('safely handles rapid minimize button clicks without unhandled rejections', async () => {
+            render(<AppDesktop />);
+            await act(async () => {
+                fireEvent.click(screen.getByTestId('companion-enter-presence-btn'));
+            });
+
+            const minBtn = screen.getByTestId('presence-minimize-btn');
+
+            // Rapid fire 10 clicks on minimize button
+            for (let i = 0; i < 10; i++) {
+                await act(async () => {
+                    fireEvent.click(minBtn);
+                });
+            }
+
+            expect(pywebviewApi.minimize_window).toHaveBeenCalledTimes(10);
+            expect(screen.getByTestId('katherine-presence-surface')).toBeInTheDocument();
+        });
+
+        it('correctly toggles pin back and forth across sequential settled clicks', async () => {
+            let currentOnTop = false;
+            pywebviewApi.set_always_on_top = vi.fn(async (enabled) => {
+                currentOnTop = enabled;
+                return { ok: true, on_top: enabled };
+            });
+
+            render(<AppDesktop />);
+            await act(async () => {
+                fireEvent.click(screen.getByTestId('companion-enter-presence-btn'));
+            });
+
+            const pinBtn = screen.getByTestId('presence-pin-btn');
+
+            // Toggle 1: false -> true
+            await act(async () => {
+                fireEvent.click(pinBtn);
+            });
+            expect(currentOnTop).toBe(true);
+            expect(pinBtn).toHaveAttribute('aria-pressed', 'true');
+
+            // Toggle 2: true -> false
+            await act(async () => {
+                fireEvent.click(pinBtn);
+            });
+            expect(currentOnTop).toBe(false);
+            expect(pinBtn).toHaveAttribute('aria-pressed', 'false');
+
+            // Toggle 3: false -> true
+            await act(async () => {
+                fireEvent.click(pinBtn);
+            });
+            expect(currentOnTop).toBe(true);
+            expect(pinBtn).toHaveAttribute('aria-pressed', 'true');
+        });
+    });
+});

--- a/scripts/desktop_smoke.py
+++ b/scripts/desktop_smoke.py
@@ -626,7 +626,7 @@ def run_smoke() -> tuple[bool, list[str]]:
                     health
                     and isinstance(health, dict)
                     and health.get("ok") is True
-                    and health.get("api_version") == 2
+                    and health.get("api_version") == 3
                 ),
                 json.dumps(health)[:200] if health else "no result",
             )
@@ -946,7 +946,7 @@ def run_smoke() -> tuple[bool, list[str]]:
                 bool(
                     after_reload
                     and after_reload.get("ok") is True
-                    and after_reload.get("api_version") == 2
+                    and after_reload.get("api_version") == 3
                 ),
                 json.dumps(after_reload)[:200] if after_reload else "no result",
             )

--- a/scripts/presence_evidence.json
+++ b/scripts/presence_evidence.json
@@ -1,6 +1,6 @@
 {
   "status": "PASS",
-  "timestamp_utc": "2026-09-10T00:41:59Z",
+  "timestamp_utc": "2026-09-12T01:17:25Z",
   "point_1_lifecycle": {
     "status": "PASS",
     "repetitions_count": 5,
@@ -13,7 +13,11 @@
           "presence_1",
           "companion_2",
           "presence_2",
-          "minimize",
+          {
+            "step": "minimize",
+            "bridge_ok": true,
+            "native_iconified": true
+          },
           "restore",
           "companion_final"
         ]
@@ -25,7 +29,11 @@
           "presence_1",
           "companion_2",
           "presence_2",
-          "minimize",
+          {
+            "step": "minimize",
+            "bridge_ok": true,
+            "native_iconified": true
+          },
           "restore",
           "companion_final"
         ]
@@ -37,7 +45,11 @@
           "presence_1",
           "companion_2",
           "presence_2",
-          "minimize",
+          {
+            "step": "minimize",
+            "bridge_ok": true,
+            "native_iconified": true
+          },
           "restore",
           "companion_final"
         ]
@@ -49,7 +61,11 @@
           "presence_1",
           "companion_2",
           "presence_2",
-          "minimize",
+          {
+            "step": "minimize",
+            "bridge_ok": true,
+            "native_iconified": true
+          },
           "restore",
           "companion_final"
         ]
@@ -61,7 +77,11 @@
           "presence_1",
           "companion_2",
           "presence_2",
-          "minimize",
+          {
+            "step": "minimize",
+            "bridge_ok": true,
+            "native_iconified": true
+          },
           "restore",
           "companion_final"
         ]
@@ -133,19 +153,36 @@
   },
   "point_5_resources": {
     "companion": {
-      "rss_mb": 430.13,
+      "rss_mb": 434.05,
       "process_count": 3,
       "webkit_process_count": 2,
       "cpu_idle_percent": 100.0,
-      "cpu_percent": 0.0
+      "cpu_percent": 0.0,
+      "tree_cpu_percent": 0.0,
+      "sample_interval_seconds": 0.5
     },
     "presence": {
-      "rss_mb": 443.1,
+      "rss_mb": 448.54,
       "process_count": 3,
       "webkit_process_count": 2,
       "cpu_idle_percent": 100.0,
-      "cpu_percent": 0.0
+      "cpu_percent": 0.0,
+      "tree_cpu_percent": 0.0,
+      "sample_interval_seconds": 0.5
     },
-    "delta_rss_mb": 12.97
+    "delta_rss_mb": 14.49
+  },
+  "point_6_geometry_clamp": {
+    "status": "PASS",
+    "negative_out_of_bounds_recovered_to": [
+      0,
+      0
+    ],
+    "large_out_of_bounds_recovered_to": [
+      1720,
+      880
+    ],
+    "reconciled_without_mode_change": true,
+    "mode_after_reconciliation": "presence"
   }
 }

--- a/scripts/presence_evidence.json
+++ b/scripts/presence_evidence.json
@@ -1,0 +1,151 @@
+{
+  "status": "PASS",
+  "timestamp_utc": "2026-09-10T00:41:59Z",
+  "point_1_lifecycle": {
+    "status": "PASS",
+    "repetitions_count": 5,
+    "sequence": "companion -> presence -> companion -> presence -> minimize -> restore -> companion",
+    "repetitions": [
+      {
+        "repetition": 1,
+        "transitions": [
+          "companion_1",
+          "presence_1",
+          "companion_2",
+          "presence_2",
+          "minimize",
+          "restore",
+          "companion_final"
+        ]
+      },
+      {
+        "repetition": 2,
+        "transitions": [
+          "companion_1",
+          "presence_1",
+          "companion_2",
+          "presence_2",
+          "minimize",
+          "restore",
+          "companion_final"
+        ]
+      },
+      {
+        "repetition": 3,
+        "transitions": [
+          "companion_1",
+          "presence_1",
+          "companion_2",
+          "presence_2",
+          "minimize",
+          "restore",
+          "companion_final"
+        ]
+      },
+      {
+        "repetition": 4,
+        "transitions": [
+          "companion_1",
+          "presence_1",
+          "companion_2",
+          "presence_2",
+          "minimize",
+          "restore",
+          "companion_final"
+        ]
+      },
+      {
+        "repetition": 5,
+        "transitions": [
+          "companion_1",
+          "presence_1",
+          "companion_2",
+          "presence_2",
+          "minimize",
+          "restore",
+          "companion_final"
+        ]
+      }
+    ],
+    "single_window_verified": true,
+    "zero_duplicate_runtime": true
+  },
+  "point_2_always_on_top": {
+    "status": "PASS",
+    "rule": "set_always_on_top is sole authority; state preserved across mode transitions",
+    "steps": [
+      {
+        "step": "startup_default",
+        "on_top": false,
+        "verified": true
+      },
+      {
+        "step": "enter_presence_maintains_false",
+        "on_top": false,
+        "aria_pressed": "false",
+        "verified": true
+      },
+      {
+        "step": "user_pins_true",
+        "on_top": true,
+        "aria_pressed": "true",
+        "verified": true
+      },
+      {
+        "step": "return_companion_preserves_true",
+        "on_top": true,
+        "verified": true
+      },
+      {
+        "step": "reenter_presence_preserves_true",
+        "on_top": true,
+        "aria_pressed": "true",
+        "verified": true
+      },
+      {
+        "step": "user_unpins_false",
+        "on_top": false,
+        "aria_pressed": "false",
+        "verified": true
+      },
+      {
+        "step": "return_companion_preserves_false",
+        "on_top": false,
+        "verified": true
+      }
+    ]
+  },
+  "point_3_privacy_canary": {
+    "status": "PASS",
+    "canary_token_found": false,
+    "leaked_forbidden_selectors_count": 0,
+    "leaked_selectors": [],
+    "chat_strings_leaked": false
+  },
+  "point_4_transparency": {
+    "is_composited": true,
+    "dom_presence_bg": "rgba(0, 0, 0, 0)",
+    "dom_root_bg": "rgba(0, 0, 0, 0)",
+    "tested_mode": "presence",
+    "pixbuf_has_alpha": true,
+    "corner_alpha": 0,
+    "status": "VERIFIED"
+  },
+  "point_5_resources": {
+    "companion": {
+      "rss_mb": 430.13,
+      "process_count": 3,
+      "webkit_process_count": 2,
+      "cpu_idle_percent": 100.0,
+      "cpu_percent": 0.0
+    },
+    "presence": {
+      "rss_mb": 443.1,
+      "process_count": 3,
+      "webkit_process_count": 2,
+      "cpu_idle_percent": 100.0,
+      "cpu_percent": 0.0
+    },
+    "delta_rss_mb": 12.97
+  }
+}

--- a/scripts/presence_evidence.json
+++ b/scripts/presence_evidence.json
@@ -1,6 +1,6 @@
 {
   "status": "PASS",
-  "timestamp_utc": "2026-09-12T01:17:25Z",
+  "timestamp_utc": "2026-09-12T01:40:48Z",
   "point_1_lifecycle": {
     "status": "PASS",
     "repetitions_count": 5,
@@ -153,7 +153,7 @@
   },
   "point_5_resources": {
     "companion": {
-      "rss_mb": 434.05,
+      "rss_mb": 434.55,
       "process_count": 3,
       "webkit_process_count": 2,
       "cpu_idle_percent": 100.0,
@@ -162,7 +162,7 @@
       "sample_interval_seconds": 0.5
     },
     "presence": {
-      "rss_mb": 448.54,
+      "rss_mb": 448.37,
       "process_count": 3,
       "webkit_process_count": 2,
       "cpu_idle_percent": 100.0,
@@ -170,7 +170,7 @@
       "tree_cpu_percent": 0.0,
       "sample_interval_seconds": 0.5
     },
-    "delta_rss_mb": 14.49
+    "delta_rss_mb": 13.82
   },
   "point_6_geometry_clamp": {
     "status": "PASS",

--- a/scripts/presence_review.py
+++ b/scripts/presence_review.py
@@ -274,24 +274,60 @@ def call_bridge_js(window, call_expr, timeout=10.0):
     raise TimeoutError(f"Timed out waiting for {call_expr}")
 
 
-def measure_system_resources():
-    """Measure real system resources using psutil (or /proc fallback)."""
+def measure_system_resources(sample_interval: float = 0.5):
+    """Measure real system resources across Katherine process and all WebKit children (#342, #366).
+
+    Bounded, reproducible measurement:
+    - Queries total RSS of [current process] + all recursive children (WebKit processes).
+    - Measures CPU utilization of the entire application process tree across a bounded window (default 0.5s).
+    - Reports idle percentage = 100 - sum(tree CPU percent).
+    """
     import os
     try:
         import psutil
         current = psutil.Process(os.getpid())
         children = current.children(recursive=True)
         all_procs = [current] + children
-        total_rss = sum(p.memory_info().rss for p in all_procs)
+        total_rss = 0
+        for p in all_procs:
+            try:
+                total_rss += p.memory_info().rss
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
         rss_mb = round(total_rss / (1024 * 1024), 2)
-        webkit_procs = [p for p in children if "WebKitWebProcess" in p.name() or "WebKit" in p.name()]
-        cpu_pct = round(current.cpu_percent(interval=0.5), 2)
+        webkit_procs = [
+            p for p in children
+            if "WebKit" in p.name() or "bwrap" in p.name()
+        ]
+
+        # Initialize CPU counter on all processes in the tree
+        for p in all_procs:
+            try:
+                p.cpu_percent(None)
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+
+        time.sleep(sample_interval)
+
+        # Sample CPU over the bounded window for the entire process tree
+        tree_cpu = 0.0
+        for p in all_procs:
+            try:
+                tree_cpu += p.cpu_percent(None)
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+
+        tree_cpu_pct = round(tree_cpu, 2)
+        idle_pct = round(max(0.0, 100.0 - tree_cpu_pct), 2)
+
         return {
             "rss_mb": rss_mb,
             "process_count": len(all_procs),
             "webkit_process_count": len(webkit_procs),
-            "cpu_idle_percent": round(max(0.0, 100.0 - cpu_pct), 2),
-            "cpu_percent": cpu_pct,
+            "cpu_idle_percent": idle_pct,
+            "cpu_percent": tree_cpu_pct,
+            "tree_cpu_percent": tree_cpu_pct,
+            "sample_interval_seconds": sample_interval,
         }
     except Exception as exc:
         return {"error": str(exc)}
@@ -543,10 +579,38 @@ def verify_matrix(window, output_dir):
         assert st.get("mode") == "presence", f"Rep {rep}: Must be presence, got {st}"
         rep_data["transitions"].append("presence_2")
 
-        # -> hide/minimize
+        # -> hide/minimize (verified bridge return + observed native state)
+        window.evaluate_js('window.__lastMinimizeResult = null')
         window.evaluate_js('document.querySelector("[data-testid=\\"presence-minimize-btn\\"]").click()')
+
+        # Wait for bridge call completion and verify ok: true
+        deadline = time.monotonic() + 5.0
+        min_res = None
+        while time.monotonic() < deadline:
+            min_res = window.evaluate_js('window.__lastMinimizeResult')
+            if min_res is not None:
+                break
+            time.sleep(0.05)
+
+        assert isinstance(min_res, dict), f"Rep {rep}: Minimize bridge call timed out or returned non-dict: {min_res}"
+        assert min_res.get("ok") is True, f"Rep {rep}: Minimize bridge returned non-ok: {min_res}"
+
+        # Verify native GTK window state
         time.sleep(0.2)
-        rep_data["transitions"].append("minimize")
+        native_minimized = False
+        native = getattr(window, "native", None)
+        if native is not None:
+            gdk_win = native.get_window()
+            if gdk_win:
+                st_flags = gdk_win.get_state()
+                if st_flags is not None:
+                    native_minimized = bool(st_flags & Gdk.WindowState.ICONIFIED)
+
+        rep_data["transitions"].append({
+            "step": "minimize",
+            "bridge_ok": True,
+            "native_iconified": native_minimized,
+        })
 
         # -> restore
         restore_done = threading.Event()
@@ -560,9 +624,10 @@ def verify_matrix(window, output_dir):
                 restore_done.set()
             return False
         GLib.idle_add(_restore_win)
-        restore_done.wait(3.0)
+        assert restore_done.wait(5.0), f"Rep {rep}: Native restore timed out"
         time.sleep(0.2)
         wait_for(window, 'Boolean(document.querySelector("[data-testid=\\"katherine-presence-surface\\"]"))')
+        assert len(webview.windows) == 1, f"Rep {rep}: Window count must remain 1 after restore"
         rep_data["transitions"].append("restore")
 
         # -> companion
@@ -574,7 +639,67 @@ def verify_matrix(window, output_dir):
         rep_data["transitions"].append("companion_final")
 
         lifecycle_results.append(rep_data)
-        print(f"  Repetition {rep}/5 completed cleanly (window count: {len(webview.windows)})", flush=True)
+        print(f"  Repetition {rep}/5 completed cleanly (minimized bridge_ok=True, native_iconified={native_minimized}, windows={len(webview.windows)})", flush=True)
+
+    # Point 6: Runtime Geometry Clamp Recovery Proof (§BLOCKER 1 / #342)
+    print("\n[Point 6] Verifying Runtime Geometry Clamp Recovery (§BLOCKER 1)...", flush=True)
+    # Switch to presence mode
+    window.evaluate_js('document.querySelector("[data-testid=\\"companion-enter-presence-btn\\"]").click()')
+    wait_for(window, 'Boolean(document.querySelector("[data-testid=\\"katherine-presence-surface\\"]"))')
+    time.sleep(0.3)
+
+    st_p = call_bridge_js(window, "window.pywebview.api.window_state()")
+    assert st_p.get("ok") and st_p.get("mode") == "presence", f"Must be in presence mode: {st_p}"
+
+    # 6.1 Move out of bounds (negative coordinates)
+    native = getattr(window, "native", None)
+    window.move(-400, -400)
+    time.sleep(0.5)
+
+    st_check1 = call_bridge_js(window, "window.pywebview.api.window_state()")
+    assert st_check1.get("ok") and st_check1.get("mode") == "presence", f"Mode must remain presence: {st_check1}"
+    assert st_check1.get("x") is not None and st_check1.get("x") >= 0, f"Clamped x must be >= 0: {st_check1}"
+    assert st_check1.get("y") is not None and st_check1.get("y") >= 0, f"Clamped y must be >= 0: {st_check1}"
+
+    gdk_win = native.get_window() if native else None
+    if gdk_win and hasattr(gdk_win, "get_origin"):
+        origin1 = gdk_win.get_origin()
+        if len(origin1) == 3:
+            assert origin1[1] >= 0 and origin1[2] >= 0, f"GDK origin outside screen: {origin1}"
+
+    # 6.2 Move out of bounds (large positive coordinates beyond screen)
+    window.move(9999, 9999)
+    time.sleep(0.5)
+
+    display = Gdk.Display.get_default()
+    primary_mon = display.get_primary_monitor() if display and hasattr(display, "get_primary_monitor") else None
+    wa = primary_mon.get_workarea() if primary_mon and hasattr(primary_mon, "get_workarea") else None
+    screen_w = wa.width if wa else 1280
+    screen_h = wa.height if wa else 800
+
+    st_check2 = call_bridge_js(window, "window.pywebview.api.window_state()")
+    assert st_check2.get("ok") and st_check2.get("mode") == "presence", f"Mode must remain presence: {st_check2}"
+    assert st_check2.get("x") <= screen_w - 200, f"Clamped x must be within screen: {st_check2}"
+    assert st_check2.get("y") <= screen_h - 200, f"Clamped y must be within screen: {st_check2}"
+
+    if gdk_win and hasattr(gdk_win, "get_origin"):
+        origin2 = gdk_win.get_origin()
+        if len(origin2) == 3:
+            assert origin2[1] <= screen_w - 200 and origin2[2] <= screen_h - 200, f"GDK origin outside bounds: {origin2}"
+
+    clamp_proof = {
+        "status": "PASS",
+        "negative_out_of_bounds_recovered_to": [st_check1.get("x"), st_check1.get("y")],
+        "large_out_of_bounds_recovered_to": [st_check2.get("x"), st_check2.get("y")],
+        "reconciled_without_mode_change": True,
+        "mode_after_reconciliation": "presence",
+    }
+    print(f"  Runtime geometry clamp recovery verified (negative->{[st_check1.get('x'), st_check1.get('y')]}, large->{[st_check2.get('x'), st_check2.get('y')]}: PASS", flush=True)
+
+    # Return to companion
+    window.evaluate_js('document.querySelector("[data-testid=\\"presence-return-btn\\"]").click()')
+    wait_for(window, 'Boolean(document.querySelector("[data-testid=\\"companion-layout\\"]"))')
+    time.sleep(0.3)
 
     # Compile final matrix results
     final_matrix = {
@@ -602,6 +727,7 @@ def verify_matrix(window, output_dir):
         },
         "point_4_transparency": transparency_data,
         "point_5_resources": resource_matrix,
+        "point_6_geometry_clamp": clamp_proof,
     }
 
     # Save to files

--- a/scripts/presence_review.py
+++ b/scripts/presence_review.py
@@ -7,23 +7,38 @@ The scripted provider is fixture evidence, not live provider acceptance.
 import argparse
 import asyncio
 import json
+import os
+import sys
 import threading
 import time
+import uuid
 from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 import webview
 from backend.desktop.app import run_desktop_shell
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--output', required=True, type=Path)
+parser.add_argument('--output', type=Path, default=Path('scripts/presence_evidence'))
+parser.add_argument('--clean', action='store_true', help='Clean output directory before running')
 parser.add_argument('--scripted', action='store_true')
+parser.add_argument('--verify-matrix', action='store_true', help='Execute 5-point Runtime Evidence Matrix (#342 / #366)')
 parser.add_argument('--verify-v2', action='store_true')
 parser.add_argument('--verify-scaling', action='store_true')
 parser.add_argument('--reduced-motion', action='store_true')
 args = parser.parse_args()
 args.output.mkdir(parents=True, exist_ok=True)
 if (args.output / 'isolated.sqlite3').exists():
-    parser.error('Use a fresh output directory so captures start with empty isolated storage.')
+    if args.clean or args.verify_matrix:
+        try:
+            (args.output / 'isolated.sqlite3').unlink()
+        except OSError:
+            pass
+    else:
+        parser.error('Use a fresh output directory so captures start with empty isolated storage.')
 if args.reduced_motion:
     import gi
     gi.require_version('Gtk', '3.0')
@@ -31,7 +46,7 @@ if args.reduced_motion:
     Gtk.Settings.get_default().set_property('gtk-enable-animations', False)
 release = threading.Event()
 failures = []
-results = {'provider': 'scripted offline fixture' if args.scripted else 'unconfigured real runtime', 'captures': []}
+results = {'provider': 'scripted offline fixture' if (args.scripted or args.verify_matrix) else 'unconfigured real runtime', 'captures': []}
 
 class ReviewProvider:
     async def appraise(self, message, budget):
@@ -234,6 +249,377 @@ def verify_scaling_matrix(window):
         time.sleep(0.3)
 
 
+def call_bridge_js(window, call_expr, timeout=10.0):
+    """Execute an async bridge expression and await its deposited result."""
+    prop = f"__bridge_res_{uuid.uuid4().hex}"
+    window.evaluate_js(f"""(() => {{
+        window['{prop}'] = '__pending__';
+        (async () => {{
+            try {{
+                window['{prop}'] = await ({call_expr});
+            }} catch (err) {{
+                window['{prop}'] = {{ __threw: true, error: String(err) }};
+            }}
+        }})();
+    }})()""")
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        res = window.evaluate_js(f"window['{prop}']")
+        if res != '__pending__' and res is not None:
+            window.evaluate_js(f"delete window['{prop}']")
+            if isinstance(res, dict) and res.get('__threw'):
+                raise RuntimeError(f"Bridge JS error in {call_expr}: {res.get('error')}")
+            return res
+        time.sleep(0.05)
+    raise TimeoutError(f"Timed out waiting for {call_expr}")
+
+
+def measure_system_resources():
+    """Measure real system resources using psutil (or /proc fallback)."""
+    import os
+    try:
+        import psutil
+        current = psutil.Process(os.getpid())
+        children = current.children(recursive=True)
+        all_procs = [current] + children
+        total_rss = sum(p.memory_info().rss for p in all_procs)
+        rss_mb = round(total_rss / (1024 * 1024), 2)
+        webkit_procs = [p for p in children if "WebKitWebProcess" in p.name() or "WebKit" in p.name()]
+        cpu_pct = round(current.cpu_percent(interval=0.5), 2)
+        return {
+            "rss_mb": rss_mb,
+            "process_count": len(all_procs),
+            "webkit_process_count": len(webkit_procs),
+            "cpu_idle_percent": round(max(0.0, 100.0 - cpu_pct), 2),
+            "cpu_percent": cpu_pct,
+        }
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+def verify_matrix(window, output_dir):
+    print("\n" + "=" * 70)
+    print("EXECUTING 5-POINT RUNTIME EVIDENCE MATRIX (PR #366 / Issue #342)")
+    print("=" * 70, flush=True)
+
+    # 0. Wait for bridge and initial companion layout to be ready
+    wait_for(window, 'Boolean(document.querySelector("[data-testid=companion-layout]"))')
+    wait_for(window, 'Boolean(document.querySelector("[data-testid=desktop-bridge-indicator]"))')
+    time.sleep(0.5)
+
+    # Point 5 (Part A): Baseline Companion Resources
+    print("\n[Point 5] Measuring Companion baseline resources...", flush=True)
+    time.sleep(0.5)
+    companion_resources = measure_system_resources()
+    print(f"  Companion RSS: {companion_resources.get('rss_mb')} MB | Procs: {companion_resources.get('process_count')} (WebKit: {companion_resources.get('webkit_process_count')}) | CPU idle: {companion_resources.get('cpu_idle_percent')}%", flush=True)
+
+    # Point 2: Always-on-Top Decoupling Verification (§BLOCKER 1)
+    print("\n[Point 2] Verifying Always-on-Top Decoupling (§BLOCKER 1)...", flush=True)
+    aot_steps = []
+
+    # 2.1 Default at startup must be False
+    st_init = call_bridge_js(window, "window.pywebview.api.window_state()")
+    assert st_init.get("ok") and st_init.get("on_top") is False, f"Startup on_top must be False: {st_init}"
+    aot_steps.append({"step": "startup_default", "on_top": False, "verified": True})
+
+    # 2.2 Enter presence: on_top must remain False
+    window.evaluate_js('document.querySelector("[data-testid=\\"companion-enter-presence-btn\\"]").click()')
+    wait_for(window, 'Boolean(document.querySelector("[data-testid=\\"katherine-presence-surface\\"]"))')
+    st_pres = call_bridge_js(window, "window.pywebview.api.window_state()")
+    assert st_pres.get("ok") and st_pres.get("mode") == "presence", f"Must be in presence mode: {st_pres}"
+    assert st_pres.get("on_top") is False, f"Entering presence must NOT activate on_top: {st_pres}"
+    pin_aria = window.evaluate_js('document.querySelector("[data-testid=\\"presence-pin-btn\\"]").getAttribute("aria-pressed")')
+    assert pin_aria == "false", f"Pin button aria-pressed must be false, got {pin_aria}"
+    aot_steps.append({"step": "enter_presence_maintains_false", "on_top": False, "aria_pressed": "false", "verified": True})
+
+    # 2.3 User pins: click pin button -> on_top becomes True
+    window.evaluate_js('document.querySelector("[data-testid=\\"presence-pin-btn\\"]").click()')
+    wait_for(window, 'document.querySelector("[data-testid=\\"presence-pin-btn\\"]").getAttribute("aria-pressed") === "true"')
+    st_pinned = call_bridge_js(window, "window.pywebview.api.window_state()")
+    assert st_pinned.get("ok") and st_pinned.get("on_top") is True, f"Explicit pin must set on_top=True: {st_pinned}"
+    aot_steps.append({"step": "user_pins_true", "on_top": True, "aria_pressed": "true", "verified": True})
+
+    # 2.4 Return companion: on_top must persist as True
+    window.evaluate_js('document.querySelector("[data-testid=\\"presence-return-btn\\"]").click()')
+    wait_for(window, 'Boolean(document.querySelector("[data-testid=\\"companion-layout\\"]"))')
+    st_comp_pinned = call_bridge_js(window, "window.pywebview.api.window_state()")
+    assert st_comp_pinned.get("ok") and st_comp_pinned.get("mode") == "companion"
+    assert st_comp_pinned.get("on_top") is True, f"Returning to companion must preserve on_top=True: {st_comp_pinned}"
+    aot_steps.append({"step": "return_companion_preserves_true", "on_top": True, "verified": True})
+
+    # 2.5 Enter presence again: on_top must persist as True
+    window.evaluate_js('document.querySelector("[data-testid=\\"companion-enter-presence-btn\\"]").click()')
+    wait_for(window, 'Boolean(document.querySelector("[data-testid=\\"katherine-presence-surface\\"]"))')
+    st_pres_pinned = call_bridge_js(window, "window.pywebview.api.window_state()")
+    assert st_pres_pinned.get("ok") and st_pres_pinned.get("on_top") is True, f"Entering presence must preserve on_top=True: {st_pres_pinned}"
+    pin_aria = window.evaluate_js('document.querySelector("[data-testid=\\"presence-pin-btn\\"]").getAttribute("aria-pressed")')
+    assert pin_aria == "true", f"Pin button aria-pressed must remain true, got {pin_aria}"
+    aot_steps.append({"step": "reenter_presence_preserves_true", "on_top": True, "aria_pressed": "true", "verified": True})
+
+    # 2.6 User unpins: click pin button -> on_top becomes False
+    window.evaluate_js('document.querySelector("[data-testid=\\"presence-pin-btn\\"]").click()')
+    wait_for(window, 'document.querySelector("[data-testid=\\"presence-pin-btn\\"]").getAttribute("aria-pressed") === "false"')
+    st_unpinned = call_bridge_js(window, "window.pywebview.api.window_state()")
+    assert st_unpinned.get("ok") and st_unpinned.get("on_top") is False, f"Explicit unpin must set on_top=False: {st_unpinned}"
+    aot_steps.append({"step": "user_unpins_false", "on_top": False, "aria_pressed": "false", "verified": True})
+
+    # 2.7 Return companion: on_top persists as False
+    window.evaluate_js('document.querySelector("[data-testid=\\"presence-return-btn\\"]").click()')
+    wait_for(window, 'Boolean(document.querySelector("[data-testid=\\"companion-layout\\"]"))')
+    st_comp_unpinned = call_bridge_js(window, "window.pywebview.api.window_state()")
+    assert st_comp_unpinned.get("ok") and st_comp_unpinned.get("on_top") is False, f"Companion must remain unpinned: {st_comp_unpinned}"
+    aot_steps.append({"step": "return_companion_preserves_false", "on_top": False, "verified": True})
+    print("  Always-on-top decoupling verified: PASS", flush=True)
+
+    # Point 3: DOM Privacy Canary (§MAJOR 6)
+    print("\n[Point 3] Verifying DOM Privacy Canary (§MAJOR 6)...", flush=True)
+    canary_token = "CANARY_CONFIDENTIAL_TOKEN_PR366_789"
+    window.evaluate_js(f"""(() => {{
+        const input = document.querySelector('textarea[aria-label="Sua mensagem"]');
+        if (input) {{
+            Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set.call(input, '{canary_token}');
+            input.dispatchEvent(new Event('input', {{bubbles: true}}));
+        }}
+    }})()""")
+    time.sleep(0.3)
+
+    # Switch to presence mode
+    window.evaluate_js('document.querySelector("[data-testid=\\"companion-enter-presence-btn\\"]").click()')
+    wait_for(window, 'Boolean(document.querySelector("[data-testid=\\"katherine-presence-surface\\"]"))')
+    time.sleep(0.3)
+
+    # Inspect DOM for any private/companion leak
+    privacy_inspection = window.evaluate_js(f"""(() => {{
+        const forbiddenSelectors = [
+            'textarea',
+            'button[aria-label*="Enviar mensagem"]',
+            '[data-testid="companion-history"]',
+            '[data-testid="companion-layout"]',
+            '[data-testid="companion-utilities"]',
+            '[data-testid="companion-emotion-details"]',
+            '[data-testid="companion-privacy-details"]',
+            '[data-testid="privacy-panel"]',
+            '[data-testid="message-list"]',
+            '[data-testid="chat-header"]',
+            '[data-testid="companion-auxiliary-slot"]',
+            '.companion-layout__conversation',
+            '.chat-header',
+            '.companion-layout__history'
+        ];
+        const leaked = forbiddenSelectors.filter(sel => document.querySelector(sel) !== null);
+        const text = document.body.innerText || '';
+        const html = document.body.innerHTML || '';
+        return {{
+            leakedSelectors: leaked,
+            canaryInText: text.includes('{canary_token}'),
+            canaryInHtml: html.includes('{canary_token}'),
+            chatStringsLeaked: text.includes('Comece uma conversa') || text.includes('Histórico da conversa'),
+            hasPresenceSurface: Boolean(document.querySelector('[data-testid="katherine-presence-surface"]')),
+            hasFace: Boolean(document.querySelector('[data-testid="katherine-face"]')),
+            hasControls: Boolean(document.querySelector('[data-testid="katherine-presence-controls"]')),
+            bodyText: text.trim(),
+        }};
+    }})()""")
+
+    assert len(privacy_inspection["leakedSelectors"]) == 0, f"Privacy canary failed: found selectors {privacy_inspection['leakedSelectors']}"
+    assert not privacy_inspection["canaryInText"], "Privacy canary failed: confidential token found in body text!"
+    assert not privacy_inspection["canaryInHtml"], "Privacy canary failed: confidential token found in body HTML!"
+    assert not privacy_inspection["chatStringsLeaked"], "Privacy canary failed: chat strings found in presence DOM!"
+    assert privacy_inspection["hasPresenceSurface"], "Presence surface must be present in DOM"
+    print("  DOM Privacy Canary verified: 0 leaked elements, 0 private tokens, 0 chat strings: PASS", flush=True)
+
+    # Point 4: Transparency Verification (§MAJOR 6)
+    print("\n[Point 4] Verifying Window Surface Transparency (§MAJOR 6)...", flush=True)
+    import gi
+    gi.require_version('Gtk', '3.0')
+    gi.require_version('Gdk', '3.0')
+    from gi.repository import Gdk, GLib
+
+    screen = Gdk.Screen.get_default()
+    is_composited = screen.is_composited() if screen else False
+
+    dom_transparency = window.evaluate_js("""(() => {
+        const pres = document.querySelector('.katherine-presence');
+        const root = document.querySelector('[data-testid="app-desktop-root"]');
+        return {
+            presenceBg: pres ? getComputedStyle(pres).backgroundColor : null,
+            rootBg: root ? getComputedStyle(root).backgroundColor : null,
+        };
+    })()""")
+
+    transparency_data = {
+        "is_composited": is_composited,
+        "dom_presence_bg": dom_transparency.get("presenceBg"),
+        "dom_root_bg": dom_transparency.get("rootBg"),
+        "tested_mode": "presence",
+    }
+
+    if not is_composited:
+        transparency_data["status"] = "NOT VERIFIED"
+        transparency_data["reason"] = "Display server does not report an active compositing manager (e.g. standard Xvfb); marked NOT VERIFIED per §MAJOR 6"
+        print(f"  Transparency status: NOT VERIFIED ({transparency_data['reason']})", flush=True)
+    else:
+        native = window.native
+        w, h = native.get_size()
+        pixbuf_done = threading.Event()
+        pb_holder = []
+        def _get_pb():
+            try:
+                pb = Gdk.pixbuf_get_from_window(native.get_window(), 0, 0, w, h)
+                pb_holder.append(pb)
+            except Exception:
+                pb_holder.append(None)
+            finally:
+                pixbuf_done.set()
+            return False
+        GLib.idle_add(_get_pb)
+        pixbuf_done.wait(5.0)
+        pb = pb_holder[0] if pb_holder else None
+
+        if pb and pb.get_has_alpha():
+            pixels = pb.get_pixels()
+            channels = pb.get_n_channels()
+            corner_alpha = pixels[channels - 1] if len(pixels) >= channels else None
+            transparency_data["pixbuf_has_alpha"] = True
+            transparency_data["corner_alpha"] = corner_alpha
+            transparency_data["status"] = "VERIFIED"
+            print(f"  Transparency status: VERIFIED (Composited GDK screen, pixbuf alpha present, corner alpha={corner_alpha})", flush=True)
+        else:
+            transparency_data["pixbuf_has_alpha"] = False
+            transparency_data["status"] = "NOT VERIFIED"
+            transparency_data["reason"] = "Compositor active but native window capture lacks alpha plane in this graphical session; marked NOT VERIFIED per §MAJOR 6"
+            print(f"  Transparency status: NOT VERIFIED ({transparency_data['reason']})", flush=True)
+
+    # Point 5 (Part B): Presence Mode Resources
+    print("\n[Point 5] Measuring Presence resources...", flush=True)
+    time.sleep(1.0)
+    presence_resources = measure_system_resources()
+    print(f"  Presence RSS: {presence_resources.get('rss_mb')} MB | Procs: {presence_resources.get('process_count')} (WebKit: {presence_resources.get('webkit_process_count')}) | CPU idle: {presence_resources.get('cpu_idle_percent')}%", flush=True)
+
+    delta_rss = round(presence_resources.get("rss_mb", 0) - companion_resources.get("rss_mb", 0), 2)
+    resource_matrix = {
+        "companion": companion_resources,
+        "presence": presence_resources,
+        "delta_rss_mb": delta_rss,
+    }
+
+    # Return to companion mode before lifecycle loop
+    window.evaluate_js('document.querySelector("[data-testid=\\"presence-return-btn\\"]").click()')
+    wait_for(window, 'Boolean(document.querySelector("[data-testid=\\"companion-layout\\"]"))')
+    time.sleep(0.3)
+
+    # Point 1: Lifecycle (5 Repetitions) (§MAJOR 6)
+    print("\n[Point 1] Executing Lifecycle 5x (companion -> presence -> companion -> presence -> minimize -> restore -> companion)...", flush=True)
+    lifecycle_results = []
+
+    for rep in range(1, 6):
+        rep_data = {"repetition": rep, "transitions": []}
+
+        # In companion
+        wait_for(window, 'Boolean(document.querySelector("[data-testid=companion-layout]"))')
+        assert len(webview.windows) == 1, f"Rep {rep}: Expected 1 window, found {len(webview.windows)}"
+        st = call_bridge_js(window, "window.pywebview.api.window_state()")
+        assert st.get("mode") == "companion", f"Rep {rep}: Must be companion, got {st}"
+        rep_data["transitions"].append("companion_1")
+
+        # -> presence
+        window.evaluate_js('document.querySelector("[data-testid=\\"companion-enter-presence-btn\\"]").click()')
+        wait_for(window, 'Boolean(document.querySelector("[data-testid=\\"katherine-presence-surface\\"]"))')
+        st = call_bridge_js(window, "window.pywebview.api.window_state()")
+        assert st.get("mode") == "presence", f"Rep {rep}: Must be presence, got {st}"
+        rep_data["transitions"].append("presence_1")
+
+        # -> companion
+        window.evaluate_js('document.querySelector("[data-testid=\\"presence-return-btn\\"]").click()')
+        wait_for(window, 'Boolean(document.querySelector("[data-testid=\\"companion-layout\\"]"))')
+        st = call_bridge_js(window, "window.pywebview.api.window_state()")
+        assert st.get("mode") == "companion", f"Rep {rep}: Must be companion, got {st}"
+        rep_data["transitions"].append("companion_2")
+
+        # -> presence
+        window.evaluate_js('document.querySelector("[data-testid=\\"companion-enter-presence-btn\\"]").click()')
+        wait_for(window, 'Boolean(document.querySelector("[data-testid=\\"katherine-presence-surface\\"]"))')
+        st = call_bridge_js(window, "window.pywebview.api.window_state()")
+        assert st.get("mode") == "presence", f"Rep {rep}: Must be presence, got {st}"
+        rep_data["transitions"].append("presence_2")
+
+        # -> hide/minimize
+        window.evaluate_js('document.querySelector("[data-testid=\\"presence-minimize-btn\\"]").click()')
+        time.sleep(0.2)
+        rep_data["transitions"].append("minimize")
+
+        # -> restore
+        restore_done = threading.Event()
+        def _restore_win():
+            try:
+                if hasattr(window, 'restore'):
+                    window.restore()
+                elif hasattr(window.native, 'deiconify'):
+                    window.native.deiconify()
+            finally:
+                restore_done.set()
+            return False
+        GLib.idle_add(_restore_win)
+        restore_done.wait(3.0)
+        time.sleep(0.2)
+        wait_for(window, 'Boolean(document.querySelector("[data-testid=\\"katherine-presence-surface\\"]"))')
+        rep_data["transitions"].append("restore")
+
+        # -> companion
+        window.evaluate_js('document.querySelector("[data-testid=\\"presence-return-btn\\"]").click()')
+        wait_for(window, 'Boolean(document.querySelector("[data-testid=\\"companion-layout\\"]"))')
+        st = call_bridge_js(window, "window.pywebview.api.window_state()")
+        assert st.get("mode") == "companion", f"Rep {rep}: Must be companion, got {st}"
+        assert len(webview.windows) == 1, f"Rep {rep}: Window count must be 1"
+        rep_data["transitions"].append("companion_final")
+
+        lifecycle_results.append(rep_data)
+        print(f"  Repetition {rep}/5 completed cleanly (window count: {len(webview.windows)})", flush=True)
+
+    # Compile final matrix results
+    final_matrix = {
+        "status": "PASS",
+        "timestamp_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "point_1_lifecycle": {
+            "status": "PASS",
+            "repetitions_count": len(lifecycle_results),
+            "sequence": "companion -> presence -> companion -> presence -> minimize -> restore -> companion",
+            "repetitions": lifecycle_results,
+            "single_window_verified": len(webview.windows) == 1,
+            "zero_duplicate_runtime": True,
+        },
+        "point_2_always_on_top": {
+            "status": "PASS",
+            "rule": "set_always_on_top is sole authority; state preserved across mode transitions",
+            "steps": aot_steps,
+        },
+        "point_3_privacy_canary": {
+            "status": "PASS",
+            "canary_token_found": privacy_inspection["canaryInText"] or privacy_inspection["canaryInHtml"],
+            "leaked_forbidden_selectors_count": len(privacy_inspection["leakedSelectors"]),
+            "leaked_selectors": privacy_inspection["leakedSelectors"],
+            "chat_strings_leaked": privacy_inspection["chatStringsLeaked"],
+        },
+        "point_4_transparency": transparency_data,
+        "point_5_resources": resource_matrix,
+    }
+
+    # Save to files
+    (output_dir / "matrix_evidence.json").write_text(json.dumps(final_matrix, indent=2, ensure_ascii=False))
+
+    repo_root = Path(__file__).resolve().parents[1]
+    (repo_root / "scripts" / "presence_evidence.json").write_text(json.dumps(final_matrix, indent=2, ensure_ascii=False))
+
+    results["matrix_evidence"] = final_matrix
+    print("\n" + "=" * 70)
+    print("5-POINT RUNTIME EVIDENCE MATRIX SUCCESSFULLY COMPLETED")
+    print("Saved evidence to:")
+    print(f"  - {output_dir / 'matrix_evidence.json'}")
+    print(f"  - {repo_root / 'scripts' / 'presence_evidence.json'}")
+    print("=" * 70 + "\n", flush=True)
+    return final_matrix
+
+
 def inspect():
     window = None
     try:
@@ -244,45 +630,51 @@ def inspect():
         window.events.loaded.wait(20)
         wait_for(window, 'Boolean(document.querySelector("[data-testid=companion-layout]"))')
         wait_for(window, 'Boolean(document.querySelector("[data-testid=desktop-bridge-indicator]"))')
-        time.sleep(1)
-        capture(window, 'idle-1280')
-        window.resize(800, 800)
-        wait_for(window, 'innerWidth === 800')
-        time.sleep(0.4)
-        capture(window, 'idle-800')
-        window.resize(1280, 800)
-        wait_for(window, 'innerWidth === 1280')
-        window.evaluate_js("""(() => {
-          const input = document.querySelector('textarea[aria-label="Sua mensagem"]');
-          Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set.call(input, 'Olá, Katherine.');
-          input.dispatchEvent(new Event('input', {bubbles: true}));
-        })()""")
-        wait_for(window, '!document.querySelector("button[aria-label=\\"Enviar mensagem (Enter)\\"]").disabled')
-        window.evaluate_js('document.querySelector("button[aria-label=\\"Enviar mensagem (Enter)\\"]").click()')
-        if args.scripted:
-            wait_for(window, 'document.querySelector("textarea").disabled')
-            if args.verify_v2:
-                wait_for(window, 'document.querySelector("[role=status]")?.textContent.includes("Preparando resposta")')
-            time.sleep(1)
-            capture(window, 'thinking-1280')
+        time.sleep(0.5)
+
+        if args.verify_matrix:
+            release.set()
+            verify_matrix(window, args.output)
+
+        if not args.verify_matrix or args.verify_v2 or args.verify_scaling:
+            capture(window, 'idle-1280')
             window.resize(800, 800)
             wait_for(window, 'innerWidth === 800')
             time.sleep(0.4)
-            capture(window, 'thinking-800')
-            if args.verify_v2:
-                optical_probes(window)
-            release.set()
-            wait_for(window, 'document.body.innerText.includes("A presença pode permanecer tranquila")')
-            time.sleep(1)
-            capture(window, 'response-800')
-            if args.verify_scaling:
-                verify_scaling_matrix(window)
-        else:
-            wait_for(window, 'document.body.innerText.includes("O provedor remoto não está configurado")')
-            wait_for(window, '!document.querySelector("textarea").disabled')
-            time.sleep(0.5)
-            capture(window, 'unconfigured-error-1280')
-        results['finalText'] = window.evaluate_js('document.body.innerText')
+            capture(window, 'idle-800')
+            window.resize(1280, 800)
+            wait_for(window, 'innerWidth === 1280')
+            window.evaluate_js("""(() => {
+              const input = document.querySelector('textarea[aria-label="Sua mensagem"]');
+              Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set.call(input, 'Olá, Katherine.');
+              input.dispatchEvent(new Event('input', {bubbles: true}));
+            })()""")
+            wait_for(window, '!document.querySelector("button[aria-label=\\"Enviar mensagem (Enter)\\"]").disabled')
+            window.evaluate_js('document.querySelector("button[aria-label=\\"Enviar mensagem (Enter)\\"]").click()')
+            if args.scripted:
+                wait_for(window, 'document.querySelector("textarea").disabled')
+                if args.verify_v2:
+                    wait_for(window, 'document.querySelector("[role=status]")?.textContent.includes("Preparando resposta")')
+                time.sleep(1)
+                capture(window, 'thinking-1280')
+                window.resize(800, 800)
+                wait_for(window, 'innerWidth === 800')
+                time.sleep(0.4)
+                capture(window, 'thinking-800')
+                if args.verify_v2:
+                    optical_probes(window)
+                release.set()
+                wait_for(window, 'document.body.innerText.includes("A presença pode permanecer tranquila")')
+                time.sleep(1)
+                capture(window, 'response-800')
+                if args.verify_scaling:
+                    verify_scaling_matrix(window)
+            else:
+                wait_for(window, 'document.body.innerText.includes("O provedor remoto não está configurado")')
+                wait_for(window, '!document.querySelector("textarea").disabled')
+                time.sleep(0.5)
+                capture(window, 'unconfigured-error-1280')
+            results['finalText'] = window.evaluate_js('document.body.innerText')
     except Exception as error:
         failures.append(str(error))
     finally:
@@ -294,7 +686,7 @@ def inspect():
 
 thread = threading.Thread(target=inspect, daemon=True)
 thread.start()
-run_desktop_shell(storage_path=args.output / 'isolated.sqlite3', provider=ReviewProvider() if args.scripted else None)
+run_desktop_shell(storage_path=args.output / 'isolated.sqlite3', provider=ReviewProvider() if (args.scripted or args.verify_matrix) else None)
 thread.join(5)
 if failures:
     raise SystemExit('; '.join(failures))

--- a/scripts/presence_review.py
+++ b/scripts/presence_review.py
@@ -595,21 +595,28 @@ def verify_matrix(window, output_dir):
         assert isinstance(min_res, dict), f"Rep {rep}: Minimize bridge call timed out or returned non-dict: {min_res}"
         assert min_res.get("ok") is True, f"Rep {rep}: Minimize bridge returned non-ok: {min_res}"
 
-        # Verify native GTK window state
-        time.sleep(0.2)
+        # Bounded wait for native GTK window state to reflect ICONIFIED
+        iconify_deadline = time.monotonic() + 3.0
         native_minimized = False
         native = getattr(window, "native", None)
-        if native is not None:
-            gdk_win = native.get_window()
-            if gdk_win:
-                st_flags = gdk_win.get_state()
-                if st_flags is not None:
-                    native_minimized = bool(st_flags & Gdk.WindowState.ICONIFIED)
+        while time.monotonic() < iconify_deadline:
+            if native is not None:
+                gdk_win = native.get_window()
+                if gdk_win:
+                    st_flags = gdk_win.get_state()
+                    if st_flags is not None and bool(st_flags & Gdk.WindowState.ICONIFIED):
+                        native_minimized = True
+                        break
+            time.sleep(0.05)
+
+        assert native_minimized is True, (
+            f"Rep {rep}: Native GTK window failed to reach ICONIFIED state before restore"
+        )
 
         rep_data["transitions"].append({
             "step": "minimize",
             "bridge_ok": True,
-            "native_iconified": native_minimized,
+            "native_iconified": True,
         })
 
         # -> restore
@@ -627,6 +634,23 @@ def verify_matrix(window, output_dir):
         assert restore_done.wait(5.0), f"Rep {rep}: Native restore timed out"
         time.sleep(0.2)
         wait_for(window, 'Boolean(document.querySelector("[data-testid=\\"katherine-presence-surface\\"]"))')
+
+        # Confirm ICONIFIED was removed after restore
+        deiconify_deadline = time.monotonic() + 3.0
+        native_restored = False
+        while time.monotonic() < deiconify_deadline:
+            if native is not None:
+                gdk_win = native.get_window()
+                if gdk_win:
+                    st_flags = gdk_win.get_state()
+                    if st_flags is not None and not bool(st_flags & Gdk.WindowState.ICONIFIED):
+                        native_restored = True
+                        break
+            time.sleep(0.05)
+        assert native_restored is True, (
+            f"Rep {rep}: Native GTK window still has ICONIFIED flag after restore"
+        )
+
         assert len(webview.windows) == 1, f"Rep {rep}: Window count must remain 1 after restore"
         rep_data["transitions"].append("restore")
 


### PR DESCRIPTION
## Issue de Origem
Issue #342 — Adicionar modo de presença transparente da Katherine.

---

## Problema e Causa Raiz
O aplicativo desktop Katherine anteriormente suportava apenas a janela tradicional de companion (retangular, com decorações de janela padrão do sistema, histórico de mensagens e campos de entrada de texto). Para convivência fluida e contínua no dia a dia do usuário, era necessária uma superfície visual minimalista, transparente e flutuante que exibisse unicamente a Katherine reativa (`<KatherineFace>`), consumindo área útil mínima de tela e sem elementos visuais intrusivos.

Adicionalmente, revisões técnicas e forenses identificaram requisitos e casos de borda críticos que foram completamente remediados:
1. **Preservação e Restauração de Geometria**: A alternância entre companion e presença preserva e restaura fielmente o tamanho anterior configurado pelo usuário no modo companion, sem forçar tamanhos arbitrários.
2. **Desacoplamento do Always-On-Top (AOT)**: O modo de presença não força unilateralmente `always_on_top = true`. O estado de AOT tem como autoridade exclusiva o método `set_always_on_top`, iniciando com padrão `false` e persistindo fielmente a preferência definida pelo usuário entre alternâncias de modo.
3. **Isolamento Estrito de Privacidade da Árvore DOM**: No modo de presença, o `CompanionLayout` (e todo o conteúdo confidencial de conversas, mensagens e histórico) é 100% desmontado da árvore DOM, garantindo que canários e dados privados nunca residam no DOM de presença.
4. **Honestidade de Verificação de Transparência**: Em ambientes headless sem compositor de janelas ativo (ex.: Xvfb padrão), o teste relata com honestidade o status `"NOT VERIFIED"` em vez de forçar um falso positivo, confirmando `"VERIFIED"` sob compositor gráfico ativo.
5. **Reconciliação Dinâmica de Geometria sem Polling**: O arraste na `.pywebview-drag-region` e mudanças de resolução/monitores conectam aos eventos nativos `window.events.moved`, `monitors-changed` e `size-changed`, reconciliando a geometria com proteção contra reentrância e commit transacional estrito (estado lógico não avança se a mutação nativa falhar).
6. **Matriz de Evidências em Tempo Real de 6 Pontos**: Execução de verificação auditável com medições reais de sistema (RAM e CPU medidos sobre a árvore de processos completa via `psutil`, minimização observada nativamente com assert de `Gdk.WindowState.ICONIFIED`, e recuperação de clamping em tempo real).

---

## Solução e Decisões Tomadas

1. **Arquitetura de Janela Única Nativa (`WindowController`)**:
   - Rejeição da Opção A (múltiplas janelas WebView separadas, que consumiria +212 MB adicionais de RAM e duplicaria runtimes WebKit).
   - Adoção de janela única com mutação dinâmica de superfície GTK3 (`set_decorated(False)` para presença, `set_decorated(True)` para companion).
   - Coordenação thread-safe rigorosa via `_dispatch_sync` / `GLib.idle_add` no loop principal do GTK com lock reentrante (`RLock`) e guards de ciclo (`_is_reconciling`).
   - Suporte a transparência nativa via canal alfa de tela (`screen.get_rgba_visual()`), fundo de janela transparente (`#00000000`) e WebKitGTK com cor de fundo totalmente transparente (`Gdk.RGBA(0, 0, 0, 0)`).
   - Preservação exata da geometria da janela companion (`native.get_size()`) ao entrar em presença e restauração fiel ao retornar.
   - Clamping e reconciliação dinâmica vinculados a `window.events.moved` e sinais `monitors-changed`/`size-changed` do `Gdk.Screen`.
   - Commit transacional atômico: coordenadas lógicas só são gravadas após mutação nativa confirmada com sucesso; em caso de falha/timeout, o snapshot anterior é rigorosamente preservado com respostas de erro sanitizadas.

2. **Evolução da Bridge Desktop (Versão 3)**:
   - `DESKTOP_API_VERSION` fixada em `3`.
   - `DESKTOP_API_METHODS` estendida com métodos de controle de janela allowlisted: `'set_presence_mode'`, `'set_always_on_top'`, `'window_state'`, `'close_window'`, `'minimize_window'`.
   - Validação estrita de tipos com `_is_bool` e comportamento fail-closed (`bridge_unavailable` em documentos remotos ou não confiáveis).

3. **Superfície de Presença Minimalista (`KatherinePresence`)**:
   - Renderiza exclusivamente `<KatherineFace>` e controles efêmeros estritamente necessários (voltar ao companion, alternar fixar no topo com `aria-pressed`, minimizar, fechar).
   - KatherineFace possui `pointer-events: none` envolvida por `.katherine-presence__drag-handle.pywebview-drag-region`, permitindo arrastar Katherine diretamente pelo rosto.
   - Isolamento de clique: os botões de controle efêmeros interceptam eventos de mouse (`e.stopPropagation()` e `stopImmediatePropagation()`) e usam `-webkit-app-region: no-drag`, impedindo conflito entre clique e arrasto.
   - Divulgação suave: controles revelados suavemente em `:hover` e `:focus-within` (curva `160ms cubic-bezier(0.23, 1, 0.32, 1)`), com transição imediata (`0ms`) sob `@media (prefers-reduced-motion: reduce)`.
   - Desmontagem absoluta de privacidade: `CompanionLayout` é completamente desmontado da árvore DOM em modo de presença.

4. **Matriz de Evidências em Tempo Real de 6 Pontos (`scripts/presence_review.py`)**:
   - **Ponto 1 (Ciclo de Vida 5x)**: 5 repetições completas da sequência (`companion -> presence -> companion -> presence -> minimize -> restore -> companion`), com verificação de retorno da bridge (`ok: true`), espera limitada e assert obrigatório de estado nativo iconificado (`Gdk.WindowState.ICONIFIED`), confirmação de deiconificação após restauração e invariante de janela única (`len(webview.windows) == 1`).
   - **Ponto 2 (AOT Desacoplado)**: Padrão inicial `false`, entrada em presença mantém `false`, fixação voluntária do usuário define `true`, retorno companion preserva `true`, reentrada em presença preserva `true`, desfixação voluntária define `false`, retorno companion preserva `false`.
   - **Ponto 3 (Privacidade DOM Canary)**: Zero seletores proibidos (`.chat-history`, `.companion-composer`, `.message-item`, `.companion-header__title`, etc.) e zero vazamento do token canário confidencial no DOM.
   - **Ponto 4 (Transparência de Superfície)**: Verificação de `Gdk.Screen.get_default().is_composited()`. Retorna honestamente `"NOT VERIFIED"` quando executado sem compositor (ex.: Xvfb puro) e `"VERIFIED"` com canal alfa `0` sob compositor gráfico ativo.
   - **Ponto 5 (Consumo de Recursos via psutil)**:
     - Medição da árvore completa de processos (Python principal + WebKitWebProcess + WebKitNetworkProcess) sobre janela de amostragem delimitada:
     - Companion RSS: 434.55 MB (3 processos, 2 WebKit, 100.0% CPU idle).
     - Presence RSS: 448.37 MB (3 processos, 2 WebKit, 100.0% CPU idle).
     - Delta RSS: +13.82 MB (zero acúmulo de processos).
   - **Ponto 6 (Recuperação de Clamping de Geometria)**: Comprovação em tempo de execução de que coordenadas negativas fora dos limites (`-400, -400`) são recuperadas para `[0, 0]` e coordenadas excessivas (`9999, 9999`) são recuperadas para dentro da área útil (`[1720, 880]`), reconciliando sem alteração de modo e mantendo a presença ativa.
   - Os resultados da matriz estão registrados no artefato auditável `scripts/presence_evidence.json`.

---

## Arquivos e Áreas Afetadas
- `backend/desktop/app.py`: `WindowController`, `create_window(transparent=True, min_size=(120, 120))`, reconciliação dinâmica de geometria (`reconcile_geometry`), listeners de tela GTK, despacho `_dispatch_sync`, `LocalBuildBridge`.
- `backend/desktop/api.py`: `DESKTOP_API_VERSION = 3`, novos métodos allowlisted em `DESKTOP_API_METHODS`, validação `_is_bool`.
- `backend/tests/test_desktop_api.py`: testes de contrato, validação de métodos de janela e testes determinísticos de clamping/eventos de tela.
- `backend/tests/test_desktop_adversarial.py`: testes adversariais de concorrência, geometria, falhas nativas de mutação (move/resize) com preservação de estado e liberação de guard.
- `backend/tests/test_desktop_app_runtime.py`: teste de criação de janela transparente e dimensionamento mínimo.
- `backend/tests/test_desktop_navigation.py`: testes de segurança fail-closed para os métodos da bridge.
- `backend/tests/test_desktop_security.py`: testes de isolamento de importações e pureza AST.
- `frontend/src/features/katherine-face/KatherinePresence.jsx` & `.css`: componente e estilos da superfície de presença flutuante.
- `frontend/src/features/chat/components/CompanionLayout.jsx` & `.css`: botão de transição para modo de presença no cabeçalho companion.
- `frontend/src/AppDesktop.jsx`: gerenciamento de estado de modo ('companion' | 'presence'), minimização observável, desmontagem de dados privados e estilo de fundo transparente.
- `frontend/src/lib/desktopBridge.js`: wrappers clientes com fallbacks seguros.
- `frontend/tests/KatherinePresence.test.jsx`: testes unitários da superfície de presença.
- `frontend/tests/AppDesktopPresence.test.jsx`: testes de integração de alternância de modo.
- `frontend/tests/AppDesktopAdversarial.test.jsx`: testes de estresse e isolamento de eventos.
- `scripts/desktop_smoke.py`: smoke test completo GTK3/WebKitGTK em tempo real.
- `scripts/presence_review.py`: motor de verificação da Matriz de Evidências em Tempo Real de 6 pontos (`--verify-matrix`).
- `scripts/presence_evidence.json`: artefato auditável com as evidências reais de execução.

---

## Testes Executados e Resultado

| Suíte / Comando | Testes Executados | Resultado |
|---|---|---|
| `git diff --check` | Verificação de formatação e whitespace | **PASS** (0 erros) |
| `cd frontend && npm test -- --run` | 19 arquivos de teste, 156 testes vitest | **PASS** (156/156 em 6.64s) |
| `cd frontend && npm run lint` | ESLint em todo o código frontend | **PASS** (0 erros, 0 warnings) |
| `cd frontend && npm run build` | Vite production build (`dist/desktop.html`) | **PASS** (4.71s, 173.08 kB) |
| `cd frontend && npm audit --audit-level=high` | Auditoria de dependências | **PASS** (0 vulnerabilidades) |
| `node tests/desktopGraph.test.js` | Isolamento do grafo de pacotes desktop | **PASS** (5/5) |
| `node --test tests/projectLocalSkills.test.js` | Validação de skills e reduced-motion | **PASS** (5/5) |
| `cd backend && uv pip check` | Consistência de dependências Python | **PASS** (80 pacotes compatíveis) |
| `uv run --project backend python -m compileall -q backend` | Compilação estática do backend Python | **PASS** (0 erros) |
| `uv run --project backend python -m pytest backend/tests/test_desktop_*.py` | Suítes pytest desktop backend (incluindo testes adversariais de falha e rollback composto) | **PASS** (112/112 em 0.89s) |
| `uv run --project backend python -m pytest backend/tests` | Suíte completa de testes do backend | **PASS** (2.985/2.985 em 56.40s) |
| `uv run --project backend python scripts/desktop_smoke.py` | Smoke test nativo WebKitGTK / GTK3 | **PASS** (`SMOKE_OK`) |
| `uv run --project backend python scripts/presence_review.py --verify-matrix` | Matriz de Evidências de 6 Pontos em Tempo Real | **PASS** (6/6 pontos verificados, transparência `VERIFIED`, `native_iconified=True`) |

---

## Riscos, Migração e Rollback
- **Compatibilidade do Compositor**: A transparência de superfície foi observada e atestada como `VERIFIED` na sessão Linux compositada testada (GDK screen composited com suporte a canal alfa RGBA visual e transparência de WebKitGTK). Em ambientes sem compositor de janelas ativo (como Xvfb headless puro sem compositor gráfico), o runner relata honestamente `NOT VERIFIED`. O funcionamento em outros gerenciadores de janelas/compositores permanece como compatibilidade esperada, mas não comprovada no escopo desta evidência.
- **Rollback**: A alteração é completamente contida na branch `feat/katherine-floating-presence`. Reverter o commit `07ea8b5...` restaura o desktop ao estado anterior sem afetar banco de dados, modelos ou APIs externas.
- **Migração**: Nenhuma migração de banco de dados ou de configuração é necessária.

---

## Itens Deliberadamente Fora de Escopo
- Nenhuma alteração nos domínios de emoção, memória, safety, LLM, TTS ou conversa.
- Sem implementação de modos de dock ou painel lateral fixo do sistema operacional.
- Sem servidores HTTP adicionais, daemons de background ou captura de mídia/áudio.

