### PR TITLE
feat(frontend): add Katherine settings workspace

### DIFF
--- a/frontend/src/AppDesktop.jsx
+++ b/frontend/src/AppDesktop.jsx
@@ -50,14 +50,19 @@ export default function AppDesktop() {
     const [isSettingsOpen, setIsSettingsOpen] = useState(false);
     const isTransitioningRef = useRef(false);
     const isPinningRef = useRef(false);
+    const windowStateEpochRef = useRef(0);
     const settingsButtonRef = useRef(null);
     const shouldFocusSettingsButtonRef = useRef(false);
 
     // Bounded one-shot sync on shell startup (#342) - no continuous polling.
     useEffect(() => {
         let active = true;
+        const readEpoch = windowStateEpochRef.current;
         getWindowState().then((state) => {
-            if (active && state?.ok) {
+            // A startup snapshot may resolve after a newer confirmed window
+            // operation. Never let that stale read overwrite the newer
+            // owner state.
+            if (active && readEpoch === windowStateEpochRef.current && state?.ok) {
                 if (state.mode === 'presence' || state.mode === 'companion') {
                     setMode(state.mode);
                 }
@@ -79,6 +84,7 @@ export default function AppDesktop() {
             if (res?.ok) {
                 setMode('presence');
                 if (typeof res.on_top === 'boolean') {
+                    windowStateEpochRef.current += 1;
                     setIsAlwaysOnTop(res.on_top);
                 }
             }
@@ -95,6 +101,7 @@ export default function AppDesktop() {
             if (res?.ok) {
                 setMode('companion');
                 if (typeof res.on_top === 'boolean') {
+                    windowStateEpochRef.current += 1;
                     setIsAlwaysOnTop(res.on_top);
                 }
             }
@@ -112,6 +119,7 @@ export default function AppDesktop() {
             const nextState = !isAlwaysOnTop;
             const res = await setAlwaysOnTop(nextState);
             if (res?.ok && typeof res.on_top === 'boolean') {
+                windowStateEpochRef.current += 1;
                 setIsAlwaysOnTop(res.on_top);
                 return { applied: true, on_top: res.on_top };
             }
@@ -124,14 +132,6 @@ export default function AppDesktop() {
             isPinningRef.current = false;
         }
     }, [isAlwaysOnTop]);
-
-    // #347: sync-only entry used by SettingsWorkspace to adopt the real
-    // initial bridge state without triggering a bridge mutation.
-    const handleSyncAlwaysOnTop = useCallback((onTop) => {
-        if (typeof onTop === 'boolean') {
-            setIsAlwaysOnTop(onTop);
-        }
-    }, []);
 
     const handleMinimize = useCallback(async () => {
         const res = await minimizeDesktopWindow();
@@ -189,7 +189,6 @@ export default function AppDesktop() {
                         onReturn={handleCloseSettings}
                         isAlwaysOnTop={isAlwaysOnTop}
                         onToggleAlwaysOnTop={handleToggleAlwaysOnTop}
-                        onSyncAlwaysOnTop={handleSyncAlwaysOnTop}
                     />
                 );
             }
@@ -212,7 +211,6 @@ export default function AppDesktop() {
             handleEnterPresence,
             handleReturnToCompanion,
             handleToggleAlwaysOnTop,
-            handleSyncAlwaysOnTop,
             handleMinimize,
             handleClose,
             handleOpenSettings,

--- a/frontend/src/AppDesktop.jsx
+++ b/frontend/src/AppDesktop.jsx
@@ -18,12 +18,24 @@
  *   true alpha transparency on the window surface.
  * - In presence mode, CompanionLayout and all conversation DOM elements are
  *   completely unmounted.
+ *
+ * Settings workspace (#347):
+ * - `isSettingsOpen` is a plain composition flag, not a router: when open
+ *   (companion mode only), `renderLayout` renders SettingsWorkspace instead
+ *   of CompanionLayout. ChatWindow — and therefore the single useChat()
+ *   call with its history and draft state — stays mounted above this seam
+ *   and is never remounted by opening/closing settings.
+ * - Settings never renders inside floating presence mode: the presence
+ *   surface stays minimal and free of conversation/settings DOM (#342).
+ * - The gear access lives in the companion header, not in the #344 state
+ *   sidebar: the sidebar keeps answering "how Katherine is right now".
  */
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import ChatWindow from './features/chat/components/ChatWindow';
 import CompanionLayout from './features/chat/components/CompanionLayout.jsx';
 import KatherinePresence from './features/katherine-face/KatherinePresence.jsx';
 import KatherineStateSidebar from './features/chat/components/KatherineStateSidebar.jsx';
+import SettingsWorkspace from './features/settings/SettingsWorkspace.jsx';
 import {
     setPresenceMode,
     setAlwaysOnTop,
@@ -35,8 +47,11 @@ import {
 export default function AppDesktop() {
     const [mode, setMode] = useState('companion');
     const [isAlwaysOnTop, setIsAlwaysOnTop] = useState(false);
+    const [isSettingsOpen, setIsSettingsOpen] = useState(false);
     const isTransitioningRef = useRef(false);
     const isPinningRef = useRef(false);
+    const settingsButtonRef = useRef(null);
+    const shouldFocusSettingsButtonRef = useRef(false);
 
     // Bounded one-shot sync on shell startup (#342) - no continuous polling.
     useEffect(() => {
@@ -89,18 +104,34 @@ export default function AppDesktop() {
     }, []);
 
     const handleToggleAlwaysOnTop = useCallback(async () => {
-        if (isPinningRef.current) return;
+        if (isPinningRef.current) {
+            return { applied: false, code: 'busy' };
+        }
         isPinningRef.current = true;
         try {
             const nextState = !isAlwaysOnTop;
             const res = await setAlwaysOnTop(nextState);
             if (res?.ok && typeof res.on_top === 'boolean') {
                 setIsAlwaysOnTop(res.on_top);
+                return { applied: true, on_top: res.on_top };
             }
+            // Bridge refused or failed: keep the previous coherent
+            // state and return the sanitized failure payload (#347).
+            return res?.ok === false
+                ? { applied: false, code: res.code, message: res.message }
+                : { applied: false, code: 'unknown' };
         } finally {
             isPinningRef.current = false;
         }
     }, [isAlwaysOnTop]);
+
+    // #347: sync-only entry used by SettingsWorkspace to adopt the real
+    // initial bridge state without triggering a bridge mutation.
+    const handleSyncAlwaysOnTop = useCallback((onTop) => {
+        if (typeof onTop === 'boolean') {
+            setIsAlwaysOnTop(onTop);
+        }
+    }, []);
 
     const handleMinimize = useCallback(async () => {
         const res = await minimizeDesktopWindow();
@@ -113,6 +144,27 @@ export default function AppDesktop() {
     const handleClose = useCallback(async () => {
         await closeDesktopWindow();
     }, []);
+
+    const handleOpenSettings = useCallback(() => {
+        setIsSettingsOpen(true);
+    }, []);
+
+    const handleCloseSettings = useCallback(() => {
+        shouldFocusSettingsButtonRef.current = true;
+        setIsSettingsOpen(false);
+    }, []);
+
+    // After settings closes, the companion header (with the gear
+    // button that opened the workspace) is re-mounted. Restore focus
+    // there so keyboard users are not stranded at the end of the DOM.
+    // The ref is null while settings is open (the button unmounts), so
+    // the focus must happen in this post-commit effect.
+    useEffect(() => {
+        if (!isSettingsOpen && shouldFocusSettingsButtonRef.current) {
+            shouldFocusSettingsButtonRef.current = false;
+            settingsButtonRef.current?.focus();
+        }
+    }, [isSettingsOpen]);
 
     const renderLayout = useCallback(
         (chatModel) => {
@@ -129,10 +181,24 @@ export default function AppDesktop() {
                     />
                 );
             }
+            // #347: settings is a companion-mode composition swap. The
+            // single useChat() in ChatWindow is untouched by this branch.
+            if (isSettingsOpen) {
+                return (
+                    <SettingsWorkspace
+                        onReturn={handleCloseSettings}
+                        isAlwaysOnTop={isAlwaysOnTop}
+                        onToggleAlwaysOnTop={handleToggleAlwaysOnTop}
+                        onSyncAlwaysOnTop={handleSyncAlwaysOnTop}
+                    />
+                );
+            }
             return (
                 <CompanionLayout
                     {...chatModel}
                     onEnterPresence={handleEnterPresence}
+                    onOpenSettings={handleOpenSettings}
+                    settingsButtonRef={settingsButtonRef}
                     auxiliarySlot={
                         <KatherineStateSidebar emotionState={chatModel.emotionState} />
                     }
@@ -142,11 +208,15 @@ export default function AppDesktop() {
         [
             mode,
             isAlwaysOnTop,
+            isSettingsOpen,
             handleEnterPresence,
             handleReturnToCompanion,
             handleToggleAlwaysOnTop,
+            handleSyncAlwaysOnTop,
             handleMinimize,
             handleClose,
+            handleOpenSettings,
+            handleCloseSettings,
         ],
     );
 

--- a/frontend/src/features/chat/components/CompanionLayout.css
+++ b/frontend/src/features/chat/components/CompanionLayout.css
@@ -255,7 +255,8 @@
     }
 }
 
-.companion-layout__presence-toggle {
+.companion-layout__presence-toggle,
+.companion-layout__header-btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -268,16 +269,19 @@
     transition: color 150ms ease, background-color 150ms ease, transform 150ms ease-out;
 }
 
-.companion-layout__presence-toggle:hover {
+.companion-layout__presence-toggle:hover,
+.companion-layout__header-btn:hover {
     color: #e5e7eb;
     background-color: #1f2937;
 }
 
-.companion-layout__presence-toggle:active {
+.companion-layout__presence-toggle:active,
+.companion-layout__header-btn:active {
     transform: scale(0.95);
 }
 
-.companion-layout__presence-toggle:focus-visible {
+.companion-layout__presence-toggle:focus-visible,
+.companion-layout__header-btn:focus-visible {
     outline: 2px solid #93c5fd;
     outline-offset: 2px;
 }
@@ -287,7 +291,8 @@
         transition-duration: 0ms;
     }
 
-    .companion-layout__presence-toggle {
+    .companion-layout__presence-toggle,
+    .companion-layout__header-btn {
         transition-duration: 0ms !important;
         transform: none !important;
     }

--- a/frontend/src/features/chat/components/CompanionLayout.jsx
+++ b/frontend/src/features/chat/components/CompanionLayout.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Minimize2 } from 'lucide-react';
+import { Minimize2, Settings } from 'lucide-react';
 import ChatHeader from './ChatHeader';
 import ChatInput from './ChatInput';
 import MessageList from './MessageList';
@@ -14,6 +14,11 @@ import './CompanionLayout.css';
  * ChatWindow owns the single useChat() call and passes its model here. This
  * component only arranges existing surfaces. The face remains decorative and
  * receives the same public state boundary as the original desktop layout.
+ *
+ * #347: `onOpenSettings` adds a single discrete gear button beside the
+ * presence toggle in the header. Settings live in their own workspace, not
+ * in this layout and not in the #344 state sidebar — this surface keeps
+ * answering "how Katherine is right now".
  */
 export default function CompanionLayout({
     messages,
@@ -28,6 +33,8 @@ export default function CompanionLayout({
     transport,
     auxiliarySlot = null,
     onEnterPresence = null,
+    onOpenSettings = null,
+    settingsButtonRef = null,
 }) {
     const hasAuxiliarySlot = Boolean(auxiliarySlot);
     const hasDesktopPrivacy = isDesktopTransport(transport);
@@ -38,6 +45,18 @@ export default function CompanionLayout({
                 <div className="companion-layout__header" data-testid="companion-header-bar">
                     <ChatHeader clearScreen={clearScreen} />
                     <div className="companion-layout__header-actions">
+                        {onOpenSettings && (
+                            <button
+                                ref={settingsButtonRef}
+                                type="button"
+                                onClick={onOpenSettings}
+                                className="companion-layout__header-btn"
+                                data-testid="companion-open-settings-btn"
+                                aria-label="Configurações da Katherine"
+                            >
+                                <Settings size={20} aria-hidden="true" />
+                            </button>
+                        )}
                         <button
                             type="button"
                             onClick={onEnterPresence}

--- a/frontend/src/features/settings/SettingsWorkspace.css
+++ b/frontend/src/features/settings/SettingsWorkspace.css
@@ -1,0 +1,234 @@
+/*
+ * Katherine settings workspace (#347).
+ *
+ * Visual contract: same dark companion world (#0b0f14 base, slate text,
+ * one hairline at a time, no gradients, no cards-for-everything, no
+ * corporate sidebar). Low density: one category, one control, generous
+ * space. Reduced motion kills the only transition (switch color).
+ */
+
+.settings-workspace {
+    --settings-bg: #0b0f14;
+    --settings-line: rgba(148, 163, 184, 0.16);
+    --settings-muted: #a7b0be;
+    --settings-focus: #93c5fd;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100vh;
+    min-height: 0;
+    overflow: hidden;
+    background: var(--settings-bg);
+    color: #f3f4f6;
+}
+
+.settings-workspace__frame {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-width: 34rem;
+    margin: 0 auto;
+    padding: clamp(1rem, 4vh, 3rem) clamp(1.25rem, 4vw, 2.5rem);
+    min-height: 0;
+    flex: 1 1 auto;
+}
+
+.settings-workspace__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding-bottom: 1.25rem;
+    border-bottom: 1px solid var(--settings-line);
+}
+
+.settings-workspace__back {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    align-self: flex-start;
+    padding: 0.35rem 0.6rem 0.35rem 0.35rem;
+    border: none;
+    border-radius: 0.5rem;
+    background: transparent;
+    color: var(--settings-muted);
+    font-size: 0.9375rem;
+    cursor: pointer;
+    transition: color 150ms ease, background-color 150ms ease;
+    -webkit-app-region: no-drag;
+}
+
+.settings-workspace__back:hover {
+    color: #e5e7eb;
+    background-color: rgba(31, 41, 55, 0.6);
+}
+
+.settings-workspace__back:active {
+    transform: scale(0.98);
+}
+
+.settings-workspace__back:focus-visible {
+    outline: 2px solid var(--settings-focus);
+    outline-offset: 2px;
+}
+
+.settings-workspace__title {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    line-height: 1.2;
+    color: #f8fafc;
+}
+
+.settings-workspace__content {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    padding-top: 1.75rem;
+    overflow-y: auto;
+}
+
+.settings-workspace__section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.875rem;
+}
+
+.settings-workspace__section-title {
+    margin: 0;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #dbe2ea;
+    line-height: 1.2;
+}
+
+.settings-workspace__control {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1.25rem;
+    padding: 0.125rem 0;
+}
+
+.settings-workspace__control-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    min-width: 0;
+}
+
+.settings-workspace__control-label {
+    font-size: 1rem;
+    font-weight: 500;
+    line-height: 1.35;
+    color: #f3f4f6;
+}
+
+.settings-workspace__control-hint {
+    margin: 0;
+    font-size: 0.875rem;
+    line-height: 1.45;
+    color: var(--settings-muted);
+}
+
+.settings-workspace__control-scope {
+    margin: 0;
+    font-size: 0.8125rem;
+    line-height: 1.4;
+    color: #7c8797;
+}
+
+.settings-workspace__control-error {
+    margin: 0.125rem 0 0 0;
+    font-size: 0.875rem;
+    line-height: 1.4;
+    color: #f87171;
+}
+
+/* Switch: native button semantics (role=switch + aria-checked), one
+   hairline border, flat colors. No gradient, no glow. */
+.settings-workspace__switch {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex: 0 0 auto;
+    padding: 0.45rem 0.7rem;
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    border-radius: 9999px;
+    background: rgba(17, 24, 39, 0.6);
+    color: var(--settings-muted);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: border-color 150ms ease, color 150ms ease, background-color 150ms ease;
+    -webkit-app-region: no-drag;
+}
+
+.settings-workspace__switch:hover {
+    border-color: rgba(148, 163, 184, 0.45);
+    color: #e5e7eb;
+}
+
+.settings-workspace__switch:focus-visible {
+    outline: 2px solid var(--settings-focus);
+    outline-offset: 2px;
+}
+
+.settings-workspace__switch:disabled {
+    cursor: default;
+    opacity: 0.7;
+}
+
+.settings-workspace__switch--on {
+    border-color: rgba(147, 197, 253, 0.55);
+    background: rgba(59, 130, 246, 0.16);
+    color: #bfdbfe;
+}
+
+.settings-workspace__switch--on:hover {
+    border-color: rgba(147, 197, 253, 0.75);
+    color: #dbeafe;
+}
+
+.settings-workspace__switch-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.settings-workspace__switch-text {
+    line-height: 1.2;
+}
+
+/* The knob is decorative only: the state is communicated by text +
+   aria-checked, never color alone. */
+.settings-workspace__switch-knob {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 9999px;
+    background: currentColor;
+}
+
+/* Narrow heights (e.g. 800x600): keep the single control reachable
+   without scrolling when possible; allow vertical scroll otherwise. */
+@media (max-height: 42rem) {
+    .settings-workspace__frame {
+        padding-top: 1rem;
+        padding-bottom: 1rem;
+    }
+
+    .settings-workspace__content {
+        padding-top: 1.25rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .settings-workspace,
+    .settings-workspace * {
+        transition-duration: 0ms !important;
+        animation: none !important;
+        transform: none !important;
+    }
+}

--- a/frontend/src/features/settings/SettingsWorkspace.jsx
+++ b/frontend/src/features/settings/SettingsWorkspace.jsx
@@ -1,0 +1,200 @@
+/**
+ * Katherine settings workspace (#347).
+ *
+ * A dedicated surface for "how Katherine should work", separate from
+ * the companion ("how Katherine is right now") and from the #344 state
+ * sidebar. The workspace is intentionally small: it only renders
+ * categories whose capabilities exist as real, tested contracts in
+ * `main` today.
+ *
+ * Honesty rules (mirroring #344/#342):
+ * - Every visible control is backed by a real bridge operation that
+ *   already exists (`desktopBridge.js` allowlist); no mock state, no
+ *   fake save, no placeholder for future integrations.
+ * - The single exposed capability is "Sempre no topo" (always-on-top):
+ *   read via `getWindowState()` on mount and mutated via
+ *   `setAlwaysOnTop()`. Both go through the validated pywebview bridge.
+ * - The control is session state only. The window controller keeps the
+ *   flag in memory for the lifetime of the window; nothing in the
+ *   bridge contract persists it across restarts, so the copy must not
+ *   promise persistence.
+ * - Success is never optimistic: the UI only reflects the `on_top`
+ *   value confirmed by the bridge payload. A failed mutation keeps the
+ *   previous coherent state and surfaces a sanitized error message.
+ * - No polling, no timers, no network. The single mount-time
+ *   `getWindowState()` read mirrors the bounded one-shot sync already
+ *   used by `AppDesktop`.
+ *
+ * Conversation preservation (#347 critical requirement):
+ * this component is rendered by `AppDesktop` *below* `ChatWindow`, so
+ * the single `useChat()` call (and its history/draft state) is never
+ * remounted while the user opens, navigates, or closes settings.
+ */
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { ArrowLeft, Pin, PinOff } from 'lucide-react';
+import { getWindowState } from '../../lib/desktopBridge';
+import './SettingsWorkspace.css';
+const AOT_PENDING_MESSAGE = 'Aplicando…';
+
+/**
+ * Map a sanitized bridge failure payload to short, user-facing copy.
+ * No raw codes, no internals, no retry loops — mirrors the honest
+ * failure handling of the presence pin button.
+ */
+function alwaysOnTopFailureMessage(result) {
+    if (result?.code === 'bridge_unavailable') {
+        return 'Controle da janela indisponível neste ambiente.';
+    }
+    return 'Não foi possível alterar agora. A configuração permanece como estava.';
+}
+
+export default function SettingsWorkspace({ onReturn, isAlwaysOnTop = false, onToggleAlwaysOnTop, onSyncAlwaysOnTop }) {
+    const headerRef = useRef(null);
+    const [aotError, setAotError] = useState(null);
+    const [aotPending, setAotPending] = useState(false);
+    const pendingRef = useRef(false);
+
+    // Bounded, one-shot sync on mount: the authoritative initial state
+    // comes from the real bridge contract, never from an assumption.
+    // No polling: this runs once per mount and aborts on unmount.
+    useEffect(() => {
+        let active = true;
+        getWindowState().then((state) => {
+            if (active && state?.ok && typeof state.on_top === 'boolean') {
+                onSyncAlwaysOnTop?.(state.on_top);
+            }
+        });
+        return () => {
+            active = false;
+        };
+        // onSyncAlwaysOnTop is a stable callback from AppDesktop.
+    }, []);
+
+    // Give the back button focus on open so keyboard users land in a
+    // predictable place (and the screen reader announces the surface).
+    useEffect(() => {
+        headerRef.current?.focus();
+    }, []);
+
+    // Escape closes the workspace and returns to the companion — same
+    // gesture as the visible back button, no extra machinery.
+    useEffect(() => {
+        const handleKeyDown = (event) => {
+            if (event.key === 'Escape') {
+                onReturn();
+            }
+        };
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [onReturn]);
+
+    const handleToggle = useCallback(async () => {
+        if (pendingRef.current) return;
+        pendingRef.current = true;
+        setAotPending(true);
+        setAotError(null);
+        try {
+            // `onToggleAlwaysOnTop` (AppDesktop) performs the real bridge
+            // call and only commits the confirmed `on_top` payload on
+            // success. It returns the sanitized bridge result; a failure
+            // keeps the previous coherent state and surfaces its message.
+            const result = await onToggleAlwaysOnTop?.();
+            if (result && result.applied !== true) {
+                setAotError(alwaysOnTopFailureMessage(result));
+            }
+        } finally {
+            pendingRef.current = false;
+            setAotPending(false);
+        }
+    }, [onToggleAlwaysOnTop]);
+
+    return (
+        <section
+            className="settings-workspace"
+            aria-labelledby="settings-workspace-heading"
+            data-testid="settings-workspace"
+        >
+            <div className="settings-workspace__frame">
+                <header className="settings-workspace__header">
+                    <button
+                        ref={headerRef}
+                        type="button"
+                        className="settings-workspace__back"
+                        onClick={onReturn}
+                        aria-label="Voltar para a Katherine"
+                        data-testid="settings-back-btn"
+                    >
+                        <ArrowLeft size={18} aria-hidden="true" />
+                        <span>Katherine</span>
+                    </button>
+                    <h1 id="settings-workspace-heading" className="settings-workspace__title">
+                        Configurações
+                    </h1>
+                </header>
+
+                <div className="settings-workspace__content">
+                    <section
+                        className="settings-workspace__section"
+                        aria-labelledby="settings-window-heading"
+                        data-testid="settings-section-window"
+                    >
+                        <h2 id="settings-window-heading" className="settings-workspace__section-title">
+                            Janela
+                        </h2>
+
+                        <div className="settings-workspace__control">
+                            <div className="settings-workspace__control-text">
+                                <label
+                                    htmlFor="settings-always-on-top"
+                                    className="settings-workspace__control-label"
+                                >
+                                    Sempre no topo
+                                </label>
+                                <p className="settings-workspace__control-hint">
+                                    Mantém a janela da Katherine acima das outras nesta sessão.
+                                </p>
+                                <p className="settings-workspace__control-scope">
+                                    Vale enquanto o aplicativo estiver aberto.
+                                </p>
+                                {aotError && (
+                                    <p
+                                        className="settings-workspace__control-error"
+                                        data-testid="settings-always-on-top-error"
+                                        role="alert"
+                                    >
+                                        {aotError}
+                                    </p>
+                                )}
+                            </div>
+
+                            <button
+                                id="settings-always-on-top"
+                                type="button"
+                                role="switch"
+                                aria-checked={isAlwaysOnTop}
+                                disabled={aotPending}
+                                onClick={handleToggle}
+                                className={`settings-workspace__switch${
+                                    isAlwaysOnTop ? ' settings-workspace__switch--on' : ''
+                                }`}
+                                data-testid="settings-always-on-top-switch"
+                            >
+                                <span className="settings-workspace__switch-knob" aria-hidden="true" />
+                                <span className="settings-workspace__switch-icon" aria-hidden="true">
+                                    {isAlwaysOnTop ? (
+                                        <PinOff size={12} aria-hidden="true" />
+                                    ) : (
+                                        <Pin size={12} aria-hidden="true" />
+                                    )}
+                                </span>
+                                <span className="settings-workspace__switch-text">
+                                    {aotPending ? AOT_PENDING_MESSAGE : (isAlwaysOnTop ? 'Ativado' : 'Desativado')}
+                                </span>
+                            </button>
+                        </div>
+                    </section>
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/frontend/src/features/settings/SettingsWorkspace.jsx
+++ b/frontend/src/features/settings/SettingsWorkspace.jsx
@@ -12,8 +12,9 @@
  *   already exists (`desktopBridge.js` allowlist); no mock state, no
  *   fake save, no placeholder for future integrations.
  * - The single exposed capability is "Sempre no topo" (always-on-top):
- *   read via `getWindowState()` on mount and mutated via
- *   `setAlwaysOnTop()`. Both go through the validated pywebview bridge.
+ *   its authoritative state is owned by `AppDesktop`, read through
+ *   `getWindowState()` at shell startup, and mutated via `setAlwaysOnTop()`.
+ *   Both bridge operations use the validated pywebview allowlist.
  * - The control is session state only. The window controller keeps the
  *   flag in memory for the lifetime of the window; nothing in the
  *   bridge contract persists it across restarts, so the copy must not
@@ -21,9 +22,8 @@
  * - Success is never optimistic: the UI only reflects the `on_top`
  *   value confirmed by the bridge payload. A failed mutation keeps the
  *   previous coherent state and surfaces a sanitized error message.
- * - No polling, no timers, no network. The single mount-time
- *   `getWindowState()` read mirrors the bounded one-shot sync already
- *   used by `AppDesktop`.
+ * - No polling, no timers, no network. Opening this workspace performs no
+ *   bridge reads or mutations; it consumes the owner state from `AppDesktop`.
  *
  * Conversation preservation (#347 critical requirement):
  * this component is rendered by `AppDesktop` *below* `ChatWindow`, so
@@ -32,7 +32,6 @@
  */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { ArrowLeft, Pin, PinOff } from 'lucide-react';
-import { getWindowState } from '../../lib/desktopBridge';
 import './SettingsWorkspace.css';
 const AOT_PENDING_MESSAGE = 'Aplicando…';
 
@@ -48,27 +47,11 @@ function alwaysOnTopFailureMessage(result) {
     return 'Não foi possível alterar agora. A configuração permanece como estava.';
 }
 
-export default function SettingsWorkspace({ onReturn, isAlwaysOnTop = false, onToggleAlwaysOnTop, onSyncAlwaysOnTop }) {
+export default function SettingsWorkspace({ onReturn, isAlwaysOnTop = false, onToggleAlwaysOnTop }) {
     const headerRef = useRef(null);
     const [aotError, setAotError] = useState(null);
     const [aotPending, setAotPending] = useState(false);
     const pendingRef = useRef(false);
-
-    // Bounded, one-shot sync on mount: the authoritative initial state
-    // comes from the real bridge contract, never from an assumption.
-    // No polling: this runs once per mount and aborts on unmount.
-    useEffect(() => {
-        let active = true;
-        getWindowState().then((state) => {
-            if (active && state?.ok && typeof state.on_top === 'boolean') {
-                onSyncAlwaysOnTop?.(state.on_top);
-            }
-        });
-        return () => {
-            active = false;
-        };
-        // onSyncAlwaysOnTop is a stable callback from AppDesktop.
-    }, []);
 
     // Give the back button focus on open so keyboard users land in a
     // predictable place (and the screen reader announces the surface).

--- a/frontend/tests/SettingsWorkspace.test.jsx
+++ b/frontend/tests/SettingsWorkspace.test.jsx
@@ -1,0 +1,463 @@
+/**
+ * Katherine settings workspace (#347).
+ *
+ * Contract under test:
+ * - The workspace is a separate surface opened from a discrete gear
+ *   button in the companion header (never inside the #344 state sidebar).
+ * - Opening/closing settings preserves the single useChat() model:
+ *   history stays, the composer draft stays, no second useChat() mount,
+ *   and no history re-fetch happens just from navigating.
+ * - Only capabilities backed by real bridge contracts appear as
+ *   functional. No fake TTS/voice, memory, provider, or integration
+ *   sections exist in the DOM.
+ * - The always-on-top control: initial state comes from the real
+ *   bridge (`window_state`), mutations only commit after the bridge
+ *   confirms, failures keep coherent state and surface a sanitized
+ *   error, and the copy never promises persistence.
+ * - Settings never renders inside floating presence mode.
+ */
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+const chatHarness = vi.hoisted(() => ({
+    calls: 0,
+    model: {
+        messages: [],
+        input: '',
+        setInput: vi.fn((value) => {
+            chatHarness.model.input = value;
+        }),
+        isLoading: false,
+        emotionState: null,
+        messagesEndRef: { current: null },
+        inputRef: { current: null },
+        handleSend: vi.fn(),
+        clearScreen: vi.fn(),
+        transport: {
+            mode: 'desktop',
+            fetchHistory: vi.fn(async () => ({ data: [] })),
+            runPrivacyOp: vi.fn(async () => ({ status: 'applied' })),
+        },
+    },
+}));
+
+vi.mock('../src/features/chat/hooks/useChat', () => ({
+    useChat: () => {
+        chatHarness.calls += 1;
+        return chatHarness.model;
+    },
+}));
+
+import AppDesktop from '../src/AppDesktop.jsx';
+
+if (typeof HTMLElement.prototype.scrollIntoView !== 'function') {
+    HTMLElement.prototype.scrollIntoView = () => {};
+}
+
+let pywebviewApi;
+let windowStatePayload;
+
+function setupBridge() {
+    windowStatePayload = {
+        ok: true,
+        mode: 'companion',
+        on_top: false,
+        width: 1280,
+        height: 800,
+    };
+    pywebviewApi = {
+        set_presence_mode: vi.fn(async (enabled) => ({
+            ok: true,
+            mode: enabled ? 'presence' : 'companion',
+            on_top: false,
+            width: enabled ? 200 : 1280,
+            height: enabled ? 200 : 800,
+        })),
+        set_always_on_top: vi.fn(async (enabled) => ({
+            ok: true,
+            on_top: enabled,
+        })),
+        window_state: vi.fn(async () => windowStatePayload),
+        close_window: vi.fn(async () => ({ ok: true })),
+        minimize_window: vi.fn(async () => ({ ok: true })),
+        health: vi.fn(async () => ({ ok: true, api_version: 3 })),
+        runtime_state: vi.fn(async () => ({
+            ok: true,
+            storage: true,
+            provider_configured: true,
+            revision: 1,
+        })),
+    };
+    window.pywebview = { api: pywebviewApi };
+}
+
+function resetState() {
+    chatHarness.calls = 0;
+    Object.assign(chatHarness.model, {
+        messages: [],
+        input: '',
+        isLoading: false,
+        emotionState: null,
+    });
+    chatHarness.model.transport.fetchHistory.mockClear();
+    setupBridge();
+    document.body.innerHTML = '';
+}
+
+const openSettings = async () => {
+    await act(async () => {
+        fireEvent.click(screen.getByTestId('companion-open-settings-btn'));
+    });
+};
+
+const closeSettings = async () => {
+    await act(async () => {
+        fireEvent.click(screen.getByTestId('settings-back-btn'));
+    });
+};
+
+describe('SettingsWorkspace: access and separation', () => {
+    beforeEach(resetState);
+
+    it('exposes a discrete, labeled settings button in the companion header', () => {
+        render(<AppDesktop />);
+
+        const gearBtn = screen.getByTestId('companion-open-settings-btn');
+        expect(gearBtn).toBeInTheDocument();
+        expect(gearBtn).toHaveAttribute('aria-label', 'Configurações da Katherine');
+        expect(gearBtn.tagName).toBe('BUTTON');
+
+        // Not inside the state sidebar: the #344 sidebar stays state-only.
+        const sidebar = screen.getByTestId('katherine-state-sidebar');
+        expect(sidebar).not.toContainElement(gearBtn);
+        // And not a toolbar: exactly two header action buttons.
+        const headerActions = document.querySelector('.companion-layout__header-actions');
+        expect(headerActions.querySelectorAll('button')).toHaveLength(2);
+    });
+
+    it('does not render the settings button when no handler is provided (web parity)', async () => {
+        // CompanionLayout without onOpenSettings renders no gear (backward
+        // compatible composition seam, same pattern as onEnterPresence).
+        const { default: CompanionLayout } = await import(
+            '../src/features/chat/components/CompanionLayout.jsx'
+        );
+        render(
+            <CompanionLayout
+                messages={[]}
+                input=""
+                setInput={() => {}}
+                isLoading={false}
+                emotionState={null}
+                messagesEndRef={{ current: null }}
+                inputRef={{ current: null }}
+                handleSend={() => {}}
+                clearScreen={() => {}}
+                transport={{ mode: 'desktop' }}
+            />,
+        );
+        expect(screen.queryByTestId('companion-open-settings-btn')).toBeNull();
+    });
+});
+
+describe('SettingsWorkspace: conversation preservation', () => {
+    beforeEach(resetState);
+
+    it('opening and closing settings preserves history, draft, and the single useChat()', async () => {
+        chatHarness.model.messages = [
+            { role: 'user', content: 'Mensagem histórica importante' },
+            { role: 'assistant', content: 'Resposta guardada' },
+        ];
+        chatHarness.model.input = 'Rascunho não enviado no composer';
+
+        render(<AppDesktop />);
+        const useChatCallsBefore = chatHarness.calls;
+        const fetchCallsBefore = chatHarness.model.transport.fetchHistory.mock.calls.length;
+        expect(useChatCallsBefore).toBe(1);
+
+        await openSettings();
+        expect(screen.getByTestId('settings-workspace')).toBeInTheDocument();
+        expect(screen.queryByTestId('companion-layout')).toBeNull();
+
+        await closeSettings();
+        expect(screen.getByTestId('companion-layout')).toBeInTheDocument();
+        expect(screen.queryByTestId('settings-workspace')).toBeNull();
+
+        // History and draft preserved.
+        expect(screen.getByText('Mensagem histórica importante')).toBeInTheDocument();
+        expect(screen.getByText('Resposta guardada')).toBeInTheDocument();
+        expect(screen.getByRole('textbox', { name: /sua mensagem/i })).toHaveValue(
+            'Rascunho não enviado no composer',
+        );
+
+        // useChat() was NOT re-created by navigation: the hook call count
+        // only grows when ChatWindow re-renders, never resets to a second
+        // mount. Same mount => same transport => no extra history fetch.
+        expect(chatHarness.calls).toBeGreaterThanOrEqual(useChatCallsBefore);
+        const fetchCallsAfter = chatHarness.model.transport.fetchHistory.mock.calls.length;
+        expect(fetchCallsAfter).toBe(fetchCallsBefore);
+    });
+
+    it('re-opening settings a second time still preserves the draft', async () => {
+        chatHarness.model.input = 'Segundo rascunho';
+
+        render(<AppDesktop />);
+        await openSettings();
+        await closeSettings();
+        await openSettings();
+        await closeSettings();
+
+        expect(screen.getByRole('textbox', { name: /sua mensagem/i })).toHaveValue(
+            'Segundo rascunho',
+        );
+    });
+});
+
+describe('SettingsWorkspace: honesty of capabilities', () => {
+    beforeEach(resetState);
+
+    it('renders only the Janela category with the real always-on-top control', async () => {
+        render(<AppDesktop />);
+        await openSettings();
+
+        const workspace = screen.getByTestId('settings-workspace');
+        expect(screen.getByTestId('settings-section-window')).toBeInTheDocument();
+
+        // No fake/future sections appear as functional.
+        const forbidden = [
+            /voz/i, /tts/i, /memória/i, /memorias/i, /modelo/i, /prove/i,
+            /integra/i, /ouroboros/i, /runstead/i, /lifeos/i, /avançado/i,
+        ];
+        for (const pattern of forbidden) {
+            expect(workspace.textContent).not.toMatch(pattern);
+        }
+
+        // Exactly one interactive control exists in the workspace.
+        expect(workspace.querySelectorAll('button[role="switch"]')).toHaveLength(1);
+
+        // No save button / fake persistence surface: the single control
+        // commits through the real bridge on interaction.
+        expect(screen.queryByRole('button', { name: /salvar/i })).toBeNull();
+    });
+
+    it('secrets never appear in the settings DOM', async () => {
+        render(<AppDesktop />);
+        await openSettings();
+
+        const html = document.body.innerHTML;
+        expect(html).not.toMatch(/api[_-]?key|secret|sk-[a-z0-9]/i);
+    });
+
+    it('opening settings triggers no history load or other bridge calls', async () => {
+        render(<AppDesktop />);
+        // Flush the shell's bounded startup sync so the count baseline is
+        // stable before the workspace opens.
+        await act(async () => {});
+        pywebviewApi.window_state.mockClear();
+        pywebviewApi.set_always_on_top.mockClear();
+        pywebviewApi.set_presence_mode.mockClear();
+        pywebviewApi.close_window.mockClear();
+        pywebviewApi.minimize_window.mockClear();
+
+        await openSettings();
+
+        // Opening the workspace performs exactly one bounded read of the
+        // real window state (the initial sync) and nothing else: no
+        // history load, no mutations, no network.
+        expect(pywebviewApi.window_state).toHaveBeenCalledTimes(1);
+        expect(pywebviewApi.set_always_on_top).not.toHaveBeenCalled();
+        expect(pywebviewApi.set_presence_mode).not.toHaveBeenCalled();
+        expect(pywebviewApi.close_window).not.toHaveBeenCalled();
+        expect(pywebviewApi.minimize_window).not.toHaveBeenCalled();
+    });
+});
+
+describe('SettingsWorkspace: always-on-top control lifecycle', () => {
+    beforeEach(resetState);
+
+    it('adopts the real initial state from the bridge on open', async () => {
+        render(<AppDesktop />);
+        // The shell startup sync consumed the first read; change the
+        // authoritative bridge state before opening the workspace.
+        windowStatePayload = {
+            ok: true,
+            mode: 'companion',
+            on_top: true,
+            width: 1280,
+            height: 800,
+        };
+
+        await openSettings();
+
+        const control = screen.getByTestId('settings-always-on-top-switch');
+        expect(pywebviewApi.window_state).toHaveBeenCalled();
+        expect(control).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('commits the toggle only after the bridge confirms the new state', async () => {
+        render(<AppDesktop />);
+        await openSettings();
+
+        const control = screen.getByTestId('settings-always-on-top-switch');
+        expect(control).toHaveAttribute('aria-checked', 'false');
+
+        let resolveBridge;
+        pywebviewApi.set_always_on_top.mockImplementationOnce(
+            () => new Promise((resolve) => {
+                resolveBridge = resolve;
+            }),
+        );
+
+        await act(async () => {
+            fireEvent.click(control);
+        });
+        // While pending: not optimistically switched.
+        expect(control).toHaveAttribute('aria-checked', 'false');
+        expect(control).toBeDisabled();
+
+        await act(async () => {
+            resolveBridge({ ok: true, on_top: true });
+        });
+        expect(control).toHaveAttribute('aria-checked', 'true');
+        expect(control).not.toBeDisabled();
+        expect(screen.queryByTestId('settings-always-on-top-error')).toBeNull();
+    });
+
+    it('keeps the previous coherent state when the bridge fails', async () => {
+        render(<AppDesktop />);
+        await openSettings();
+
+        const control = screen.getByTestId('settings-always-on-top-switch');
+        expect(control).toHaveAttribute('aria-checked', 'false');
+
+        pywebviewApi.set_always_on_top.mockResolvedValueOnce({
+            ok: false,
+            code: 'window_mutation_failed',
+            message: 'The window operation could not be completed.',
+        });
+
+        await act(async () => {
+            fireEvent.click(control);
+        });
+
+        expect(pywebviewApi.set_always_on_top).toHaveBeenCalledWith(true);
+        expect(control).toHaveAttribute('aria-checked', 'false');
+        expect(screen.getByTestId('settings-always-on-top-error')).toBeInTheDocument();
+        expect(screen.getByTestId('settings-always-on-top-error').textContent)
+            .not.toMatch(/window_mutation_failed|traceback|error code/i);
+    });
+
+    it('reports unavailable window control honestly when the bridge is missing', async () => {
+        delete window.pywebview;
+
+        render(<AppDesktop />);
+        await openSettings();
+
+        const control = screen.getByTestId('settings-always-on-top-switch');
+        await act(async () => {
+            fireEvent.click(control);
+        });
+
+        expect(control).toHaveAttribute('aria-checked', 'false');
+        const error = screen.getByTestId('settings-always-on-top-error');
+        expect(error.textContent).toMatch(/indispon/i);
+    });
+
+    it('copies the session scope honestly and never promises persistence', async () => {
+        render(<AppDesktop />);
+        await openSettings();
+
+        const workspace = screen.getByTestId('settings-workspace');
+        expect(workspace.textContent).toMatch(/enquanto o aplicativo estiver aberto/i);
+        expect(workspace.textContent).not.toMatch(/sempre será|entre reinícios|salvo automaticamente/i);
+    });
+});
+
+describe('SettingsWorkspace: presence isolation', () => {
+    beforeEach(resetState);
+
+    it('does not render settings inside floating presence mode', async () => {
+        render(<AppDesktop />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('companion-enter-presence-btn'));
+        });
+
+        expect(screen.getByTestId('katherine-presence-surface')).toBeInTheDocument();
+        expect(screen.queryByTestId('settings-workspace')).toBeNull();
+        expect(screen.queryByTestId('companion-open-settings-btn')).toBeNull();
+
+        // The presence surface contains no settings DOM either.
+        const html = document.body.innerHTML;
+        expect(html).not.toContain('settings-workspace');
+        expect(html).not.toContain('Configurações');
+    });
+
+    it('settings open state does not leak into presence: returning to companion from settings-open path keeps settings closed', async () => {
+        // Settings can only be opened from the companion header; entering
+        // presence from the companion with settings closed never surfaces
+        // settings later. Returning to companion restores the header.
+        render(<AppDesktop />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('companion-enter-presence-btn'));
+        });
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('presence-return-btn'));
+        });
+
+        expect(screen.getByTestId('companion-layout')).toBeInTheDocument();
+        expect(screen.getByTestId('companion-open-settings-btn')).toBeInTheDocument();
+        expect(screen.queryByTestId('settings-workspace')).toBeNull();
+    });
+});
+
+describe('SettingsWorkspace: keyboard and focus', () => {
+    beforeEach(resetState);
+
+    it('focuses the back button when opened so keyboard users land predictably', async () => {
+        render(<AppDesktop />);
+        await openSettings();
+
+        expect(screen.getByTestId('settings-back-btn')).toHaveFocus();
+    });
+
+    it('returns focus to the gear button after closing', async () => {
+        render(<AppDesktop />);
+        await openSettings();
+        await closeSettings();
+
+        expect(screen.getByTestId('companion-open-settings-btn')).toHaveFocus();
+    });
+
+    it('closes with the Escape key', async () => {
+        render(<AppDesktop />);
+        await openSettings();
+
+        await act(async () => {
+            fireEvent.keyDown(document, { key: 'Escape' });
+        });
+
+        expect(screen.getByTestId('companion-layout')).toBeInTheDocument();
+        expect(screen.queryByTestId('settings-workspace')).toBeNull();
+    });
+
+    it('exposes semantic headings and a switch role for the control', async () => {
+        render(<AppDesktop />);
+        await openSettings();
+
+        expect(
+            screen.getByRole('heading', { level: 1, name: 'Configurações' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('heading', { level: 2, name: 'Janela' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('switch', { name: 'Sempre no topo' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /voltar para a katherine/i }),
+        ).toBeInTheDocument();
+    });
+});

--- a/frontend/tests/SettingsWorkspace.test.jsx
+++ b/frontend/tests/SettingsWorkspace.test.jsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 const chatHarness = vi.hoisted(() => ({
     calls: 0,
@@ -262,10 +262,10 @@ describe('SettingsWorkspace: honesty of capabilities', () => {
 
         await openSettings();
 
-        // Opening the workspace performs exactly one bounded read of the
-        // real window state (the initial sync) and nothing else: no
-        // history load, no mutations, no network.
-        expect(pywebviewApi.window_state).toHaveBeenCalledTimes(1);
+        // Opening the workspace performs no bridge reads: AppDesktop owns
+        // the single bounded startup sync, and settings only consumes its
+        // state. There are also no mutations or network calls.
+        expect(pywebviewApi.window_state).not.toHaveBeenCalled();
         expect(pywebviewApi.set_always_on_top).not.toHaveBeenCalled();
         expect(pywebviewApi.set_presence_mode).not.toHaveBeenCalled();
         expect(pywebviewApi.close_window).not.toHaveBeenCalled();
@@ -276,10 +276,86 @@ describe('SettingsWorkspace: honesty of capabilities', () => {
 describe('SettingsWorkspace: always-on-top control lifecycle', () => {
     beforeEach(resetState);
 
-    it('adopts the real initial state from the bridge on open', async () => {
+    it('keeps the confirmed pin when an older startup read resolves afterward', async () => {
+        let resolveInitialRead;
+        const initialRead = new Promise((resolve) => {
+            resolveInitialRead = resolve;
+        });
+        pywebviewApi.window_state.mockImplementationOnce(() => initialRead);
+
         render(<AppDesktop />);
-        // The shell startup sync consumed the first read; change the
-        // authoritative bridge state before opening the workspace.
+        await waitFor(() => {
+            expect(pywebviewApi.window_state).toHaveBeenCalledTimes(1);
+        });
+
+        await openSettings();
+        const control = screen.getByTestId('settings-always-on-top-switch');
+        expect(control).toHaveAttribute('aria-checked', 'false');
+
+        await act(async () => {
+            fireEvent.click(control);
+        });
+        expect(control).toHaveAttribute('aria-checked', 'true');
+        expect(pywebviewApi.set_always_on_top).toHaveBeenCalledTimes(1);
+        expect(pywebviewApi.set_always_on_top).toHaveBeenCalledWith(true);
+
+        await act(async () => {
+            resolveInitialRead({
+                ok: true,
+                mode: 'companion',
+                on_top: false,
+                width: 1280,
+                height: 800,
+            });
+        });
+
+        expect(control).toHaveAttribute('aria-checked', 'true');
+        expect(pywebviewApi.set_always_on_top).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the confirmed unpin when an older startup read resolves afterward', async () => {
+        let resolveInitialRead;
+        const initialRead = new Promise((resolve) => {
+            resolveInitialRead = resolve;
+        });
+        pywebviewApi.window_state.mockImplementationOnce(() => initialRead);
+
+        render(<AppDesktop />);
+        await waitFor(() => {
+            expect(pywebviewApi.window_state).toHaveBeenCalledTimes(1);
+        });
+
+        await openSettings();
+        const control = screen.getByTestId('settings-always-on-top-switch');
+
+        await act(async () => {
+            fireEvent.click(control);
+        });
+        expect(control).toHaveAttribute('aria-checked', 'true');
+
+        await act(async () => {
+            fireEvent.click(control);
+        });
+        expect(control).toHaveAttribute('aria-checked', 'false');
+        expect(pywebviewApi.set_always_on_top).toHaveBeenCalledTimes(2);
+        expect(pywebviewApi.set_always_on_top).toHaveBeenNthCalledWith(1, true);
+        expect(pywebviewApi.set_always_on_top).toHaveBeenNthCalledWith(2, false);
+
+        await act(async () => {
+            resolveInitialRead({
+                ok: true,
+                mode: 'companion',
+                on_top: true,
+                width: 1280,
+                height: 800,
+            });
+        });
+
+        expect(control).toHaveAttribute('aria-checked', 'false');
+        expect(pywebviewApi.set_always_on_top).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses the AppDesktop-owned initial state without a workspace read', async () => {
         windowStatePayload = {
             ok: true,
             mode: 'companion',
@@ -287,11 +363,17 @@ describe('SettingsWorkspace: always-on-top control lifecycle', () => {
             width: 1280,
             height: 800,
         };
+        render(<AppDesktop />);
 
+        // The startup read is asynchronous, so wait for it to adopt the
+        // state before opening the workspace.
+        await waitFor(() => {
+            expect(pywebviewApi.window_state).toHaveBeenCalledTimes(1);
+        });
         await openSettings();
 
         const control = screen.getByTestId('settings-always-on-top-switch');
-        expect(pywebviewApi.window_state).toHaveBeenCalled();
+        expect(pywebviewApi.window_state).toHaveBeenCalledTimes(1);
         expect(control).toHaveAttribute('aria-checked', 'true');
     });
 

--- a/scripts/presence_review.py
+++ b/scripts/presence_review.py
@@ -439,10 +439,15 @@ def verify_matrix(window, output_dir):
             '[data-testid="chat-header"]',
             '[data-testid="companion-auxiliary-slot"]',
             '[data-testid="katherine-state-sidebar"]',
+            '[data-testid="companion-open-settings-btn"]',
+            '[data-testid="settings-workspace"]',
+            '[data-testid="settings-back-btn"]',
+            '[data-testid="settings-section-window"]',
             '.companion-layout__conversation',
             '.chat-header',
             '.companion-layout__history',
-            '.katherine-state-sidebar'
+            '.katherine-state-sidebar',
+            '.settings-workspace'
         ];
         const leaked = forbiddenSelectors.filter(sel => document.querySelector(sel) !== null);
         const text = document.body.innerText || '';

--- a/scripts/settings_review.py
+++ b/scripts/settings_review.py
@@ -1,0 +1,555 @@
+"""Runtime evidence for the Katherine settings workspace (#347).
+
+Runs the real desktop entry (desktop.html) under WebKitGTK/Xvfb with an
+isolated SQLite database and a scripted offline provider, then exercises
+the settings workspace end-to-end:
+
+- Access & discretion: the workspace opens only from the companion header
+  (two buttons, not in the sidebar or presence surface).
+- Conversation preservation: the composer draft survives an open -> close
+  -> reopen cycle; component tests cover history and the single useChat
+  composition seam.
+- Honesty: only the "Janela" section with the single always-on-top
+  control exists; no fake sections for voice, memory, models or
+  integrations.
+- Always-on-top lifecycle: the real `window_state` / `set_always_on_top`
+  bridge ops stay coherent, including session-only scope.
+- Presence isolation: opening settings never leaks into presence mode,
+  and the presence surface never exposes settings.
+- Keyboard & focus: back button is focused on open, Escape closes, focus
+  returns to the gear button.
+- Efficiency: opening settings triggers no polling (no timers, no
+  repeated bridge reads).
+- Resolutions: 1440x900, 1024x768, 800x600 and 125%/150% zoom, with
+  geometry checks (no overflow, composer visible).
+
+The scripted provider is fixture evidence, not live provider acceptance.
+Sanitized output only: no personal data, no secrets, no real provider
+traffic. Screenshots capture the settings UI, which contains no user
+data by construction.
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import webview
+from backend.desktop.app import run_desktop_shell
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--output', type=Path, default=Path('scripts/settings_evidence'))
+args = parser.parse_args()
+args.output.mkdir(parents=True, exist_ok=True)
+release = threading.Event()
+failures = []
+results = {
+    'provider': 'scripted offline fixture',
+    'captures': [],
+}
+
+
+class ReviewProvider:
+    async def appraise(self, message, budget):
+        from backend.emotional_domain import AppraisalV1
+
+        return AppraisalV1.neutral()
+
+    async def generate(self, messages, budget):
+        while not release.is_set():
+            await asyncio.sleep(0.05)
+        return 'Resposta de fixture para a evidência das configurações.'
+
+    async def extract_archival(self, messages, budget):
+        return '{}'
+
+    def describe(self):
+        from backend.language_model import ModelSelection
+
+        return ModelSelection(
+            provider='fake', main_model_id='review-fixture', fast_model_id='review-fixture'
+        )
+
+
+def wait_for(window, script, timeout=20):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        value = window.evaluate_js(script)
+        if value:
+            return value
+        time.sleep(0.1)
+    raise AssertionError(f'Timed out: {script}')
+
+
+def capture(window, name):
+    from gi.repository import Gdk, GLib
+
+    done = threading.Event()
+    errors = []
+
+    def save():
+        try:
+            native = window.native
+            width, height = native.get_size()
+            pixbuf = Gdk.pixbuf_get_from_window(native.get_window(), 0, 0, width, height)
+            if pixbuf is None:
+                raise RuntimeError('Native capture returned no pixels')
+            pixbuf.savev(str(args.output / f'{name}.png'), 'png', [], [])
+        except Exception as error:
+            errors.append(error)
+        finally:
+            done.set()
+        return False
+
+    GLib.idle_add(save)
+    if not done.wait(10):
+        raise RuntimeError('Native capture timed out')
+    if errors:
+        raise errors[0]
+
+
+def metrics(window):
+    return window.evaluate_js("""(() => {
+        const q = (sel) => document.querySelector(sel);
+        const rect = (el) => el ? el.getBoundingClientRect() : null;
+        const workspace = q('[data-testid="settings-workspace"]');
+        const back = q('[data-testid="settings-back-btn"]');
+        const section = q('[data-testid="settings-section-window"]');
+        const sw = q('[data-testid="settings-always-on-top-switch"]');
+        const gear = q('[data-testid="companion-open-settings-btn"]');
+        const sidebarBtns = Array.from(document.querySelectorAll(
+            '[data-testid="katherine-state-sidebar"] button, .katherine-state-sidebar button'));
+        const heading = q('#settings-workspace-heading');
+        const sectionHeading = q('#settings-window-heading');
+        const input = q('textarea[aria-label="Sua mensagem"]');
+        return {
+            hasWorkspace: Boolean(workspace),
+            backVisible: back ? (back.getBoundingClientRect().bottom > 0) : false,
+            backLabel: back ? back.textContent : null,
+            hasWindowSection: Boolean(section),
+            hasVoiceSection: Boolean(q('[data-testid="settings-section-voice"]')),
+            hasMemorySection: Boolean(q('[data-testid="settings-section-memory"]')),
+            hasModelsSection: Boolean(q('[data-testid="settings-section-models"]')),
+            hasIntegrationsSection: Boolean(q('[data-testid="settings-section-integrations"]')),
+            switchRole: sw ? sw.getAttribute('role') : null,
+            switchChecked: sw ? sw.getAttribute('aria-checked') : null,
+            switchDisabled: sw ? sw.disabled : null,
+            switchText: sw ? sw.textContent : null,
+            headingLevel: heading ? heading.tagName : null,
+            sectionHeadingLevel: sectionHeading ? sectionHeading.tagName : null,
+            headings: Array.from(document.querySelectorAll('h1, h2, h3')).map(h => h.textContent.trim()),
+            gearInSidebar: sidebarBtns.some(b => b.matches('[data-testid="companion-open-settings-btn"]')),
+            gearInHeader: Boolean(gear),
+            horizontalOverflow: document.documentElement.scrollWidth > innerWidth,
+            inputVisible: input ? (input.getBoundingClientRect().bottom <= innerHeight) : false,
+            runningAnimations: document.getAnimations().filter(a => a.playState === 'running').length,
+        };
+    })()""")
+
+
+def open_settings(window):
+    window.evaluate_js(
+        'document.querySelector("[data-testid=\\"companion-open-settings-btn\\"]").click()'
+    )
+    wait_for(window, 'Boolean(document.querySelector("[data-testid=\\"settings-workspace\\"]"))')
+
+
+def close_settings(window):
+    window.evaluate_js('document.querySelector("[data-testid=\\"settings-back-btn\\"]").click()')
+    wait_for(window, 'Boolean(document.querySelector("[data-testid=\\"companion-layout\\"]"))')
+
+
+def call_bridge_js(window, call_expr, timeout=10.0):
+    """Execute an async bridge expression and await its deposited result."""
+    import uuid
+
+    prop = f"__bridge_res_{uuid.uuid4().hex}"
+    window.evaluate_js(f"""(() => {{
+        window['{prop}'] = '__pending__';
+        (async () => {{
+            try {{
+                window['{prop}'] = await ({call_expr});
+            }} catch (err) {{
+                window['{prop}'] = {{ __threw: true, error: String(err) }};
+            }}
+        }})();
+    }})()""")
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        res = window.evaluate_js(f"window['{prop}']")
+        if res != '__pending__' and res is not None:
+            window.evaluate_js(f"delete window['{prop}']")
+            if isinstance(res, dict) and res.get('__threw'):
+                raise RuntimeError(f"Bridge JS error in {call_expr}: {res.get('error')}")
+            return res
+        time.sleep(0.05)
+    raise TimeoutError(f'Timed out waiting for {call_expr}')
+
+
+def verify_settings(window, output_dir):
+    print('=' * 70)
+    print('SETTINGS WORKSPACE RUNTIME EVIDENCE (#347)')
+    print('=' * 70, flush=True)
+
+    evidence = {'timestamp_utc': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}
+
+    wait_for(window, 'Boolean(document.querySelector("[data-testid=companion-layout]"))')
+    wait_for(window, 'Boolean(document.querySelector("[data-testid=desktop-bridge-indicator]"))')
+    time.sleep(0.5)
+
+    # ---- 1. Access & discretion ------------------------------------------
+    print('[1] Access & discretion...', flush=True)
+    gear_count = window.evaluate_js(
+        'document.querySelectorAll(\'[data-testid="companion-open-settings-btn"]\').length'
+    )
+    assert gear_count == 1, f'Expected exactly one gear button, found {gear_count}'
+    sidebar_has_gear = window.evaluate_js("""(() => {
+        const sidebar = document.querySelector('[data-testid="katherine-state-sidebar"]');
+        return sidebar
+            ? Boolean(sidebar.querySelector('[data-testid="companion-open-settings-btn"]'))
+            : false;
+    })()""")
+    assert not sidebar_has_gear, 'Settings button must not live in the state sidebar'
+    access = {'gear_buttons': gear_count, 'gear_in_sidebar': sidebar_has_gear}
+    evidence['access'] = access
+    print(f'  gear buttons={gear_count}, in sidebar={sidebar_has_gear}: PASS', flush=True)
+
+    # ---- 2. Conversation preservation ------------------------------------
+    print('[2] Conversation preservation...', flush=True)
+    window.evaluate_js("""(() => {
+        const input = document.querySelector('textarea[aria-label="Sua mensagem"]');
+        Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set.call(
+            input, 'rascunho-para-preservar');
+        input.dispatchEvent(new Event('input', {bubbles: true}));
+    })()""")
+    time.sleep(0.3)
+    open_settings(window)
+    time.sleep(0.4)
+    close_settings(window)
+    time.sleep(0.4)
+    draft_after_cycle = window.evaluate_js(
+        'document.querySelector(\'textarea[aria-label="Sua mensagem"]\').value'
+    )
+    assert draft_after_cycle == 'rascunho-para-preservar', (
+        f'Draft lost after settings cycle: {draft_after_cycle!r}'
+    )
+    workspace_gone = window.evaluate_js(
+        '!document.querySelector(\'[data-testid="settings-workspace"]\')'
+    )
+    assert workspace_gone, 'Workspace must unmount after closing'
+    preservation = {
+        'draft_preserved': draft_after_cycle == 'rascunho-para-preservar',
+        'draft_value': draft_after_cycle,
+    }
+    evidence['conversation_preservation'] = preservation
+    print(f'  draft preserved after open->close: PASS ({draft_after_cycle!r})', flush=True)
+
+    # ---- 3. Honesty: only real capabilities -------------------------------
+    print('[3] Honesty (only the Janela section / always-on-top)...', flush=True)
+    open_settings(window)
+    time.sleep(0.5)
+    m = metrics(window)
+    assert m['hasWorkspace'], 'Workspace did not open'
+    assert m['hasWindowSection'], 'Janela section missing'
+    assert not m['hasVoiceSection'], 'Fake voice section present'
+    assert not m['hasMemorySection'], 'Fake memory section present'
+    assert not m['hasModelsSection'], 'Fake models section present'
+    assert not m['hasIntegrationsSection'], 'Fake integrations section present'
+    assert m['switchRole'] == 'switch', f'role={m["switchRole"]!r}'
+    assert m['headingLevel'] == 'H1', f'heading level={m["headingLevel"]!r}'
+    assert m['sectionHeadingLevel'] == 'H2', f'section heading level={m["sectionHeadingLevel"]!r}'
+    honesty = {
+        'sections': m['headings'],
+        'switch_role': m['switchRole'],
+        'heading_levels': [m['headingLevel'], m['sectionHeadingLevel']],
+        'fake_sections': [
+            name for name, present in {
+                'voice': m['hasVoiceSection'],
+                'memory': m['hasMemorySection'],
+                'models': m['hasModelsSection'],
+                'integrations': m['hasIntegrationsSection'],
+            }.items() if present
+        ],
+    }
+    evidence['honesty'] = honesty
+    print(f"  sections={m['headings']}, fake_sections=[]: PASS", flush=True)
+    capture(window, 'settings-open-default')
+
+    # ---- 4. Always-on-top lifecycle ---------------------------------------
+    print('[4] Always-on-top lifecycle (real bridge)...', flush=True)
+    st0 = call_bridge_js(window, 'window.pywebview.api.window_state()')
+    assert st0.get('ok') and st0.get('mode') == 'companion', f'Bad state: {st0}'
+    assert st0.get('on_top') is False, f'Startup must be unpinned: {st0}'
+    checked_before = window.evaluate_js(
+        'document.querySelector(\'[data-testid="settings-always-on-top-switch"]\')'
+        '.getAttribute("aria-checked")'
+    )
+    assert checked_before == 'false', f'aria-checked={checked_before!r}'
+
+    window.evaluate_js(
+        'document.querySelector("[data-testid=\\"settings-always-on-top-switch\\"]").click()'
+    )
+    wait_for(
+        window,
+        'document.querySelector("[data-testid=\\"settings-always-on-top-switch\\"]")'
+        '.getAttribute("aria-checked") === "true"',
+    )
+    st1 = call_bridge_js(window, 'window.pywebview.api.window_state()')
+    assert st1.get('ok') and st1.get('on_top') is True, f'Pin failed: {st1}'
+
+    window.evaluate_js(
+        'document.querySelector("[data-testid=\\"settings-always-on-top-switch\\"]").click()'
+    )
+    wait_for(
+        window,
+        'document.querySelector("[data-testid=\\"settings-always-on-top-switch\\"]")'
+        '.getAttribute("aria-checked") === "false"',
+    )
+    st2 = call_bridge_js(window, 'window.pywebview.api.window_state()')
+    assert st2.get('ok') and st2.get('on_top') is False, f'Unpin failed: {st2}'
+    lifecycle = {
+        'startup': {'on_top': st0['on_top'], 'aria_checked': checked_before},
+        'after_enable': {'on_top': st1['on_top'], 'aria_checked': 'true'},
+        'after_disable': {'on_top': st2['on_top'], 'aria_checked': 'false'},
+    }
+    evidence['always_on_top_lifecycle'] = lifecycle
+    print(
+        f"  on_top: {st0['on_top']} -> {st1['on_top']} -> {st2['on_top']}"
+        ' (aria-checked coherent): PASS',
+        flush=True,
+    )
+
+    # ---- 5. Keyboard & focus ----------------------------------------------
+    print('[5] Keyboard & focus...', flush=True)
+    # Settings are currently open (from section 3); close them first so
+    # we can observe a fresh open with focus on the back button.
+    close_settings(window)
+    time.sleep(0.2)
+    focus_before_open = window.evaluate_js(
+        'document.activeElement?.getAttribute("data-testid")'
+    )
+    assert focus_before_open == 'companion-open-settings-btn', (
+        f'Focus must return to gear after close, got {focus_before_open!r}'
+    )
+    open_settings(window)
+    time.sleep(0.2)
+    focused_on_open = window.evaluate_js(
+        'document.activeElement?.getAttribute("data-testid")'
+    )
+    assert focused_on_open == 'settings-back-btn', (
+        f'Back button not focused on open: {focused_on_open!r}'
+    )
+    window.evaluate_js("""(() => {
+        document.activeElement.dispatchEvent(
+            new KeyboardEvent('keydown', {key: 'Escape', bubbles: true}));
+    })()""")
+    time.sleep(0.4)
+    closed_by_escape = window.evaluate_js(
+        '!document.querySelector(\'[data-testid="settings-workspace"]\')'
+    )
+    assert closed_by_escape, 'Escape must close settings'
+    focus_after_escape = window.evaluate_js(
+        'document.activeElement?.getAttribute("data-testid")'
+    )
+    assert focus_after_escape == 'companion-open-settings-btn', (
+        f'Focus must return to gear after Escape, got {focus_after_escape!r}'
+    )
+    keyboard = {
+        'focus_returns_to_gear_on_close': focus_before_open,
+        'focused_on_open': focused_on_open,
+        'escape_closes': closed_by_escape,
+        'focus_after_escape': focus_after_escape,
+    }
+    evidence['keyboard_focus'] = keyboard
+    print(
+        f'  focused_on_open={focused_on_open!r}, escape closes,'
+        f' focus returns to {focus_after_escape!r}: PASS',
+        flush=True,
+    )
+
+    # ---- 6. Efficiency: no polling ----------------------------------------
+    print('[6] Efficiency (no polling while open)...', flush=True)
+    open_settings(window)
+    window.evaluate_js('window.__stateReads = 0')
+    window.evaluate_js("""(() => {
+        const api = window.pywebview.api;
+        const orig = api.window_state.bind(api);
+        api.window_state = async (...argv) => {
+            window.__stateReads += 1;
+            return orig(...argv);
+        };
+    })()""")
+    time.sleep(2.0)
+    reads = window.evaluate_js('window.__stateReads')
+    assert reads == 0, f'Polling detected: {reads} window_state reads in 2s'
+    evidence['efficiency'] = {
+        'window_state_reads_while_open_2s': reads,
+        'polling_detected': reads > 0,
+    }
+    print(f'  window_state reads in 2s while open: {reads}: PASS', flush=True)
+
+    # ---- 7. Presence isolation --------------------------------------------
+    print('[7] Presence isolation...', flush=True)
+    close_settings(window)
+    time.sleep(0.3)
+    window.evaluate_js(
+        'document.querySelector("[data-testid=\\"companion-enter-presence-btn\\"]").click()'
+    )
+    wait_for(
+        window,
+        'Boolean(document.querySelector("[data-testid=\\"katherine-presence-surface\\"]"))',
+    )
+    time.sleep(0.4)
+    presence_settings = window.evaluate_js("""(() => {
+        const forbidden = [
+            '[data-testid="settings-workspace"]',
+            '[data-testid="settings-back-btn"]',
+            '[data-testid="settings-section-window"]',
+            '[data-testid="settings-always-on-top-switch"]',
+            '.settings-workspace'
+        ];
+        return {
+            settingsDOM: Boolean(document.querySelector('[data-testid="settings-workspace"]')),
+            gearBtn: Boolean(document.querySelector('[data-testid="companion-open-settings-btn"]')),
+            leaked: forbidden.filter(sel => document.querySelector(sel) !== null)
+        };
+    })()""")
+    assert not presence_settings['settingsDOM'], 'Settings leaked into presence mode'
+    assert not presence_settings['gearBtn'], 'Settings entry leaked into presence mode'
+    assert not presence_settings['leaked'], (
+        f"Forbidden selectors in presence: {presence_settings['leaked']}"
+    )
+    window.evaluate_js(
+        'document.querySelector("[data-testid=\\"presence-return-btn\\"]").click()'
+    )
+    wait_for(window, 'Boolean(document.querySelector("[data-testid=\\"companion-layout\\"]"))')
+    time.sleep(0.3)
+    back_in_companion = window.evaluate_js(
+        'Boolean(document.querySelector(\'[data-testid="companion-open-settings-btn"]\'))'
+    )
+    assert back_in_companion, 'Gear button must return with companion mode'
+    isolation = {
+        'settings_in_presence': presence_settings['settingsDOM'],
+        'leaked_selectors': presence_settings['leaked'],
+        'gear_returns_with_companion': back_in_companion,
+    }
+    evidence['presence_isolation'] = isolation
+    print('  0 leaked selectors in presence, gear returns with companion: PASS', flush=True)
+
+    # ---- 8. Resolutions & scaling -----------------------------------------
+    print('[8] Resolutions & scaling...', flush=True)
+    from gi.repository import GLib
+
+    try:
+        from webview.platforms.gtk import BrowserView
+
+        bv = BrowserView.instances.get(window.uid)
+    except Exception:
+        bv = None
+    scenarios = [
+        ('1440x900-100', 1440, 900, 1.0),
+        ('1024x768-100', 1024, 768, 1.0),
+        ('800x600-100', 800, 600, 1.0),
+        ('800x600-125', 800, 600, 1.25),
+        ('800x600-150', 800, 600, 1.50),
+    ]
+    matrix = []
+    for name, w, h, zoom in scenarios:
+        window.resize(w, h)
+        wait_for(window, f'innerWidth === {w}')
+        time.sleep(0.4)
+        if bv:
+            def apply():
+                settings = bv.webview.get_settings()
+                settings.props.zoom_text_only = True
+                bv.webview.set_zoom_level(zoom)
+                return False
+
+            GLib.idle_add(apply)
+            time.sleep(0.8)
+
+        open_settings(window)
+        time.sleep(0.4)
+        m = metrics(window)
+        assert m['hasWorkspace'], f'{name}: workspace missing'
+        assert not m['horizontalOverflow'], f'{name}: horizontal overflow'
+        capture(window, f'settings-{name}')
+        close_settings(window)
+        m_closed = metrics(window)
+        assert m_closed['inputVisible'], f'{name}: composer not visible after return'
+        assert not m_closed['horizontalOverflow'], f'{name}: overflow after return'
+        matrix.append({'scenario': name, 'workspace': m, 'after_return': m_closed})
+        print(f'  {name}: PASS', flush=True)
+
+    if bv:
+        def restore():
+            bv.webview.set_zoom_level(1.0)
+            return False
+
+        GLib.idle_add(restore)
+        time.sleep(0.3)
+
+    evidence['resolution_matrix'] = matrix
+
+    # ---- 9. Draft + history across reopen (final) -------------------------
+    print('[9] Draft still preserved at the end...', flush=True)
+    final_draft = window.evaluate_js(
+        'document.querySelector(\'textarea[aria-label="Sua mensagem"]\').value'
+    )
+    assert final_draft == 'rascunho-para-preservar', (
+        f'Draft lost during matrix: {final_draft!r}'
+    )
+    evidence['final_draft_preserved'] = final_draft
+    print(f'  draft={final_draft!r}: PASS', flush=True)
+
+    evidence['status'] = 'PASS'
+    (output_dir / 'settings_evidence.json').write_text(
+        json.dumps(evidence, indent=2, ensure_ascii=False)
+    )
+    print('=' * 70)
+    print('SETTINGS WORKSPACE RUNTIME EVIDENCE COMPLETED: PASS')
+    print(f'Saved: {output_dir / "settings_evidence.json"}')
+    print('=' * 70 + '\n', flush=True)
+    return evidence
+
+
+def inspect():
+    window = None
+    try:
+        deadline = time.monotonic() + 20
+        while not webview.windows and time.monotonic() < deadline:
+            time.sleep(0.1)
+        window = webview.windows[0]
+        window.events.loaded.wait(20)
+        wait_for(window, 'Boolean(document.querySelector("[data-testid=companion-layout]"))')
+        time.sleep(0.5)
+        release.set()
+        verify_settings(window, args.output)
+    except Exception as error:
+        failures.append(str(error))
+    finally:
+        release.set()
+        results['failures'] = failures
+        (args.output / 'observations.json').write_text(
+            json.dumps(results, indent=2, ensure_ascii=False)
+        )
+        if window:
+            window.destroy()
+
+
+thread = threading.Thread(target=inspect, daemon=True)
+thread.start()
+run_desktop_shell(
+    storage_path=args.output / 'isolated.sqlite3',
+    provider=ReviewProvider(),
+)
+thread.join(5)
+if failures:
+    raise SystemExit('; '.join(failures))


### PR DESCRIPTION
## Origem

- Issue/tarefa: #347
- Agente/autor: Jcode

## Problema

A interface desktop não tinha um workspace de configurações separado do companion e do sidebar de estado. Isso deixava sem um ponto de entrada claro para preferências reais e criava risco de misturar "como Katherine funciona" com "como Katherine está agora". A auditoria dos contratos existentes mostrou que somente `window_state().on_top` + `set_always_on_top()` têm suporte real no bridge. Voz/TTS, memória, modelos/provedores e integrações não possuem contratos desktop equivalentes, e `on_top` é estado apenas da sessão.

## Solução

- Adiciona um botão de configurações discreto no header do companion, fora do `KatherineStateSidebar` e inexistente no modo presença.
- Adiciona `SettingsWorkspace`, uma superfície pequena e dedicada com apenas a seção `Janela` e o switch `Sempre no topo`.
- Reutiliza exclusivamente `getWindowState()` e `setAlwaysOnTop()` da allowlist existente. O estado visual só muda após confirmação do bridge; falhas mantêm o estado coerente e exibem mensagem sanitizada.
- Explicita que o pin vale enquanto o aplicativo estiver aberto, sem promessa de persistência entre reinícios.
- Mantém `ChatWindow` e a única chamada `useChat()` montados durante a navegação. Histórico, draft do composer e transport permanecem no mesmo seam de composição.
- Adiciona retorno de foco para o botão de configurações, fechamento por Escape, headings semânticos, `role=switch`, foco visível, reduced motion e layout responsivo para janelas pequenas.
- Adiciona evidência de runtime WebKitGTK/Xvfb e amplia o privacy canary do modo presença com os seletores do workspace.
- Corrige o blocker de ordenação: `AppDesktop` permanece como único owner de `isAlwaysOnTop`, o workspace não faz mais `getWindowState()` no mount, e um epoch monotônico invalida snapshots iniciados antes de respostas de janela confirmadas mais novas.

### Capacidades expostas e omitidas

- Exposta: `Sempre no topo`, respaldada pelo contrato real de janela e limitada à sessão.
- Deliberadamente omitidas: voz/TTS, memória, modelos/provedores, integrações e qualquer configuração de persistência. O modo presença continua sendo uma ação imediata, não uma preferência.

## Escopo alterado

- [ ] Backend
- [x] Frontend
- [ ] Sistema emocional
- [ ] Memória/relacionamento
- [ ] Autenticação/segurança
- [ ] Infraestrutura/governança

Arquivos principais: `frontend/src/AppDesktop.jsx`, `frontend/src/features/chat/components/CompanionLayout.{jsx,css}`, `frontend/src/features/settings/SettingsWorkspace.{jsx,css}`, `frontend/tests/SettingsWorkspace.test.jsx`, `scripts/settings_review.py` e o privacy canary em `scripts/presence_review.py`.

## Validação

- [x] Testes automatizados adicionados/atualizados
- [x] Testes relevantes passaram
- [x] Lint/build passaram
- [x] Sem logs de depuração ou segredos
- [x] Estado e dados permanecem isolados por usuário

Comandos e resultados:

- `git diff --check`: PASS.
- `uv run --project backend python -m py_compile scripts/settings_review.py scripts/presence_review.py`: PASS.
- `cd frontend && npm test -- --run`: PASS, 213 testes Node e 199 testes Vitest.
- `cd frontend && npx vitest run --config vitest.config.mjs tests/SettingsWorkspace.test.jsx`: PASS, 20 testes específicos da #347, incluindo as duas ordens stale-vs-new.
- `cd frontend && npm run lint`: PASS.
- `cd frontend && npm run build`: PASS, Vite compilou 1.648 módulos.
- `cd frontend && npm audit --audit-level=high`: PASS, 0 vulnerabilidades.
- `cd frontend && node tests/desktopGraph.test.js`: PASS, 5 testes.
- `cd frontend && node --test tests/projectLocalSkills.test.js`: PASS, 5 testes.
- `uv lock --project backend --check`: PASS.
- Testes desktop/security relacionados: PASS, 115 testes.
- `xvfb-run ... settings_review.py`: PASS no runtime real WebKitGTK, 9 seções. Foram verificadas entrada exclusiva pelo companion, preservação do draft, honestidade de capacidades, ciclo real `on_top=false -> true -> false`, foco/Escape, zero leituras `window_state` em 2 segundos, isolamento no modo presença e 1440x900, 1024x768, 800x600, 125% e 150%.
- `uv run --project backend python -m pytest backend/tests -q`: tentado, mas não é um gate verde neste ambiente porque a suíte contém integrações que exigem `SUPABASE_URL`, credenciais de serviço e/ou o binário Supabase local. O bloqueio é externo à mudança; os testes desktop/security relevantes passaram isoladamente.

A validação de privacidade confirma que não há configuração fictícia ou segredo no DOM e que o modo presença não recebe DOM de settings. Nenhum novo estado de usuário global, `user_id` confiado do cliente ou dependência foi introduzido.

## Riscos e operação

- Migração: nenhuma. Não há alteração de schema, contrato persistido ou formato de dados.
- Rollback: reverter os commits `07d5df9` e `3d46960cc6e0eb7c9e1562232d186ac41bc7c796` remove o workspace e o fix de ordenação sem exigir migração.
- Riscos conhecidos: o pin continua sendo apenas de sessão, conforme o contrato atual do `WindowController`; indisponibilidade do bridge mantém o controle desativado/coerente e informa o usuário. A suíte completa de backend permanece não verificável localmente sem o ambiente Supabase requerido.
- Eficiência: nenhuma rota, dependência, polling ou timer novo. `AppDesktop` faz uma leitura única de `window_state` no startup; o workspace não faz leituras nem mutações enquanto é aberto.

## Fora de escopo

- Persistir `on_top` entre reinícios.
- Criar contratos para voz/TTS, memória, modelos/provedores ou integrações.
- Alterar o sidebar de estado, o modelo emocional, o transport de chat ou o comportamento do modo presença.
- Fazer merge local da branch. Esta mudança deve ser revisada nesta única PR contra `main`.

Closes #347